### PR TITLE
Refactored should record

### DIFF
--- a/docs/dev/core/new-metric-type.md
+++ b/docs/dev/core/new-metric-type.md
@@ -18,22 +18,28 @@ pub struct CounterMetric {
 }
 ```
 
+Implement the `MetricType` trait to expose the meta data.
+This also gives you a `should_record` method on the metric type.
+
+```
+impl MetricType for CounterMetric {
+    fn meta(&self) -> &CommonMetricData {
+        &self.meta
+    }
+}
+```
+
 Its implementation should have a way to create a new metric from the common metric data. It should be the same for all metric types.
-It should also provide a `should_record` function as shown below.
 
 ```rust,noplaypen
 impl CounterMetric {
     pub fn new(meta: CommonMetricData) -> Self {
         Self { meta }
     }
-
-    pub fn should_record(&self, glean: &Glean) -> bool {
-        glean.is_upload_enabled() && self.meta.should_record()
-    }
 }
 ```
 
-Implement each method. The first argument to accept should always be `glean: &Glean`, that is: a reference to the Glean object, used to access the storage:
+Implement each method for the type. The first argument to accept should always be `glean: &Glean`, that is: a reference to the Glean object, used to access the storage:
 
 ```rust,noplaypen
 impl CounterMetric { // same block as above

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::metrics::Metric;
+use crate::metrics::MetricType;
 use crate::storage::StorageManager;
 use crate::CommonMetricData;
 use crate::Glean;
@@ -12,13 +13,15 @@ pub struct BooleanMetric {
     meta: CommonMetricData,
 }
 
+impl MetricType for BooleanMetric {
+    fn meta(&self) -> &CommonMetricData {
+        &self.meta
+    }
+}
+
 impl BooleanMetric {
     pub fn new(meta: CommonMetricData) -> Self {
         Self { meta }
-    }
-
-    pub fn should_record(&self, glean: &Glean) -> bool {
-        glean.is_upload_enabled() && self.meta.should_record()
     }
 
     pub fn set(&self, glean: &Glean, value: bool) {

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::metrics::Metric;
+use crate::metrics::MetricType;
 use crate::storage::StorageManager;
 use crate::CommonMetricData;
 use crate::Glean;
@@ -12,13 +13,15 @@ pub struct CounterMetric {
     meta: CommonMetricData,
 }
 
+impl MetricType for CounterMetric {
+    fn meta(&self) -> &CommonMetricData {
+        &self.meta
+    }
+}
+
 impl CounterMetric {
     pub fn new(meta: CommonMetricData) -> Self {
         Self { meta }
-    }
-
-    pub fn should_record(&self, glean: &Glean) -> bool {
-        glean.is_upload_enabled() && self.meta.should_record()
     }
 
     pub fn add(&self, glean: &Glean, amount: i32) {

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -11,6 +11,9 @@ mod string;
 mod string_list;
 mod uuid;
 
+use crate::CommonMetricData;
+use crate::Glean;
+
 pub use self::boolean::BooleanMetric;
 pub use self::counter::CounterMetric;
 pub use self::string::StringMetric;
@@ -24,6 +27,14 @@ pub enum Metric {
     Counter(i32),
     Uuid(String),
     StringList(Vec<String>),
+}
+
+pub trait MetricType {
+    fn meta(&self) -> &CommonMetricData;
+
+    fn should_record(&self, glean: &Glean) -> bool {
+        glean.is_upload_enabled() && self.meta().should_record()
+    }
 }
 
 impl Metric {

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -4,6 +4,7 @@
 
 use crate::error_recording::{record_error, ErrorType};
 use crate::metrics::Metric;
+use crate::metrics::MetricType;
 use crate::storage::StorageManager;
 use crate::CommonMetricData;
 use crate::Glean;
@@ -15,13 +16,15 @@ pub struct StringMetric {
     meta: CommonMetricData,
 }
 
+impl MetricType for StringMetric {
+    fn meta(&self) -> &CommonMetricData {
+        &self.meta
+    }
+}
+
 impl StringMetric {
     pub fn new(meta: CommonMetricData) -> Self {
         Self { meta }
-    }
-
-    pub fn should_record(&self, glean: &Glean) -> bool {
-        glean.is_upload_enabled() && self.meta.should_record()
     }
 
     pub fn set<S: Into<String>>(&self, glean: &Glean, value: S) {


### PR DESCRIPTION
Bikeshed:

Should we call the trait `MetricType` or something else?

right now it only exposes the `meta()` method and the `should_record` method, but maybe we have more in the future?