### PR TITLE
Redirect logging to stdout in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ name = "glean_ffi"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "glean-core 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -20,8 +20,6 @@ class BooleanMetricType(
     private var handle: Long
 
     init {
-        println("New Boolean: $category.$name")
-
         val ffiPingsList = StringArray(sendInPings.toTypedArray(), "utf-8")
         this.handle = LibGleanFFI.INSTANCE.glean_new_boolean_metric(
                 category = category,

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -13,9 +13,6 @@ import mozilla.telemetry.glean.rust.toByte
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.rust.toBoolean
 
-// import mozilla.components.service.glean.storages.CountersStorageEngine
-// import mozilla.components.support.base.log.logger.Logger
-
 /**
  * This implements the developer facing API for recording counter metrics.
  *
@@ -33,13 +30,9 @@ class CounterMetricType(
     val sendInPings: List<String>
 ) {
 
-    // private val logger = Logger("glean/CounterMetricType")
-
     private var handle: Long
 
     init {
-        println("New Counter: $category.$name")
-
         val ffiPingsList = StringArray(sendInPings.toTypedArray(), "utf-8")
         this.handle = LibGleanFFI.INSTANCE.glean_new_counter_metric(
                 category = category,

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -14,9 +14,6 @@ import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.rust.toBoolean
 
-// import mozilla.components.service.glean.storages.StringsStorageEngine
-// import mozilla.components.support.base.log.logger.Logger
-
 /**
  * This implements the developer facing API for recording string metrics.
  *
@@ -33,13 +30,9 @@ class StringMetricType(
     name: String,
     val sendInPings: List<String>
 ) {
-    // private val logger = Logger("glean/StringMetricType")
-
     private var handle: Long
 
     init {
-        println("New String: $category.$name")
-
         val ffiPingsList = StringArray(sendInPings.toTypedArray(), "utf-8")
         this.handle = LibGleanFFI.INSTANCE.glean_new_string_metric(
                 category = category,

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -28,6 +28,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert
+import org.robolectric.shadows.ShadowLog
 import java.util.concurrent.ExecutionException
 
 /**
@@ -116,8 +117,13 @@ internal fun checkPingSchema(content: String): JSONObject {
 internal fun resetGlean(
     context: Context = ApplicationProvider.getApplicationContext(),
     config: Configuration = Configuration(),
-    clearStores: Boolean = true
+    clearStores: Boolean = true,
+    redirectRobolectricLogs: Boolean = true
 ) {
+    if (redirectRobolectricLogs) {
+        ShadowLog.stream = System.out
+    }
+
     Glean.enableTestingMode()
 
     // We're using the WorkManager in a bunch of places, and Glean will crash

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -18,3 +18,6 @@ path = ".."
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.7.0"
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+env_logger = "0.6.1"

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -60,6 +60,9 @@ fn initialize_logging() {
     {
         match env_logger::try_init() {
             Ok(_) => log::debug!("stdout logging should be hooked up!"),
+            // Please note that this is only expected to fail during unit tests,
+            // where the logger might have already been initialized by a previous
+            // test. So it's fine to print with the "logger".
             Err(_) => log::debug!("stdout was already initialized"),
         };
     }

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -40,8 +40,9 @@ unsafe fn from_raw_string_array(arr: RawStringArray, len: i32) -> Vec<String> {
         .collect()
 }
 
-#[no_mangle]
-pub extern "C" fn glean_initialize(data_dir: FfiStr, application_id: FfiStr) -> u64 {
+/// Initialize the logging system based on the target platform. This ensures
+/// that logging is shown when executing glean unit tests.
+fn initialize_logging() {
     #[cfg(target_os = "android")]
     {
         let _ = std::panic::catch_unwind(|| {
@@ -52,6 +53,21 @@ pub extern "C" fn glean_initialize(data_dir: FfiStr, application_id: FfiStr) -> 
             log::debug!("Android logging should be hooked up!")
         });
     }
+    // Make sure logging does something on non Android platforms as well. Use
+    // the RUST_LOG environment variable to set the desired log level, e.g.
+    // setting RUST_LOG=debug sets the log level to debug.
+    #[cfg(not(target_os = "android"))]
+    {
+        match env_logger::try_init() {
+            Ok(_) => log::debug!("stdout logging should be hooked up!"),
+            Err(_) => log::debug!("stdout was already initialized"),
+        };
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn glean_initialize(data_dir: FfiStr, application_id: FfiStr) -> u64 {
+    initialize_logging();
 
     GLEAN.insert_with_log(|| {
         let data_dir = data_dir.into_string();


### PR DESCRIPTION
This enables a logger implementation on platforms that are not Android: we couldn't see any log beyond FFI for this reason, since tests are x86/x64.

This additionally redirects Kotlin logcat to stdout in tests.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
