### PR TITLE
Name the Glean SDK more clearly vs. the Glean project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All documentation is available online:
 
 ## Overview
 
-This repository is used to build the client-side cross-platform Telemetry library called the `Glean SDK`.
+This repository is used to build the client-side cross-platform Telemetry library part of [Glean](https://docs.telemetry.mozilla.org/concepts/glean/glean.html), called the `Glean SDK`.
 
 The code is organized as follows:
 
@@ -34,6 +34,8 @@ This repository also hosts the documentation for the `Glean SDK`:
 * [The Glean SDK book][book] - Documentation on using and developing Glean SDK.
 * [Documentation of the Rust crate][rustdoc].
 * [Documentation of the Kotlin library][ktdoc].
+
+For an overview of Glean, see the [section in the Firefox data docs](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ _Modern Firefox Telemetry for mobile platforms_
 
 ---
 
-**Note: This new approach for Glean is currently in development and not yet ready for use.
-The working and supported library is [Glean in android-components][glean-ac].**
+**Note: This new approach for the Glean SDK is currently in development and not yet ready for use.
+The working and supported library is the [Glean SDK in android-components][glean-ac].**
 
 ---
 
@@ -16,11 +16,11 @@ The working and supported library is [Glean in android-components][glean-ac].**
 
 All documentation is available online:
 
-## [The Glean Book][book]
+## [The Glean SDK Book][book]
 
 ## Overview
 
-This repository is used to build the client-side cross-platform Telemetry library called `Glean`.
+This repository is used to build the client-side cross-platform Telemetry library called the `Glean SDK`.
 
 The code is organized as follows:
 
@@ -29,9 +29,9 @@ The code is organized as follows:
 * [./glean-core/android](glean-core/android) contains the Kotlin bindings for use by Android applications.
 * [./glean-core/ios](glean-core/ios) contains the Swift bindings for use by iOS applications.
 
-This repository also hosts the documentation for `Glean`:
+This repository also hosts the documentation for the `Glean SDK`:
 
-* [The Glean book][book] - Documentation on using and developing Glean.
+* [The Glean SDK book][book] - Documentation on using and developing Glean SDK.
 * [Documentation of the Rust crate][rustdoc].
 * [Documentation of the Kotlin library][ktdoc].
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,18 +4,18 @@
 
 _Modern Firefox Telemetry for mobile platforms_
 
-`Glean` is a modern approach for a mobile Telemetry library.
+The `Glean SDK` is a modern approach for a mobile Telemetry library.
 It started out as an [android-components library](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean), written purely in Kotlin to be used on Android.
 
-`Glean` is a work-in-progress to transform the concepts behind `Glean` into a cross-platform library based on a low-level [Rust](https://www.rust-lang.org/) library and the necessary platform integrations for Android and iOS (and beyond...).
+The `Glean SDK` is a work-in-progress to transform the concepts behind the `Glean SDK` into a cross-platform library based on a low-level [Rust](https://www.rust-lang.org/) library and the necessary platform integrations for Android and iOS (and beyond...).
 
-**Note: The cross-platform `Glean` project is in development. It's not finished, and not used. Some of this documentation refers to features that were implemented in an earlier Android-specific version of Glean, but are not yet implemented in this version.**
+**Note: The cross-platform `Glean SDK` project is in development. It's not finished, and not used. Some of this documentation refers to features that were implemented in an earlier Android-specific version of the Glean SDK, but are not yet implemented in this version.**
 
 To contact us you can:
 - Find us on the Mozilla Slack in *#glean*, on [Mozilla IRC](https://wiki.mozilla.org/IRC) in *#telemetry*.
 - To report issues or request changes, file a bug in [Bugzilla in Data Platform & Tools :: Glean: SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=Glean%3A%20SDK).
 - Send an email to *glean-team@mozilla.com*.
-- The Glean team is: *:janerik*, *:dexter*, *:travis*, *:mdroettboom*, *:gfritzsche*, *:chutten*
+- The Glean SDK team is: *:janerik*, *:dexter*, *:travis*, *:mdroettboom*, *:gfritzsche*, *:chutten*
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 _Modern Firefox Telemetry for mobile platforms_
 
-The `Glean SDK` is a modern approach for a mobile Telemetry library.
+The `Glean SDK` is a modern approach for a mobile Telemetry library and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
 It started out as an [android-components library](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean), written purely in Kotlin to be used on Android.
 
 The `Glean SDK` is a work-in-progress to transform the concepts behind the `Glean SDK` into a cross-platform library based on a low-level [Rust](https://www.rust-lang.org/) library and the necessary platform integrations for Android and iOS (and beyond...).


### PR DESCRIPTION
I called the Glean library out more clearly as the *"Glean SDK"*, to make clear that this is the client-side of the end-to-end *"Glean project"*.

I also linked back to the overview article on fx-data-docs.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
