### PR TITLE
Don't overwrite existing value/running timer with raw API

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -123,9 +123,7 @@ class TimespanMetricType internal constructor(
      * This API should only be used if your library or application requires recording
      * times in a way that can not make use of [start]/[stop]/[cancel].
      *
-     * Care should be taken using this if the ping lifetime might contain more than one
-     * timespan measurement.  To be safe, [setRawNanos] should generally be followed by
-     * sending a custom ping containing the timespan.
+     * [setRawNanos] does not overwrite a running timer or an already existing value.
      *
      * @param elapsedNanos The elapsed time to record, in nanoseconds.
      */

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
@@ -155,6 +155,29 @@ class TimespanMetricTypeTest {
     }
 
     @Test
+    fun `Value unchanged if stopped twice`() {
+        // Define a timespan metric, which will be stored in "store1" and "store2"
+        val metric = TimespanMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "timespan_metric",
+            sendInPings = listOf("store1"),
+            timeUnit = TimeUnit.Nanosecond
+        )
+
+        // Record a timespan.
+        metric.start()
+        metric.stop()
+        assertTrue(metric.testHasValue())
+        val value = metric.testGetValue()
+
+        metric.stop()
+
+        assertEquals(value, metric.testGetValue())
+    }
+
+    @Test
     fun `test setRawNanos`() {
         val timespanNanos = 6 * 1000000000L
 

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -48,7 +48,7 @@ pub extern "C" fn glean_timespan_set_raw_nanos(
     let elapsed = Duration::from_nanos(elapsed_nanos);
     GLEAN.call_infallible(glean_handle, |glean| {
         TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
-            metric.set_raw(glean, elapsed, true);
+            metric.set_raw(glean, elapsed, false);
         })
     })
 }

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -108,7 +108,12 @@ impl TimespanMetric {
         }
 
         if self.start_time.is_some() {
-            log::warn!("Timespan already running. Raw value not recorded.");
+            record_error(
+                glean,
+                &self.meta,
+                ErrorType::InvalidValue,
+                "Timespan already running. Raw value not recorded.",
+            );
             return;
         }
 

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
+use glean_core::{test_get_num_recorded_errors, ErrorType};
 use glean_core::{CommonMetricData, Glean, Lifetime};
 
 // Tests ported from glean-ac
@@ -252,4 +253,10 @@ fn set_raw_time_does_nothing_when_timer_running() {
 
     // We expect the start/stop value, not the raw value.
     assert_eq!(Some(60), metric.test_get_value(&glean, "store1"));
+
+    // Make sure that the error has been recorded
+    assert_eq!(
+        Ok(1),
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+    );
 }


### PR DESCRIPTION
This adds tests to verify the behavior [we discussed in bug 1562859](https://bugzilla.mozilla.org/show_bug.cgi?id=1562859).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
