### PR TITLE
Use a closure to get the ping's name

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -289,7 +289,11 @@ open class GleanInternalAPI internal constructor () {
         sendPings(listOf(Pings.baseline, Pings.events))
     }
 
-    private fun <T> sendPingsGeneric(pings: List<T>, pingSender: (T) -> Boolean) = Dispatchers.API.launch {
+    private fun <T> sendPingsGeneric(
+        pings: List<T>,
+        pingSender: (T) -> Boolean,
+        nameFn: (T) -> String
+    ) = Dispatchers.API.launch {
         if (!isInitialized()) {
             Log.e(LOG_TAG, "Glean must be initialized before sending pings.")
             return@launch
@@ -308,7 +312,7 @@ open class GleanInternalAPI internal constructor () {
             if (pingSender(ping)) {
                 sentPing = true
             } else {
-                Log.d(LOG_TAG, "No content for ping '$ping.name', therefore no ping queued.")
+                Log.d(LOG_TAG, "No content for ping '${nameFn(ping)}', therefore no ping queued.")
             }
         }
 
@@ -338,8 +342,9 @@ open class GleanInternalAPI internal constructor () {
                 (configuration.logPings).toByte()
             ).toBoolean()
         }
+        val nameFn: (PingType) -> String = { it.name }
 
-        return sendPingsGeneric(pings, sendPing)
+        return sendPingsGeneric(pings, sendPing, nameFn)
     }
 
     /**
@@ -366,8 +371,9 @@ open class GleanInternalAPI internal constructor () {
                 (configuration.logPings).toByte()
             ).toBoolean()
         }
+        val nameFn: (String) -> String = { it }
 
-        return sendPingsGeneric(pingNames, sendPing)
+        return sendPingsGeneric(pingNames, sendPing, nameFn)
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -17,7 +17,7 @@ import mozilla.telemetry.glean.rust.toByte
  * The Ping API only exposes the [send] method, which schedules a ping for sending.
  */
 class PingType(
-    name: String,
+    internal val name: String,
     includeClientId: Boolean
 ) {
     internal var handle: Long


### PR DESCRIPTION
When we switched to either a string name or a ping type object we
introduced a generic function, but didn't adjust the log message.
This results in the object's string representation to be used (which is
most likely just `PingType0x12345` or something along those lines).

The non-generic wrapper functions do know how to get to the name, so we
can use that knowledge and pass it in.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
