### PR TITLE
Don't report errors, when no errors occurred, in timing_distribution

### DIFF
--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -250,8 +250,10 @@ impl TimingDistributionMetric {
             Metric::TimingDistribution(hist, time_unit)
         });
 
-        let msg = format!("Accumulated {} negative samples", num_errors);
-        record_error(glean, &self.meta, ErrorType::InvalidValue, msg, num_errors);
+        if num_errors > 0 {
+            let msg = format!("Accumulated {} negative samples", num_errors);
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg, num_errors);
+        }
     }
 
     /// **Test-only API (exported for FFI purposes).**


### PR DESCRIPTION
This additionally adds a test that reports no error and one
that attempts to accumulate negative samples and, as such,
triggers error reporting.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
