### PR TITLE
Merge the latest changes from a-s gradle scripts

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,11 +1,12 @@
-libraryVersion: 0.0.1
+libraryVersion: 0.0.1-TESTING1
 groupId: org.mozilla.telemetry
 projects:
   glean-core:
     path: glean-core/android
+    artifactId: glean-core
+    publishedArtifacts: [glean-core, glean-core-forUnitTests, glean-core-withoutLib]
     description: 'The glean core library'
-    publish: true
   glean-sample-app:
     path: samples/android/app
+    artifactId: glean-core-sample-app
     description: 'An app demoing how to use the Glean library to collect and send telemetry data.'
-    publish: false

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -171,5 +171,14 @@ afterEvaluate {
     }
 }
 
+apply from: "$rootDir/publish.gradle"
+// If using jnaForTestConfiguration or variantWithoutLib,
+// please also update the corresponding .buildconfig-android.yml
+// `publishedArtifacts` property.
+ext.configurePublish(
+        /* jnaForTestConfiguration= */ configurations.jnaForTest,
+        /* variantWithoutLib= */ 'androidWithoutLib',
+)
+
 //apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'
 apply from: 'sdk_generator.gradle'

--- a/publish.gradle
+++ b/publish.gradle
@@ -5,12 +5,18 @@
 def libLicense = properties.libLicense
 def libLicenseUrl = properties.libLicenseUrl
 def libRepositoryName = properties.libRepositoryName
+def libProjectName = properties.libProjectName
 def libUrl = properties.libUrl
 def libVcsUrl = properties.libVcsUrl
 
-ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
-                         jnaForTestConfiguration = null,
+// If using jnaForTestConfiguration or variantWithoutLib,
+// please also update the corresponding .buildconfig-android.yml
+// `publishedArtifacts` property.
+ext.configurePublish = { jnaForTestConfiguration = null,
                          variantWithoutLib = null ->
+    def theGroupId = rootProject.ext.library.groupId
+    def theArtifactId = project.ext.artifactId
+    def theDescription = project.ext.description
     // `jnaForTestConfiguration` is a hacky way to say yes, I'm using JNA and
     // want to pack the JNA dispatch libraries and my Rust libraries into a
     // single JAR for use in unit tests that run on a development host (and not
@@ -49,9 +55,14 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
         def forUnitTestsJarTask = task forUnitTestsJar(type: Jar) {
             from extractJnaResources
             from "$buildDir/rustJniLibs/desktop"
+            from "$buildDir/nativeLibs/desktop"
         }
 
         project.afterEvaluate {
+            def copyNativeLibsTask = tasks.findByName("copyNativeLibs")
+            if (copyNativeLibsTask != null) {
+                forUnitTestsJarTask.dependsOn(copyNativeLibsTask)
+            }
             forUnitTestsJarTask.dependsOn(tasks["cargoBuild"])
         }
     }
