### PR TITLE
Bug 1555031 - Generate kotlin docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ buildscript {
 
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
 
+        // Docs generation
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17"
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -13,6 +13,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'org.jetbrains.dokka-android'
 
 /*
  * This defines the location of the JSON schema used to validate the pings
@@ -180,6 +181,13 @@ ext.configurePublish(
         /* jnaForTestConfiguration= */ configurations.jnaForTest,
         /* variantWithoutLib= */ 'androidWithoutLib',
 )
+
+task docs(type: org.jetbrains.dokka.gradle.DokkaAndroidTask, overwrite: true) {
+    moduleName = "$rootProject.name"
+    outputDirectory = "$buildDir/javadoc"
+    outputFormat = "html"
+    jdkVersion = 7
+}
 
 //apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'
 apply from: 'sdk_generator.gradle'


### PR DESCRIPTION
With this `./gradlew docs` will generate HTML documentation in build/javadoc/glean.rs/

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
