### PR TITLE
Add error reporting for labeled metrics (and counters)

### DIFF
--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -2,18 +2,34 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! # Error Recording
+//!
+//! Glean keeps track of errors that occured due to invalid labels or invalid values when recording
+//! other metrics.
+//!
+//! Error counts are stored in labeled counters in the `glean.error` category.
+//! The labeled counter metrics that store the errors are defined in the `metrics.yaml` for documentation purposes,
+//! but are not actually used directly, since the `send_in_pings` value needs to match the pings of the metric that is erroring (plus the "metrics" ping),
+//! not some constant value that we could define in `metrics.yaml`.
+
+use std::fmt::Display;
+
 use crate::metrics::CounterMetric;
 use crate::CommonMetricData;
 use crate::Glean;
 use crate::Lifetime;
 
+/// The possible error types for metric recording.
 #[derive(Debug)]
 pub enum ErrorType {
+    /// For when the value to be recorded does not match the metric-specific restrictions
     InvalidValue,
+    /// For when the label of a labeled metric does not match the restrictions
     InvalidLabel,
 }
 
 impl ErrorType {
+    /// The error type's metric name
     pub fn to_string(&self) -> &'static str {
         match self {
             ErrorType::InvalidValue => "invalid_value",
@@ -22,21 +38,45 @@ impl ErrorType {
     }
 }
 
-pub fn record_error(glean: &Glean, meta: &CommonMetricData, error: ErrorType) {
+/// Records an error into Glean.
+///
+/// Errors are recorded as labeled counters in the `glean.error` category.
+///
+/// *Note*: We do make assumptions here how labeled metrics are encoded, namely by having the name
+/// `<name>/<label>`.
+/// Errors do not adhere to the usual "maximum label" restriction.
+///
+/// ## Arguments
+///
+/// * glean - The Glean instance containing the database
+/// * meta - The metric's meta data
+/// * error -  The error type to record
+/// * message - The message to log. This message is not sent with the ping.
+///             It does not need to include the metric name, as that is automatically prepended to the message.
+pub fn record_error(
+    glean: &Glean,
+    meta: &CommonMetricData,
+    error: ErrorType,
+    message: impl Display,
+) {
+    // Split off any label of the identifier
     let identifier = meta.identifier();
+    let name = identifier.splitn(2, '/').next().unwrap(); // safe unwrap, first field of a split always valid
 
+    // Record errors in the pings the metric is in, as well as the metrics ping.
     let mut send_in_pings = meta.send_in_pings.clone();
     if !send_in_pings.contains(&"metrics".to_string()) {
         send_in_pings.push("metrics".into());
     }
 
     let metric = CounterMetric::new(CommonMetricData {
-        name: format!("{}/{}", error.to_string(), identifier),
+        name: format!("{}/{}", error.to_string(), name),
         category: "glean.error".into(),
         lifetime: Lifetime::Ping,
         send_in_pings,
         ..Default::default()
     });
 
+    log::warn!("{}: {}", identifier, message);
     metric.add(glean, 1);
 }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -23,7 +23,7 @@ mod util;
 
 pub use crate::common_metric_data::{CommonMetricData, Lifetime};
 use crate::database::Database;
-pub use crate::error_recording::ErrorType;
+pub use crate::error_recording::{test_get_num_recorded_errors, ErrorType};
 use crate::internal_metrics::CoreMetrics;
 use crate::ping::PingMaker;
 use crate::storage::StorageManager;

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::error_recording::{record_error, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -34,8 +35,12 @@ impl CounterMetric {
         }
 
         if amount <= 0 {
-            // TODO: Turn this into logging an error
-            log::warn!("CounterMetric::add: got negative amount. Not recording.");
+            record_error(
+                glean,
+                &self.meta,
+                ErrorType::InvalidValue,
+                format!("Added negative or zero value {}", amount),
+            );
             return;
         }
 

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 use lazy_static::lazy_static;
 use regex::Regex;
 
+use crate::error_recording::{record_error, ErrorType};
 use crate::metrics::{Metric, MetricType};
 use crate::Glean;
 use crate::Lifetime;
@@ -112,16 +113,18 @@ where
                 return OTHER_LABEL;
             } else {
                 if label.len() > MAX_LABEL_LENGTH {
-                    log::error!(
+                    let msg = format!(
                         "label length {} exceeds maximum of {}",
                         label.len(),
                         MAX_LABEL_LENGTH
                     );
+                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg);
                     return OTHER_LABEL;
                 }
 
                 if !LABEL_REGEX.is_match(label) {
-                    log::error!("label must be snake_case, got '{}'", label,);
+                    let msg = format!("label must be snake_case, got '{}'", label);
+                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg);
                     return OTHER_LABEL;
                 }
 

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -38,7 +38,12 @@ impl StringMetric {
 
         let s = value.into();
         let s = if s.len() > MAX_LENGTH_VALUE {
-            record_error(glean, &self.meta, ErrorType::InvalidValue);
+            let msg = format!(
+                "Value length {} exceeds maximum of {}",
+                s.len(),
+                MAX_LENGTH_VALUE
+            );
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
             s[0..MAX_LENGTH_VALUE].to_string()
         } else {
             s

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -40,7 +40,12 @@ impl StringListMetric {
 
         let value = value.into();
         let value = if value.len() > MAX_STRING_LENGTH {
-            record_error(glean, &self.meta, ErrorType::InvalidValue);
+            let msg = format!(
+                "Individual value length {} exceeds maximum of {}",
+                value.len(),
+                MAX_STRING_LENGTH
+            );
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
             value[0..MAX_STRING_LENGTH].to_string()
         } else {
             value
@@ -51,7 +56,12 @@ impl StringListMetric {
             .record_with(&self.meta, |old_value| match old_value {
                 Some(Metric::StringList(mut old_value)) => {
                     if old_value.len() == MAX_LIST_LENGTH {
-                        record_error(glean, &self.meta, ErrorType::InvalidValue);
+                        let msg = format!(
+                            "String list length of {} exceeds maximum of {}",
+                            old_value.len() + 1,
+                            MAX_LIST_LENGTH
+                        );
+                        record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
                         return Metric::StringList(old_value);
                     }
                     old_value.push(value.clone());
@@ -67,7 +77,12 @@ impl StringListMetric {
         }
 
         let value = if value.len() > MAX_LIST_LENGTH {
-            record_error(glean, &self.meta, ErrorType::InvalidValue);
+            let msg = format!(
+                "Individual value length {} exceeds maximum of {}",
+                value.len(),
+                MAX_STRING_LENGTH
+            );
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
             value[0..MAX_LIST_LENGTH].to_vec()
         } else {
             value
@@ -77,7 +92,12 @@ impl StringListMetric {
             .into_iter()
             .map(|elem| {
                 if elem.len() > MAX_STRING_LENGTH {
-                    record_error(glean, &self.meta, ErrorType::InvalidValue);
+                    let msg = format!(
+                        "String list length of {} exceeds maximum of {}",
+                        elem.len() + 1,
+                        MAX_LIST_LENGTH
+                    );
+                    record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
                     elem[0..MAX_STRING_LENGTH].to_string()
                 } else {
                     elem

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -116,7 +116,7 @@ fn counters_must_not_increment_when_passed_zero_or_negative() {
     // Make sure that the errors have been recorded
     assert_eq!(
         2,
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
     );
 }
 

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
+use glean_core::{test_get_num_recorded_errors, ErrorType};
 use glean_core::{CommonMetricData, Glean, Lifetime};
 
 // Tests ported from glean-ac
@@ -112,13 +113,11 @@ fn counters_must_not_increment_when_passed_zero_or_negative() {
     // Check that nothing was recorded
     assert_eq!(1, metric.test_get_value(&glean, "store1").unwrap());
 
-    // Attempt increment counter properly
-    metric.add(&glean, -1);
-    // Check that nothing was recorded
-    assert_eq!(1, metric.test_get_value(&glean, "store1").unwrap());
-
-    // TODO: 1551975 Implement error reporting
-    // assert_eq!(2, test_get_num_recorded_errors(metric, ...))
+    // Make sure that the errors have been recorded
+    assert_eq!(
+        2,
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
+    );
 }
 
 // New tests for glean-core below

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -210,6 +210,7 @@ fn dynamic_labels_too_long() {
     assert_eq!(
         json!({
             "labeled_counter": {
+                "glean.error.invalid_label": { "telemetry.labeled_metric": 1 },
                 "telemetry.labeled_metric": {
                     "__other__": 1,
                 }
@@ -244,6 +245,7 @@ fn dynamic_labels_regex_mimsatch() {
     assert_eq!(
         json!({
             "labeled_counter": {
+                "glean.error.invalid_label": { "telemetry.labeled_metric": 3 },
                 "telemetry.labeled_metric": {
                     "__other__": 3,
                 }

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
+use glean_core::{test_get_num_recorded_errors, ErrorType};
 use glean_core::{CommonMetricData, Glean, Lifetime};
 
 // SKIPPED from glean-ac: string deserializer should correctly parse integers
@@ -105,6 +106,9 @@ fn long_string_values_are_truncated() {
         metric.test_get_value(&glean, "store1").unwrap()
     );
 
-    // TODO: Requires error reporting (bug 1551975)
-    //assertEquals(1, testGetNumRecordedErrors(stringMetric, ErrorType.InvalidValue))
+    // Make sure that the errors have been recorded
+    assert_eq!(
+        1,
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
+    );
 }

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -109,6 +109,6 @@ fn long_string_values_are_truncated() {
     // Make sure that the errors have been recorded
     assert_eq!(
         1,
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
     );
 }


### PR DESCRIPTION
Based on #95, needs a rebase when that lands.

The last 3 commits are relevant. We now have all things in place for error reporting using labeled metrics.
Even though the error reporting itself doesn't use the labeled metrics, we simply depend on the same "encoding" of labels into the key.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
