### PR TITLE
Bug 1552850 - Implement shouldRecord on the Kotlin side

### DIFF
--- a/docs/dev/core/new-metric-type.md
+++ b/docs/dev/core/new-metric-type.md
@@ -209,6 +209,13 @@ class CounterMetricType(
                 disabled = disabled.toByte())
     }
 
+    protected fun finalize() {
+        if (this.handle != 0L) {
+            val error = RustError.ByReference()
+            LibGleanFFI.INSTANCE.glean_destroy_counter_metric(this.handle, error)
+        }
+    }
+
     fun shouldRecord(): Boolean {
         // Don't record metrics if we aren't initialized
         if (!Glean.isInitialized()) {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -41,13 +41,29 @@ class BooleanMetricType(
         }
     }
 
+    fun shouldRecord(): Boolean {
+        // Don't record metrics if we aren't initialized
+        if (!Glean.isInitialized()) {
+            return false
+        }
+
+        return LibGleanFFI.INSTANCE.glean_boolean_should_record(Glean.handle, this.handle).toBoolean()
+    }
+
     /**
      * Set a boolean value.
      *
      * @param value This is a user defined boolean value.
      */
     fun set(value: Boolean) {
-        LibGleanFFI.INSTANCE.glean_boolean_set(Glean.handle, this.handle, value.toByte())
+        if (!shouldRecord()) {
+            return
+        }
+
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.launch {
+            LibGleanFFI.INSTANCE.glean_boolean_set(Glean.handle, this@BooleanMetricType.handle, value.toByte())
+        }
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -51,6 +51,15 @@ class CounterMetricType(
         }
     }
 
+    fun shouldRecord(): Boolean {
+        // Don't record metrics if we aren't initialized
+        if (!Glean.isInitialized()) {
+            return false
+        }
+
+        return LibGleanFFI.INSTANCE.glean_counter_should_record(Glean.handle, this.handle).toBoolean()
+    }
+
     /**
      * Add to counter value.
      *
@@ -58,9 +67,9 @@ class CounterMetricType(
      * without parameters.
      */
     fun add(amount: Int = 1) {
-        /*if (!shouldRecord(logger)) {
+        if (!shouldRecord()) {
             return
-        }*/
+        }
 
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -51,6 +51,15 @@ class StringMetricType(
         }
     }
 
