### PR TITLE
Make Gradle adhere to a strict 2GB heap limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,8 @@ jobs:
       - run:
           name: Android tests
           command: ./gradlew --no-daemon test
+          environment:
+            GRADLE_OPTS: -Xmx2048m
       - store_artifacts:
           path: glean-core/android/build/reports/tests
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
