### PR TITLE
Fix showing "not implemented" status in docs

### DIFF
--- a/docs/user/debugging.md
+++ b/docs/user/debugging.md
@@ -1,7 +1,5 @@
 # Debugging products using Glean
 
-**STATUS: [Not implemented](https://bugzilla.mozilla.org/show_bug.cgi?id=1554116)**
-
 Glean exports the `GleanDebugActivity` that can be used to toggle debugging features on or off. 
 Users can invoke this special activity, at run-time, using the following [`adb`](https://developer.android.com/studio/command-line/adb) command:
 

--- a/docs/user/metrics/datetime.md
+++ b/docs/user/metrics/datetime.md
@@ -1,7 +1,5 @@
 # Datetime
 
-**STATUS: Not implemented.**
-
 Datetimes are used to record an absolute date and time, for example the date and time that the application was first run.
 
 The device's offset from UTC is recorded and sent with the datetime value in the ping.

--- a/docs/user/metrics/event.md
+++ b/docs/user/metrics/event.md
@@ -1,7 +1,5 @@
 # Events
 
-**Status: [Not implemented.](https://bugzilla.mozilla.org/show_bug.cgi?id=1552872)**
-
 Events allow recording of e.g. individual occurences of user actions, say every time a view was open and from where. Each time you record an event, it records a
 timestamp, the event's name and a set of custom values.
 

--- a/docs/user/metrics/timespan.md
+++ b/docs/user/metrics/timespan.md
@@ -1,7 +1,5 @@
 # Timespan
 
-**STATUS: [Not implemented.](https://bugzilla.mozilla.org/show_bug.cgi?id=1552863)**
-
 Timespans are used to make a summed measurement of how much time is spent in a particular task. 
 
 To measure the distribution of multiple timespans, see [Timing Distributions](timing_distribution.md). To record absolute times, see [Datetimes](datetime.md).

--- a/docs/user/metrics/timing_distribution.md
+++ b/docs/user/metrics/timing_distribution.md
@@ -1,7 +1,5 @@
 # Timing Distribution
 
-**STATUS: [Not implemented.](https://bugzilla.mozilla.org/show_bug.cgi?id=1552865)**
-
 Timing distributions are used to accumulate and store time measurement, for analyzing distributions of the timing data.
 
 To measure the distribution of multiple timespans, see [Timing Distributions](timing_distribution.md). To record absolute times, see [Datetimes](datetime.md).

--- a/docs/user/metrics/uuid.md
+++ b/docs/user/metrics/uuid.md
@@ -1,7 +1,5 @@
 # UUID
 
-**STATUS: [Not implemented.](https://bugzilla.mozilla.org/show_bug.cgi?id=1552870)**
-
 UUIDs are used to record values that uniquely identify some entity, such as a client id.
 
 ## Configuration

--- a/docs/user/pings/events.md
+++ b/docs/user/pings/events.md
@@ -1,7 +1,5 @@
 # The `events` ping
 
-**STATUS: [Not implemented.](https://bugzilla.mozilla.org/show_bug.cgi?id=1552872)**
-
 ## Description
 The events ping's purpose is to transport all of the event metric information.
 

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -56,8 +56,6 @@ All the metrics surviving application restarts (e.g. `client_id`, ...) are remov
 
 ### The `experiments` object
 
-**STATUS: Not implemented.**
-
 This object (included in the [`ping_info` section](#The-ping_info-section)) contains experiments keyed by the experiment `id`. Each listed experiment contains the `branch` the client is enrolled in and may contain a string to string map with additional data in the `extra` key. Both the `id` and `branch` are truncated to 30 characters.
 
 ```json

--- a/docs/user/pings/metrics.md
+++ b/docs/user/pings/metrics.md
@@ -1,7 +1,5 @@
 # The `metrics** ping
 
-**STATUS: [Not implemented.](https://bugzilla.mozilla.org/show_bug.cgi?id=1551159)**
-
 ## Description
 The `metrics` ping is intended for all of the metrics that are explicitly set by the application or are included in the application's `metrics.yaml` file (except events). 
 The reported data is tied to the ping's *measurement window*, which is the time between the collection of two `metrics` ping. 


### PR DESCRIPTION
The current docs show *"status: not implemented"* for a few features (metrics, pings, debug activity).
However, we now point from android-components to these docs as the main docs, so this is misleading.

We should prioritize providing correct and helpful docs for the a-c glean sdk, as this is actively getting used.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
