### PR TITLE
Implement sequence numbers as a counter

### DIFF
--- a/docs/dev/core/internal.md
+++ b/docs/dev/core/internal.md
@@ -19,3 +19,12 @@ When re-enabling metrics:
 - Application lifetime metrics owned by Glean are regenerated from scratch so that they will appear in subsequent pings. This is the same process that happens during every startup of the application when Glean is enabled. The application is also responsible for setting any application lifetime metrics that it manages at this time.
 
 - Ping lifetime metrics do not need special handling.  They will begin recording again after metric uploading is re-enabled.
+
+## Reservered ping names
+
+The Glean SDK reserves all ping names starting with `glean_`.
+
+This currently includes, but is not limited to:
+
+* `glean_client_info`
+* `glean_internal_info`

--- a/glean-core/examples/sample.rs
+++ b/glean-core/examples/sample.rs
@@ -63,11 +63,10 @@ fn main() {
 
     let ping_maker = PingMaker::new();
     let ping = ping_maker
-        .collect_string(glean.storage(), glean.get_ping_by_name("baseline").unwrap())
+        .collect_string(&glean, glean.get_ping_by_name("baseline").unwrap())
         .unwrap();
     println!("Baseline Ping:\n{}", ping);
 
-    let ping =
-        ping_maker.collect_string(glean.storage(), glean.get_ping_by_name("metrics").unwrap());
+    let ping = ping_maker.collect_string(&glean, glean.get_ping_by_name("metrics").unwrap());
     println!("Metrics Ping: {:?}", ping);
 }

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -462,7 +462,7 @@ pub extern "C" fn glean_ping_collect(glean_handle: u64, ping_type_handle: u64) -
         let res: glean_core::Result<String> = PING_TYPES.get_u64(ping_type_handle, |ping_type| {
             let ping_maker = glean_core::ping::PingMaker::new();
             let data = ping_maker
-                .collect_string(glean.storage(), ping_type)
+                .collect_string(glean, ping_type)
                 .unwrap_or_else(|| String::from(""));
             log::info!("Ping({}): {}", ping_type.name.as_str(), data);
             Ok(data)

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -138,7 +138,7 @@ impl Glean {
         let ping_maker = PingMaker::new();
         let doc_id = Uuid::new_v4().to_string();
         let url_path = self.make_path(&ping.name, &doc_id);
-        match ping_maker.collect(self.storage(), &ping) {
+        match ping_maker.collect(self, &ping) {
             None => {
                 log::info!(
                     "No content for ping '{}', therefore no ping queued.",

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -35,7 +35,7 @@ fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
 fn ping_info_must_contain_a_nonempty_start_and_end_time() {
     let (glean, ping_maker, ping_type, _t) = set_up_basic_ping();
 
-    let content = ping_maker.collect(glean.storage(), &ping_type).unwrap();
+    let content = ping_maker.collect(&glean, &ping_type).unwrap();
     let ping_info = content["ping_info"].as_object().unwrap();
 
     let start_time_str = ping_info["start_time"].as_str().unwrap();
@@ -51,7 +51,7 @@ fn ping_info_must_contain_a_nonempty_start_and_end_time() {
 fn get_ping_info_must_report_all_the_required_fields() {
     let (glean, ping_maker, ping_type, _t) = set_up_basic_ping();
 
-    let content = ping_maker.collect(glean.storage(), &ping_type).unwrap();
+    let content = ping_maker.collect(&glean, &ping_type).unwrap();
     let ping_info = content["ping_info"].as_object().unwrap();
 
     assert_eq!("store1", ping_info["ping_type"].as_str().unwrap());
@@ -64,7 +64,7 @@ fn get_ping_info_must_report_all_the_required_fields() {
 fn get_client_info_must_report_all_the_available_data() {
     let (glean, ping_maker, ping_type, _t) = set_up_basic_ping();
 
-    let content = ping_maker.collect(glean.storage(), &ping_type).unwrap();
+    let content = ping_maker.collect(&glean, &ping_type).unwrap();
     let client_info = content["client_info"].as_object().unwrap();
 
     client_info["telemetry_sdk_build"].as_str().unwrap();
@@ -84,9 +84,7 @@ fn collect_must_report_none_when_no_data_is_stored() {
     let unknown_ping_type = PingType::new("unknown", true);
     glean.register_ping_type(&ping_type);
 
-    assert!(ping_maker
-        .collect(glean.storage(), &unknown_ping_type)
-        .is_none());
+    assert!(ping_maker.collect(&glean, &unknown_ping_type).is_none());
 }
 
 #[test]
@@ -106,7 +104,7 @@ fn seq_number_must_be_sequential() {
     for i in 0..=1 {
         for ping_name in ["store1", "store2"].iter() {
             let ping_type = PingType::new(*ping_name, true);
-            let content = ping_maker.collect(glean.storage(), &ping_type).unwrap();
+            let content = ping_maker.collect(&glean, &ping_type).unwrap();
             let seq_num = content["ping_info"]["seq"].as_i64().unwrap();
             // Ensure sequence numbers in different stores are independent of
             // each other

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -88,7 +88,6 @@ fn collect_must_report_none_when_no_data_is_stored() {
 }
 
 #[test]
-#[ignore] // sequence numbers aren't implemented
 fn seq_number_must_be_sequential() {
     let (glean, ping_maker, _ping_type, _t) = set_up_basic_ping();
 
@@ -110,5 +109,38 @@ fn seq_number_must_be_sequential() {
             // each other
             assert_eq!(i, seq_num);
         }
+    }
+
+    // Test that ping sequence numbers increase independently.
+    {
+        let ping_type = PingType::new("store1", true);
+
+        // 3rd ping of store1
+        let content = ping_maker.collect(&glean, &ping_type).unwrap();
+        let seq_num = content["ping_info"]["seq"].as_i64().unwrap();
+        assert_eq!(2, seq_num);
+
+        // 4th ping of store1
+        let content = ping_maker.collect(&glean, &ping_type).unwrap();
+        let seq_num = content["ping_info"]["seq"].as_i64().unwrap();
+        assert_eq!(3, seq_num);
+    }
+
+    {
+        let ping_type = PingType::new("store2", true);
+
+        // 3rd ping of store2
+        let content = ping_maker.collect(&glean, &ping_type).unwrap();
+        let seq_num = content["ping_info"]["seq"].as_i64().unwrap();
+        assert_eq!(2, seq_num);
+    }
+
+    {
+        let ping_type = PingType::new("store1", true);
+
+        // 5th ping of store1
+        let content = ping_maker.collect(&glean, &ping_type).unwrap();
+        let seq_num = content["ping_info"]["seq"].as_i64().unwrap();
+        assert_eq!(4, seq_num);
     }
 }


### PR DESCRIPTION
Sequence numbers are stored as a counter under a name that includes the storage name:

    <storage name>#sequence

Everything is stored in the special `glean.internal` storage.
This is not used for anything else.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
