### PR TITLE
1556486: Output logging from Android tests

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -62,6 +62,14 @@ android {
 
     // Uncomment to include debug symbols in native library builds.
     // packagingOptions { doNotStrip "**/*.so" }
+
+    testOptions {
+        unitTests.all {
+            testLogging {
+                showStandardStreams = true
+            }
+        }
+    }
 }
 
 configurations {


### PR DESCRIPTION
This does (more-or-less) what android-components does to get logging messages out from running the Android tests.  This will make it easier to diagnose what's going on when tests fail in CI.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
