### PR TITLE
Skip Android tests if commit contains marker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,13 @@ jobs:
     steps:
       - android-setup
       - run:
+          name: Check skip condition
+          command: |
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[doc only\]'; then
+                echo "Skipping this step. Last commit was tagged to not require Android tests."
+                circleci-agent step halt
+            fi
+      - run:
           name: Android tests
           command: ./gradlew --no-daemon test
           environment:

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -90,4 +90,4 @@ It is possible to completely skip running CI on a given push by including the fo
 [ci skip]
 ```
 
-This should only be used for meatdata files, such as those in `.github`, `LICENSE` or `CODE_OF_CONDUCT.md`.
+This should only be used for metadata files, such as those in `.github`, `LICENSE` or `CODE_OF_CONDUCT.md`.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -56,3 +56,38 @@ To run the full Android test suite, in the "Gradle" pane, navigate to `glean-cor
 You can save this task permanently by opening the task dropdown in the toolbar and selecting "Save glean.rs:glean-core:android [testDebugUnitTest] Configuration".
 
 To run a single Android test, navigate to the file containing the test, and right click on the green arrow in the left margin next to the test.  There you have a choice of running or debugging the test.
+
+## Testing in CI
+
+We run multiple tests on CI for every Pull Request and every commit to the `master` branch.
+These include:
+
+* Full Android tests
+* Rust tests
+* Rust source code formatting
+* Rust and Android source code linting
+* Generating documentation from Rust & Kotlin code and the book
+* Checking link validity of documentation
+* Deploying generated documentation
+
+These checks are required to pass before a Pull Request is merged.
+
+### Documentation-only changes
+
+Documentation is deployed from CI, we therefore need it to run on documentation changes.
+However, some of the long-running code tests can be skipped.
+For that add the following literal string to the last commit message to be pushed:
+
+```
+[doc only]
+```
+
+### Skipping CI completely
+
+It is possible to completely skip running CI on a given push by including the following literal string in the commit message:
+
+```
+[ci skip]
+```
+
+This should only be used for meatdata files, such as those in `.github`, `LICENSE` or `CODE_OF_CONDUCT.md`.


### PR DESCRIPTION
Here's an idea to reduce CI time for doc-only changes:

For doc-only changes we might not require the full CI run.
The Android tests are what's taking the longest, so let's make this
easily skippable.

Just add `[skip android]` somewhere in the commit message.

* Should we do this?
* If so, where to document?
* If so, skipping only Android or also rust tests? What about lints?
    * Everything else is reasonably fast, which is why I didn't add a way to skip it yet
* Naming: `skip android`, `doc only`, ...
    * not possible: `ci skip` - circleci uses that to skip the full build (but we require the build to deploy docs)

**Update**

* Docs added.
* Marker changed to `[doc only]`