### PR TITLE
1567914: String truncation shouldn't truncate in the middle of a codepoint

### DIFF
--- a/glean-core/src/metrics/experiment.rs
+++ b/glean-core/src/metrics/experiment.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
+use crate::util::truncate_string_at_boundary;
 use crate::CommonMetricData;
 use crate::Glean;
 use crate::Lifetime;
@@ -63,7 +64,7 @@ impl ExperimentMetric {
                 id.len(),
                 MAX_EXPERIMENTS_IDS_LEN
             );
-            id[0..MAX_EXPERIMENTS_IDS_LEN].to_string()
+            truncate_string_at_boundary(id, MAX_EXPERIMENTS_IDS_LEN)
         } else {
             id
         };
@@ -106,7 +107,7 @@ impl ExperimentMetric {
                 branch.len(),
                 MAX_EXPERIMENTS_IDS_LEN
             );
-            branch[0..MAX_EXPERIMENTS_IDS_LEN].to_string()
+            truncate_string_at_boundary(branch, MAX_EXPERIMENTS_IDS_LEN)
         } else {
             branch
         };

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
+use crate::util::truncate_string_at_boundary_with_error;
 use crate::CommonMetricData;
 use crate::Glean;
 
@@ -51,18 +51,7 @@ impl StringMetric {
             return;
         }
 
-        let s = value.into();
-        let s = if s.len() > MAX_LENGTH_VALUE {
-            let msg = format!(
-                "Value length {} exceeds maximum of {}",
-                s.len(),
-                MAX_LENGTH_VALUE
-            );
-            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
-            s[0..MAX_LENGTH_VALUE].to_string()
-        } else {
-            s
-        };
+        let s = truncate_string_at_boundary_with_error(glean, &self.meta, value, MAX_LENGTH_VALUE);
 
         let value = Metric::String(s);
         glean.storage().record(&self.meta, &value)

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -6,6 +6,7 @@ use crate::error_recording::{record_error, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
+use crate::util::truncate_string_at_boundary_with_error;
 use crate::CommonMetricData;
 use crate::Glean;
 
@@ -53,18 +54,8 @@ impl StringListMetric {
             return;
         }
 
-        let value = value.into();
-        let value = if value.len() > MAX_STRING_LENGTH {
-            let msg = format!(
-                "Individual value length {} exceeds maximum of {}",
-                value.len(),
-                MAX_STRING_LENGTH
-            );
-            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
-            value[0..MAX_STRING_LENGTH].to_string()
-        } else {
-            value
-        };
+        let value =
+            truncate_string_at_boundary_with_error(glean, &self.meta, value, MAX_STRING_LENGTH);
 
         let mut error = None;
         glean

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -187,8 +187,12 @@ mod test {
     #[test]
     fn truncate_safely_test() {
         let value = "电脑坏了".to_string();
-        let truncated = truncate_string_at_boundary(value.clone(), 10);
+        let truncated = truncate_string_at_boundary(value, 10);
         assert_eq!("电脑坏", truncated);
+
+        let value = "0123456789abcdef".to_string();
+        let truncated = truncate_string_at_boundary(value, 10);
+        assert_eq!("0123456789", truncated);
     }
 
     #[test]


### PR DESCRIPTION
This works by starting one character beyond the truncation point and moves back until it finds a character boundary.  The string is then truncated to the byte immediately preceding that boundary.

An alternative would have been to iterate over characters from the beginning, but that would be O(n), whereas this is O(1) (since barring corrupted string data, it should only have to look at at most 3 bytes).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
