### PR TITLE
Move PingType metadata to the Rust side

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -399,6 +399,7 @@ open class GleanInternalAPI internal constructor () {
     /**
      * Register a [PingType] in the registry associated with this [Glean] object.
      */
+    @Synchronized
     internal fun registerPingType(pingType: PingType) {
         if (!this.isInitialized()) {
             pingTypeQueue.add(pingType)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -120,7 +120,9 @@ internal interface LibGleanFFI : Library {
 
     fun glean_ping_collect(glean_handle: Long, ping_name: String): Pointer?
 
-    fun glean_send_ping(glean_handle: Long, ping_name: String, log_ping: Byte): Byte
+    fun glean_send_ping(glean_handle: Long, ping_type_handle: Long, log_ping: Byte): Byte
+
+    fun glean_send_ping_by_name(glean_handle: Long, ping_name: String, log_ping: Byte): Byte
 
     fun glean_set_upload_enabled(glean_handle: Long, flag: Byte)
 
@@ -136,7 +138,15 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_counter_metric(handle: Long, error: RustError.ByReference)
 
+    fun glean_destroy_ping_type(handle: Long, error: RustError.ByReference)
+
     fun glean_str_free(ptr: Pointer)
+
+    fun glean_register_ping_type(glean_handle: Long, ping_type_id: Long)
+
+    fun glean_new_ping_type(name: String, include_client_id: Byte): Long
+
+    fun glean_test_has_ping_type(glean_handle: Long, name: String): Byte
 }
 
 internal typealias MetricHandle = Long

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -19,7 +19,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -71,7 +70,6 @@ class PingTypeTest {
         checkPingSchema(pingJson)
     }
 
-    @Ignore("Sending pings without a client_id is not supported")
     @Test
     fun `test sending of custom pings without client_id`() {
         val server = getMockWebServer()
@@ -139,8 +137,8 @@ class PingTypeTest {
 
     @Test
     fun `Registry should contain built-in pings`() {
-        assertTrue(PingType.pingRegistry.containsKey("metrics"))
-        assertTrue(PingType.pingRegistry.containsKey("events"))
-        assertTrue(PingType.pingRegistry.containsKey("baseline"))
+        assertTrue(Glean.testHasPingType("metrics"))
+        assertTrue(Glean.testHasPingType("events"))
+        assertTrue(Glean.testHasPingType("baseline"))
     }
 }

--- a/glean-core/examples/sample.rs
+++ b/glean-core/examples/sample.rs
@@ -19,6 +19,8 @@ fn main() {
     };
 
     let mut glean = Glean::new(&data_path, "org.mozilla.glean_core.example", true).unwrap();
+    glean.register_ping_type(&PingType::new("core", true));
+
     assert!(glean.is_initialized());
 
     let local_metric: StringMetric = StringMetric::new(CommonMetricData {
@@ -59,13 +61,17 @@ fn main() {
     list.add(&glean, "upon");
 
     let ping_maker = PingMaker::new();
-    let ping = ping_maker.collect_string(glean.storage(), "core").unwrap();
+    let ping = ping_maker
+        .collect_string(glean.storage(), glean.get_ping_by_name("core").unwrap())
+        .unwrap();
     println!("Ping:\n{}", ping);
 
     let mut long_string = std::iter::repeat('x').take(49).collect::<String>();
     long_string.push('a');
     long_string.push('b');
     local_metric.set(&glean, long_string);
-    let ping = ping_maker.collect_string(glean.storage(), "core").unwrap();
+    let ping = ping_maker
+        .collect_string(glean.storage(), glean.get_ping_by_name("core").unwrap())
+        .unwrap();
     println!("Metrics Ping:\n{}", ping);
 }

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -106,6 +106,8 @@ uint64_t glean_new_counter_metric(FfiStr category,
                                   int32_t lifetime,
                                   uint8_t disabled);
 
+uint64_t glean_new_ping_type(FfiStr ping_name, uint8_t include_client_id);
+
 uint64_t glean_new_string_metric(FfiStr category,
                                  FfiStr name,
                                  RawStringArray send_in_pings,
@@ -115,7 +117,11 @@ uint64_t glean_new_string_metric(FfiStr category,
 
 char *glean_ping_collect(uint64_t glean_handle, FfiStr ping_name);
 
-uint8_t glean_send_ping(uint64_t glean_handle, FfiStr ping_name, uint8_t log_ping);
+void glean_register_ping_type(uint64_t glean_handle, uint64_t ping_type_handle);
+
+uint8_t glean_send_ping(uint64_t glean_handle, uint64_t ping_type_handle, uint8_t log_ping);
+
+uint8_t glean_send_ping_by_name(uint64_t glean_handle, FfiStr ping_name, uint8_t log_ping);
 
 void glean_set_upload_enabled(uint64_t glean_handle, uint8_t flag);
 
@@ -126,6 +132,8 @@ uint8_t glean_string_should_record(uint64_t glean_handle, uint64_t metric_id);
 char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
 
 uint8_t glean_string_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+
+uint8_t glean_test_has_ping_type(uint64_t glean_handle, FfiStr ping_name);
 
 void glean_destroy_glean(uint64_t handle, ExternError *error);
 void glean_destroy_boolean_metric(uint64_t handle, ExternError *error);

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -19,6 +19,7 @@ use handlemap_ext::HandleMapExtension;
 
 lazy_static! {
     static ref GLEAN: ConcurrentHandleMap<Glean> = ConcurrentHandleMap::new();
+    static ref PING_TYPES: ConcurrentHandleMap<PingType> = ConcurrentHandleMap::new();
     static ref BOOLEAN_METRICS: ConcurrentHandleMap<BooleanMetric> = ConcurrentHandleMap::new();
     static ref STRING_METRICS: ConcurrentHandleMap<StringMetric> = ConcurrentHandleMap::new();
     static ref COUNTER_METRICS: ConcurrentHandleMap<CounterMetric> = ConcurrentHandleMap::new();
@@ -100,9 +101,41 @@ pub extern "C" fn glean_set_upload_enabled(glean_handle: u64, flag: u8) {
 }
 
 #[no_mangle]
-pub extern "C" fn glean_send_ping(glean_handle: u64, ping_name: FfiStr, log_ping: u8) -> u8 {
+pub extern "C" fn glean_send_ping(glean_handle: u64, ping_type_handle: u64, log_ping: u8) -> u8 {
+    GLEAN.call_infallible(glean_handle, |glean| {
+        PING_TYPES.call_with_log(ping_type_handle, |ping_type| {
+            glean.send_ping(ping_type, log_ping != 0)
+        })
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn glean_send_ping_by_name(
+    glean_handle: u64,
+    ping_name: FfiStr,
+    log_ping: u8,
+) -> u8 {
     GLEAN.call_with_log(glean_handle, |glean| {
-        glean.send_ping(ping_name.as_str(), log_ping != 0)
+        glean.send_ping_by_name(ping_name.as_str(), log_ping != 0)
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn glean_new_ping_type(ping_name: FfiStr, include_client_id: u8) -> u64 {
+    PING_TYPES.insert_with_log(|| Ok(PingType::new(ping_name.as_str(), include_client_id != 0)))
+}
+
+#[no_mangle]
+pub extern "C" fn glean_test_has_ping_type(glean_handle: u64, ping_name: FfiStr) -> u8 {
+    GLEAN.call_infallible(glean_handle, |glean| {
+        glean.get_ping_by_name(ping_name.as_str()).is_some()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn glean_register_ping_type(glean_handle: u64, ping_type_handle: u64) {
+    PING_TYPES.call_infallible(ping_type_handle, |ping_type| {
+        GLEAN.call_infallible_mut(glean_handle, |glean| glean.register_ping_type(ping_type))
     })
 }
 
@@ -314,7 +347,10 @@ pub extern "C" fn glean_ping_collect(glean_handle: u64, ping_name: FfiStr) -> *m
     GLEAN.call_infallible(glean_handle, |glean| {
         let ping_maker = glean_core::ping::PingMaker::new();
         let data = ping_maker
-            .collect_string(glean.storage(), ping_name.as_str())
+            .collect_string(
+                glean.storage(),
+                glean.get_ping_by_name(ping_name.as_str()).unwrap(),
+            )
             .unwrap_or_else(|| String::from(""));
         log::info!("Ping({}): {}", ping_name.as_str(), data);
         data
@@ -322,6 +358,7 @@ pub extern "C" fn glean_ping_collect(glean_handle: u64, ping_name: FfiStr) -> *m
 }
 
 define_handle_map_deleter!(GLEAN, glean_destroy_glean);
+define_handle_map_deleter!(PING_TYPES, glean_destroy_ping_type);
 define_handle_map_deleter!(BOOLEAN_METRICS, glean_destroy_boolean_metric);
 define_handle_map_deleter!(STRING_METRICS, glean_destroy_string_metric);
 define_handle_map_deleter!(COUNTER_METRICS, glean_destroy_counter_metric);

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -132,7 +132,7 @@ impl Glean {
     ///
     /// If the ping currently contains no content, it will not be sent.
     ///
-    /// Returns true if a ping was sent, false otherwise.
+    /// Returns true if a ping was assembled and queued, false otherwise.
     /// Returns an error if collecting or writing the ping to disk failed.
     pub fn send_ping(&self, ping: &PingType, log_ping: bool) -> Result<bool> {
         let ping_maker = PingMaker::new();
@@ -166,7 +166,7 @@ impl Glean {
     ///
     /// If the ping currently contains no content, it will not be sent.
     ///
-    /// Returns true if a ping was sent, false otherwise.
+    /// Returns true if a ping was assembled and queued, false otherwise.
     /// Returns an error if collecting or writing the ping to disk failed.
     pub fn send_ping_by_name(&self, ping_name: &str, log_ping: bool) -> Result<bool> {
         match self.get_ping_by_name(ping_name) {
@@ -187,9 +187,6 @@ impl Glean {
             log::error!("Duplicate ping named {}", ping.name)
         }
 
-        // TODO: This just clones the PingType.  This means we have a copy of the PingType
-        // for the ping registry and another managed by handles on the language-specific
-        // side, but these objects are small and this seems like a simple solution...
         self.ping_registry.insert(ping.name.clone(), ping.clone());
     }
 }

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value as JsonValue};
 
 mod boolean;
 mod counter;
+mod ping;
 mod string;
 mod string_list;
 mod uuid;
@@ -16,6 +17,7 @@ use crate::Glean;
 
 pub use self::boolean::BooleanMetric;
 pub use self::counter::CounterMetric;
+pub use self::ping::PingType;
 pub use self::string::StringMetric;
 pub use self::string_list::StringListMetric;
 pub use self::uuid::UuidMetric;

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -12,7 +12,7 @@ pub struct PingType {
 }
 
 impl PingType {
-    pub fn new<A: Into<String> + Copy>(name: A, include_client_id: bool) -> Self {
+    pub fn new<A: Into<String>>(name: A, include_client_id: bool) -> Self {
         Self {
             name: name.into(),
             include_client_id,

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -7,6 +7,8 @@ use crate::Glean;
 
 #[derive(Debug, Clone)]
 /// Stores information about a ping.
+/// This is required so that given metric data queued on disk we can send
+/// pings with the correct settings, e.g. whether it has a client_id.
 pub struct PingType {
     /// The name of the ping.
     pub name: String,

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -6,8 +6,11 @@ use crate::error::Result;
 use crate::Glean;
 
 #[derive(Debug, Clone)]
+/// Stores information about a ping.
 pub struct PingType {
+    /// The name of the ping.
     pub name: String,
+    /// Whether the ping should include the client_id data
     pub include_client_id: bool,
 }
 

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::error::Result;
+use crate::Glean;
+
+#[derive(Debug, Clone)]
+pub struct PingType {
+    pub name: String,
+    pub include_client_id: bool,
+}
+
+impl PingType {
+    pub fn new<A: Into<String> + Copy>(name: A, include_client_id: bool) -> Self {
+        Self {
+            name: name.into(),
+            include_client_id,
+        }
+    }
+
+    pub fn send(&self, glean: &Glean, log_ping: bool) -> Result<bool> {
+        glean.send_ping(self, log_ping)
+    }
+}

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -10,7 +10,10 @@ use glean_core::CommonMetricData;
 
 #[test]
 fn write_ping_to_disk() {
-    let (glean, temp) = new_glean();
+    let (mut glean, temp) = new_glean();
+
+    let ping = PingType::new("metrics", true);
+    glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.
     let counter = CounterMetric::new(CommonMetricData {
@@ -21,7 +24,7 @@ fn write_ping_to_disk() {
     });
     counter.add(&glean, 1);
 
-    assert!(glean.send_ping("metrics", false).unwrap());
+    assert!(ping.send(&glean, true).unwrap());
 
     let path = temp.path().join("pings");
 


### PR DESCRIPTION
I'm just posting this here for discussion -- either here or in our next meeting if that's more efficient.  FFI and Kotlin side not implemented yet.

I first considered putting the ping registry on the Glean object, since it sort of logically makes sense there.  However, libraries need to register pings at any time during startup, including before `Glean::initialize` is called.  Since we've tied `new` and `initialize` together, we couldn't add pings to the ping registry before the Glean singleton is initialized, since before that there is no Rust-side Glean object.  An alternative to make that work would be to split `new` and `initialize` apart again, which isn't great.

So I came up with this solution which uses an actual global object and state on the Rust side.  It's not bad, but it does mean for testing that there is state carried over between tests.

Tl;dr: I thought this could use more feedback / brainstorming before filling out the rest of the pieces.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
