### PR TITLE
Use i32 everywhere for counters

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -64,7 +64,7 @@ class CounterMetricType(
             LibGleanFFI.INSTANCE.glean_counter_add(
                 Glean.handle,
                 this@CounterMetricType.handle,
-                amount.toLong())
+                amount)
         }
     }
 
@@ -96,10 +96,9 @@ class CounterMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = sendInPings.first()): Int {
-        // FIXME(#19): glean-core should give us an int to begin with
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        return LibGleanFFI.INSTANCE.glean_counter_test_get_value(Glean.handle, this.handle, pingName).toInt()
+        return LibGleanFFI.INSTANCE.glean_counter_test_get_value(Glean.handle, this.handle, pingName)
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -60,9 +60,9 @@ internal interface LibGleanFFI : Library {
 
     fun glean_boolean_set(glean_handle: Long, metric_id: Long, value: Byte)
 
-    fun glean_counter_add(glean_handle: Long, metric_id: Long, amount: Long)
+    fun glean_counter_add(glean_handle: Long, metric_id: Long, amount: Int)
 
-    fun glean_counter_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Long
+    fun glean_counter_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Int
 
     fun glean_counter_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CounterMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CounterMetricTypeTest.kt
@@ -135,4 +135,28 @@ class CounterMetricTypeTest {
         assertTrue(counterMetric.testHasValue("store2"))
         assertEquals(11, counterMetric.testGetValue("store2"))
     }
+
+    @Test
+    fun `negative values are not counted`() {
+        // Define a 'counterMetric' counter metric, which will be stored in "store1"
+        val counterMetric = CounterMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "counter_metric",
+            sendInPings = listOf("store1")
+        )
+
+        // Increment to 1 (initial value)
+        counterMetric.add()
+
+        // Check that the count was incremented
+        assertTrue(counterMetric.testHasValue("store1"))
+        assertEquals(1, counterMetric.testGetValue("store1"))
+
+        counterMetric.add(-10)
+        // Check that count was NOT incremented.
+        assertTrue(counterMetric.testHasValue("store1"))
+        assertEquals(1, counterMetric.testGetValue("store1"))
+    }
 }

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -173,7 +173,7 @@ pub extern "C" fn glean_new_counter_metric(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_counter_add(glean_handle: u64, metric_id: u64, amount: u64) {
+pub extern "C" fn glean_counter_add(glean_handle: u64, metric_id: u64, amount: i32) {
     GLEAN.call_infallible(glean_handle, |glean| {
         COUNTER_METRICS.call_infallible(metric_id, |metric| {
             metric.add(glean, amount);
@@ -201,7 +201,7 @@ pub extern "C" fn glean_counter_test_get_value(
     glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
-) -> u64 {
+) -> i32 {
     GLEAN.call_infallible(glean_handle, |glean| {
         COUNTER_METRICS.call_infallible(metric_id, |metric| {
             metric.test_get_value(glean, storage_name.as_str()).unwrap()

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -17,8 +17,14 @@ impl CounterMetric {
         Self { meta }
     }
 
-    pub fn add(&self, glean: &Glean, amount: u64) {
+    pub fn add(&self, glean: &Glean, amount: i32) {
         if !self.meta.should_record() || !glean.is_upload_enabled() {
+            return;
+        }
+
+        if amount <= 0 {
+            // TODO: Turn this into logging an error
+            log::warn!("CounterMetric::add: got negative amount. Not recording.");
             return;
         }
 
@@ -35,7 +41,7 @@ impl CounterMetric {
     /// Get the currently stored value as an integer.
     ///
     /// This doesn't clear the stored value.
-    pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<u64> {
+    pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<i32> {
         let snapshot = match StorageManager.snapshot_as_json(glean.storage(), storage_name, false) {
             Some(snapshot) => snapshot,
             None => return None,
@@ -45,6 +51,6 @@ impl CounterMetric {
             .and_then(|o| o.get("counter"))
             .and_then(|o| o.as_object())
             .and_then(|o| o.get(&self.meta.identifier()))
-            .and_then(|o| o.as_i64().map(|i| i as u64))
+            .and_then(|o| o.as_i64().map(|i| i as i32))
     }
 }

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -21,7 +21,7 @@ pub use self::uuid::UuidMetric;
 pub enum Metric {
     String(String),
     Boolean(bool),
-    Counter(u64),
+    Counter(i32),
     Uuid(String),
     StringList(Vec<String>),
 }


### PR DESCRIPTION
We actually should use u32 internally, but:
because Kotlin doesn't (yet) have unsigned integers, it's always going to pass us signed values.
We also do all the error checking on the Rust side, so we need to receive the signed value to check for negativity and bail out.

We still don't do overflow checks though.

[Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1552131)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo clean; cargo test --all` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
