### PR TITLE
Use Android 27 docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
 
   Lint Android with ktlint and detekt:
     docker:
-      - image: circleci/android:api-23-ndk
+      - image: circleci/android:api-27-ndk
     steps:
       - checkout
       - run: ./gradlew ktlint
@@ -111,7 +111,7 @@ jobs:
         
   Android tests:
     docker:
-      - image: circleci/android:api-23-ndk
+      - image: circleci/android:api-27-ndk
     steps:
       - android-tests
 


### PR DESCRIPTION
The Android 27 SDK ends up getting downloaded by the build script.  Using the Docker image with that version already baked should save on CI runtime, theoretically, though we should confirm that before merging.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo clean; cargo test --all` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
