### PR TITLE
1557046: Document more about event payload

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,7 +33,6 @@
     - [Rust Component](dev/core/index.md)
         - [Dependency Management](dev/core/dependency-management.md)
         - [Adding a new metric type](dev/core/new-metric-type.md)
-        - [Internal design details](dev/core/internal.md)
     - [FFI Layer](dev/ffi/index.md)
         - [When/How FFI](dev/ffi/when-to-use-what-in-the-ffi.md)
     - [Contributing](contributing.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,4 +37,8 @@
     - [FFI Layer](dev/ffi/index.md)
         - [When/How FFI](dev/ffi/when-to-use-what-in-the-ffi.md)
     - [Contributing](contributing.md)
+    - [Internal implementation details](dev/core/internal/index.md)
+        - [Reserved ping names](dev/core/internal/reserved-ping-names.md).
+        - [Clearing metrics when disabling/enabling Glean](dev/core/internal/clearing.md).
+        - [Payload format](dev/core/internal/payload.md).
 - [API Documentation](api/index.md)

--- a/docs/dev/core/internal/clearing.md
+++ b/docs/dev/core/internal/clearing.md
@@ -1,6 +1,4 @@
-# Internal design details
-
-## Clearing metrics when disabling/enabling Glean
+# Clearing metrics when disabling/enabling Glean
 
 When disabling upload (`Glean.setUploadEnabled(false)`), metrics are also cleared to prevent their storage on the local device, and lessen the likelihood
 of accidentally sending them.
@@ -20,11 +18,3 @@ When re-enabling metrics:
 
 - Ping lifetime metrics do not need special handling.  They will begin recording again after metric uploading is re-enabled.
 
-## Reservered ping names
-
-The Glean SDK reserves all ping names starting with `glean_`.
-
-This currently includes, but is not limited to:
-
-* `glean_client_info`
-* `glean_internal_info`

--- a/docs/dev/core/internal/index.md
+++ b/docs/dev/core/internal/index.md
@@ -1,0 +1,9 @@
+# Internal documentation
+
+This chapter describes aspects of Glean that are internal implementation details.
+
+This includes
+
+* [Reserved ping names](reserved-ping-names.md).
+* [Clearing metrics when disabling/enabling Glean](clearing.md).
+* [Payload format](payload.md).

--- a/docs/dev/core/internal/payload.md
+++ b/docs/dev/core/internal/payload.md
@@ -1,8 +1,8 @@
 # Payload format
 
-The main sections of a Glean ping are described in [Ping Sections](../../user/pings/index.md#Ping-sections).
+The main sections of a Glean ping are described in [Ping Sections](../../../user/pings/index.md#Ping-sections).
 This **Payload format** chapter describes details of the ping payload that are relevant for decoding Glean pings in the pipeline.
-This is less relevant for end users of the Glean SDK. 
+This is less relevant for end users of the Glean SDK.
 
 ## JSON Schema
 
@@ -11,30 +11,50 @@ It is written as a set of [templates](https://github.com/mozilla-services/mozill
 
 ## Metric types
 
-TODO: Fill in the rest of the metric types.
+TODO: Fill in the rest of the metric types. https://bugzilla.mozilla.org/show_bug.cgi?id=1566854
 
 ### Event
 
 Events are represented as an array of objects, with one object for each event.
 Each event object has the following keys:
 
-- `timestamp`: (integer) A monotonically increasing timestamp value, in milliseconds.  
-  The first timestamp in the array is always zero, and subsequent timestamps in the array are relative to that reference point.
-  
+- `timestamp`: (integer) A monotonically increasing timestamp value, in milliseconds.
+  To avoid leaking absolute times, the first timestamp in the array is always zero, and subsequent timestamps in the array are relative to that reference point.
+
 - `category`: (string) The event's category.
   This comes directly from the category under which the metric was defined in the `metrics.yaml` file.
-  
+
 - `name`: (string) The event's name, as defined in the `metrics.yaml` file.
 
 - `extra`: (object, optional) Extra data associated with the event.
   Both the keys and values of this object are strings.
   The keys must be from the set defined for this event in the `metrics.yaml` file.
   The values have a maximum length of 50 bytes, when encoded as UTF-8.
-  
+
+For example:
+
+```json
+[
+  {
+    "timestamp": 0,
+    "category": "app",
+    "name": "ss_menu_opened"
+  },
+  {
+    "timestamp": 124,
+    "category": "search",
+    "name": "performed_search",
+    "extra": {
+      "source": "default.action"
+    }
+  }
+]
+```
+
 Also see [the JSON schema for events](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/templates/include/glean/event.1.schema.json).
 
 To avoid losing events when the application is killed by the operating system, events are queued on disk as they are recorded.
 When the application starts up again, there is no good way to determine if the device has rebooted since the last run and therefore any timestamps recorded in the new run could not be guaranteed to be consistent with those recorded in the previous run.
 To get around this, on application startup, any queued events are immediately collected into pings and then cleared.
-These "startup-triggered pings" are likely to have a very short duration, as recorded in `ping_info.start_time` and `ping_info.end_time` (see [the `ping_info` section](../../user/pings/index.md#The-ping_info-section)).
+These "startup-triggered pings" are likely to have a very short duration, as recorded in `ping_info.start_time` and `ping_info.end_time` (see [the `ping_info` section](../../../user/pings/index.md#The-ping_info-section)).
 The maximum timestamp of the events in these pings are quite likely to exceed the duration of the ping, but this is to be expected.

--- a/docs/dev/core/internal/payload.md
+++ b/docs/dev/core/internal/payload.md
@@ -15,7 +15,7 @@ TODO: Fill in the rest of the metric types. https://bugzilla.mozilla.org/show_bu
 
 ### Event
 
-Events are represented as an array of objects, with one object for each event.
+[Events](../../../user/metrics/event.md) are represented as an array of objects, with one object for each event.
 Each event object has the following keys:
 
 - `timestamp`: (integer) A monotonically increasing timestamp value, in milliseconds.

--- a/docs/dev/core/internal/payload.md
+++ b/docs/dev/core/internal/payload.md
@@ -1,0 +1,39 @@
+# Payload format
+
+The main sections of a Glean ping are described in [Ping Sections](../../user/pings/index.md#Ping-sections).
+This **Payload format** chapter describes details of the ping payload that are less relevant to end users of Glean.
+
+## JSON Schema
+
+Glean's ping payloads have a formal JSON schema defined in the [mozilla-pipeline-schemas](https://github.com/mozilla-services/mozilla-pipeline-schemas/) project.
+It is written as a set of [templates](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/master/templates/include/glean) that are expanded by the mozilla-pipeline-schemas build infrastructure into a [fully expanded schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/glean/baseline/baseline.1.schema.json).
+
+## Metric types
+
+TODO: Fill in the rest of the metric types.
+
+### Event
+
+Events are represented as an array of objects, with one object for each event.
+Each event object has the following keys:
+
+- `timestamp`: (integer) A monotonically increasing timestamp value, in milliseconds.  
+  The first timestamp in the array is always zero, and subsequent timestamps in the array are relative to that reference point.
+  
+- `category`: (string) The event's category.
+  This comes directly from the category under which the metric was defined in the `metrics.yaml` file.
+  
+- `name`: (string) The event's name, as defined in the `metrics.yaml` file.
+
+- `extra`: (object, optional) Extra data associated with the event.
+  Both the keys and values of this object are strings.
+  The keys must be from the set defined for this event in the `metrics.yaml` file.
+  The values have a maximum length of 50 bytes, when encoded as UTF-8.
+  
+Also see [the JSON schema for events](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/templates/include/glean/event.1.schema.json).
+
+To avoid losing events when the application is killed by the operating system, events are queued on disk as they are recorded.
+When the application starts up again, there is no good way to determine if the device has rebooted since the last run and therefore any timestamps recorded in the new run could not be guaranteed to be consistent with those recorded in the previous run.
+To get around this, on application startup, any queued events are immediately collected into pings and then cleared.
+These "startup-triggered pings" are likely to have a very short duration, as recorded in `ping_info.start_time` and `ping_info.end_time` (see [the `ping_info` section](../../user/pings/index.md#The-ping_info-section)).
+The maximum timestamp of the events in these pings are quite likely to exceed the duration of the ping, but this is to be expected.

--- a/docs/dev/core/internal/payload.md
+++ b/docs/dev/core/internal/payload.md
@@ -1,7 +1,8 @@
 # Payload format
 
 The main sections of a Glean ping are described in [Ping Sections](../../user/pings/index.md#Ping-sections).
-This **Payload format** chapter describes details of the ping payload that are less relevant to end users of Glean.
+This **Payload format** chapter describes details of the ping payload that are relevant for decoding Glean pings in the pipeline.
+This is less relevant for end users of the Glean SDK. 
 
 ## JSON Schema
 

--- a/docs/dev/core/internal/reserved-ping-names.md
+++ b/docs/dev/core/internal/reserved-ping-names.md
@@ -1,0 +1,8 @@
+# Reserved ping names
+
+The Glean SDK reserves all ping names starting with `glean_`.
+
+This currently includes, but is not limited to:
+
+* `glean_client_info`
+* `glean_internal_info`

--- a/docs/user/metrics/event.md
+++ b/docs/user/metrics/event.md
@@ -49,7 +49,9 @@ assertEquals("login_opened", first.name)
 
 * When 500 events are queued on the client, and events pings is immediately sent.
 
-* Event timestamps use a system timer that is guaranteed to be monotonic only within a particular boot of the device. Therefore, if there are any unsent recorded events on disk when the application starts, any pings containing those events are sent immediately, so that the Glean SDK can start over using a new timer and events based on different timers are never sent within the same ping.
+* The keys in the `extra_keys` list must be in dotted snake case, with a maximum length of 40.  For the original Kotlin implementation of the Glean SDK, this is measured in Unicode characters. For the Rust implementation, this is measured in the number of bytes when the string is encoded in UTF-8.
+
+* The values in the `extras` object have a maximum length of 50. For the original Kotlin implementation of the Glean SDK, this is measured in Unicode characters. For the Rust implementation, this is measured in the number of bytes when the string is encoded in UTF-8.
   
 ## Examples
 
@@ -57,7 +59,7 @@ assertEquals("login_opened", first.name)
 
 ## Recorded errors 
 
-* None.
+* `invalid_value`: if any of the values in the `extras` object are greater than 50 bytes in length. 
  
 ## Reference
 


### PR DESCRIPTION
This also sets up a space for more documentation about metrics in the ping payload.  We should fill this out, but I've created a [separate bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1566854) to do that as follow-on work.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
