### PR TITLE
Use created temporary directory

### DIFF
--- a/glean-core/src/error.rs
+++ b/glean-core/src/error.rs
@@ -32,19 +32,19 @@ pub enum ErrorKind {
     Lifetime(i32),
 
     /// FFI-Support error
-    #[fail(display = "Invalid handle")]
+    #[fail(display = "Invalid handle: {}", _0)]
     Handle(HandleError),
 
     /// IO error
-    #[fail(display = "An I/O error occurred.")]
+    #[fail(display = "An I/O error occurred: {}", _0)]
     IoError(io::Error),
 
     /// IO error
-    #[fail(display = "An Rkv error occurred.")]
+    #[fail(display = "An Rkv error occurred: {}", _0)]
     Rkv(StoreError),
 
     /// JSON error
-    #[fail(display = "A JSON error occurred.")]
+    #[fail(display = "A JSON error occurred: {}", _0)]
     Json(serde_json::error::Error),
 
     /// TimeUnit conversion failed

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -195,6 +195,12 @@ impl PingMaker {
         Ok(pings_dir)
     }
 
+    fn get_tmp_dir(&self, data_path: &Path) -> std::io::Result<PathBuf> {
+        let pings_dir = data_path.join("tmp");
+        create_dir_all(&pings_dir)?;
+        Ok(pings_dir)
+    }
+
     /// Store a ping to disk in the pings directory.
     pub fn store_ping(
         &self,
@@ -204,10 +210,11 @@ impl PingMaker {
         ping_content: &JsonValue,
     ) -> std::io::Result<()> {
         let pings_dir = self.get_pings_dir(data_path)?;
+        let temp_dir = self.get_tmp_dir(data_path)?;
 
         // Write to a temporary location and then move when done,
         // for transactional writes.
-        let temp_ping_path = std::env::temp_dir().join(doc_id);
+        let temp_ping_path = temp_dir.join(doc_id);
         let ping_path = pings_dir.join(doc_id);
 
         {

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -189,12 +189,20 @@ impl PingMaker {
             .map(|ping| ::serde_json::to_string_pretty(&ping).unwrap())
     }
 
+    /// Get path to a directory for ping storage.
+    ///
+    /// The directory will be created inside the `data_path`.
+    /// The `pings` directory (and its parents) is created if it does not exist.
     fn get_pings_dir(&self, data_path: &Path) -> std::io::Result<PathBuf> {
         let pings_dir = data_path.join("pings");
         create_dir_all(&pings_dir)?;
         Ok(pings_dir)
     }
 
+    /// Get path to a directory for temporary storage.
+    ///
+    /// The directory will be created inside the `data_path`.
+    /// The `tmp` directory (and its parents) is created if it does not exist.
     fn get_tmp_dir(&self, data_path: &Path) -> std::io::Result<PathBuf> {
         let pings_dir = data_path.join("tmp");
         create_dir_all(&pings_dir)?;


### PR DESCRIPTION
glean AC uses `context.cacheDir`, but I didn't want to pass that through the FFI, so now we build our own temp directory to which we can write files.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
