### PR TITLE
Reinstate deep JSON inspection of labeled metric tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,19 @@ jobs:
     steps:
       - rust-tests:
           rust-version: "beta"
+  C tests:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - test-setup:
+          rust-version: stable
+      - run: cargo build --release
+      # Just a basic smoke test for now to make sure it compiles and runs
+      # without returning an error
+      - run: |
+          cd glean-core/ffi/examples
+          make
+          ./glean_app
 
   Lint Android with ktlint and detekt:
     docker:
@@ -176,6 +189,7 @@ workflows:
       - Rust tests - stable
       - Rust tests - beta
       - Android tests
+      - C tests
   documentation:
     jobs:
       - Generate documentation

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -282,7 +282,7 @@ open class GleanInternalAPI internal constructor () {
      * Collect a ping and return a string
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun collect(ping: PingType): String? {
+    internal fun testCollect(ping: PingType): String? {
         return LibGleanFFI.INSTANCE.glean_ping_collect(handle, ping.handle)?.getAndConsumeRustString()
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -17,6 +17,7 @@ import java.io.File
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.MetricHandle
 import mozilla.telemetry.glean.rust.RustError
+import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
 import mozilla.telemetry.glean.rust.toByte
 import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
@@ -277,9 +278,12 @@ open class GleanInternalAPI internal constructor () {
         return this.gleanDataDir
     }
 
-    fun collect(pingName: String) {
-        val s = LibGleanFFI.INSTANCE.glean_ping_collect(handle, pingName)!!
-        LibGleanFFI.INSTANCE.glean_str_free(s)
+    /**
+     * Collect a ping and return a string
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal fun collect(ping: PingType): String? {
+        return LibGleanFFI.INSTANCE.glean_ping_collect(handle, ping.handle)?.getAndConsumeRustString()
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -157,7 +157,7 @@ internal interface LibGleanFFI : Library {
 
     fun glean_string_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
-    fun glean_ping_collect(glean_handle: Long, ping_name: String): Pointer?
+    fun glean_ping_collect(glean_handle: Long, ping_type_handle: Long): Pointer?
 
     fun glean_send_ping(glean_handle: Long, ping_type_handle: Long, log_ping: Byte): Byte
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -23,6 +23,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.scheduler.PingUploadWorker
+import mozilla.telemetry.glean.private.PingType
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -98,14 +99,10 @@ internal fun checkPingSchema(content: String): JSONObject {
  * @return the ping contents, in a JSONObject
  * @throws AssertionError If the JSON content is not valid
  */
-/*internal fun collectAndCheckPingSchema(ping: PingType): JSONObject {
-    val appContext = ApplicationProvider.getApplicationContext<Context>()
-    val jsonString = PingMaker(
-        StorageEngineManager(applicationContext = appContext),
-        appContext
-    ).collect(ping)!!
+internal fun collectAndCheckPingSchema(ping: PingType): JSONObject {
+    val jsonString = Glean.collect(ping)!!
     return checkPingSchema(jsonString)
-}*/
+}
 
 /**
  * Resets the Glean state and trigger init again.

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -100,7 +100,7 @@ internal fun checkPingSchema(content: String): JSONObject {
  * @throws AssertionError If the JSON content is not valid
  */
 internal fun collectAndCheckPingSchema(ping: PingType): JSONObject {
-    val jsonString = Glean.collect(ping)!!
+    val jsonString = Glean.testCollect(ping)!!
     return checkPingSchema(jsonString)
 }
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -9,7 +9,9 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 */
+import mozilla.telemetry.glean.collectAndCheckPingSchema
 import mozilla.telemetry.glean.resetGlean
+import mozilla.telemetry.glean.GleanMetrics.Pings
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -90,16 +92,6 @@ class LabeledMetricTypeTest {
         assertTrue(counterMetric.testHasValue())
         assertEquals(3, counterMetric.testGetValue())
 
-        /*
-        CountersStorageEngine.record(counterMetric, 3)
-
-        val snapshot = CountersStorageEngine.getSnapshot(storeName = "metrics", clearStore = false)
-
-        assertEquals(3, snapshot!!.size)
-        assertEquals(1, snapshot.get("telemetry.labeled_counter_metric/label1"))
-        assertEquals(2, snapshot.get("telemetry.labeled_counter_metric/label2"))
-        assertEquals(3, snapshot.get("telemetry.labeled_counter_metric"))
-
         val json = collectAndCheckPingSchema(Pings.metrics).getJSONObject("metrics")!!
         // Do the same checks again on the JSON structure
         assertEquals(
@@ -119,7 +111,6 @@ class LabeledMetricTypeTest {
             json.getJSONObject("counter")!!
                 .get("telemetry.labeled_counter_metric")
         )
-        */
     }
 
     @Test
@@ -154,6 +145,27 @@ class LabeledMetricTypeTest {
         assertFalse(labeledCounterMetric["baz"].testHasValue())
         // The rest all lands in the __other__ bucket
         assertEquals(3, labeledCounterMetric["not_there"].testGetValue())
+
+        val json = collectAndCheckPingSchema(Pings.metrics).getJSONObject("metrics")!!
+        // Do the same checks again on the JSON structure
+        assertEquals(
+            3,
+            json.getJSONObject("labeled_counter")!!
+                .getJSONObject("telemetry.labeled_counter_metric")
+                .get("foo")
+        )
+        assertEquals(
+            1,
+            json.getJSONObject("labeled_counter")!!
+                .getJSONObject("telemetry.labeled_counter_metric")
+                .get("bar")
+        )
+        assertEquals(
+            3,
+            json.getJSONObject("labeled_counter")!!
+                .getJSONObject("telemetry.labeled_counter_metric")
+                .get("__other__")
+        )
     }
 
     @Test
@@ -186,6 +198,29 @@ class LabeledMetricTypeTest {
             assertEquals(1, labeledCounterMetric["label_$i"].testGetValue())
         }
         assertEquals(5, labeledCounterMetric["__other__"].testGetValue())
+
+        val json = collectAndCheckPingSchema(Pings.metrics).getJSONObject("metrics")!!
+        // Do the same checks again on the JSON structure
+        assertEquals(
+            2,
+            json.getJSONObject("labeled_counter")!!
+                .getJSONObject("telemetry.labeled_counter_metric")!!
+                .get("label_0")
+        )
+        for (i in 1..15) {
+            assertEquals(
+                1,
+                json.getJSONObject("labeled_counter")!!
+                    .getJSONObject("telemetry.labeled_counter_metric")!!
+                    .get("label_$i")
+            )
+        }
+        assertEquals(
+            5,
+            json.getJSONObject("labeled_counter")!!
+                .getJSONObject("telemetry.labeled_counter_metric")!!
+                .get("__other__")
+        )
     }
 
     @Test
@@ -212,6 +247,7 @@ class LabeledMetricTypeTest {
         labeledCounterMetric["with/slash"].add(1)
         labeledCounterMetric["this_string_has_more_than_thirty_characters"].add(1)
 
+        // TODO: 1551975
         /*assertEquals(*/
             /*4,*/
             /*ErrorRecording.testGetNumRecordedErrors(*/

--- a/glean-core/ffi/examples/Makefile
+++ b/glean-core/ffi/examples/Makefile
@@ -1,4 +1,4 @@
-objects = glean_app.c ../../../target/release/libglean_ffi.dylib
+objects = glean_app.c $(wildcard ../../../target/release/libglean_ffi.so) $(wildcard ../../../target/release/libglean_ffi.dylib)
 headers = glean.h
 
 glean_app: $(objects) $(headers)

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -115,7 +115,7 @@ uint64_t glean_new_string_metric(FfiStr category,
                                  int32_t lifetime,
                                  uint8_t disabled);
 
-char *glean_ping_collect(uint64_t glean_handle, FfiStr ping_name);
+char *glean_ping_collect(uint64_t glean_handle, uint64_t ping_type_handle);
 
 void glean_register_ping_type(uint64_t glean_handle, uint64_t ping_type_handle);
 

--- a/glean-core/ffi/examples/glean_app.c
+++ b/glean-core/ffi/examples/glean_app.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,6 +15,8 @@ int main(void)
 {
   glean_enable_logging();
   uint64_t glean = glean_initialize("/tmp/glean_data", "c-app", true);
+  uint64_t store1 = glean_new_ping_type("store1", true);
+  glean_register_ping_type(glean, store1);
 
   printf("Glean upload enabled? %d\n", glean_is_upload_enabled(glean));
   glean_set_upload_enabled(glean, 0);
@@ -28,7 +31,7 @@ int main(void)
 
   glean_counter_add(glean, metric, 2);
 
-  char *payload = glean_ping_collect(glean, "store1");
+  char *payload = glean_ping_collect(glean, store1);
   printf("Payload:\n%s\n", payload);
   glean_str_free(payload);
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -346,17 +346,17 @@ pub extern "C" fn glean_string_test_get_value(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_ping_collect(glean_handle: u64, ping_name: FfiStr) -> *mut c_char {
+pub extern "C" fn glean_ping_collect(glean_handle: u64, ping_type_handle: u64) -> *mut c_char {
     GLEAN.call_infallible(glean_handle, |glean| {
-        let ping_maker = glean_core::ping::PingMaker::new();
-        let data = ping_maker
-            .collect_string(
-                glean.storage(),
-                glean.get_ping_by_name(ping_name.as_str()).unwrap(),
-            )
-            .unwrap_or_else(|| String::from(""));
-        log::info!("Ping({}): {}", ping_name.as_str(), data);
-        data
+        let res: glean_core::Result<String> = PING_TYPES.get_u64(ping_type_handle, |ping_type| {
+            let ping_maker = glean_core::ping::PingMaker::new();
+            let data = ping_maker
+                .collect_string(glean.storage(), ping_type)
+                .unwrap_or_else(|| String::from(""));
+            log::info!("Ping({}): {}", ping_type.name.as_str(), data);
+            Ok(data)
+        });
+        res.unwrap()
     })
 }
 


### PR DESCRIPTION
This brings back in some testing content from glean-ac in LabeledMetricTypeTests.kt.

Mainly, this checks pings against the schema, since getting that right for labeled metrics is a bit fiddly.

In order to do this, it makes `collectAndCheckPingSchema` from glean-ac work and updates the API to use `PingType` rather than ping names.

This had knockon effects in the FFI, and then the C FFI example, so that's been updated to run on Linux and also run in CI.  **I plan to go back and make that work on Mac as well again, once I've verified CI is working on that.**

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
