### PR TITLE
Bug 1553424 - Setting uploadEnabled before initialization should not crash

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -44,7 +44,7 @@ open class GleanInternalAPI internal constructor () {
     private lateinit var gleanDataDir: File
 
     // Keep track of this flag before Glean is initialized
-    private var uploadEnabled: Boolean? = null
+    private var uploadEnabled: Boolean = true
 
     // This object holds data related to any persistent information about the metrics ping,
     // such as the last time it was sent and the store name
@@ -79,11 +79,7 @@ open class GleanInternalAPI internal constructor () {
         this.configuration = configuration
 
         this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR)
-        handle = LibGleanFFI.INSTANCE.glean_initialize(this.gleanDataDir.path, applicationContext.packageName)
-
-        uploadEnabled?.let {
-            LibGleanFFI.INSTANCE.glean_set_upload_enabled(handle, it.toByte())
-        }
+        handle = LibGleanFFI.INSTANCE.glean_initialize(this.gleanDataDir.path, applicationContext.packageName, uploadEnabled.toByte())
 
         // TODO: on glean-legacy we perform other actions before initialize the metrics (e.g.
         // init the engines), then init the core metrics, and finally kick off the metrics
@@ -158,7 +154,7 @@ open class GleanInternalAPI internal constructor () {
         if (isInitialized()) {
             return LibGleanFFI.INSTANCE.glean_is_upload_enabled(handle).toBoolean()
         } else {
-            return uploadEnabled ?: false
+            return uploadEnabled
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -155,7 +155,11 @@ open class GleanInternalAPI internal constructor () {
      * Get whether or not Glean is allowed to record and upload data.
      */
     fun getUploadEnabled(): Boolean {
-        return LibGleanFFI.INSTANCE.glean_is_upload_enabled(handle).toBoolean()
+        if (isInitialized()) {
+            return LibGleanFFI.INSTANCE.glean_is_upload_enabled(handle).toBoolean()
+        } else {
+            return uploadEnabled ?: false
+        }
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -81,7 +81,7 @@ internal interface LibGleanFFI : Library {
 
     fun glean_counter_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
-    fun glean_initialize(data_dir: String, application_id: String): Long
+    fun glean_initialize(data_dir: String, application_id: String, upload_enabled: Byte): Long
 
     fun glean_is_initialized(glean_handle: Long): Byte
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -94,7 +94,6 @@ class GleanTest {
         val context: Context = ApplicationProvider.getApplicationContext()
         val config = Configuration()
 
-        assertFalse(Glean.getUploadEnabled())
         Glean.setUploadEnabled(true)
         assertTrue(Glean.getUploadEnabled())
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -74,6 +74,18 @@ class GleanTest {
         Glean.setUploadEnabled(true)
     }
 
+    @Test
+    fun `setting uploadEnabled before initialization should not crash`() {
+        // Can't use resetGlean directly
+        Glean.testDestroyGleanHandle()
+
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val config = Configuration()
+
+        Glean.setUploadEnabled(true)
+        Glean.initialize(context, config)
+    }
+
     // New from glean-core.
     @Test
     fun `send a ping`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -86,6 +86,22 @@ class GleanTest {
         Glean.initialize(context, config)
     }
 
+    @Test
+    fun `getting uploadEnabled before initialization should not crash`() {
+        // Can't use resetGlean directly
+        Glean.testDestroyGleanHandle()
+
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val config = Configuration()
+
+        assertFalse(Glean.getUploadEnabled())
+        Glean.setUploadEnabled(true)
+        assertTrue(Glean.getUploadEnabled())
+
+        Glean.initialize(context, config)
+        assertTrue(Glean.getUploadEnabled())
+    }
+
     // New from glean-core.
     @Test
     fun `send a ping`() {

--- a/glean-core/examples/sample.rs
+++ b/glean-core/examples/sample.rs
@@ -18,7 +18,7 @@ fn main() {
         root.path().display().to_string()
     };
 
-    let mut glean = Glean::new(&data_path, "org.mozilla.glean_core.example").unwrap();
+    let mut glean = Glean::new(&data_path, "org.mozilla.glean_core.example", true).unwrap();
     assert!(glean.is_initialized());
 
     let local_metric: StringMetric = StringMetric::new(CommonMetricData {

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -86,7 +86,7 @@ uint8_t glean_counter_test_has_value(uint64_t glean_handle,
  */
 void glean_enable_logging(void);
 
-uint64_t glean_initialize(FfiStr data_dir, FfiStr application_id);
+uint64_t glean_initialize(FfiStr data_dir, FfiStr application_id, uint8_t upload_enabled);
 
 uint8_t glean_is_initialized(uint64_t glean_handle);
 

--- a/glean-core/ffi/examples/glean_app.c
+++ b/glean-core/ffi/examples/glean_app.c
@@ -13,7 +13,7 @@ typedef struct ExternError {
 int main(void)
 {
   glean_enable_logging();
-  uint64_t glean = glean_initialize("/tmp/glean_data", "c-app");
+  uint64_t glean = glean_initialize("/tmp/glean_data", "c-app", true);
 
   printf("Glean upload enabled? %d\n", glean_is_upload_enabled(glean));
   glean_set_upload_enabled(glean, 0);

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -70,11 +70,15 @@ pub extern "C" fn glean_enable_logging() {
 }
 
 #[no_mangle]
-pub extern "C" fn glean_initialize(data_dir: FfiStr, application_id: FfiStr) -> u64 {
+pub extern "C" fn glean_initialize(
+    data_dir: FfiStr,
+    application_id: FfiStr,
+    upload_enabled: u8,
+) -> u64 {
     GLEAN.insert_with_log(|| {
         let data_dir = data_dir.into_string();
         let application_id = application_id.into_string();
-        let glean = Glean::new(&data_dir, &application_id)?;
+        let glean = Glean::new(&data_dir, &application_id, upload_enabled != 0)?;
         log::info!("Glean initialized");
         Ok(glean)
     })

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -46,13 +46,13 @@ impl Glean {
     ///
     /// This will create the necessary directories and files in `data_path`.
     /// This will also initialize the core metrics.
-    pub fn new(data_path: &str, application_id: &str) -> Result<Self> {
+    pub fn new(data_path: &str, application_id: &str, upload_enabled: bool) -> Result<Self> {
         log::info!("Creating new glean");
 
         let application_id = sanitize_application_id(application_id);
         let mut glean = Self {
-            initialized: true,
-            upload_enabled: true,
+            initialized: false,
+            upload_enabled,
             data_store: Database::new(data_path)?,
             core_metrics: CoreMetrics::new(),
             data_path: PathBuf::from(data_path),
@@ -164,7 +164,7 @@ mod test {
     fn path_is_constructed_from_data() {
         let t = tempfile::tempdir().unwrap();
         let name = t.path().display().to_string();
-        let glean = Glean::new(&name, "org.mozilla.glean").unwrap();
+        let glean = Glean::new(&name, "org.mozilla.glean", true).unwrap();
 
         assert_eq!(
             "/submit/org-mozilla-glean/baseline/1/this-is-a-docid",

--- a/glean-core/tests/boolean.rs
+++ b/glean-core/tests/boolean.rs
@@ -18,7 +18,7 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 fn boolean_serializer_should_correctly_serialize_boolean() {
     let (_t, tmpname) = tempdir();
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
+        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
         let metric = BooleanMetric::new(CommonMetricData {
             name: "boolean_metric".into(),
@@ -42,7 +42,7 @@ fn boolean_serializer_should_correctly_serialize_boolean() {
     // Make a new glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
+        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -21,7 +21,7 @@ pub fn new_glean() -> (Glean, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
 
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
+    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
     (glean, dir)
 }

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -20,7 +20,7 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 fn counter_serializer_should_correctly_serialize_counters() {
     let (_t, tmpname) = tempdir();
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
+        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
         let metric = CounterMetric::new(CommonMetricData {
             name: "counter_metric".into(),
@@ -44,7 +44,7 @@ fn counter_serializer_should_correctly_serialize_counters() {
     // Make a new glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
+        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -18,7 +18,7 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 fn string_serializer_should_correctly_serialize_strings() {
     let (_t, tmpname) = tempdir();
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
+        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
         let metric = StringMetric::new(CommonMetricData {
             name: "string_metric".into(),
@@ -42,7 +42,7 @@ fn string_serializer_should_correctly_serialize_strings() {
     // Make a new glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
+        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();


### PR DESCRIPTION
Follow up to #90 in which we now keep track of the flag before we initialize.

We can eventually deprecate the "call before init" way and move the flag into the initializer.
For now this is the easy way out of crashing.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
