### PR TITLE
Remove GCP ping redirection

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -65,7 +65,6 @@ data class Configuration internal constructor(
 
     companion object {
         const val DEFAULT_TELEMETRY_ENDPOINT = "https://incoming.telemetry.mozilla.org"
-        const val DEFAULT_DEBUGVIEW_ENDPOINT = "https://stage.ingestion.nonprod.dataops.mozgcp.net"
         const val DEFAULT_USER_AGENT = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)"
         const val DEFAULT_CONNECTION_TIMEOUT = 10000L
         const val DEFAULT_READ_TIMEOUT = 30000L

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/net/HttpPingUploader.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/net/HttpPingUploader.kt
@@ -88,17 +88,12 @@ internal open class HttpPingUploader : PingUploader {
             "X-Client-Version" to BuildConfig.LIBRARY_VERSION
         )
 
-        var endpoint = config.serverEndpoint
+        val endpoint = config.serverEndpoint
 
         // If there is a pingTag set, then this header needs to be added in order to flag pings
         // for "debug view" use.
         config.pingTag?.let {
             headers.append("X-Debug-ID", it)
-
-            // NOTE: Tagged pings must be redirected to the GCP endpoint as the AWS endpoint isn't
-            // configured to handle them.  This may pose an issue with testing if a local server
-            // is used to capture pings.
-            endpoint = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT
         }
 
         return Request(

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -237,7 +237,7 @@ internal fun triggerWorkManager() {
  * This is a helper class to facilitate testing of ping tagging
  */
 internal class TestPingTagClient(
-    private val responseUrl: String = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT,
+    private val responseUrl: String = Configuration.DEFAULT_TELEMETRY_ENDPOINT,
     private val responseStatus: Int = 200,
     private val responseHeaders: Headers = MutableHeaders(),
     private val responseBody: Response.Body = Response.Body.empty(),

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -204,10 +204,9 @@ class GleanDebugActivityTest {
     fun `pings are correctly tagged using tagPings`() {
         val pingTag = "test-debug-ID"
 
-        // The TestClient class found at the bottom of this file is used to intercept the request
-        // in order to check that the header has been added and the URL has been redirected.
+        // The TestClient class found in TestUtil is used to intercept the request in order to check
+        // that the header has been added correctly for the tagged ping.
         val testClient = TestPingTagClient(
-            responseUrl = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT,
             debugHeaderValue = pingTag)
 
         // Use the test client in the Glean configuration

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/net/HttpPingUploaderTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/net/HttpPingUploaderTest.kt
@@ -10,7 +10,6 @@ import mozilla.components.concept.fetch.Response
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.lib.fetch.okhttp.OkHttpClient
 import mozilla.telemetry.glean.BuildConfig
-import mozilla.telemetry.glean.TestPingTagClient
 import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.getMockWebServer
 import mozilla.components.support.test.any
@@ -287,27 +286,5 @@ class HttpPingUploaderTest {
 
         val request = uploader.buildRequest(testPath, testPing, debugConfig)
         assertEquals("this-ping-is-tagged", request.headers!!["X-Debug-ID"])
-    }
-
-    @Test
-    fun `server is correctly redirected when pings are tagged`() {
-        val pingTag = "this-ping-is-tagged"
-
-        // The TestClient class found at the bottom of this file is used to intercept the request
-        // in order to check that the header has been added and the URL has been redirected.
-        val testClient = TestPingTagClient(
-            responseUrl = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT,
-            debugHeaderValue = pingTag)
-
-        // Use the test client in the Glean configuration
-        val testConfig = testDefaultConfig.copy(
-            httpClient = lazy { testClient },
-            pingTag = pingTag
-        )
-
-        // This should trigger the call to `fetch()` within the TestPingTagClient which will perform
-        // both a check against the url and that a header was added.
-        val client = HttpPingUploader()
-        assertTrue(client.upload(testPath, testPing, testConfig))
     }
 }


### PR DESCRIPTION
This removes the GCP ping redirection, in parallel with the glean-ac change [here](https://github.com/mozilla-mobile/android-components/pull/3343)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
