### PR TITLE
Upgrade the WorkManager dependency to 2.0.1

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -133,7 +133,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1"
 
     implementation "androidx.annotation:annotation:1.0.2"
-    implementation "androidx.work:work-runtime-ktx:2.0.0"
+    implementation "androidx.work:work-runtime-ktx:2.0.1"
 
     // For reasons unknown, resolving the jnaForTest configuration directly
     // trips a nasty issue with the Android-Gradle plugin 3.2.1, like `Cannot
@@ -150,7 +150,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
     testImplementation "org.mozilla.components:lib-fetch-okhttp:$android_components_version"
     testImplementation "org.mozilla.components:support-test:$android_components_version"
-    testImplementation "androidx.work:work-testing:2.0.0"
+    testImplementation "androidx.work:work-testing:2.0.1"
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'


### PR DESCRIPTION
This fixes a crash occurring in glean when the connectivity is disabled and then enabled. See
https://github.com/mozilla-mobile/android-components/issues/3110 for context.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
