### PR TITLE
Use a macro to reduce boilerplate in FFI layer

### DIFF
--- a/glean-core/ffi/src/boolean.rs
+++ b/glean-core/ffi/src/boolean.rs
@@ -2,51 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::convert::TryFrom;
+use ffi_support::FfiStr;
 
-use ffi_support::{define_handle_map_deleter, ConcurrentHandleMap, FfiStr};
-use lazy_static::lazy_static;
+use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
-use glean_core::metrics::{BooleanMetric, MetricType};
-use glean_core::{CommonMetricData, Lifetime};
-
-use crate::handlemap_ext::HandleMapExtension;
-use crate::{from_raw_string_array, RawStringArray, GLEAN};
-
-lazy_static! {
-    pub static ref BOOLEAN_METRICS: ConcurrentHandleMap<BooleanMetric> = ConcurrentHandleMap::new();
-}
-define_handle_map_deleter!(BOOLEAN_METRICS, glean_destroy_boolean_metric);
-
-#[no_mangle]
-pub extern "C" fn glean_new_boolean_metric(
-    category: FfiStr,
-    name: FfiStr,
-    send_in_pings: RawStringArray,
-    send_in_pings_len: i32,
-    lifetime: i32,
-    disabled: u8,
-) -> u64 {
-    BOOLEAN_METRICS.insert_with_log(|| {
-        let send_in_pings = unsafe { from_raw_string_array(send_in_pings, send_in_pings_len) };
-        let lifetime = Lifetime::try_from(lifetime)?;
-
-        Ok(BooleanMetric::new(CommonMetricData {
-            name: name.into_string(),
-            category: category.into_string(),
-            send_in_pings,
-            lifetime,
-            disabled: disabled != 0,
-        }))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_boolean_should_record(glean_handle: u64, metric_id: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        BOOLEAN_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
-    })
-}
+define_metric!(BooleanMetric => BOOLEAN_METRICS {
+    new           -> glean_new_boolean_metric(),
+    destroy       -> glean_destroy_boolean_metric,
+    should_record -> glean_boolean_should_record,
+});
 
 #[no_mangle]
 pub extern "C" fn glean_boolean_set(glean_handle: u64, metric_id: u64, value: u8) {

--- a/glean-core/ffi/src/counter.rs
+++ b/glean-core/ffi/src/counter.rs
@@ -2,60 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::convert::TryFrom;
+use ffi_support::FfiStr;
 
-use ffi_support::{define_handle_map_deleter, ConcurrentHandleMap, FfiStr};
-use lazy_static::lazy_static;
+use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
-use glean_core::metrics::{CounterMetric, MetricType};
-use glean_core::{CommonMetricData, Lifetime};
+define_metric!(CounterMetric => COUNTER_METRICS {
+    new           -> glean_new_counter_metric(),
+    destroy       -> glean_destroy_counter_metric,
+    should_record -> glean_counter_should_record,
 
-use crate::handlemap_ext::HandleMapExtension;
-use crate::{from_raw_string_array, RawStringArray, GLEAN};
-
-lazy_static! {
-    pub static ref COUNTER_METRICS: ConcurrentHandleMap<CounterMetric> = ConcurrentHandleMap::new();
-}
-define_handle_map_deleter!(COUNTER_METRICS, glean_destroy_counter_metric);
-
-#[no_mangle]
-pub extern "C" fn glean_new_counter_metric(
-    category: FfiStr,
-    name: FfiStr,
-    send_in_pings: RawStringArray,
-    send_in_pings_len: i32,
-    lifetime: i32,
-    disabled: u8,
-) -> u64 {
-    COUNTER_METRICS.insert_with_log(|| {
-        let send_in_pings = unsafe { from_raw_string_array(send_in_pings, send_in_pings_len) };
-        let lifetime = Lifetime::try_from(lifetime)?;
-
-        Ok(CounterMetric::new(CommonMetricData {
-            name: name.into_string(),
-            category: category.into_string(),
-            send_in_pings,
-            lifetime,
-            disabled: disabled != 0,
-        }))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_counter_should_record(glean_handle: u64, metric_id: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        COUNTER_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_counter_add(glean_handle: u64, metric_id: u64, amount: i32) {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        COUNTER_METRICS.call_infallible(metric_id, |metric| {
-            metric.add(glean, amount);
-        })
-    })
-}
+    add -> glean_counter_add(amount: i32),
+});
 
 #[no_mangle]
 pub extern "C" fn glean_counter_test_has_value(

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -13,6 +13,8 @@ use lazy_static::lazy_static;
 
 use glean_core::Glean;
 
+mod macros;
+
 mod boolean;
 mod counter;
 mod datetime;

--- a/glean-core/ffi/src/macros.rs
+++ b/glean-core/ffi/src/macros.rs
@@ -1,0 +1,82 @@
+/// Define the global handle map, constructor and destructor functions and any user-defined
+/// functions for a new metric
+///
+/// This allows to define most common functionality and simple operations for a metric type.
+/// More complex operations should be written as plain functions directly.
+///
+/// ## Arguments
+///
+/// * `$metric_type` - metric type to use from glean_core, e.g. `CounterMetric`.
+/// * `$metric_map` - name to use for the global name, should be all uppercase, e.g. `COUNTER_METRICS`.
+/// * `$new_fn(...)` - name of the constructor function, followed by all additional (non-common) arguments.
+/// * `$destroy` - name of the destructor function.
+/// * `$should_record` - name of the function to determine if the metric should be recorded.
+///
+/// Additional simple functions can be define as a mapping `$op -> $op_fn`:
+///
+/// * `$op` - function on the metric type to call.
+/// * `$op_fn` - FFI function name for the operation, followed by its arguments.
+///              Arguments are converted into the target type using `TryFrom::try_from`.
+#[macro_export]
+macro_rules! define_metric {
+    ($metric_type:ident => $metric_map:ident {
+        new -> $new_fn:ident($($new_argname:ident: $new_argtyp:ty),* $(,)*),
+        destroy -> $destroy_fn:ident,
+        should_record -> $should_record_fn:ident,
+
+        $(
+            $op:ident -> $op_fn:ident($($op_argname:ident: $op_argtyp:ty),* $(,)*)
+        ),* $(,)*
+    }) => {
+        lazy_static::lazy_static! {
+            pub static ref $metric_map: ffi_support::ConcurrentHandleMap<glean_core::metrics::$metric_type> = ffi_support::ConcurrentHandleMap::new();
+        }
+        ffi_support::define_handle_map_deleter!($metric_map, $destroy_fn);
+
+        #[no_mangle]
+        pub extern "C" fn $should_record_fn(glean_handle: u64, metric_id: u64) -> u8 {
+            crate::handlemap_ext::HandleMapExtension::call_infallible(&*crate::GLEAN, glean_handle, |glean| {
+                crate::handlemap_ext::HandleMapExtension::call_infallible(&*$metric_map, metric_id, |metric| glean_core::metrics::MetricType::should_record(&*metric, &glean))
+            })
+        }
+
+        #[no_mangle]
+        pub extern "C" fn $new_fn(
+            category: ffi_support::FfiStr,
+            name: ffi_support::FfiStr,
+            send_in_pings: crate::RawStringArray,
+            send_in_pings_len: i32,
+            lifetime: i32,
+            disabled: u8,
+            $($new_argname: $new_argtyp),*
+        ) -> u64 {
+            $metric_map.insert_with_log(|| {
+                let send_in_pings = unsafe { crate::from_raw_string_array(send_in_pings, send_in_pings_len) };
+                let lifetime = std::convert::TryFrom::try_from(lifetime)?;
+
+                $(
+                    let $new_argname = std::convert::TryFrom::try_from($new_argname)?;
+                )*
+
+                Ok(glean_core::metrics::$metric_type::new(glean_core::CommonMetricData {
+                    name: name.into_string(),
+                    category: category.into_string(),
+                    send_in_pings,
+                    lifetime,
+                    disabled: disabled != 0,
+                }, $($new_argname),*))
+            })
+        }
+
+        $(
+            #[no_mangle]
+            pub extern "C" fn $op_fn(glean_handle: u64, metric_id: u64, $($op_argname: $op_argtyp),*) {
+                crate::handlemap_ext::HandleMapExtension::call_infallible(&*crate::GLEAN, glean_handle, |glean| {
+                    crate::handlemap_ext::HandleMapExtension::call_infallible(&*$metric_map, metric_id, |metric| {
+                        metric.$op(glean, $($op_argname),*);
+                    })
+                })
+            }
+        )*
+    }
+}

--- a/glean-core/ffi/src/string.rs
+++ b/glean-core/ffi/src/string.rs
@@ -2,62 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::convert::TryFrom;
 use std::os::raw::c_char;
 
-use ffi_support::{define_handle_map_deleter, ConcurrentHandleMap, FfiStr};
-use lazy_static::lazy_static;
+use ffi_support::FfiStr;
 
-use glean_core::metrics::{MetricType, StringMetric};
-use glean_core::{CommonMetricData, Lifetime};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
-use crate::handlemap_ext::HandleMapExtension;
-use crate::{from_raw_string_array, RawStringArray, GLEAN};
+define_metric!(StringMetric => STRING_METRICS {
+    new           -> glean_new_string_metric(),
+    destroy       -> glean_destroy_string_metric,
+    should_record -> glean_string_should_record,
 
-lazy_static! {
-    pub static ref STRING_METRICS: ConcurrentHandleMap<StringMetric> = ConcurrentHandleMap::new();
-}
-define_handle_map_deleter!(STRING_METRICS, glean_destroy_string_metric);
-
-#[no_mangle]
-pub extern "C" fn glean_new_string_metric(
-    category: FfiStr,
-    name: FfiStr,
-    send_in_pings: RawStringArray,
-    send_in_pings_len: i32,
-    lifetime: i32,
-    disabled: u8,
-) -> u64 {
-    STRING_METRICS.insert_with_log(|| {
-        let send_in_pings = unsafe { from_raw_string_array(send_in_pings, send_in_pings_len) };
-        let lifetime = Lifetime::try_from(lifetime)?;
-
-        Ok(StringMetric::new(CommonMetricData {
-            name: name.into_string(),
-            category: category.into_string(),
-            send_in_pings,
-            lifetime,
-            disabled: disabled != 0,
-        }))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_string_should_record(glean_handle: u64, metric_id: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        STRING_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_string_set(glean_handle: u64, metric_id: u64, value: FfiStr) {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        STRING_METRICS.call_infallible(metric_id, |metric| {
-            let value = value.into_string();
-            metric.set(glean, value);
-        })
-    })
-}
+    set -> glean_string_set(value: FfiStr),
+});
 
 #[no_mangle]
 pub extern "C" fn glean_string_test_has_value(

--- a/glean-core/ffi/src/string_list.rs
+++ b/glean-core/ffi/src/string_list.rs
@@ -2,63 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::convert::TryFrom;
 use std::os::raw::c_char;
 
-use ffi_support::{define_handle_map_deleter, ConcurrentHandleMap, FfiStr};
-use lazy_static::lazy_static;
+use ffi_support::FfiStr;
 
-use glean_core::metrics::{MetricType, StringListMetric};
-use glean_core::{CommonMetricData, Lifetime};
+use crate::{
+    define_metric, from_raw_string_array, handlemap_ext::HandleMapExtension, RawStringArray, GLEAN,
+};
 
-use crate::handlemap_ext::HandleMapExtension;
-use crate::{from_raw_string_array, RawStringArray, GLEAN};
+define_metric!(StringListMetric => STRING_LIST_METRICS {
+    new           -> glean_new_string_list_metric(),
+    destroy       -> glean_destroy_string_list_metric,
+    should_record -> glean_string_list_should_record,
 
-lazy_static! {
-    pub static ref STRING_LIST_METRICS: ConcurrentHandleMap<StringListMetric> =
-        ConcurrentHandleMap::new();
-}
-define_handle_map_deleter!(STRING_LIST_METRICS, glean_destroy_string_list_metric);
-
-#[no_mangle]
-pub extern "C" fn glean_new_string_list_metric(
-    category: FfiStr,
-    name: FfiStr,
-    send_in_pings: RawStringArray,
-    send_in_pings_len: i32,
-    lifetime: i32,
-    disabled: u8,
-) -> u64 {
-    STRING_LIST_METRICS.insert_with_log(|| {
-        let send_in_pings = unsafe { from_raw_string_array(send_in_pings, send_in_pings_len) };
-        let lifetime = Lifetime::try_from(lifetime)?;
-
-        Ok(StringListMetric::new(CommonMetricData {
-            name: name.into_string(),
-            category: category.into_string(),
-            send_in_pings,
-            lifetime,
-            disabled: disabled != 0,
-        }))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_string_list_should_record(glean_handle: u64, metric_id: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        STRING_LIST_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_string_list_add(glean_handle: u64, metric_id: u64, value: FfiStr) {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        STRING_LIST_METRICS.call_infallible(metric_id, |metric| {
-            let value = value.into_string();
-            metric.add(glean, value);
-        })
-    })
-}
+    add -> glean_string_list_add(value: FfiStr),
+});
 
 #[no_mangle]
 pub extern "C" fn glean_string_list_set(

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -2,58 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::convert::TryFrom;
 use std::time::Duration;
 
-use ffi_support::{define_handle_map_deleter, ConcurrentHandleMap, FfiStr};
-use lazy_static::lazy_static;
+use ffi_support::FfiStr;
 
-use glean_core::metrics::{MetricType, TimeUnit, TimespanMetric};
-use glean_core::{CommonMetricData, Lifetime};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
-use crate::handlemap_ext::HandleMapExtension;
-use crate::{from_raw_string_array, RawStringArray, GLEAN};
-
-lazy_static! {
-    pub static ref TIMESPAN_METRICS: ConcurrentHandleMap<TimespanMetric> =
-        ConcurrentHandleMap::new();
-}
-define_handle_map_deleter!(TIMESPAN_METRICS, glean_destroy_timespan_metric);
-
-#[no_mangle]
-pub extern "C" fn glean_new_timespan_metric(
-    category: FfiStr,
-    name: FfiStr,
-    send_in_pings: RawStringArray,
-    send_in_pings_len: i32,
-    lifetime: i32,
-    disabled: u8,
-    time_unit: i32,
-) -> u64 {
-    TIMESPAN_METRICS.insert_with_log(|| {
-        let send_in_pings = unsafe { from_raw_string_array(send_in_pings, send_in_pings_len) };
-        let lifetime = Lifetime::try_from(lifetime)?;
-        let tu = TimeUnit::try_from(time_unit)?;
-
-        Ok(TimespanMetric::new(
-            CommonMetricData {
-                name: name.into_string(),
-                category: category.into_string(),
-                send_in_pings,
-                lifetime,
-                disabled: disabled != 0,
-            },
-            tu,
-        ))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_timespan_should_record(glean_handle: u64, metric_id: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        TIMESPAN_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
-    })
-}
+define_metric!(TimespanMetric => TIMESPAN_METRICS {
+    new           -> glean_new_timespan_metric(time_unit: i32),
+    destroy       -> glean_destroy_timespan_metric,
+    should_record -> glean_timespan_should_record,
+});
 
 #[no_mangle]
 pub extern "C" fn glean_timespan_set_start(glean_handle: u64, metric_id: u64, start_time: u64) {

--- a/glean-core/ffi/src/uuid.rs
+++ b/glean-core/ffi/src/uuid.rs
@@ -2,52 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::convert::TryFrom;
 use std::os::raw::c_char;
 
-use ffi_support::{define_handle_map_deleter, ConcurrentHandleMap, FfiStr};
-use lazy_static::lazy_static;
+use ffi_support::FfiStr;
 
-use glean_core::metrics::{MetricType, UuidMetric};
-use glean_core::{CommonMetricData, Lifetime};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
-use crate::handlemap_ext::HandleMapExtension;
-use crate::{from_raw_string_array, RawStringArray, GLEAN};
-
-lazy_static! {
-    static ref UUID_METRICS: ConcurrentHandleMap<UuidMetric> = ConcurrentHandleMap::new();
-}
-define_handle_map_deleter!(UUID_METRICS, glean_destroy_uuid_metric);
-
-#[no_mangle]
-pub extern "C" fn glean_new_uuid_metric(
-    category: FfiStr,
-    name: FfiStr,
-    send_in_pings: RawStringArray,
-    send_in_pings_len: i32,
-    lifetime: i32,
-    disabled: u8,
-) -> u64 {
-    UUID_METRICS.insert_with_log(|| {
-        let send_in_pings = unsafe { from_raw_string_array(send_in_pings, send_in_pings_len) };
-        let lifetime = Lifetime::try_from(lifetime)?;
-
-        Ok(UuidMetric::new(CommonMetricData {
-            name: name.into_string(),
-            category: category.into_string(),
-            send_in_pings,
-            lifetime,
-            disabled: disabled != 0,
-        }))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_uuid_should_record(glean_handle: u64, metric_id: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        UUID_METRICS.call_infallible(metric_id, |metric| metric.should_record(&glean))
-    })
-}
+define_metric!(UuidMetric => UUID_METRICS {
+    new           -> glean_new_uuid_metric(),
+    destroy       -> glean_destroy_uuid_metric,
+    should_record -> glean_uuid_should_record,
+});
 
 #[no_mangle]
 pub extern "C" fn glean_uuid_set(glean_handle: u64, metric_id: u64, value: FfiStr) {


### PR DESCRIPTION
This should be considered a discussion ground.
Notable things:

* It doesn't handle the `test_(get|has)_value` functions yet
	* In part because some of those are a bit more complex
* It can't wrap all actual record functions
	* It can do some, see e.g. the counter
	* It might be possible to include some more
* The chosen syntax in the macro is arbitrary and can be changed


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
