### PR TITLE
Bump the string length limit to 100 characters to match glean-ac

### DIFF
--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -9,7 +9,7 @@ use crate::storage::StorageManager;
 use crate::CommonMetricData;
 use crate::Glean;
 
-const MAX_LENGTH_VALUE: usize = 50;
+const MAX_LENGTH_VALUE: usize = 100;
 
 #[derive(Clone, Debug)]
 pub struct StringMetric {

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -97,10 +97,7 @@ fn long_string_values_are_truncated() {
     });
 
     let test_sting = "01234567890".repeat(20);
-    metric.set(
-        &glean,
-        test_sting.clone(),
-    );
+    metric.set(&glean, test_sting.clone());
 
     // Check that data was truncated
     assert_eq!(

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -96,14 +96,15 @@ fn long_string_values_are_truncated() {
         lifetime: Lifetime::Ping,
     });
 
+    let test_sting = "01234567890".repeat(20);
     metric.set(
         &glean,
-        "0123456789012345678901234567890123456789012345678901234567890123456789",
+        test_sting.clone(),
     );
 
     // Check that data was truncated
     assert_eq!(
-        "01234567890123456789012345678901234567890123456789",
+        test_sting[..100],
         metric.test_get_value(&glean, "store1").unwrap()
     );
 


### PR DESCRIPTION
This is about to land in glean-ac too. Let's not merge it until mozilla-mobile/android-components#3236 is merged.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
