### PR TITLE
Add a common histogram base class to `TimingDistributionMetricType`

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/HistogramBase.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/HistogramBase.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.private
+
+/**
+ * A common interface to be implemented by all the histogram-like metric types
+ * supported by the Glean SDK.
+ */
+interface HistogramBase {
+    /**
+     * Accumulates the provided samples in the metric.
+     *
+     * Please note that this assumes that the provided samples are already in the
+     * "unit" declared by the instance of the implementing metric type (e.g. if the
+     * implementing class is a [TimingDistributionMetricType] and the instance this
+     * method was called on is using [TimeUnit.Second], then `samples` are assumed
+     * to be in that unit).
+     *
+     * @param samples the [LongArray] holding the samples to be recorded by the metric.
+     */
+    fun accumulateSamples(samples: LongArray)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/HistogramBase.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/HistogramBase.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.service.glean.private
+package mozilla.telemetry.glean.private
 
 /**
  * A common interface to be implemented by all the histogram-like metric types

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import android.os.SystemClock
 import com.sun.jna.StringArray
-import mozilla.components.service.glean.private.HistogramBase
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.GleanTimerId
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
@@ -72,14 +71,12 @@ class TimingDistributionMetricType internal constructor(
     }
 
     /**
-     * Start tracking time for the provided metric and associated object. This
+     * Start tracking time for the provided metric and [GleanTimerId]. This
      * records an error if it’s already tracking time (i.e. start was already
      * called with no corresponding [stopAndAccumulate]): in that case the original
      * start time will be preserved.
      *
-     * @param timerId The object to associate with this timing.  This allows
-     * for concurrent timing of events associated with different objects to the
-     * same timespan metric.
+     * @return The [GleanTimerId] object to associate with this timing.
      */
     fun start(): GleanTimerId? {
         if (!shouldRecord()) {
@@ -98,12 +95,12 @@ class TimingDistributionMetricType internal constructor(
     }
 
     /**
-     * Stop tracking time for the provided metric and associated object. Add a
+     * Stop tracking time for the provided metric and associated timer id. Add a
      * count to the corresponding bucket in the timing distribution.
      * This will record an error if no [start] was called.
      *
-     * @param timerId The object to associate with this timing.  This allows
-     * for concurrent timing of events associated with different objects to the
+     * @param timerId The [GleanTimerId] to associate with this timing.  This allows
+     * for concurrent timing of events associated with different ids to the
      * same timespan metric.
      */
     fun stopAndAccumulate(timerId: GleanTimerId?) {
@@ -130,9 +127,9 @@ class TimingDistributionMetricType internal constructor(
     /**
      * Abort a previous [start] call. No error is recorded if no [start] was called.
      *
-     * @param timerId The object to associate with this timing.  This allows
-     * for concurrent timing of events associated with different objects to the
-     * same timespan metric.
+     * @param timerId The [GleanTimerId] to associate with this timing. This allows
+     * for concurrent timing of events associated with different ids to the
+     * same timing distribution metric.
      */
     fun cancel(timerId: GleanTimerId?) {
         if (!shouldRecord() || timerId == null) {
@@ -150,10 +147,14 @@ class TimingDistributionMetricType internal constructor(
             return
         }
 
-        samples.forEach {
-            println("Kotlin sample: ${it}")
-        }
-
+        // The reason we're using [Long](s) instead of [UInt](s) in Kotlin-land is
+        // the lack of [UInt] (in stable form). The positive part of [Int] would not
+        // be enough to represent the values coming in:
+        // - [UInt.MAX_VALUE] is 4294967295
+        // - [Int.MAX_VALUE] is 2147483647
+        // - [Long.MAX_VALUE] is 9223372036854775807
+        //
+        // On the rust side, Long(s) are handled as u64 and then casted to u32.
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_timing_distribution_accumulate_samples(

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -308,6 +308,8 @@ internal interface LibGleanFFI : Library {
 
     fun glean_timing_distribution_cancel(metric_id: Long, timer_id: GleanTimerId)
 
+    fun glean_timing_distribution_accumulate_samples(glean_handle: Long, metric_id: Long, samples: LongArray?, len: Int)
+
     fun glean_timing_distribution_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
     fun glean_timing_distribution_test_get_value_as_json_string(

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
@@ -141,4 +141,33 @@ class TimingDistributionMetricTypeTest {
         // Check that the 3L fell into the third bucket
         assertEquals(1L, snapshot2.values[3])
     }
+
+    @Test
+    fun `The accumulateSamples API correctly stores timing values`() {
+        // Define a timing distribution metric which will be stored in multiple stores
+        val metric = TimingDistributionMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "timing_distribution_samples",
+            sendInPings = listOf("store1"),
+            timeUnit = TimeUnit.Second
+        )
+
+        // Accumulate a few values
+        val testSamples = (1L..3L).toList().toLongArray()
+        metric.accumulateSamples(testSamples)
+
+        // Check that data was properly recorded in the second ping.
+        assertTrue(metric.testHasValue("store1"))
+        val snapshot = metric.testGetValue("store1")
+        // Check the sum
+        assertEquals(6L, snapshot.sum)
+        // Check that the 1L fell into the first bucket
+        assertEquals(1L, snapshot.values[1])
+        // Check that the 2L fell into the second bucket
+        assertEquals(1L, snapshot.values[2])
+        // Check that the 3L fell into the third bucket
+        assertEquals(1L, snapshot.values[3])
+    }
 }

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -165,7 +165,7 @@ fn from_raw_int64_array(values: RawInt64Array, len: i32) -> Vec<i64> {
         }
 
         let value_slice = std::slice::from_raw_parts(values, len as usize);
-        value_slice.iter().map(|&v| v as i64).collect()
+        value_slice.to_vec()
     }
 }
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -153,21 +153,19 @@ fn from_raw_string_array_and_string_array(
 
 /// Create a Vec<u32> from a raw C uint64 array.
 ///
-/// This will never return an `Error`. However, this is returning
-/// a `Result` for consistency with `from_raw_string_array` and
-/// returning an empty `Vec` if the input is empty.
+/// This will return an empty `Vec` if the input is empty.
 ///
 /// ## Safety
 ///
 /// * We check the array pointer for validity (non-null).
-fn from_raw_int64_array(values: RawInt64Array, len: i32) -> glean_core::Result<Vec<i64>> {
+fn from_raw_int64_array(values: RawInt64Array, len: i32) -> Vec<i64> {
     unsafe {
         if values.is_null() || len == 0 {
-            return Ok(vec![]);
+            return vec![];
         }
 
-        let values_ptrs = std::slice::from_raw_parts(values, len as usize);
-        Ok(values_ptrs.iter().map(|&v| v as i64).collect())
+        let value_slice = std::slice::from_raw_parts(values, len as usize);
+        value_slice.iter().map(|&v| v as i64).collect()
     }
 }
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -38,7 +38,7 @@ lazy_static! {
 
 type RawStringArray = *const *const c_char;
 type RawIntArray = *const i32;
-type RawUIntArray = *const u32;
+type RawUInt64Array = *const u64;
 
 /// Create a vector of strings from a raw C-like string array.
 ///
@@ -151,7 +151,7 @@ fn from_raw_string_array_and_string_array(
     }
 }
 
-/// Create a Vec<u32> from a raw C uint array.
+/// Create a Vec<u32> from a raw C uint64 array.
 ///
 /// This will never return an `Error`. However, this is returning
 /// a `Result` for consistency with `from_raw_string_array` and
@@ -160,8 +160,8 @@ fn from_raw_string_array_and_string_array(
 /// ## Safety
 ///
 /// * We check the array pointer for validity (non-null).
-fn from_raw_uint_array(
-    values: RawUIntArray,
+fn from_raw_uint64_array_to_u32(
+    values: RawUInt64Array,
     len: i32,
 ) -> glean_core::Result<Vec<u32>> {
     unsafe {
@@ -170,10 +170,10 @@ fn from_raw_uint_array(
         }
 
         let values_ptrs = std::slice::from_raw_parts(values, len as usize);
-        Ok(values_ptrs.to_vec())/*
+        Ok(values_ptrs
             .iter()
-            .map(|&v| {v})
-            .collect())*/
+            .map(|&v| {v as u32})
+            .collect())
     }
 }
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -38,6 +38,7 @@ lazy_static! {
 
 type RawStringArray = *const *const c_char;
 type RawIntArray = *const i32;
+type RawUIntArray = *const u32;
 
 /// Create a vector of strings from a raw C-like string array.
 ///
@@ -147,6 +148,32 @@ fn from_raw_string_array_and_string_array(
             })
             .collect();
         res.map(Some)
+    }
+}
+
+/// Create a Vec<u32> from a raw C uint array.
+///
+/// This will never return an `Error`. However, this is returning
+/// a `Result` for consistency with `from_raw_string_array` and
+/// returning an empty `Vec` if the input is empty.
+///
+/// ## Safety
+///
+/// * We check the array pointer for validity (non-null).
+fn from_raw_uint_array(
+    values: RawUIntArray,
+    len: i32,
+) -> glean_core::Result<Vec<u32>> {
+    unsafe {
+        if values.is_null() || len == 0 {
+            return Ok(vec![]);
+        }
+
+        let values_ptrs = std::slice::from_raw_parts(values, len as usize);
+        Ok(values_ptrs.to_vec())/*
+            .iter()
+            .map(|&v| {v})
+            .collect())*/
     }
 }
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -160,20 +160,14 @@ fn from_raw_string_array_and_string_array(
 /// ## Safety
 ///
 /// * We check the array pointer for validity (non-null).
-fn from_raw_uint64_array_to_u32(
-    values: RawUInt64Array,
-    len: i32,
-) -> glean_core::Result<Vec<u32>> {
+fn from_raw_uint64_array_to_u32(values: RawUInt64Array, len: i32) -> glean_core::Result<Vec<u32>> {
     unsafe {
         if values.is_null() || len == 0 {
             return Ok(vec![]);
         }
 
         let values_ptrs = std::slice::from_raw_parts(values, len as usize);
-        Ok(values_ptrs
-            .iter()
-            .map(|&v| {v as u32})
-            .collect())
+        Ok(values_ptrs.iter().map(|&v| v as u32).collect())
     }
 }
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -38,7 +38,7 @@ lazy_static! {
 
 type RawStringArray = *const *const c_char;
 type RawIntArray = *const i32;
-type RawUInt64Array = *const u64;
+type RawInt64Array = *const i64;
 
 /// Create a vector of strings from a raw C-like string array.
 ///
@@ -160,14 +160,14 @@ fn from_raw_string_array_and_string_array(
 /// ## Safety
 ///
 /// * We check the array pointer for validity (non-null).
-fn from_raw_uint64_array_to_u32(values: RawUInt64Array, len: i32) -> glean_core::Result<Vec<u32>> {
+fn from_raw_int64_array(values: RawInt64Array, len: i32) -> glean_core::Result<Vec<i64>> {
     unsafe {
         if values.is_null() || len == 0 {
             return Ok(vec![]);
         }
 
         let values_ptrs = std::slice::from_raw_parts(values, len as usize);
-        Ok(values_ptrs.iter().map(|&v| v as u32).collect())
+        Ok(values_ptrs.iter().map(|&v| v as i64).collect())
     }
 }
 

--- a/glean-core/ffi/src/timing_distribution.rs
+++ b/glean-core/ffi/src/timing_distribution.rs
@@ -6,7 +6,10 @@ use std::os::raw::c_char;
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, RawUInt64Array, from_raw_uint64_array_to_u32, GLEAN};
+use crate::{
+    define_metric, from_raw_uint64_array_to_u32, handlemap_ext::HandleMapExtension, RawUInt64Array,
+    GLEAN,
+};
 use glean_core::metrics::TimerId;
 
 define_metric!(TimingDistributionMetric => TIMING_DISTRIBUTION_METRICS {

--- a/glean-core/ffi/src/timing_distribution.rs
+++ b/glean-core/ffi/src/timing_distribution.rs
@@ -62,11 +62,9 @@ pub extern "C" fn glean_timing_distribution_accumulate_samples(
             // The Kotlin code is sending Long(s), which are 64 bits, as there's
             // currently no stable UInt type. The positive part of [Int] would not
             // be enough to represent the values coming in:.
-            // Here Long(s) are handled as i64 and then casted to u32.
-            //
-            // Note: It's safe to unwrap from the result of `from_raw_uint_array`,
-            // its always returning `Ok`.
-            let samples = from_raw_int64_array(raw_samples, num_samples).unwrap();
+            // Here Long(s) are handled as i64 and then casted in `accumulate_samples_signed`
+            // to u32.
+            let samples = from_raw_int64_array(raw_samples, num_samples);
             metric.accumulate_samples_signed(glean, samples);
         })
     })

--- a/glean-core/ffi/src/timing_distribution.rs
+++ b/glean-core/ffi/src/timing_distribution.rs
@@ -7,8 +7,7 @@ use std::os::raw::c_char;
 use ffi_support::FfiStr;
 
 use crate::{
-    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, RawInt64Array,
-    GLEAN,
+    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, RawInt64Array, GLEAN,
 };
 use glean_core::metrics::TimerId;
 

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -55,7 +55,7 @@ impl ErrorType {
 /// * message - The message to log. This message is not sent with the ping.
 ///             It does not need to include the metric name, as that is automatically prepended to the message.
 //  * num_errors - The number of errors of the same type to report.
-pub fn record_error<O: Into<Option<usize>>>(
+pub fn record_error<O: Into<Option<i32>>>(
     glean: &Glean,
     meta: &CommonMetricData,
     error: ErrorType,
@@ -81,7 +81,7 @@ pub fn record_error<O: Into<Option<usize>>>(
     });
 
     log::warn!("{}: {}", identifier, message);
-    metric.add(glean, num_errors.into().unwrap_or(1) as i32);
+    metric.add(glean, num_errors.into().unwrap_or(1));
 }
 
 /// Get the number of recorded errors for the given metric and error type.
@@ -163,7 +163,7 @@ mod test {
             string_metric.meta(),
             ErrorType::InvalidLabel,
             "Invalid label",
-            expected_invalid_labels_errors as usize,
+            expected_invalid_labels_errors,
         );
 
         for store in &["store1", "store2", "metrics"] {

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -60,7 +60,7 @@ pub fn record_error<O: Into<Option<usize>>>(
     meta: &CommonMetricData,
     error: ErrorType,
     message: impl Display,
-    num_errors: O
+    num_errors: O,
 ) {
     // Split off any label of the identifier
     let identifier = meta.identifier();

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -81,7 +81,9 @@ pub fn record_error<O: Into<Option<i32>>>(
     });
 
     log::warn!("{}: {}", identifier, message);
-    metric.add(glean, num_errors.into().unwrap_or(1));
+    let to_report = num_errors.into().unwrap_or(1);
+    debug_assert!(to_report > 0);
+    metric.add(glean, to_report);
 }
 
 /// Get the number of recorded errors for the given metric and error type.

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -55,6 +55,7 @@ impl CounterMetric {
                 &self.meta,
                 ErrorType::InvalidValue,
                 format!("Added negative or zero value {}", amount),
+                None,
             );
             return;
         }

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -71,7 +71,7 @@ impl DatetimeMetric {
         let timezone_offset = FixedOffset::east_opt(offset_seconds);
         if timezone_offset.is_none() {
             let msg = format!("Invalid timezone offset {}. Not recording.", offset_seconds);
-            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg, None);
             return;
         };
 
@@ -87,6 +87,7 @@ impl DatetimeMetric {
                     &self.meta,
                     ErrorType::InvalidValue,
                     "Invalid input data. Not recording.",
+                    None,
                 );
             }
         }

--- a/glean-core/src/metrics/event.rs
+++ b/glean-core/src/metrics/event.rs
@@ -86,7 +86,7 @@ impl EventMetric {
                         ),
                         None => {
                             let msg = format!("Invalid key index {}", k);
-                            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
+                            record_error(glean, &self.meta, ErrorType::InvalidValue, msg, None);
                             return;
                         }
                     };

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -137,13 +137,13 @@ where
                         label.len(),
                         MAX_LABEL_LENGTH
                     );
-                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg);
+                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg, None);
                     return OTHER_LABEL;
                 }
 
                 if !LABEL_REGEX.is_match(label) {
                     let msg = format!("label must be snake_case, got '{}'", label);
-                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg);
+                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg, None);
                     return OTHER_LABEL;
                 }
 

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -137,13 +137,25 @@ where
                         label.len(),
                         MAX_LABEL_LENGTH
                     );
