### PR TITLE
Correctly set first_run_date as a datetime metric

### DIFF
--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -7,7 +7,7 @@ use super::{metrics::*, CommonMetricData, Lifetime};
 #[derive(Debug)]
 pub struct CoreMetrics {
     pub client_id: UuidMetric,
-    pub first_run_date: StringMetric,
+    pub first_run_date: DatetimeMetric,
 }
 
 impl CoreMetrics {
@@ -21,14 +21,16 @@ impl CoreMetrics {
                 disabled: false,
             }),
 
-            // TODO: this should really be a "DatetimeType".
-            first_run_date: StringMetric::new(CommonMetricData {
-                name: "first_run_date".into(),
-                category: "".into(),
-                send_in_pings: vec!["glean_client_info".into()],
-                lifetime: Lifetime::User,
-                disabled: false,
-            }),
+            first_run_date: DatetimeMetric::new(
+                CommonMetricData {
+                    name: "first_run_date".into(),
+                    category: "".into(),
+                    send_in_pings: vec!["glean_client_info".into()],
+                    lifetime: Lifetime::User,
+                    disabled: false,
+                },
+                TimeUnit::Day,
+            ),
         }
     }
 }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -72,9 +72,7 @@ impl Glean {
 
     fn initialize_core_metrics(&mut self) -> Result<()> {
         if first_run::is_first_run(&self.data_path)? {
-            self.core_metrics
-                .first_run_date
-                .set(self, "2019-05-09-04:00");
+            self.core_metrics.first_run_date.set(self, None);
         }
         self.core_metrics.client_id.generate_if_missing(self);
         Ok(())

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -93,7 +93,7 @@ impl PingMaker {
         let end_time_data = local_now_with_offset();
 
         // Update the start time with the current time.
-        start_time.set(glean, end_time_data);
+        start_time.set(glean, Some(end_time_data));
 
         // Format the times.
         let start_time_data = get_iso_time_string(start_time_data, time_unit);

--- a/glean-core/tests/datetime.rs
+++ b/glean-core/tests/datetime.rs
@@ -37,7 +37,7 @@ fn datetime_serializer_should_correctly_serialize_datetime() {
         let dt = FixedOffset::east(0)
             .ymd(1983, 4, 13)
             .and_hms_milli(12, 9, 14, 274);
-        metric.set(&glean, dt);
+        metric.set(&glean, Some(dt));
 
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
@@ -82,7 +82,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
     let dt = FixedOffset::east(0)
         .ymd(1983, 4, 13)
         .and_hms_nano(12, 9, 14, 1_560_274);
-    metric.set(&glean, dt);
+    metric.set(&glean, Some(dt));
 
     for store_name in store_names {
         assert_eq!(
@@ -168,7 +168,7 @@ fn test_that_truncation_works() {
             },
             t.desired_resolution,
         );
-        metric.set(&glean, high_res_datetime);
+        metric.set(&glean, Some(high_res_datetime));
 
         assert_eq!(
             t.expected_result,


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
