### PR TITLE
1559133: Make landing page less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@
 
 _Modern telemetry for mobile platforms_
 
-
----
-
-**Note: This new approach for the Glean SDK is currently in development and not yet ready for use.
-The working and supported library is the [Glean SDK in android-components][glean-ac].**
-
----
-
 ## Documentation
 
 All documentation is available online:
@@ -20,22 +12,21 @@ All documentation is available online:
 
 ## Overview
 
-This repository is used to build the client-side cross-platform Telemetry library part of [Glean](https://docs.telemetry.mozilla.org/concepts/glean/glean.html), called the `Glean SDK`.
+Refer to the documentation for [using and developing the Glean SDK](book).
 
-The code is organized as follows:
+For an overview of Glean beyond just the SDK, see the [section in the Firefox data docs](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
+
+There currently two independent implementations of the Glean SDK:
+
+- An Android-only implementation in [android-components](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean).
+- A [cross-platform implementation](https://github.com/mozilla/glean/). (This implementation is currently under development and not ready for use).
+
+The code in this repository for the cross-platform implementation is organized as follows:
 
 * [./glean-core/](glean-core) contains the source for the low-level Rust library.
 * [./glean-core/ffi](glean-core/ffi) contains the mapping into a C FFI.
 * [./glean-core/android](glean-core/android) contains the Kotlin bindings for use by Android applications.
 * [./glean-core/ios](glean-core/ios) contains the Swift bindings for use by iOS applications.
-
-This repository also hosts the documentation for the `Glean SDK`:
-
-* [The Glean SDK book][book] - Documentation on using and developing Glean SDK.
-* [Documentation of the Rust crate][rustdoc].
-* [Documentation of the Kotlin library][ktdoc].
-
-For an overview of Glean, see the [section in the Firefox data docs](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
 
 ## Contact
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,11 @@
 _Modern telemetry for mobile platforms_
 
 The `Glean SDK` is a modern approach for a mobile Telemetry library and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
-It started out as an [android-components library](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean), written purely in Kotlin to be used on Android.
 
-The `Glean SDK` is a work-in-progress to transform the concepts behind the `Glean SDK` into a cross-platform library based on a low-level [Rust](https://www.rust-lang.org/) library and the necessary platform integrations for Android and iOS (and beyond...).
+There currently two independent implementations of the Glean SDK, both sharing the documentation here:
 
-**Note: The cross-platform `Glean SDK` project is in development. It's not finished, and not used. Some of this documentation refers to features that were implemented in an earlier Android-specific version of the Glean SDK, but are not yet implemented in this version.**
+- An Android-only implementation in [android-components](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean).
+- A [cross-platform implementation](https://github.com/mozilla/glean/).  (This implementation is currently under development and not ready for use).
 
 To contact us you can:
 - Find us on the Mozilla Slack in *#glean*, on [Mozilla IRC](https://wiki.mozilla.org/IRC) in *#telemetry*.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,7 @@
 # Contributing to the Glean SDK
 
+> **Note:** This document describes contributing to the cross-platform implementation of the Glean SDK. To contribute to the Android-specific implementation, see [android-components](https://github.com/mozilla-mobile/android-components).
+
 Anyone is welcome to help with the Glean SDK project. Feel free to get in touch with other community members on IRC
 or through issues here on GitHub.
 

--- a/docs/dev/android/setup-android-build-environment.md
+++ b/docs/dev/android/setup-android-build-environment.md
@@ -1,5 +1,7 @@
 # Setup the Android Build Environment
 
+> **Important:** This documentation refers to setting up the development environment for the [cross-platform implementation of the Glean SDK](https://github.com/mozilla/glean).  Instructions for setting up the implementation in android-components is documented in the [android-components repository](https://github.com/mozilla-mobile/android-components).
+
 ## Doing a local build of the Android Components:
 
 This document describes how to make local builds of the Android components in

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,5 +1,7 @@
 # Running the tests
 
+> **Note:** This document describes testing the cross-platform implementation of the Glean SDK. For information about testing Android-specific implementation, see [android-components](https://github.com/mozilla-mobile/android-components).
+
 ## Running all tests
 
 The tests for all languages may be run from the command line:

--- a/docs/user/debugging.md
+++ b/docs/user/debugging.md
@@ -12,11 +12,11 @@ In the above:
 - `[extra keys]` is a list of extra keys to be passed to the debug activity. See the [documentation](https://developer.android.com/studio/command-line/adb#IntentSpec) for the command line switches used to pass the extra keys. 
   These are the currently supported keys:
 
-    |key|type|description|
-    |---|----|-----------|
-    | logPings | boolean (--ez) | If set to `true`, pings are dumped to logcat; defaults to `false` |
-    | sendPing | string (--es) | Sends the ping with the given name immediately |
-    | tagPings | string (--es) | Tags all outgoing pings as debug pings to make them available for real-time validation. The value must match the pattern `[a-zA-Z0-9-]{1,20}` |
+|key|type|description|
+|---|----|-----------|
+| logPings | boolean (--ez) | If set to `true`, pings are dumped to logcat; defaults to `false` |
+| sendPing | string (--es) | Sends the ping with the given name immediately |
+| tagPings | string (--es) | Tags all outgoing pings as debug pings to make them available for real-time validation. The value must match the pattern `[a-zA-Z0-9-]{1,20}` |
 
 For example, to direct a release build of the Glean sample application to (1) dump pings to logcat, (2) tag the ping with the `test-metrics-ping` tag, and (3) send the "metrics" ping immediately, the following command can be used:
 


### PR DESCRIPTION
This should make the docs make sense whether the reader is coming for glean-ac or glean-core.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