-                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg, None);
+                    record_error(
+                        glean,
+                        &self.submetric.meta(),
+                        ErrorType::InvalidLabel,
+                        msg,
+                        None,
+                    );
                     return OTHER_LABEL;
                 }
 
                 if !LABEL_REGEX.is_match(label) {
                     let msg = format!("label must be snake_case, got '{}'", label);
-                    record_error(glean, &self.submetric.meta(), ErrorType::InvalidLabel, msg, None);
+                    record_error(
+                        glean,
+                        &self.submetric.meta(),
+                        ErrorType::InvalidLabel,
+                        msg,
+                        None,
+                    );
                     return OTHER_LABEL;
                 }
 

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -56,7 +56,6 @@ impl StringListMetric {
 
         let value =
             truncate_string_at_boundary_with_error(glean, &self.meta, value, MAX_STRING_LENGTH);
-
         let mut error = None;
         glean
             .storage()
@@ -78,7 +77,7 @@ impl StringListMetric {
             });
 
         if let Some(msg) = error {
-            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg, None);
         }
     }
 
@@ -104,7 +103,7 @@ impl StringListMetric {
                 value.len(),
                 MAX_LIST_LENGTH
             );
-            record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg, None);
             value[0..MAX_LIST_LENGTH].to_vec()
         } else {
             value
@@ -119,7 +118,7 @@ impl StringListMetric {
                         elem.len(),
                         MAX_STRING_LENGTH
                     );
-                    record_error(glean, &self.meta, ErrorType::InvalidValue, msg);
+                    record_error(glean, &self.meta, ErrorType::InvalidValue, msg, None);
                     elem[0..MAX_STRING_LENGTH].to_string()
                 } else {
                     elem

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -115,6 +115,7 @@ impl TimespanMetric {
                 &self.meta,
                 ErrorType::InvalidValue,
                 "Timespan already running. Raw value not recorded.",
+                None,
             );
             return;
         }

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -58,6 +58,7 @@ impl TimespanMetric {
                 &self.meta,
                 ErrorType::InvalidValue,
                 "Timespan already started",
+                None,
             );
             return;
         }
