### PR TITLE
1557734: Reinstate dependency instructions

### DIFF
--- a/docs/user/adding-glean-to-your-project.md
+++ b/docs/user/adding-glean-to-your-project.md
@@ -12,13 +12,12 @@ Products using Glean to collect telemetry **must**:
 
 ### Setting up the dependency
 
-TODO: 1556494 
-<!-- Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/)  -->
-<!-- ([Setup repository](../../../README.md#maven-repository)): -->
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/)
+([Setup repository](../../../README.md#maven-repository)):
 
-<!-- ```Groovy -->
-<!-- implementation "org.mozilla.components:service-glean:{latest-version}" -->
-<!-- ``` -->
+```Groovy
+implementation "org.mozilla.components:service-glean:{latest-version}"
+```
 
 ### Integrating with the build system
 


### PR DESCRIPTION
These are the correct and current dependency instructions for glean-ac, which are likely to remain the same even when glean-ac becomes a wrapper around glean-core.  So I'm just uncommenting this back in preparation for removing most of the docs in glean-ac and linking to the docs here.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
