### PR TITLE
Update docs for the metrics ping.

### DIFF
--- a/docs/user/pings/metrics.md
+++ b/docs/user/pings/metrics.md
@@ -9,15 +9,18 @@ If the application crashes, unsent recorded metrics are sent along with the next
 
 ## Scheduling
 The desired behaviour is to collect the ping at the first available opportunity after 4AM local time on a new calendar day. 
-This breaks down into two scenarios:
+This breaks down into three scenarios:
 
-1. the application was just started (after a crash or a long inactivity period);
-2. the application was open and the 4AM due time was hit.
+1. the application was just installed;
+2. the application was just started (after a crash or a long inactivity period);
+3. the application was open and the 4AM due time was hit.
 
-In the first case, if the `metrics` ping was already collected on the current calendar day, a new collection will be scheduled for the next calendar day, at 4AM. 
+In the first case, since the application was just installed, if the due time for the current calendar day has passed, a `metrics` ping is immediately generated and scheduled for sending. Otherwise, if the due time for the current calendar day has not passed, a ping collection is scheduled for that time.
+
+In the second case, if the `metrics` ping was already collected on the current calendar day, a new collection will be scheduled for the next calendar day, at 4AM. 
 If no collection happened yet, and the due time for the current calendar day has passed, a `metrics` ping is immediately generated and scheduled for sending.
 
-In the second case, similarly to the previous case, if the `metrics` ping was already collected on the current calendar day when we hit 4AM, then a new collection is scheduled for the next calendar day.
+In the third case, similarly to the previous case, if the `metrics` ping was already collected on the current calendar day when we hit 4AM, then a new collection is scheduled for the next calendar day.
 Otherwise, the `metrics` is immediately collected and scheduled for sending.
 
 More [scheduling examples](#Scheduling-examples) are included below.


### PR DESCRIPTION
As discovered by @chutten...

This is a port of just the documentation part of
https://github.com/mozilla-mobile/android-components/pull/3204

This keeps the docs in line with the current behavior of glean-ac.

The code parts of that PR are not relevant since we don't yet have a metrics ping scheduler in glean-core.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