@@ -86,10 +97,10 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
                 // see https://github.com/researchgate/gradle-release/issues/125 and
                 // https://stackoverflow.com/q/28020520.
                 pom {
-                    groupId = groupIdArg
-                    artifactId = artifactIdArg
-                    description = descriptionArg
-                    version = rootProject.ext.library['version']
+                    groupId = theGroupId
+                    artifactId = theArtifactId
+                    description = theDescription
+                    version = rootProject.ext.library.version
 
                     licenses {
                         license {
@@ -130,10 +141,10 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
                     // artifact javadocJar
 
                     pom {
-                        groupId = groupIdArg
-                        artifactId = "${artifactIdArg}-withoutLib"
-                        description = descriptionArg
-                        version = rootProject.ext.library['version']
+                        groupId = theGroupId
+                        artifactId = "${theArtifactId}-withoutLib"
+                        description = theDescription
+                        version = rootProject.ext.library.version
 
                         licenses {
                             license {
@@ -163,10 +174,10 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
                     artifact tasks['forUnitTestsJar']
 
                     pom {
-                        groupId = groupIdArg
-                        artifactId = "${artifactIdArg}-forUnitTests"
-                        description = descriptionArg
-                        version = rootProject.ext.library['version']
+                        groupId = theGroupId
+                        artifactId = "${theArtifactId}-forUnitTests"
+                        description = theDescription
+                        version = rootProject.ext.library.version
 
                         licenses {
                             license {
@@ -197,63 +208,25 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
         }
     }
 
-    apply plugin: 'com.jfrog.bintray'
+    task zipMavenArtifacts
 
-    // It feels like this shouldn't be necessary, but without it an
-    // "unspecified" creeps into bintray URLs -- just like
-    // https://github.com/bintray/gradle-bintray-plugin/issues/244, but not
-    // fixed by gradle-bintray-plugin:1.8.4.
-    version = rootProject.ext.library['version']
+    publishing.publications.withType(MavenPublication).each {publication ->
+        def zipTask = task "zipMavenArtifact-${publication.artifactId}"(type: Zip) {
+            from "${project.buildDir}/maven"
 
-    Properties localProperties = null;
-    if (project.rootProject.file('local.properties').canRead()) {
-        localProperties = new Properties()
-        localProperties.load(project.rootProject.file('local.properties').newDataInputStream())
-    }
+            include "**/${publication.artifactId}/**/*.aar"
+            include "**/${publication.artifactId}/**/*.md5"
+            include "**/${publication.artifactId}/**/*.sha1"
+            include "**/${publication.artifactId}/**/*.pom"
+            include "**/${publication.artifactId}/**/*.jar"
 
-    def thePublications = ['aar']
-    if (variantWithoutLib != null) {
-        thePublications << 'aarWithoutLib'
-    }
-    if (jnaForTestConfiguration != null) {
-        thePublications << 'forUnitTestsJar'
-    }
+            // Metadata is generated by maven.mozilla.org directly
+            exclude '**/*maven-metadata.xml*'
 
-    bintray {
-        user = localProperties != null ? localProperties.getProperty("bintray.user") : ""
-        key = localProperties != null ? localProperties.getProperty("bintray.apikey") : ""
-
-        publications = thePublications
-
-        pkg {
-            repo = libRepositoryName
-            name = artifactIdArg
-            desc = descriptionArg
-            websiteUrl = libUrl
-            vcsUrl = libVcsUrl
-            if (project.ext.has('vcsTag')) {
-                vcsTag = project.ext.vcsTag
-            }
-            licenses = [libLicense]
-            publish = true
-            publicDownloadNumbers = true
+            archiveName "${publication.artifactId}.maven.zip"
+            includeEmptyDirs = false
+            destinationDir(file("${project.buildDir}"))
         }
-    }
-
-    task zipMavenArtifacts(type: Zip) {
-        from "${project.buildDir}/maven"
-
-        include '**/*.aar'
-        include '**/*.jar'
-        include '**/*.pom'
-        include '**/*.md5'
-        include '**/*.sha1'
-
-        // Metadata is generated by maven.mozilla.org directly
-        exclude '**/*maven-metadata.xml*'
-
-        archiveName "target.maven.zip"
-        includeEmptyDirs = false
-        destinationDir(file("${project.buildDir}"))
+        zipMavenArtifacts.dependsOn(zipTask)
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,18 +3,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import org.yaml.snakeyaml.Yaml
-
 buildscript {
-    repositories {
-        jcenter()
-    }
-
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
     }
+    repositories {
+        jcenter()
+    }
 }
 
-def setupProject(name, path, description) {
+// See https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:deferred_configuration.
+enableFeaturePreview('STABLE_PUBLISHING')
+
+def setupProject(name, projectProps) {
+    def path = projectProps.path
+    def description = projectProps.description
+    def artifactId = projectProps.artifactId
+
     settings.include(":$name")
 
     project(":$name").projectDir = new File(rootDir, path)
@@ -25,6 +30,7 @@ def setupProject(name, path, description) {
         // So, once we filter for the project we care about, we can set whatever we want
         if (project.name == name) {
             project.ext.description = description
+            project.ext.artifactId = artifactId
         }
     }
 }
@@ -32,14 +38,15 @@ def setupProject(name, path, description) {
 def yaml = new Yaml()
 def buildconfig = yaml.load(new File(rootDir, '.buildconfig.yml').newInputStream())
 buildconfig.projects.each { project ->
-    setupProject(project.key, project.value.path, project.value.description)
+    setupProject(project.key, project.value)
 }
 
 gradle.projectsLoaded { ->
     // Wait until root project is "loaded" before we set "config"
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
     // gradle files. This means that they can just access "config.<value>", and it'll function properly
-  gradle.rootProject.ext.library = [
-    version: buildconfig.libraryVersion,
-  ]
+    gradle.rootProject.ext.library = [
+            version: buildconfig.libraryVersion,
+            groupId: buildconfig.groupId,
+    ]
 }


### PR DESCRIPTION
This enables back artifact publishing by integrating back the changes to the gradle scripts up until
changeset mozilla/application-services@5d8dd7b .

This allows to publish glean-core to a local Maven repo with the following command:

`./gradlew publishToMavenLocal`

Once published, the package can be consumed by other applications built locally. Instructions on how to do that will come as part of [bug 1551156](https://bugzilla.mozilla.org/show_bug.cgi?id=1551156).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
