### PR TITLE
Store an instance of the underlying metric and clone it on request

### DIFF
--- a/docs/dev/core/new-metric-type.md
+++ b/docs/dev/core/new-metric-type.md
@@ -12,7 +12,7 @@ A metric type implementation is defined in its own file under `glean-core/src/me
 Start by defining a structure to hold the metric's metadata:
 
 ```rust,noplaypen
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CounterMetric {
     meta: CommonMetricData
 }
@@ -23,12 +23,12 @@ This also gives you a `should_record` method on the metric type.
 
 ```
 impl MetricType for CounterMetric {
-    fn with_meta(meta: CommonMetricData) -> Self {
-        Self { meta }
-    }
-
     fn meta(&self) -> &CommonMetricData {
         &self.meta
+    }
+
+    fn meta_mut(&mut self) -> &mut CommonMetricData {
+        &mut self.meta
     }
 }
 ```

--- a/glean-core/ffi/src/labeled.rs
+++ b/glean-core/ffi/src/labeled.rs
@@ -58,13 +58,13 @@ macro_rules! impl_labeled_metric {
                 let lifetime = Lifetime::try_from(lifetime)?;
 
                 Ok(LabeledMetric::new(
-                    CommonMetricData {
+                    <$metric>::new(CommonMetricData {
                         name: name.into_string(),
                         category: category.into_string(),
                         send_in_pings,
                         lifetime,
                         disabled: disabled != 0,
-                    },
+                    }),
                     labels,
                 ))
             })

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -8,18 +8,18 @@ use crate::storage::StorageManager;
 use crate::CommonMetricData;
 use crate::Glean;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BooleanMetric {
     meta: CommonMetricData,
 }
 
 impl MetricType for BooleanMetric {
-    fn with_meta(meta: CommonMetricData) -> Self {
-        Self { meta }
-    }
-
     fn meta(&self) -> &CommonMetricData {
         &self.meta
+    }
+
+    fn meta_mut(&mut self) -> &mut CommonMetricData {
+        &mut self.meta
     }
 }
 

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -8,18 +8,18 @@ use crate::storage::StorageManager;
 use crate::CommonMetricData;
 use crate::Glean;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CounterMetric {
     meta: CommonMetricData,
 }
 
 impl MetricType for CounterMetric {
-    fn with_meta(meta: CommonMetricData) -> Self {
-        Self { meta }
-    }
-
     fn meta(&self) -> &CommonMetricData {
         &self.meta
+    }
+
+    fn meta_mut(&mut self) -> &mut CommonMetricData {
+        &mut self.meta
     }
 }
 

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -24,7 +24,7 @@ pub use self::string::StringMetric;
 pub use self::string_list::StringListMetric;
 pub use self::uuid::UuidMetric;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Metric {
     Boolean(bool),
     Counter(i32),
@@ -34,9 +34,9 @@ pub enum Metric {
 }
 
 pub trait MetricType {
-    fn with_meta(meta: CommonMetricData) -> Self;
-
     fn meta(&self) -> &CommonMetricData;
+
+    fn meta_mut(&mut self) -> &mut CommonMetricData;
 
     fn should_record(&self, glean: &Glean) -> bool {
         glean.is_upload_enabled() && self.meta().should_record()

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -5,7 +5,7 @@
 use crate::error::Result;
 use crate::Glean;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 /// Stores information about a ping.
 /// This is required so that given metric data queued on disk we can send
 /// pings with the correct settings, e.g. whether it has a client_id.

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -11,18 +11,18 @@ use crate::Glean;
 
 const MAX_LENGTH_VALUE: usize = 50;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StringMetric {
     meta: CommonMetricData,
 }
 
 impl MetricType for StringMetric {
-    fn with_meta(meta: CommonMetricData) -> Self {
-        Self { meta }
-    }
-
     fn meta(&self) -> &CommonMetricData {
         &self.meta
+    }
+
+    fn meta_mut(&mut self) -> &mut CommonMetricData {
+        &mut self.meta
     }
 }
 

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -13,18 +13,18 @@ const MAX_LIST_LENGTH: usize = 20;
 // Maximum length of any string in the list
 const MAX_STRING_LENGTH: usize = 50;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StringListMetric {
     meta: CommonMetricData,
 }
 
 impl MetricType for StringListMetric {
-    fn with_meta(meta: CommonMetricData) -> Self {
-        Self { meta }
-    }
-
     fn meta(&self) -> &CommonMetricData {
         &self.meta
+    }
+
+    fn meta_mut(&mut self) -> &mut CommonMetricData {
+        &mut self.meta
     }
 }
 

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -7,18 +7,18 @@ use crate::metrics::MetricType;
 use crate::CommonMetricData;
 use crate::Glean;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct UuidMetric {
     meta: CommonMetricData,
 }
 
 impl MetricType for UuidMetric {
-    fn with_meta(meta: CommonMetricData) -> Self {
-        Self { meta }
-    }
-
     fn meta(&self) -> &CommonMetricData {
         &self.meta
+    }
+
+    fn meta_mut(&mut self) -> &mut CommonMetricData {
+        &mut self.meta
     }
 }
 

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -14,14 +14,14 @@ use glean_core::{CommonMetricData, Lifetime};
 #[test]
 fn can_create_labeled_counter_metric() {
     let (glean, _t) = new_glean();
-    let mut labeled: LabeledMetric<CounterMetric> = LabeledMetric::new(
-        CommonMetricData {
+    let mut labeled = LabeledMetric::new(
+        CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
             category: "telemetry".into(),
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
-        },
+        }),
         Some(vec!["label1".into()]),
     );
 
@@ -45,14 +45,14 @@ fn can_create_labeled_counter_metric() {
 #[test]
 fn can_create_labeled_string_metric() {
     let (glean, _t) = new_glean();
-    let mut labeled: LabeledMetric<StringMetric> = LabeledMetric::new(
-        CommonMetricData {
+    let mut labeled = LabeledMetric::new(
+        StringMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
             category: "telemetry".into(),
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
-        },
+        }),
         Some(vec!["label1".into()]),
     );
 
@@ -76,14 +76,14 @@ fn can_create_labeled_string_metric() {
 #[test]
 fn can_create_labeled_bool_metric() {
     let (glean, _t) = new_glean();
-    let mut labeled: LabeledMetric<BooleanMetric> = LabeledMetric::new(
-        CommonMetricData {
+    let mut labeled = LabeledMetric::new(
+        BooleanMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
             category: "telemetry".into(),
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
-        },
+        }),
         Some(vec!["label1".into()]),
     );
 
@@ -107,14 +107,14 @@ fn can_create_labeled_bool_metric() {
 #[test]
 fn can_use_multiple_labels() {
     let (glean, _t) = new_glean();
-    let mut labeled: LabeledMetric<CounterMetric> = LabeledMetric::new(
-        CommonMetricData {
+    let mut labeled = LabeledMetric::new(
+        CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
             category: "telemetry".into(),
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
-        },
+        }),
         None,
     );
 
@@ -144,14 +144,14 @@ fn can_use_multiple_labels() {
 #[test]
 fn labels_are_checked_against_static_list() {
     let (glean, _t) = new_glean();
-    let mut labeled: LabeledMetric<CounterMetric> = LabeledMetric::new(
-        CommonMetricData {
+    let mut labeled = LabeledMetric::new(
+        CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
             category: "telemetry".into(),
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
-        },
+        }),
         Some(vec!["label1".into(), "label2".into()]),
     );
 
@@ -188,14 +188,14 @@ fn labels_are_checked_against_static_list() {
 #[test]
 fn dynamic_labels_too_long() {
     let (glean, _t) = new_glean();
-    let mut labeled: LabeledMetric<CounterMetric> = LabeledMetric::new(
-        CommonMetricData {
+    let mut labeled = LabeledMetric::new(
+        CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
             category: "telemetry".into(),
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
-        },
+        }),
         None,
     );
 
@@ -221,14 +221,14 @@ fn dynamic_labels_too_long() {
 #[test]
 fn dynamic_labels_regex_mimsatch() {
     let (glean, _t) = new_glean();
-    let mut labeled: LabeledMetric<CounterMetric> = LabeledMetric::new(
-        CommonMetricData {
+    let mut labeled = LabeledMetric::new(
+        CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
             category: "telemetry".into(),
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
-        },
+        }),
         None,
     );
 


### PR DESCRIPTION
This has the overhead of storing a metric instance per labeled metric.
However, these should be rather small.

And on the upside this allows us to store metric-type-specific data
(e.g. the time unit for DateTime) for that metric only instead of inside
the common metric data.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
