### PR TITLE
1551153: Enable the ping uploader in glean-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
 
   Lint Android with ktlint and detekt:
     docker:
-      - image: circleci/android:api-27-ndk
+      - image: circleci/android:api-28-ndk
     steps:
       - checkout
       - run: ./gradlew ktlint
@@ -111,7 +111,7 @@ jobs:
         
   Android tests:
     docker:
-      - image: circleci/android:api-27-ndk
+      - image: circleci/android:api-28-ndk
     steps:
       - android-tests
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,12 @@
 
 buildscript {
     ext.kotlin_version = '1.3.31'
-    ext.android_components_version = '0.50.0'
+    ext.android_components_version = '0.52.0'
     ext.jna_version = '5.2.0'
 
     ext.build = [
-        compileSdkVersion: 27,
-        targetSdkVersion: 27,
+        compileSdkVersion: 28,
+        targetSdkVersion: 28,
         minSdkVersion: 21, // So that we can publish for aarch64.
     ]
 

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -33,6 +33,9 @@ android {
         minSdkVersion rootProject.ext.build['minSdkVersion']
         targetSdkVersion rootProject.ext.build['targetSdkVersion']
 
+        // TODO: 1551691 Get the version from git tag...? Also, we need to select a
+        // version that won't conflict with legacy glean-ac versions.
+        buildConfigField("String", "LIBRARY_VERSION", "\"0.1\"")
         buildConfigField("String", "GLEAN_PING_SCHEMA_URL", "\"" + GLEAN_PING_SCHEMA_URL + "\"")
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -118,6 +121,9 @@ android {
 }
 
 dependencies {
+    api "org.mozilla.components:concept-fetch:$android_components_version"
+    implementation "org.mozilla.components:lib-fetch-httpurlconnection:$android_components_version"
+
     jnaForTest "net.java.dev.jna:jna:$jna_version@jar"
     implementation "net.java.dev.jna:jna:$jna_version@aar"
 
@@ -125,6 +131,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1"
 
     implementation "androidx.annotation:annotation:1.0.2"
+    implementation "androidx.work:work-runtime-ktx:2.0.0"
 
     // For reasons unknown, resolving the jnaForTest configuration directly
     // trips a nasty issue with the Android-Gradle plugin 3.2.1, like `Cannot
@@ -138,6 +145,10 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.2.1'
     testImplementation 'org.mockito:mockito-core:2.24.5'
     testImplementation 'androidx.test:core-ktx:1.1.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
+    testImplementation "org.mozilla.components:lib-fetch-okhttp:$android_components_version"
+    testImplementation "org.mozilla.components:support-test:$android_components_version"
+    testImplementation "androidx.work:work-testing:2.0.0"
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/glean-core/android/src/main/AndroidManifest.xml
+++ b/glean-core/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.mozilla.gleancore" />
+    package="mozilla.telemetry.glean" />

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -9,13 +9,15 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.utils.getLocaleTag
 import java.io.File
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.MetricHandle
 import mozilla.telemetry.glean.rust.RustError
-import org.mozilla.gleancore.GleanMetrics.GleanBaseline
-import org.mozilla.gleancore.GleanMetrics.GleanInternalMetrics
+import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
+import mozilla.telemetry.glean.GleanMetrics.GleanInternalMetrics
+import mozilla.telemetry.glean.scheduler.PingUploadWorker
 
 open class GleanInternalAPI internal constructor () {
     companion object {
@@ -25,21 +27,25 @@ open class GleanInternalAPI internal constructor () {
     // `internal` so this can be modified for testing
     internal var handle: MetricHandle = 0L
 
+    internal lateinit var configuration: Configuration
+
+    private lateinit var gleanDataDir: File
+
     /**
      * Initialize glean.
      *
      * This should only be initialized once by the application, and not by
      * libraries using glean.
      */
-    fun initialize(applicationContext: Context) {
-        val dataDir = File(applicationContext.applicationInfo.dataDir, "glean_data")
-        Log.i(LOG_TAG, "data dir: $dataDir")
-
+    fun initialize(applicationContext: Context, configuration: Configuration = Configuration()) {
         if (isInitialized()) {
             return
         }
 
-        handle = LibGleanFFI.INSTANCE.glean_initialize(dataDir.path, applicationContext.packageName)
+        this.configuration = configuration
+
+        this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, "glean_data")
+        handle = LibGleanFFI.INSTANCE.glean_initialize(this.gleanDataDir.path, applicationContext.packageName)
 
         // TODO: on glean-legacy we perform other actions before initialize the metrics (e.g.
         // init the engines), then init the core metrics, and finally kick off the metrics
@@ -135,6 +141,13 @@ open class GleanInternalAPI internal constructor () {
         return false
     }
 
+    /**
+     * Get the data directory for glean.
+     */
+    internal fun getDataDir(): File {
+        return this.gleanDataDir
+    }
+
     fun collect(pingName: String) {
         val s = LibGleanFFI.INSTANCE.glean_ping_collect(handle, pingName)!!
         LibGleanFFI.INSTANCE.glean_str_free(s)
@@ -150,6 +163,8 @@ open class GleanInternalAPI internal constructor () {
 
     private fun sendPing(pingName: String) {
         LibGleanFFI.INSTANCE.glean_send_ping(handle, pingName)
+        // TODO: 1551692 Only do this when ping content was actually queued
+        PingUploadWorker.enqueueWorker()
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -32,13 +32,22 @@ open class GleanInternalAPI internal constructor () {
     private lateinit var gleanDataDir: File
 
     /**
-     * Initialize glean.
+     * Initialize Glean.
      *
      * This should only be initialized once by the application, and not by
-     * libraries using glean.
+     * libraries using Glean. A message is logged to error and no changes are made
+     * to the state if initialize is called a more than once.
+     *
+     * A LifecycleObserver will be added to send pings when the application goes
+     * into the background.
+     *
+     * @param applicationContext [Context] to access application features, such
+     * as shared preferences
+     * @param configuration A Glean [Configuration] object with global settings.
      */
     fun initialize(applicationContext: Context, configuration: Configuration = Configuration()) {
         if (isInitialized()) {
+            Log.e(LOG_TAG, "Glean should not be initialized multiple times")
             return
         }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.service.glean.config
+package mozilla.telemetry.glean.config
 
 import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
-import mozilla.components.service.glean.BuildConfig
+import mozilla.telemetry.glean.BuildConfig
 
 /**
- * The Configuration class describes how to configure the Glean.
+ * The Configuration class describes how to configure Glean.
  *
  * @property serverEndpoint the server pings are sent to. Please note that this is
  *           is only meant to be changed for tests.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.config
+
+import mozilla.components.concept.fetch.Client
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.service.glean.BuildConfig
+
+/**
+ * The Configuration class describes how to configure the Glean.
+ *
+ * @property serverEndpoint the server pings are sent to. Please note that this is
+ *           is only meant to be changed for tests.
+ * @property userAgent the user agent used when sending pings, only to be used internally.
+ * @property connectionTimeout the timeout, in milliseconds, to use when connecting to
+ *           the [serverEndpoint]
+ * @property readTimeout the timeout, in milliseconds, to use when connecting to
+ *           the [serverEndpoint]
+ * @property maxEvents the number of events to store before the events ping is sent
+ * @property logPings whether to log ping contents to the console. This is only meant to be used
+ *           internally by the `GleanDebugActivity`.
+ * @property httpClient The HTTP client implementation to use for uploading pings.
+ * @property pingTag String tag to be applied to headers when uploading pings for debug view.
+ *           This is only meant to be used internally by the `GleanDebugActivity`.
+ * @property channel the release channel the application is on, if known. This will be
+ *           sent along with all the pings, in the `client_info` section. */
+data class Configuration internal constructor(
+    val serverEndpoint: String,
+    val userAgent: String = DEFAULT_USER_AGENT,
+    val connectionTimeout: Long = DEFAULT_CONNECTION_TIMEOUT,
+    val readTimeout: Long = DEFAULT_READ_TIMEOUT,
+    val maxEvents: Int = DEFAULT_MAX_EVENTS,
+    val logPings: Boolean = DEFAULT_LOG_PINGS,
+    // NOTE: since only simple object or strings can be made `const val`s, if the
+    // default values for the lines below are ever changed, they are required
+    // to change in the public constructor below.
+    val httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() },
+    val pingTag: String? = null,
+    val channel: String? = null
+) {
+    // This is the only public constructor this class should have. It should only
+    // expose things we want to allow external applications to change. Every test
+    // only or internal configuration option should be added to the above primary internal
+    // constructor and only initialized with a proper default when calling the primary
+    // constructor from the secondary, public one, below.
+    constructor(
+        connectionTimeout: Long = DEFAULT_CONNECTION_TIMEOUT,
+        readTimeout: Long = DEFAULT_READ_TIMEOUT,
+        maxEvents: Int = DEFAULT_MAX_EVENTS,
+        httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() },
+        channel: String? = null
+    ) : this (
+        serverEndpoint = DEFAULT_TELEMETRY_ENDPOINT,
+        userAgent = DEFAULT_USER_AGENT,
+        connectionTimeout = connectionTimeout,
+        readTimeout = readTimeout,
+        maxEvents = maxEvents,
+        logPings = DEFAULT_LOG_PINGS,
+        httpClient = httpClient,
+        pingTag = null,
+        channel = channel
+    )
+
+    companion object {
+        const val DEFAULT_TELEMETRY_ENDPOINT = "https://incoming.telemetry.mozilla.org"
+        const val DEFAULT_DEBUGVIEW_ENDPOINT = "https://stage.ingestion.nonprod.dataops.mozgcp.net"
+        const val DEFAULT_USER_AGENT = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)"
+        const val DEFAULT_CONNECTION_TIMEOUT = 10000L
+        const val DEFAULT_READ_TIMEOUT = 30000L
+        const val DEFAULT_MAX_EVENTS = 500
+        const val DEFAULT_LOG_PINGS = false
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/net/HttpPingUploader.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/net/HttpPingUploader.kt
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PRIVATE
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.MutableHeaders
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.isClientError
+import mozilla.components.concept.fetch.isSuccess
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.support.base.log.logger.Logger
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * A simple ping Uploader, which implements a "send once" policy, never
+ * storing or attempting to send the ping again.
+ */
+internal class HttpPingUploader : PingUploader {
+    private val logger = Logger("glean/HttpPingUploader")
+
+    /**
+     * Log the contents of a ping to the console, if configured to do so in
+     * [Configuration.logPings].
+     *
+     * @param path the URL path to append to the server address
+     * @param data the serialized text data to send
+     * @param config the Glean configuration object
+     */
+    private fun logPing(path: String, data: String, config: Configuration) {
+        if (config.logPings) {
+            // Parse and reserialize the JSON so it has indentation and is human-readable.
+            try {
+                val json = JSONObject(data)
+                val indented = json.toString(2)
+
+                logger.debug("Glean ping to URL: $path\n$indented")
+            } catch (e: JSONException) {
+                logger.debug("Exception parsing ping as JSON: $e") // $COVERAGE-IGNORE$
+            }
+        }
+    }
+
+    /**
+     * Synchronously upload a ping to Mozilla servers.
+     * Note that the `X-Client-Type`: `Glean` and `X-Client-Version`: <SDK version>
+     * headers are added to the HTTP request in addition to the UserAgent. This allows
+     * us to easily handle pings coming from Glean on the legacy Mozilla pipeline.
+     *
+     * @param path the URL path to append to the server address
+     * @param data the serialized text data to send
+     * @param config the Glean configuration object
+     *
+     * @return true if the ping was correctly dealt with (sent successfully
+     *         or faced an unrecoverable error), false if there was a recoverable
+     *         error callers can deal with.
+     */
+    override fun upload(path: String, data: String, config: Configuration): Boolean {
+        logPing(path, data, config)
+
+        val request = buildRequest(path, data, config)
+
+        return try {
+            performUpload(config.httpClient.value, request)
+        } catch (e: IOException) {
+            logger.warn("IOException while uploading ping", e)
+            false
+        }
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal fun buildRequest(path: String, data: String, config: Configuration): Request {
+        val headers = MutableHeaders(
+            "Content-Type" to "application/json; charset=utf-8",
+            "User-Agent" to config.userAgent,
+            "Date" to createDateHeaderValue(),
+            // Add headers for supporting the legacy pipeline.
+            "X-Client-Type" to "Glean",
+            "X-Client-Version" to BuildConfig.LIBRARY_VERSION
+        )
+
+        var endpoint = config.serverEndpoint
+
+        // If there is a pingTag set, then this header needs to be added in order to flag pings
+        // for "debug view" use.
+        config.pingTag?.let {
+            headers.append("X-Debug-ID", it)
+
+            // NOTE: Tagged pings must be redirected to the GCP endpoint as the AWS endpoint isn't
+            // configured to handle them.  This may pose an issue with testing if a local server
+            // is used to capture pings.
+            endpoint = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT
+        }
+
+        return Request(
+            url = endpoint + path,
+            method = Request.Method.POST,
+            connectTimeout = Pair(config.connectionTimeout, TimeUnit.MILLISECONDS),
+            readTimeout = Pair(config.readTimeout, TimeUnit.MILLISECONDS),
+            headers = headers,
+            // Make sure we are not sending cookies. Unfortunately, HttpURLConnection doesn't
+            // offer a better API to do that, so we nuke all cookies going to our telemetry
+            // endpoint.
+            cookiePolicy = Request.CookiePolicy.OMIT,
+            body = Request.Body.fromString(data)
+        )
+    }
+
+    @Throws(IOException::class)
+    internal fun performUpload(client: Client, request: Request): Boolean {
+        logger.debug("Submitting ping to: ${request.url}")
+        client.fetch(request).use { response ->
+            when {
+                response.isSuccess -> {
+                    // Known success errors (2xx):
+                    // 200 - OK. Request accepted into the pipeline.
+
+                    // We treat all success codes as successful upload even though we only expect 200.
+                    logger.debug("Ping successfully sent (${response.status})")
+                    return true
+                }
+
+                response.isClientError -> {
+                    // Known client (4xx) errors:
+                    // 404 - not found - POST/PUT to an unknown namespace
+                    // 405 - wrong request type (anything other than POST/PUT)
+                    // 411 - missing content-length header
+                    // 413 - request body too large (Note that if we have badly-behaved clients that
+                    //       retry on 4XX, we should send back 202 on body/path too long).
+                    // 414 - request path too long (See above)
+
+                    // Something our client did is not correct. It's unlikely that the client is going
+                    // to recover from this by re-trying again, so we just log and error and report a
+                    // successful upload to the service.
+                    logger.error("Server returned client error code ${response.status} for ${request.url}")
+                    return true
+                }
+
+                else -> {
+                    // Known other errors:
+                    // 500 - internal error
+
+                    // For all other errors we log a warning an try again at a later time.
+                    logger.warn("Server returned response code ${response.status} for ${request.url}")
+                    return false
+                }
+            }
+        }
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/net/PingUploader.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/net/PingUploader.kt
@@ -2,9 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.service.glean.net
+package mozilla.telemetry.glean.net
 
-import mozilla.components.service.glean.config.Configuration
+import android.util.Log
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.config.Configuration
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileReader
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -14,6 +21,12 @@ import java.util.TimeZone
  * The interface defining how to send pings.
  */
 internal interface PingUploader {
+    companion object {
+        // Since ping file names are UUIDs, this matches UUIDs for filtering purposes
+        private const val FILE_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+        private const val LOG_TAG = "glean/PingUploader"
+    }
+
     fun upload(path: String, data: String, config: Configuration): Boolean
 
     fun createDateHeaderValue(): String {
@@ -21,5 +34,83 @@ internal interface PingUploader {
         val dateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
         dateFormat.timeZone = TimeZone.getTimeZone("GMT")
         return dateFormat.format(calendar.time)
+    }
+
+    /**
+     * Function to deserialize and process all serialized ping files.  This function will ignore
+     * files that don't match the UUID regex and just delete them to prevent files from polluting
+     * the ping storage directory.
+     *
+     * @param processingCallback Callback function to do the actual process action on the ping.
+     *                           Typically this will be the [HttpPingUploader.upload] function.
+     * @return Boolean representing the success of the upload task. This may be the value bubbled up
+     *         from the callback, or if there was an error reading the files.
+     */
+    fun process(processingCallback: (String, String, Configuration) -> Boolean): Boolean {
+        // This function is from PingsStorageEngine in glean-ac
+
+        var success = true
+        // TODO: 1551694 Get this directory from the rust side
+        val storageDirectory = File(Glean.getDataDir(), "pings")
+
+        Log.d(LOG_TAG, "Processing persisted pings at ${storageDirectory.absolutePath}")
+
+        storageDirectory.listFiles()?.forEach { file ->
+            if (file.name.matches(Regex(FILE_PATTERN))) {
+                Log.d(LOG_TAG, "Processing ping: ${file.name}")
+                if (!processFile(file, processingCallback)) {
+                    Log.e(LOG_TAG, "Error processing ping file: ${file.name}")
+                    success = false
+                }
+            } else {
+                // Delete files that don't match the UUID FILE_PATTERN regex
+                Log.d(LOG_TAG, "Pattern mismatch. Deleting ${file.name}")
+                file.delete()
+            }
+        }
+
+        return success
+    }
+
+    /**
+     * This function encapsulates processing of a single ping file.
+     *
+     * @param file The [File] to process
+     * @param processingCallback the callback that actually processes the file
+     *
+     */
+    private fun processFile(
+        file: File,
+        processingCallback: (String, String, Configuration) -> Boolean
+    ): Boolean {
+        // This function is from PingsStorageEngine in glean-ac
+
+        var processed = false
+        BufferedReader(FileReader(file)).use {
+            try {
+                val path = it.readLine()
+                val serializedPing = it.readLine()
+
+                processed = serializedPing == null ||
+                    processingCallback(path, serializedPing, Glean.configuration)
+            } catch (e: FileNotFoundException) {
+                // This shouldn't happen after we queried the directory.
+                Log.e(LOG_TAG, "Could not find ping file ${file.name}")
+                return false
+            } catch (e: IOException) {
+                // Something is not right.
+                Log.e(LOG_TAG, "IO Exception when reading file ${file.name}")
+                return false
+            }
+        }
+
+        return if (processed) {
+            val fileWasDeleted = file.delete()
+            Log.d(LOG_TAG, "${file.name} was deleted: $fileWasDeleted")
+            true
+        } else {
+            // The callback couldn't process this file.
+            false
+        }
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/net/PingUploader.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/net/PingUploader.kt
@@ -46,7 +46,7 @@ internal interface PingUploader {
      * @return Boolean representing the success of the upload task. This may be the value bubbled up
      *         from the callback, or if there was an error reading the files.
      */
-    fun process(processingCallback: (String, String, Configuration) -> Boolean): Boolean {
+    fun process(): Boolean {
         // This function is from PingsStorageEngine in glean-ac
 
         var success = true
@@ -58,7 +58,7 @@ internal interface PingUploader {
         storageDirectory.listFiles()?.forEach { file ->
             if (file.name.matches(Regex(FILE_PATTERN))) {
                 Log.d(LOG_TAG, "Processing ping: ${file.name}")
-                if (!processFile(file, processingCallback)) {
+                if (!processFile(file)) {
                     Log.e(LOG_TAG, "Error processing ping file: ${file.name}")
                     success = false
                 }
@@ -80,8 +80,7 @@ internal interface PingUploader {
      *
      */
     private fun processFile(
-        file: File,
-        processingCallback: (String, String, Configuration) -> Boolean
+        file: File
     ): Boolean {
         // This function is from PingsStorageEngine in glean-ac
 
@@ -92,7 +91,7 @@ internal interface PingUploader {
                 val serializedPing = it.readLine()
 
                 processed = serializedPing == null ||
-                    processingCallback(path, serializedPing, Glean.configuration)
+                    this.upload(path, serializedPing, Glean.configuration)
             } catch (e: FileNotFoundException) {
                 // This shouldn't happen after we queried the directory.
                 Log.e(LOG_TAG, "Could not find ping file ${file.name}")

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/net/PingUploader.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/net/PingUploader.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import mozilla.components.service.glean.config.Configuration
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * The interface defining how to send pings.
+ */
+internal interface PingUploader {
+    fun upload(path: String, data: String, config: Configuration): Boolean
+
+    fun createDateHeaderValue(): String {
+        val calendar = Calendar.getInstance()
+        val dateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
+        dateFormat.timeZone = TimeZone.getTimeZone("GMT")
+        return dateFormat.format(calendar.time)
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -63,7 +63,7 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
          */
         internal fun uploadPings(): Boolean {
             val httpPingUploader = HttpPingUploader()
-            return httpPingUploader.process(httpPingUploader::upload)
+            return httpPingUploader.process()
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.service.glean.scheduler
+package mozilla.telemetry.glean.scheduler
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
@@ -14,8 +14,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import mozilla.components.service.glean.Glean
-import mozilla.components.service.glean.net.HttpPingUploader
+import mozilla.telemetry.glean.net.HttpPingUploader
 
 /**
  * This class is the worker class used by [WorkManager] to handle uploading the ping to the server.
@@ -64,7 +63,7 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
          */
         internal fun uploadPings(): Boolean {
             val httpPingUploader = HttpPingUploader()
-            return Glean.pingStorageEngine.process(httpPingUploader::upload)
+            return httpPingUploader.process(httpPingUploader::upload)
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.scheduler
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.net.HttpPingUploader
+
+/**
+ * This class is the worker class used by [WorkManager] to handle uploading the ping to the server.
+ */
+class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+    companion object {
+        internal const val PING_WORKER_TAG = "mozac_service_glean_ping_upload_worker"
+
+        /**
+         * Build the constraints around which the worker can be run, such as whether network
+         * connectivity is required.
+         *
+         * @return [Constraints] object containing the required work constraints
+         */
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        fun buildConstraints(): Constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        /**
+         * Build the [OneTimeWorkRequest] for enqueueing in the [WorkManager].  This also adds a tag
+         * by which [isWorkScheduled] can tell if the worker object has been enqueued.
+         *
+         * @return [OneTimeWorkRequest] representing the task for the [WorkManager] to enqueue and run
+         */
+        internal fun buildWorkRequest(): OneTimeWorkRequest = OneTimeWorkRequestBuilder<PingUploadWorker>()
+            .addTag(PingUploadWorker.PING_WORKER_TAG)
+            .setConstraints(buildConstraints())
+            .build()
+
+        /**
+         * Function to aid in properly enqueuing the worker in [WorkManager]
+         */
+        internal fun enqueueWorker() {
+            WorkManager.getInstance().enqueueUniqueWork(
+                PingUploadWorker.PING_WORKER_TAG,
+                ExistingWorkPolicy.KEEP,
+                PingUploadWorker.buildWorkRequest())
+        }
+
+        /**
+         * Function to perform the actual ping upload task.  This is created here in the
+         * companion object in order to facilitate testing.
+         *
+         * @return true if process was successful
+         */
+        internal fun uploadPings(): Boolean {
+            val httpPingUploader = HttpPingUploader()
+            return Glean.pingStorageEngine.process(httpPingUploader::upload)
+        }
+    }
+
+    /**
+     * This method is called on a background thread - you are required to **synchronously** do your
+     * work and return the [androidx.work.ListenableWorker.Result] from this method.  Once you
+     * return from this method, the Worker is considered to have finished what its doing and will be
+     * destroyed.
+     *
+     * A Worker is given a maximum of ten minutes to finish its execution and return a
+     * [androidx.work.ListenableWorker.Result].  After this time has expired, the Worker will
+     * be signalled to stop.
+     *
+     * @return The [androidx.work.ListenableWorker.Result] of the computation
+     */
+    override fun doWork(): Result {
+        if (!uploadPings()) {
+            return Result.retry()
+        }
+
+        return Result.success()
+    }
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import mozilla.components.concept.fetch.Client
@@ -121,7 +122,7 @@ internal fun resetGlean(
 
     // We're using the WorkManager in a bunch of places, and Glean will crash
     // in tests without this line. Let's simply put it here.
-    // WorkManagerTestInitHelper.initializeTestWorkManager(context)
+    WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
     /* if (clearStores) {
         // Clear all the stored data.

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/net/HttpPingUploaderTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/net/HttpPingUploaderTest.kt
@@ -1,0 +1,312 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.lib.fetch.okhttp.OkHttpClient
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.TestPingTagClient
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.getMockWebServer
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.spy
+import org.robolectric.RobolectricTestRunner
+import java.io.IOException
+import java.net.CookieHandler
+import java.net.CookieManager
+import java.net.HttpCookie
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+class HttpPingUploaderTest {
+    private val testPath: String = "/some/random/path/not/important"
+    private val testPing: String = "{ 'ping': 'test' }"
+    private val testDefaultConfig = Configuration().copy(
+        userAgent = "Glean/Test 25.0.2",
+        connectionTimeout = 3050,
+        readTimeout = 7050
+    )
+
+    @Test
+    fun `connection timeouts must be properly set`() {
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
+
+        assertEquals(Pair(7050L, TimeUnit.MILLISECONDS), request.readTimeout)
+        assertEquals(Pair(3050L, TimeUnit.MILLISECONDS), request.connectTimeout)
+    }
+
+    @Test
+    fun `user-agent must be properly set`() {
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
+
+        assertEquals(testDefaultConfig.userAgent, request.headers!!["User-Agent"])
+    }
+
+    @Test
+    fun `X-Client-* headers must be properly set`() {
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
+
+        assertEquals("Glean", request.headers!!["X-Client-Type"])
+        assertEquals(BuildConfig.LIBRARY_VERSION, request.headers!!["X-Client-Version"])
+    }
+
+    @Test
+    fun `Cookie policy must be properly set`() {
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
+
+        assertEquals(request.cookiePolicy, Request.CookiePolicy.OMIT)
+    }
+
+    @Test
+    fun `upload() returns true for successful submissions (200)`() {
+        val mockClient: Client = mock()
+        `when`(mockClient.fetch(any())).thenReturn(Response(
+            "URL", 200, mock(), mock()))
+
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
+
+        assertTrue(uploader.upload(testPath, testPing, config))
+    }
+    @Test
+    fun `upload() returns false for server errors (5xx)`() {
+        for (responseCode in 500..527) {
+            val mockClient: Client = mock()
+            `when`(mockClient.fetch(any())).thenReturn(Response(
+                "URL", responseCode, mock(), mock()))
+
+            val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+            val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
+
+            assertFalse(uploader.upload(testPath, testPing, config))
+        }
+    }
+
+    @Test
+    fun `upload() returns true for successful submissions (2xx)`() {
+        for (responseCode in 200..226) {
+            val mockClient: Client = mock()
+            `when`(mockClient.fetch(any())).thenReturn(Response(
+                "URL", responseCode, mock(), mock()))
+
+            val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+            val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
+
+            assertTrue(uploader.upload(testPath, testPing, config))
+        }
+    }
+
+    @Test
+    fun `upload() returns true for failing submissions with broken requests (4xx)`() {
+        for (responseCode in 400..451) {
+            val mockClient: Client = mock()
+            `when`(mockClient.fetch(any())).thenReturn(Response(
+                "URL", responseCode, mock(), mock()))
+
+            val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+            val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
+
+            assertTrue(uploader.upload(testPath, testPing, config))
+        }
+    }
+
+    @Test
+    fun `upload() correctly uploads the ping data with default configuration`() {
+        val server = getMockWebServer()
+
+        val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
+            serverEndpoint = "http://" + server.hostName + ":" + server.port
+        )
+
+        val client = HttpPingUploader()
+        assertTrue(client.upload(testPath, testPing, testConfig))
+
+        val request = server.takeRequest()
+        assertEquals(testPath, request.path)
+        assertEquals("POST", request.method)
+        assertEquals(testPing, request.body.readUtf8())
+        assertEquals("Telemetry/42.23", request.getHeader("User-Agent"))
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"))
+
+        server.shutdown()
+    }
+
+    @Test
+    fun `upload() correctly uploads the ping data with httpurlconnection client`() {
+        val server = getMockWebServer()
+
+        val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            httpClient = lazy { HttpURLConnectionClient() }
+        )
+
+        val client = HttpPingUploader()
+        assertTrue(client.upload(testPath, testPing, testConfig))
+
+        val request = server.takeRequest()
+        assertEquals(testPath, request.path)
+        assertEquals("POST", request.method)
+        assertEquals(testPing, request.body.readUtf8())
+        assertEquals("Telemetry/42.23", request.getHeader("User-Agent"))
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"))
+        assertTrue(request.headers.values("Cookie").isEmpty())
+
+        server.shutdown()
+    }
+
+    @Test
+    fun `upload() correctly uploads the ping data with OkHttp client`() {
+        val server = getMockWebServer()
+
+        val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            httpClient = lazy { OkHttpClient() }
+        )
+
+        val client = HttpPingUploader()
+        assertTrue(client.upload(testPath, testPing, testConfig))
+
+        val request = server.takeRequest()
+        assertEquals(testPath, request.path)
+        assertEquals("POST", request.method)
+        assertEquals(testPing, request.body.readUtf8())
+        assertEquals("Telemetry/42.23", request.getHeader("User-Agent"))
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"))
+        assertTrue(request.headers.values("Cookie").isEmpty())
+
+        server.shutdown()
+    }
+
+    @Test
+    fun `upload() must not transmit any cookie`() {
+        val server = getMockWebServer()
+
+        val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
+            serverEndpoint = "http://localhost:" + server.port
+        )
+
+        // Set the default cookie manager/handler to be used for the http upload.
+        val cookieManager = CookieManager()
+        CookieHandler.setDefault(cookieManager)
+
+        // Store a sample cookie.
+        val cookie = HttpCookie("cookie-time", "yes")
+        cookie.domain = testConfig.serverEndpoint
+        cookie.path = testPath
+        cookie.version = 0
+        cookieManager.cookieStore.add(URI(testConfig.serverEndpoint), cookie)
+
+        // Store a cookie for a subdomain of the same domain's as the server endpoint,
+        // to make sure we don't accidentally remove it.
+        val cookie2 = HttpCookie("cookie-time2", "yes")
+        cookie2.domain = "sub.localhost"
+        cookie2.path = testPath
+        cookie2.version = 0
+        cookieManager.cookieStore.add(URI("http://sub.localhost:${server.port}/test"), cookie2)
+
+        // Add another cookie for the same domain. This one should be removed as well.
+        val cookie3 = HttpCookie("cookie-time3", "yes")
+        cookie3.domain = "localhost"
+        cookie3.path = testPath
+        cookie3.version = 0
+        cookieManager.cookieStore.add(URI("http://localhost:${server.port}/test"), cookie3)
+
+        // Trigger the connection.
+        val client = HttpPingUploader()
+        assertTrue(client.upload(testPath, testPing, testConfig))
+
+        val request = server.takeRequest()
+        assertEquals(testPath, request.path)
+        assertEquals("POST", request.method)
+        assertEquals(testPing, request.body.readUtf8())
+        assertEquals("Telemetry/42.23", request.getHeader("User-Agent"))
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"))
+        assertTrue(request.headers.values("Cookie").isEmpty())
+
+        // Check that we still have a cookie.
+        assertEquals(1, cookieManager.cookieStore.cookies.size)
+        assertEquals("cookie-time2", cookieManager.cookieStore.cookies[0].name)
+
+        server.shutdown()
+    }
+
+    @Test
+    fun `upload() should return false when upload fails`() {
+        val mockClient: Client = mock()
+        `when`(mockClient.fetch(any())).thenThrow(IOException())
+
+        val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
+
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        // And IOException during upload is a failed upload that we should retry. The client should
+        // return false in this case.
+        assertFalse(uploader.upload("path", "ping", config))
+    }
+
+    @Test
+    fun `X-Debug-ID header is correctly added when pingTag is not null`() {
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        val debugConfig = Configuration().copy(
+            userAgent = "Glean/Test 25.0.2",
+            connectionTimeout = 3050,
+            readTimeout = 7050,
+            pingTag = "this-ping-is-tagged"
+        )
+
+        val request = uploader.buildRequest(testPath, testPing, debugConfig)
+        assertEquals("this-ping-is-tagged", request.headers!!["X-Debug-ID"])
+    }
+
+    @Test
+    fun `server is correctly redirected when pings are tagged`() {
+        val pingTag = "this-ping-is-tagged"
+
+        // The TestClient class found at the bottom of this file is used to intercept the request
+        // in order to check that the header has been added and the URL has been redirected.
+        val testClient = TestPingTagClient(
+            responseUrl = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT,
+            debugHeaderValue = pingTag)
+
+        // Use the test client in the Glean configuration
+        val testConfig = testDefaultConfig.copy(
+            httpClient = lazy { testClient },
+            pingTag = pingTag
+        )
+
+        // This should trigger the call to `fetch()` within the TestPingTagClient which will perform
+        // both a check against the url and that a header was added.
+        val client = HttpPingUploader()
+        assertTrue(client.upload(testPath, testPing, testConfig))
+    }
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/net/HttpPingUploaderTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/net/HttpPingUploaderTest.kt
@@ -9,12 +9,13 @@ import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.lib.fetch.okhttp.OkHttpClient
-import mozilla.components.service.glean.BuildConfig
-import mozilla.components.service.glean.TestPingTagClient
-import mozilla.components.service.glean.config.Configuration
-import mozilla.components.service.glean.getMockWebServer
+import mozilla.telemetry.glean.BuildConfig
+import mozilla.telemetry.glean.TestPingTagClient
+import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.getMockWebServer
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.telemetry.glean.net.HttpPingUploader
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
@@ -1,0 +1,53 @@
+package mozilla.components.service.glean.scheduler
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.BackoffPolicy
+import androidx.work.NetworkType
+import androidx.work.WorkerParameters
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.resetGlean
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PingUploadWorkerTest {
+
+    @Mock
+    var workerParams: WorkerParameters? = null
+
+    private var pingUploadWorker: PingUploadWorker? = null
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        MockitoAnnotations.initMocks(this)
+        resetGlean(context, config = Configuration().copy(logPings = true))
+        pingUploadWorker = PingUploadWorker(context, workerParams!!)
+    }
+
+    @Test
+    fun testPingConfiguration() {
+        // Set the constraints around which the worker can be run, in this case it
+        // only requires that any network connection be available.
+        val workRequest = PingUploadWorker.buildWorkRequest()
+        val workSpec = workRequest.workSpec
+
+        // verify constraints
+        Assert.assertEquals(NetworkType.CONNECTED, workSpec.constraints.requiredNetworkType)
+        Assert.assertEquals(BackoffPolicy.EXPONENTIAL, workSpec.backoffPolicy)
+        Assert.assertTrue(workRequest.tags.contains(PingUploadWorker.PING_WORKER_TAG))
+    }
+
+    @Test
+    fun testDoWorkSuccess() {
+        val result = pingUploadWorker!!.doWork()
+        Assert.assertTrue(result.toString().contains("Success"))
+    }
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
@@ -1,12 +1,12 @@
-package mozilla.components.service.glean.scheduler
+package mozilla.telemetry.glean.scheduler
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.BackoffPolicy
 import androidx.work.NetworkType
 import androidx.work.WorkerParameters
-import mozilla.components.service.glean.config.Configuration
-import mozilla.components.service.glean.resetGlean
+import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.resetGlean
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -36,8 +36,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "com.android.support:appcompat-v7:27.0.0"
-    implementation "com.android.support:customtabs:27.0.0"
+    implementation "androidx.appcompat:appcompat:1.0.0"
+    implementation "androidx.browser:browser:1.0.0"
 }
 
 ext.gleanNamespace = "mozilla.telemetry.glean"

--- a/samples/android/app/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -6,7 +6,7 @@ package org.mozilla.samples.gleancore
 
 import android.os.Bundle
 import android.util.Log
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
 import mozilla.telemetry.glean.Glean
 import org.mozilla.samples.gleancore.GleanMetrics.Test

--- a/samples/android/app/src/main/res/layout/activity_main.xml
+++ b/samples/android/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,7 @@
     android:gravity="center"
     android:orientation="vertical"
     android:padding="10dp"
-    tools:context="org.mozilla.samples.glean_rs.MainActivity">
+    tools:context="org.mozilla.samples.gleancore.MainActivity">
 
     <!-- This is a dummy linear layout to capture focus and prevent the keyboard from popping
         when the app first launches.  This is a known issue of linear layouts and a common


### PR DESCRIPTION
We have upload \o/  (Well, mostly thanks to copying a bunch of already working code over from glean-ac -- thanks to @travis79 and @Dexterp37).

The first commit just copies the files from glean-ac over.  The second commit includes the changes to make them work in the new context.  So it might be easier to review by only looking at the second commit in order to ignore things that were already reviewed on the glean-ac side.

There are a few TODOs here, with bugs already created and noted.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo clean; cargo test --all` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
