### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 ### Pull Request checklist ###
 <!-- Before submitting the PR, please address each item -->
 - [ ] **Quality**: This PR builds and tests run cleanly
-  - `cargo clean; cargo test --all` runs without emitting any warnings
-  - `cargo fmt` does not produce any changes to the code
+  - `make test` runs without emitting any warnings
+  - `make lint` runs without emitting any errors
 - [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
 - [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
-  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
+  - Any breaking changes to language binding APIs are noted explicitly


### PR DESCRIPTION
This makes it more language-agnostic.

I like using the `Makefile` for these conveniences, and I kind of like maintaining the Makefile indefinitely as a source of developer conveniences (as long is it doesn't become the "real" build tool).  But I don't know how well it works on Windows.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo clean; cargo test --all` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
