### PR TITLE
Implement start_time/end_time for pings

### DIFF
--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -108,6 +108,31 @@ impl DatetimeMetric {
         glean.storage().record(&self.meta, &value)
     }
 
+    /// Get the stored datetime value.
+    ///
+    /// ## Arguments
+    ///
+    /// * `glean` - the Glean instance this metric belongs to.
+    /// * `storage_name` - the storage name to look into.
+    ///
+    /// ## Return value
+    ///
+    /// Returns the stored value or `None` if nothing stored.
+    pub(crate) fn get_value(
+        &self,
+        glean: &Glean,
+        storage_name: &str,
+    ) -> Option<DateTime<FixedOffset>> {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta().identifier(),
+        ) {
+            Some(Metric::Datetime(dt, _)) => Some(dt),
+            _ => None,
+        }
+    }
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Get the currently stored value as a String.

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use chrono::{DateTime, FixedOffset};
+use chrono::offset::TimeZone;
+use chrono::{DateTime, FixedOffset, Local};
 
 use crate::metrics::TimeUnit;
 
@@ -41,10 +42,21 @@ pub fn get_iso_time_string(datetime: DateTime<FixedOffset>, truncate_to: TimeUni
     datetime.format(truncate_to.format_pattern()).to_string()
 }
 
+/// Get the current date & time with a fixed-offset timezone.
+///
+/// This converts from the `Local` timezone into its fixed-offset equivalent.
+pub(crate) fn local_now_with_offset() -> DateTime<FixedOffset> {
+    // This looks more complicated than I imagined.
+
+    let now: DateTime<Local> = Local::now();
+    let naive = now.naive_utc();
+    let fixed_tz = Local.offset_from_utc_datetime(&naive);
+    fixed_tz.from_utc_datetime(&naive)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
-    use chrono::prelude::*;
 
     #[test]
     fn test_sanitize_application_id() {
@@ -93,5 +105,20 @@ mod test {
             get_iso_time_string(dt, TimeUnit::Hour)
         );
         assert_eq!("1985-07-03+01:00", get_iso_time_string(dt, TimeUnit::Day));
+    }
+
+    #[test]
+    fn local_now_gets_the_time() {
+        let now = Local::now();
+        let fixed_now = local_now_with_offset();
+
+        // We can't compare across differing timezones, so we just compare the UTC timestamps.
+        // The second timestamp should be just a few nanoseconds later.
+        assert!(
+            fixed_now.naive_utc() >= now.naive_utc(),
+            "Time mismatch. Local now: {:?}, Fixed now: {:?}",
+            now,
+            fixed_now
+        );
     }
 }


### PR DESCRIPTION
Implement start and end times for pings

The start time can be stored and persisted as a datetime metric.
The end time is only ever needed in-memory for the moment the ping is
assembled and stored.

We also store the object creation time in the Glean object itself (which
is used as the first start time), because:

* that was the easy way
* glean-ac does something similar (storing it in the PingMaker object)
* we don't have global metrics in the core library itself on which we
  could just set the date
