### PR TITLE
Make constructor function optional in macro.

### DIFF
--- a/glean-core/ffi/src/macros.rs
+++ b/glean-core/ffi/src/macros.rs
@@ -20,7 +20,7 @@
 #[macro_export]
 macro_rules! define_metric {
     ($metric_type:ident => $metric_map:ident {
-        new -> $new_fn:ident($($new_argname:ident: $new_argtyp:ty),* $(,)*),
+        $(new -> $new_fn:ident($($new_argname:ident: $new_argtyp:ty),* $(,)*),)?
         destroy -> $destroy_fn:ident,
         should_record -> $should_record_fn:ident,
 
@@ -40,6 +40,7 @@ macro_rules! define_metric {
             })
         }
 
+        $(
         #[no_mangle]
         pub extern "C" fn $new_fn(
             category: ffi_support::FfiStr,
@@ -67,6 +68,7 @@ macro_rules! define_metric {
                 }, $($new_argname),*))
             })
         }
+        )?
 
         $(
             #[no_mangle]

--- a/glean-core/ffi/src/macros.rs
+++ b/glean-core/ffi/src/macros.rs
@@ -8,7 +8,7 @@
 ///
 /// * `$metric_type` - metric type to use from glean_core, e.g. `CounterMetric`.
 /// * `$metric_map` - name to use for the global name, should be all uppercase, e.g. `COUNTER_METRICS`.
-/// * `$new_fn(...)` - name of the constructor function, followed by all additional (non-common) arguments.
+/// * `$new_fn(...)` - (optional) name of the constructor function, followed by all additional (non-common) arguments.
 /// * `$destroy` - name of the destructor function.
 /// * `$should_record` - name of the function to determine if the metric should be recorded.
 ///


### PR DESCRIPTION
This allows skipping the automatic implementation of the constructor
function.
It then has to be implemented manually (which might be required if the
type has some extra work to do during construction).

cc @mdboom 	this might solve your issues in #161 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
