### PR TITLE
Update TestUtil.triggerWorkManager to remove workaround

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -128,7 +128,7 @@ class GleanTest {
     @Test
     fun `sending an empty ping doesn't queue work`() {
         Glean.sendPings(listOf(Pings.metrics))
-        assertFalse(isWorkScheduled(PingUploadWorker.PING_WORKER_TAG))
+        assertFalse(getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 
     // Tests from glean-ac (706af1f).
@@ -302,7 +302,7 @@ class GleanTest {
         runBlocking {
             gleanSpy.handleBackgroundEvent()
         }
-        assertFalse(isWorkScheduled(PingUploadWorker.PING_WORKER_TAG))
+        assertFalse(getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 
     @Test
@@ -312,7 +312,7 @@ class GleanTest {
         runBlocking {
             Glean.handleBackgroundEvent()
         }
-        assertFalse(isWorkScheduled(PingUploadWorker.PING_WORKER_TAG))
+        assertFalse(getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 
     @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -8,7 +8,7 @@ import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.checkPingSchema
 import mozilla.telemetry.glean.getContextWithMockedInfo
 import mozilla.telemetry.glean.getMockWebServer
-import mozilla.telemetry.glean.isWorkScheduled
+import mozilla.telemetry.glean.getWorkerStatus
 import mozilla.telemetry.glean.resetGlean
 import mozilla.telemetry.glean.scheduler.PingUploadWorker
 import mozilla.telemetry.glean.triggerWorkManager
@@ -131,7 +131,7 @@ class PingTypeTest {
         Glean.sendPingsByName(listOf("unknown"))
 
         assertFalse("We shouldn't have any pings scheduled",
-            isWorkScheduled(PingUploadWorker.PING_WORKER_TAG)
+            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued
         )
     }
 


### PR DESCRIPTION
Since updating to WorkManager dependency 2.0.1, we are now able to properly run WorkManager in tests using TestDriver.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