@@ -75,6 +76,7 @@ impl TimespanMetric {
                 &self.meta,
                 ErrorType::InvalidValue,
                 "Timespan not running",
+                None,
             );
             return;
         }

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -186,7 +186,7 @@ impl TimingDistributionMetric {
     /// was called.
     ///
     /// ## Arguments
-    /// 
+    ///
     /// * `id` - The `TimerId` to associate with this timing. This allows
     ///   for concurrent timing of events associated with different ids to the
     ///   same timing distribution metric.

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -198,12 +198,14 @@ impl TimingDistributionMetric {
             });
     }
 
-    /// Abort a previous [start] call. No error is recorded if no [start] was called.
+    /// Abort a previous `set_start` call. No error is recorded if no `set_start`
+    /// was called.
     ///
-    /// @param timerId The [GleanTimerId] to associate with this timing. This allows
-    /// for concurrent timing of events associated with different ids to the
-    /// same timing distribution metric.
-    ///
+    /// ## Arguments
+    /// 
+    /// * `id` - The `TimerId` to associate with this timing. This allows
+    ///   for concurrent timing of events associated with different ids to the
+    ///   same timing distribution metric.
     pub fn cancel(&mut self, id: TimerId) {
         self.timings.cancel(id);
     }

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -109,7 +109,7 @@ pub(crate) fn truncate_string_at_boundary_with_error<S: Into<String>>(
     let s = value.into();
     if s.len() > length {
         let msg = format!("Value length {} exceeds maximum of {}", s.len(), length);
-        record_error(glean, meta, ErrorType::InvalidValue, msg);
+        record_error(glean, meta, ErrorType::InvalidValue, msg, None);
         truncate_string_at_boundary(s, length)
     } else {
         s

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -154,7 +154,7 @@ fn the_accumulate_samples_api_correctly_stores_timing_values() {
     );
 
     // Accumulate the samples.
-    metric.accumulate_samples(&glean, [1, 2, 3].to_vec());
+    metric.accumulate_samples_signed(&glean, [-1, 1, 2, 3].to_vec());
 
     let val = metric
         .test_get_value(&glean, "store1")

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -135,3 +135,37 @@ fn timing_distributions_must_not_accumulate_negative_values() {
         )
     );
 }
+
+#[test]
+fn the_accumulate_samples_api_correctly_stores_timing_values() {
+    let (_t, tmpname) = tempdir();
+
+    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+
+    let mut metric = TimingDistributionMetric::new(
+        CommonMetricData {
+            name: "distribution".into(),
+            category: "telemetry".into(),
+            send_in_pings: vec!["store1".into()],
+            disabled: false,
+            lifetime: Lifetime::Ping,
+        },
+        TimeUnit::Second,
+    );
+
+    // Accumulate the samples.
+    metric.accumulate_samples(&glean, [1, 2, 3].to_vec());
+
+    let val = metric
+        .test_get_value(&glean, "store1")
+        .expect("Value should be stored");
+
+    // Check that we got the right sum and number of samples.
+    assert_eq!(val.sum(), 6);
+    assert_eq!(val.count(), 3);
+
+    // We should get a sample in each of the first 3 buckets.
+    assert_eq!(1, val.values()[1]);
+    assert_eq!(1, val.values()[2]);
+    assert_eq!(1, val.values()[3]);
+}


### PR DESCRIPTION
This is porting over the changes from mozilla-mobile/android-components#3829 to glean-core.



### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
