### PR TITLE
Don't use the gradle daemon in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,8 @@ jobs:
       - image: circleci/android:api-28-ndk
     steps:
       - checkout
-      - run: ./gradlew ktlint
-      - run: ./gradlew detekt
+      - run: ./gradlew --no-daemon ktlint
+      - run: ./gradlew --no-daemon detekt
 
   Android tests:
     docker:
@@ -126,7 +126,7 @@ jobs:
       - android-setup
       - run:
           name: Android tests
-          command: ./gradlew test
+          command: ./gradlew --no-daemon test
       - store_artifacts:
           path: glean-core/android/build/reports/tests
 
@@ -162,7 +162,7 @@ jobs:
       - android-setup
       - run:
           name: Build Kotlin documentation
-          command: ./gradlew docs
+          command: ./gradlew --no-daemon docs
       - persist_to_workspace:
           root: build/
           paths: docs/javadoc


### PR DESCRIPTION
According to online resources using the gradle daemon means we might run into memory issues already.
Not using it is a first step.
Next one would be to tell the JVM to start with less heap to begin with.

https://support.circleci.com/hc/en-us/articles/115014359648-Exit-code-137-Out-of-memory
https://stackoverflow.com/questions/38967991/why-are-my-gradle-builds-dying-with-exit-code-137

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
