### PR TITLE
[doc only] 1562681: Add missing "type" parameter to docs

### DIFF
--- a/docs/user/metric-parameters.md
+++ b/docs/user/metric-parameters.md
@@ -2,6 +2,8 @@
 
 All metric types must include the following required parameters:
 
+- `type`: **Required.**  Specifies the type of a metric, like "counter" or "event". This defines which operations are valid for the metric, how it is stored and how data analysis tooling displays it. See the list of [supported metric types](metrics/index.md).
+
 - `description`: **Required.** A textual description of the metric for humans. It should describe what the metric does, what it means for analysts, and its edge cases or any other helpful information.
   
 - `notification_emails`: **Required.** A list of email addresses to notify for important events with the metric or when people with context or ownership for the metric need to be contacted.


### PR DESCRIPTION
This is the only bit Glean-general docs in glean_parser that hasn't already been copied over here.  (Everything else in the glean_parser docs is API docs that are specific to glean_parser).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
