### PR TITLE
Restrict Glean to only init on the main process.

### DIFF
--- a/docs/user/adding-glean-to-your-project.md
+++ b/docs/user/adding-glean-to-your-project.md
@@ -78,6 +78,7 @@ The following steps are required for applications using the Glean SDK, but not l
 ### Initializing the Glean SDK
 
 The Glean SDK should only be initialized from the main application, not individual libraries.  If you are adding Glean support to a library, you can safely skip this section.
+Please also note that the Glean SDK does not support use across multiple processes, and must only be initialized on the application's main process. Initializing in other processes is a no-op.
 
 Before any data collection can take place, the Glean SDK **must** be initialized from the application.
 An excellent place to perform this operation is within the `onCreate` method of the class that extends Android's `Application` class.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.Job
+import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.utils.getLocaleTag
 import java.io.File
@@ -75,6 +76,13 @@ open class GleanInternalAPI internal constructor () {
         applicationContext: Context,
         configuration: Configuration = Configuration()
     ) {
+        // In certain situations Glean.initialize may be called from a process other than the main
+        // process.  In this case we want initialize to be a no-op and just return.
+        if (!applicationContext.isMainProcess()) {
+            Log.e(LOG_TAG, "Attempted to initialize Glean on a process other than the main process")
+            return
+        }
+
         if (isInitialized()) {
             Log.e(LOG_TAG, "Glean should not be initialized multiple times")
             return


### PR DESCRIPTION
This additionally clarifies the documentation about the lack of support for multiple application processes and what happens in case an initialization is attempted on non-main processes.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
