### PR TITLE
Put baseline.duration into the right category

### DIFF
--- a/docs/user/pings/baseline.md
+++ b/docs/user/pings/baseline.md
@@ -54,7 +54,9 @@ A quick note about querying ping contents (i.e. for https://sql.telemetry.mozill
   },
   "metrics": {
     "string": {
-      "glean.baseline.locale": "en-US",
+      "glean.baseline.locale": "en-US"
+    },
+    "timespan": {
       "glean.baseline.duration": {
         "value": 52,
         "time_unit": "second"


### PR DESCRIPTION
Thanks for @tdsmith for noticing.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
