### PR TITLE
Provide timespan value both in the specified unit and in nanoseconds

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -160,7 +160,7 @@ class TimespanMetricType internal constructor(
     }
 
     /**
-     * Returns the stored value for testing purposes only
+     * Returns the stored value for testing purposes only, in the metric's time unit.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.  Defaults
      *                 to the either the first value in [defaultStorageDestinations] or the first
@@ -169,13 +169,33 @@ class TimespanMetricType internal constructor(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): Long {
+    fun testGetValueAsUnit(pingName: String = sendInPings.first()): Long {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        return LibGleanFFI.INSTANCE.glean_timespan_test_get_value(Glean.handle, this.handle, pingName)
+        return LibGleanFFI.INSTANCE.glean_timespan_test_get_value_as_unit(Glean.handle, this.handle, pingName)
+    }
+
+    /**
+     * Returns the stored value for testing purposes only, in nanoseconds.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.  Defaults
+     *                 to the either the first value in [defaultStorageDestinations] or the first
+     *                 value in [sendInPings]
+     * @return value of the stored metric
+     * @throws [NullPointerException] if no value is stored
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetValueAsNanos(pingName: String = sendInPings.first()): Long {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        if (!testHasValue(pingName)) {
+            throw NullPointerException()
+        }
+        return LibGleanFFI.INSTANCE.glean_timespan_test_get_value_as_nanos(Glean.handle, this.handle, pingName)
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -262,7 +262,9 @@ internal interface LibGleanFFI : Library {
 
     fun glean_timespan_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
-    fun glean_timespan_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Long
+    fun glean_timespan_test_get_value_as_unit(glean_handle: Long, metric_id: Long, storage_name: String): Long
+
+    fun glean_timespan_test_get_value_as_nanos(glean_handle: Long, metric_id: Long, storage_name: String): Long
 
     // TimingDistribution
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
@@ -46,7 +46,7 @@ class TimespanMetricTypeTest {
 
         // Check that data was properly recorded.
         assertTrue(metric.testHasValue())
-        assertTrue(metric.testGetValue() >= 0)
+        assertTrue(metric.testGetValueAsUnit() >= 0)
     }
 
     @Test
@@ -98,7 +98,7 @@ class TimespanMetricTypeTest {
     }
 
     @Test(expected = NullPointerException::class)
-    fun `testGetValue() throws NullPointerException if nothing is stored`() {
+    fun `testGetValueAsUnit() throws NullPointerException if nothing is stored`() {
         val metric = TimespanMetricType(
             disabled = false,
             category = "telemetry",
@@ -107,7 +107,7 @@ class TimespanMetricTypeTest {
             sendInPings = listOf("store1"),
             timeUnit = TimeUnit.Millisecond
         )
-        metric.testGetValue()
+        metric.testGetValueAsUnit()
     }
 
     @Test
@@ -128,7 +128,7 @@ class TimespanMetricTypeTest {
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))
-        assertTrue(metric.testGetValue("store2") >= 0)
+        assertTrue(metric.testGetValueAsUnit("store2") >= 0)
     }
 
     @Test
@@ -150,7 +150,7 @@ class TimespanMetricTypeTest {
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))
-        assertTrue(metric.testGetValue("store2") >= 0)
+        assertTrue(metric.testGetValueAsUnit("store2") >= 0)
         // TODO(bug 1556963)
         // assertEquals(1, testGetNumRecordedErrors(metric, ErrorType.InvalidValue))
     }
@@ -171,11 +171,11 @@ class TimespanMetricTypeTest {
         metric.start()
         metric.stop()
         assertTrue(metric.testHasValue())
-        val value = metric.testGetValue()
+        val value = metric.testGetValueAsUnit()
 
         metric.stop()
 
-        assertEquals(value, metric.testGetValue())
+        assertEquals(value, metric.testGetValueAsUnit())
     }
 
     @Test
@@ -192,7 +192,7 @@ class TimespanMetricTypeTest {
         )
 
         metric.setRawNanos(timespanNanos)
-        assertEquals(6, metric.testGetValue())
+        assertEquals(6, metric.testGetValueAsUnit())
     }
 
     @Test
@@ -209,11 +209,11 @@ class TimespanMetricTypeTest {
         )
 
         metric.setRawNanos(timespanNanos)
-        assertEquals(6, metric.testGetValue())
+        assertEquals(6, metric.testGetValueAsUnit())
 
         metric.start()
         metric.stop()
-        val value = metric.testGetValue()
+        val value = metric.testGetValueAsUnit()
         assertEquals(6, value)
     }
 
@@ -232,11 +232,11 @@ class TimespanMetricTypeTest {
 
         metric.start()
         metric.stop()
-        val value = metric.testGetValue()
+        val value = metric.testGetValueAsUnit()
 
         metric.setRawNanos(timespanNanos)
 
-        assertEquals(value, metric.testGetValue())
+        assertEquals(value, metric.testGetValueAsUnit())
     }
 
     @Test
@@ -256,6 +256,6 @@ class TimespanMetricTypeTest {
         metric.setRawNanos(timespanNanos)
         metric.stop()
 
-        assertNotEquals(timespanNanos, metric.testGetValue())
+        assertNotEquals(timespanNanos, metric.testGetValueAsUnit())
     }
 }

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -62,21 +62,38 @@ pub extern "C" fn glean_timespan_test_has_value(
     GLEAN.call_infallible(glean_handle, |glean| {
         TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
             metric
-                .test_get_value(glean, storage_name.as_str())
+                .test_get_value_as_nanos(glean, storage_name.as_str())
                 .is_some()
         })
     })
 }
 
 #[no_mangle]
-pub extern "C" fn glean_timespan_test_get_value(
+pub extern "C" fn glean_timespan_test_get_value_as_unit(
     glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> u64 {
     GLEAN.call_infallible(glean_handle, |glean| {
         TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
-            metric.test_get_value(glean, storage_name.as_str()).unwrap()
+            metric
+                .test_get_value_as_unit(glean, storage_name.as_str())
+                .unwrap()
+        })
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn glean_timespan_test_get_value_as_nanos(
+    glean_handle: u64,
+    metric_id: u64,
+    storage_name: FfiStr,
+) -> u64 {
+    GLEAN.call_infallible(glean_handle, |glean| {
+        TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
+            metric
+                .test_get_value_as_nanos(glean, storage_name.as_str())
+                .unwrap()
         })
     })
 }

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -131,13 +131,26 @@ impl TimespanMetric {
 
     /// **Test-only API (exported for FFI purposes).**
     ///
-    /// Get the currently stored value as an integer.
+    /// Get the currently stored value as an integer in the metric's unit.
     ///
     /// This doesn't clear the stored value.
-    pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<u64> {
+    pub fn test_get_value_as_unit(&self, glean: &Glean, storage_name: &str) -> Option<u64> {
         match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
         {
             Some(Metric::Timespan(time, time_unit)) => Some(time_unit.duration_convert(time)),
+            _ => None,
+        }
+    }
+
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Get the currently stored value as an integer in `nanoseconds`.
+    ///
+    /// This doesn't clear the stored value.
+    pub fn test_get_value_as_nanos(&self, glean: &Glean, storage_name: &str) -> Option<u64> {
+        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
+        {
+            Some(Metric::Timespan(time, _)) => Some(TimeUnit::Nanosecond.duration_convert(time)),
             _ => None,
         }
     }

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -40,7 +40,7 @@ fn serializer_should_correctly_serialize_timespans() {
         metric.set_stop(&glean, duration);
 
         let val = metric
-            .test_get_value(&glean, "store1")
+            .test_get_value_as_unit(&glean, "store1")
             .expect("Value should be stored");
         assert_eq!(duration, val, "Recorded timespan should be positive.");
     }
@@ -81,7 +81,7 @@ fn single_elapsed_time_must_be_recorded() {
     metric.set_stop(&glean, duration);
 
     let val = metric
-        .test_get_value(&glean, "store1")
+        .test_get_value_as_unit(&glean, "store1")
         .expect("Value should be stored");
     assert_eq!(duration, val, "Recorded timespan should be positive.");
 }
@@ -108,13 +108,13 @@ fn second_timer_run_is_skipped() {
     metric.set_start(&glean, 0);
     metric.set_stop(&glean, duration);
 
-    let first_value = metric.test_get_value(&glean, "store1").unwrap();
+    let first_value = metric.test_get_value_as_unit(&glean, "store1").unwrap();
     assert_eq!(duration, first_value);
 
     metric.set_start(&glean, 0);
     metric.set_stop(&glean, duration * 2);
 
-    let second_value = metric.test_get_value(&glean, "store1").unwrap();
+    let second_value = metric.test_get_value_as_unit(&glean, "store1").unwrap();
     assert_eq!(second_value, first_value);
 }
 
@@ -148,7 +148,7 @@ fn recorded_time_conforms_to_resolution() {
     ns_metric.set_start(&glean, 0);
     ns_metric.set_stop(&glean, duration);
 
-    let ns_value = ns_metric.test_get_value(&glean, "store1").unwrap();
+    let ns_value = ns_metric.test_get_value_as_unit(&glean, "store1").unwrap();
     assert_eq!(duration, ns_value);
 
     // 1 minute in nanoseconds
@@ -156,7 +156,9 @@ fn recorded_time_conforms_to_resolution() {
     minute_metric.set_start(&glean, 0);
     minute_metric.set_stop(&glean, duration_minute);
 
-    let minute_value = minute_metric.test_get_value(&glean, "store1").unwrap();
+    let minute_value = minute_metric
+        .test_get_value_as_unit(&glean, "store1")
+        .unwrap();
     assert_eq!(1, minute_value);
 }
 
@@ -180,7 +182,7 @@ fn cancel_does_not_store() {
     metric.set_start(&glean, 0);
     metric.cancel();
 
-    assert_eq!(None, metric.test_get_value(&glean, "store1"));
+    assert_eq!(None, metric.test_get_value_as_unit(&glean, "store1"));
 }
 
 #[test]
@@ -202,10 +204,13 @@ fn nothing_stored_before_stop() {
 
     metric.set_start(&glean, 0);
 
-    assert_eq!(None, metric.test_get_value(&glean, "store1"));
+    assert_eq!(None, metric.test_get_value_as_unit(&glean, "store1"));
 
     metric.set_stop(&glean, duration);
-    assert_eq!(duration, metric.test_get_value(&glean, "store1").unwrap());
+    assert_eq!(
+        duration,
+        metric.test_get_value_as_unit(&glean, "store1").unwrap()
+    );
 }
 
 #[test]
@@ -227,7 +232,10 @@ fn set_raw_time() {
     metric.set_raw(&glean, time, false);
 
     let time_in_ns = time.as_nanos() as u64;
-    assert_eq!(Some(time_in_ns), metric.test_get_value(&glean, "store1"));
+    assert_eq!(
+        Some(time_in_ns),
+        metric.test_get_value_as_unit(&glean, "store1")
+    );
 }
 
 #[test]
@@ -252,7 +260,7 @@ fn set_raw_time_does_nothing_when_timer_running() {
     metric.set_stop(&glean, 60);
 
     // We expect the start/stop value, not the raw value.
-    assert_eq!(Some(60), metric.test_get_value(&glean, "store1"));
+    assert_eq!(Some(60), metric.test_get_value_as_unit(&glean, "store1"));
 
     // Make sure that the error has been recorded
     assert_eq!(


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1562848

Todo:

- [ ] double-check current tests and change to `AsNanos` where appropriate.

cc @mozilla/glean 
What do you think about having both methods?