### PR TITLE
Fix Kotlin doc deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
             rustup target add i686-linux-android
             rustup target add x86_64-linux-android
 
-  android-tests:
+  android-setup:
     steps:
       - install-rustup
       - test-setup:
@@ -67,9 +67,6 @@ commands:
           name: Install missing Android SDK
           command: |
               sdkmanager 'build-tools;21.0.0'
-      - run:
-          name: Gradle Test
-          command: ./gradlew test
 
 jobs:
   Check Rust formatting:
@@ -126,10 +123,13 @@ jobs:
     docker:
       - image: circleci/android:api-28-ndk
     steps:
-      - android-tests
+      - android-setup
+      - run:
+          name: Android tests
+          command: ./gradlew test
 
   # via https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
-  Generate documentation:
+  Generate Rust documentation:
     docker:
       - image: circleci/rust:latest
     steps:
@@ -144,11 +144,23 @@ jobs:
               tar -xvf mdbook-v0.2.1-x86_64-unknown-linux-gnu.tar.gz
               mv mdbook /usr/local/cargo/bin/mdbook
       - run:
-          name: Build documentation
+          name: Build Rust documentation
           command: bin/build-docs.sh
       - persist_to_workspace:
           root: build/
           paths: docs
+
+  Generate Kotlin documentation:
+    docker:
+      - image: circleci/android:api-28-ndk
+    steps:
+      - android-setup
+      - run:
+          name: Build Kotlin documentation
+          command: ./gradlew docs
+      - persist_to_workspace:
+          root: build/
+          paths: docs/javadoc
 
   docs-deploy:
     docker:
@@ -192,10 +204,12 @@ workflows:
       - C tests
   documentation:
     jobs:
-      - Generate documentation
+      - Generate Rust documentation
+      - Generate Kotlin documentation
       - docs-deploy:
           requires:
-            - Generate documentation
+            - Generate Rust documentation
+            - Generate Kotlin documentation
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,10 @@ jobs:
           command: bin/build-docs.sh
       - persist_to_workspace:
           root: build/
-          paths: docs
+          paths:
+            - docs/book
+            - docs/docs
+            - docs/index.html
 
   Generate Kotlin documentation:
     docker:
@@ -172,6 +175,9 @@ jobs:
       - run:
           name: Disable jekyll builds
           command: touch build/docs/.nojekyll
+      - run:
+          name: Show contents
+          command: ls -R build/docs
       # Needed for write access to the GitHub repository;
       # see https://circleci.com/docs/2.0/gh-bb-integration/#deployment-keys-and-user-keys
       - add_ssh_keys:

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,3 +26,4 @@
         - [Labeled Metrics](user/metrics/labeled_metric.md)
     - [Pings](user/pings/index.md)
         - [Baseline Ping](user/pings/baseline.md)
+- [API Documentation](api/index.md)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,4 @@
+The following language-specific API docs are available:
+
+- [Kotlin API docs](../../javadoc/glean/index.html)
+- [Rust core (internal) API docs](../../docs/index.html)

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -184,7 +184,7 @@ ext.configurePublish(
 
 task docs(type: org.jetbrains.dokka.gradle.DokkaAndroidTask, overwrite: true) {
     moduleName = "$rootProject.name"
-    outputDirectory = "$buildDir/javadoc"
+    outputDirectory = "$buildDir/../../../build/docs/javadoc"
     outputFormat = "html"
     jdkVersion = 7
 }


### PR DESCRIPTION
Persisting the docs in two different tasks and then merging for deployment didn't work as I had hoped, so I'm trying something different.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