+    fun shouldRecord(): Boolean {
+        // Don't record metrics if we aren't initialized
+        if (!Glean.isInitialized()) {
+            return false
+        }
+
+        return LibGleanFFI.INSTANCE.glean_string_should_record(Glean.handle, this.handle).toBoolean()
+    }
+
     /**
      * Set a string value.
      *
@@ -58,9 +67,9 @@ class StringMetricType(
      *              the maximum length, it will be truncated.
      */
     fun set(value: String) {
-        /*if (!shouldRecord(logger)) {
+        if (!shouldRecord()) {
             return
-        }*/
+        }
 
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -63,11 +63,15 @@ internal interface LibGleanFFI : Library {
 
     fun glean_boolean_set(glean_handle: Long, metric_id: Long, value: Byte)
 
+    fun glean_boolean_should_record(glean_handle: Long, metric_id: Long): Byte
+
     fun glean_boolean_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
     fun glean_boolean_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
     fun glean_counter_add(glean_handle: Long, metric_id: Long, amount: Int)
+
+    fun glean_counter_should_record(glean_handle: Long, metric_id: Long): Byte
 
     fun glean_counter_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Int
 
@@ -117,6 +121,8 @@ internal interface LibGleanFFI : Library {
     fun glean_set_upload_enabled(glean_handle: Long, flag: Byte)
 
     fun glean_string_set(glean_handle: Long, metric_id: Long, value: String)
+
+    fun glean_string_should_record(glean_handle: Long, metric_id: Long): Byte
 
     fun glean_destroy_glean(handle: Long, error: RustError.ByReference)
 

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -58,7 +58,9 @@ typedef const char *const *RawStringArray;
 
 void glean_boolean_set(uint64_t glean_handle, uint64_t metric_id, uint8_t value);
 
-int32_t glean_boolean_test_get_value(uint64_t glean_handle,
+uint8_t glean_boolean_should_record(uint64_t glean_handle, uint64_t metric_id);
+
+uint8_t glean_boolean_test_get_value(uint64_t glean_handle,
                                      uint64_t metric_id,
                                      FfiStr storage_name);
 
@@ -67,6 +69,8 @@ uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
                                      FfiStr storage_name);
 
 void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
+
+uint8_t glean_counter_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 int32_t glean_counter_test_get_value(uint64_t glean_handle,
                                      uint64_t metric_id,
@@ -110,6 +114,8 @@ uint8_t glean_send_ping(uint64_t glean_handle, FfiStr ping_name, uint8_t log_pin
 void glean_set_upload_enabled(uint64_t glean_handle, uint8_t flag);
 
 void glean_string_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+
+uint8_t glean_string_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -173,6 +173,13 @@ pub extern "C" fn glean_new_counter_metric(
 }
 
 #[no_mangle]
+pub extern "C" fn glean_counter_should_record(glean_handle: u64, metric_id: u64) -> u8 {
+    GLEAN.call_infallible(glean_handle, |glean| {
+        COUNTER_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn glean_counter_add(glean_handle: u64, metric_id: u64, amount: i32) {
     GLEAN.call_infallible(glean_handle, |glean| {
         COUNTER_METRICS.call_infallible(metric_id, |metric| {
@@ -210,6 +217,13 @@ pub extern "C" fn glean_counter_test_get_value(
 }
 
 #[no_mangle]
+pub extern "C" fn glean_boolean_should_record(glean_handle: u64, metric_id: u64) -> u8 {
+    GLEAN.call_infallible(glean_handle, |glean| {
+        BOOLEAN_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn glean_boolean_set(glean_handle: u64, metric_id: u64, value: u8) {
     GLEAN.call_infallible(glean_handle, |glean| {
         BOOLEAN_METRICS.call_infallible(metric_id, |metric| {
@@ -243,6 +257,13 @@ pub extern "C" fn glean_boolean_test_get_value(
         BOOLEAN_METRICS.call_infallible(metric_id, |metric| {
             metric.test_get_value(glean, storage_name.as_str()).unwrap()
         })
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn glean_string_should_record(glean_handle: u64, metric_id: u64) -> u8 {
+    GLEAN.call_infallible(glean_handle, |glean| {
+        STRING_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
     })
 }
 

--- a/glean-core/src/common_metric_data.rs
+++ b/glean-core/src/common_metric_data.rs
@@ -78,10 +78,7 @@ impl CommonMetricData {
     }
 
     pub fn should_record(&self) -> bool {
-        if self.disabled {
-            return false;
-        }
-        true
+        !self.disabled
     }
 
     pub fn storage_names(&self) -> &[String] {

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -17,8 +17,12 @@ impl BooleanMetric {
         Self { meta }
     }
 
+    pub fn should_record(&self, glean: &Glean) -> bool {
+        glean.is_upload_enabled() && self.meta.should_record()
+    }
+
     pub fn set(&self, glean: &Glean, value: bool) {
-        if !self.meta.should_record() || !glean.is_upload_enabled() {
+        if !self.should_record(glean) {
             return;
         }
 

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -17,8 +17,12 @@ impl CounterMetric {
         Self { meta }
     }
 
+    pub fn should_record(&self, glean: &Glean) -> bool {
+        glean.is_upload_enabled() && self.meta.should_record()
+    }
+
     pub fn add(&self, glean: &Glean, amount: i32) {
-        if !self.meta.should_record() || !glean.is_upload_enabled() {
+        if !self.should_record(glean) {
             return;
         }
 

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -20,8 +20,12 @@ impl StringMetric {
         Self { meta }
     }
 
+    pub fn should_record(&self, glean: &Glean) -> bool {
+        glean.is_upload_enabled() && self.meta.should_record()
+    }
+
     pub fn set<S: Into<String>>(&self, glean: &Glean, value: S) {
-        if !self.meta.should_record() || !glean.is_upload_enabled() {
+        if !self.should_record(glean) {
             return;
         }
 


### PR DESCRIPTION
Posting this because the code part was easy, but I have some hesitations:

* The `should_record` check _also_ happens on the Rust side
	* We do avoid putting any work in the Dispatcher queue with this.
* The (Rust-side) check is on the metric and requires access to the glean object, therefore we need to re-implement it for every type
	* There might be a way of using traits here to implement it just once (we will need to "re-implement" exposing the common metric data though)
	* I opted for not doing that now (it's a refactoring, not blocking anything and the code duplication so far is simple)
*  We also need to duplicate code on the Kotlin side, because we need a `*_should_record` function per type. Unfortunately I don't see a way to avoid this (again, duplication here contains no complex logic so for now I'm fine with it)

The biggest thing remains the first statement: Do we _need_ the check on the Kotlin side or is Rust-side only actually enough? (Dispatch enqueue cost?) 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
