### PR TITLE
Rename tz -> time_unit to avoid confusion with timezone

### DIFF
--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -66,7 +66,7 @@ impl Metric {
         match self {
             Metric::Boolean(b) => json!(b),
             Metric::Counter(c) => json!(c),
-            Metric::Datetime(d, tz) => json!(get_iso_time_string(*d, *tz)),
+            Metric::Datetime(d, time_unit) => json!(get_iso_time_string(*d, *time_unit)),
             Metric::String(s) => json!(s),
             Metric::StringList(v) => json!(v),
             Metric::Uuid(s) => json!(s),


### PR DESCRIPTION
Suggesting a small change that I missed in review.

The variable name `tz` feels very much like "timezone" to me, particularly given the context here of date times.  It actually confused me when I was trying to document this for 1552774, so thought maybe I'd just change it...?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
