### PR TITLE
Use a config structure to pass data to Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Carthage
 data/
 glean-core/data
 glean_app*
+!glean_app.c

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -108,7 +108,8 @@ open class GleanInternalAPI internal constructor () {
         val cfg = FfiConfiguration(
             dataDir = this.gleanDataDir.path,
             packageName = applicationContext.packageName,
-            uploadEnabled = uploadEnabled
+            uploadEnabled = uploadEnabled,
+            maxEvents = this.configuration.maxEvents
         )
 
         handle = LibGleanFFI.INSTANCE.glean_initialize(cfg)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -14,6 +14,7 @@ import com.sun.jna.StringArray
 import kotlinx.coroutines.Job
 import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.config.FfiConfiguration
 import mozilla.telemetry.glean.utils.getLocaleTag
 import java.io.File
 import mozilla.telemetry.glean.rust.LibGleanFFI
@@ -102,13 +103,15 @@ open class GleanInternalAPI internal constructor () {
         this.applicationContext = applicationContext
 
         this.configuration = configuration
-
         this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR)
-        handle = LibGleanFFI.INSTANCE.glean_initialize(
-            this.gleanDataDir.path,
-            applicationContext.packageName,
-            uploadEnabled.toByte()
+
+        val cfg = FfiConfiguration(
+            dataDir = this.gleanDataDir.path,
+            packageName = applicationContext.packageName,
+            uploadEnabled = uploadEnabled
         )
+
+        handle = LibGleanFFI.INSTANCE.glean_initialize(cfg)
 
         // If initialization of Glean fails we bail out and don't initialize further.
         if (handle == 0L) {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -10,7 +10,7 @@ import mozilla.telemetry.glean.BuildConfig
 import mozilla.telemetry.glean.rust.toByte
 
 import com.sun.jna.Structure
-import com.sun.jna.ptr.LongByReference
+import com.sun.jna.ptr.IntByReference
 
 /**
  * Define the order of fields as laid out in memory.
@@ -22,7 +22,7 @@ internal class FfiConfiguration(
     dataDir: String,
     packageName: String,
     uploadEnabled: Boolean,
-    maxEvents: Long? = null
+    maxEvents: Int? = null
 ) : Structure() {
     /**
      * Expose all structure fields as actual fields,
@@ -36,7 +36,7 @@ internal class FfiConfiguration(
     @JvmField
     public var uploadEnabled: Byte = uploadEnabled.toByte()
     @JvmField
-    public var maxEvents: LongByReference = if (maxEvents == null) LongByReference() else LongByReference(maxEvents!!)
+    public var maxEvents: IntByReference = if (maxEvents == null) IntByReference() else IntByReference(maxEvents!!)
 
     init {
         // Force UTF-8 string encoding when passing strings over the FFI
@@ -67,7 +67,7 @@ data class Configuration internal constructor(
     val userAgent: String = DEFAULT_USER_AGENT,
     val connectionTimeout: Long = DEFAULT_CONNECTION_TIMEOUT,
     val readTimeout: Long = DEFAULT_READ_TIMEOUT,
-    val maxEvents: Int = DEFAULT_MAX_EVENTS,
+    val maxEvents: Int? = null,
     val logPings: Boolean = DEFAULT_LOG_PINGS,
     // NOTE: since only simple object or strings can be made `const val`s, if the
     // default values for the lines below are ever changed, they are required

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -7,6 +7,41 @@ package mozilla.telemetry.glean.config
 import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.telemetry.glean.BuildConfig
+import mozilla.telemetry.glean.rust.toByte
+
+import com.sun.jna.Structure
+import com.sun.jna.ptr.LongByReference
+
+/**
+ * Define the order of fields as laid out in memory.
+ * **CAUTION**: This must match _exactly_ the definition on the Rust side.
+ */
+@Structure.FieldOrder("dataDir", "packageName", "uploadEnabled", "maxEvents")
+internal class FfiConfiguration(
+    dataDir: String,
+    packageName: String,
+    uploadEnabled: Boolean,
+    maxEvents: Long? = null
+) : Structure() {
+    /**
+     * Expose all structure fields as actual fields,
+     * in order for Structure to turn them into the right memory representiation
+     */
+
+    @JvmField
+    public var dataDir: String = dataDir
+    @JvmField
+    public var packageName: String = packageName
+    @JvmField
+    public var uploadEnabled: Byte = uploadEnabled.toByte()
+    @JvmField
+    public var maxEvents: LongByReference = if (maxEvents == null) LongByReference() else LongByReference(maxEvents!!)
+
+    init {
+        // Force UTF-8 string encoding when passing strings over the FFI
+        this.stringEncoding = "UTF-8"
+    }
+}
 
 /**
  * The Configuration class describes how to configure Glean.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -15,6 +15,7 @@ import com.sun.jna.ptr.LongByReference
 /**
  * Define the order of fields as laid out in memory.
  * **CAUTION**: This must match _exactly_ the definition on the Rust side.
+ *  If this side is changed, the Rust side need to be changed, too.
  */
 @Structure.FieldOrder("dataDir", "packageName", "uploadEnabled", "maxEvents")
 internal class FfiConfiguration(

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -12,6 +12,7 @@ import com.sun.jna.Pointer
 import com.sun.jna.StringArray
 import java.lang.reflect.Proxy
 import mozilla.telemetry.glean.GleanTimerId
+import mozilla.telemetry.glean.config.FfiConfiguration
 
 // Turn a boolean into its Byte (u8) representation
 internal fun Boolean.toByte(): Byte = if (this) 1 else 0
@@ -66,7 +67,7 @@ internal interface LibGleanFFI : Library {
 
     // Glean top-level API
 
-    fun glean_initialize(data_dir: String, application_id: String, upload_enabled: Byte): Long
+    fun glean_initialize(cfg: FfiConfiguration): Long
 
     fun glean_destroy_glean(handle: Long, error: RustError.ByReference)
 

--- a/glean-core/examples/sample.rs
+++ b/glean-core/examples/sample.rs
@@ -18,7 +18,13 @@ fn main() {
         root.path().display().to_string()
     };
 
-    let mut glean = Glean::new(&data_path, "org.mozilla.glean_core.example", true).unwrap();
+    let cfg = glean_core::Configuration {
+        data_path,
+        application_id: "org.mozilla.glean_core.example".into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+    let mut glean = Glean::new(cfg).unwrap();
     glean.register_ping_type(&PingType::new("baseline", true));
     glean.register_ping_type(&PingType::new("metrics", true));
 

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -27,6 +27,15 @@ typedef const int32_t *RawIntArray;
 
 typedef const char *const *RawStringArray;
 
+typedef struct {
+  FfiStr data_dir;
+  FfiStr package_name;
+  uint8_t upload_enabled;
+  const int64_t *max_events;
+} FfiConfiguration;
+
+typedef const int64_t *RawInt64Array;
+
 void glean_boolean_set(uint64_t glean_handle, uint64_t metric_id, uint8_t value);
 
 uint8_t glean_boolean_should_record(uint64_t glean_handle, uint64_t metric_id);
@@ -125,7 +134,7 @@ char *glean_experiment_test_get_data(uint64_t glean_handle, FfiStr experiment_id
 
 uint8_t glean_experiment_test_is_active(uint64_t glean_handle, FfiStr experiment_id);
 
-uint64_t glean_initialize(FfiStr data_dir, FfiStr application_id, uint8_t upload_enabled);
+uint64_t glean_initialize(const FfiConfiguration *cfg);
 
 uint8_t glean_is_upload_enabled(uint64_t glean_handle);
 
@@ -322,6 +331,11 @@ uint64_t glean_timespan_test_get_value(uint64_t glean_handle,
 uint8_t glean_timespan_test_has_value(uint64_t glean_handle,
                                       uint64_t metric_id,
                                       FfiStr storage_name);
+
+void glean_timing_distribution_accumulate_samples(uint64_t glean_handle,
+                                                  uint64_t metric_id,
+                                                  RawInt64Array raw_samples,
+                                                  int32_t num_samples);
 
 void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
 

--- a/glean-core/ffi/examples/glean_app.c
+++ b/glean-core/ffi/examples/glean_app.c
@@ -8,7 +8,13 @@
 int main(void)
 {
   glean_enable_logging();
-  uint64_t glean = glean_initialize("/tmp/glean_data", "c-app", true);
+  FfiConfiguration cfg = {
+    "/tmp/glean_data",
+    "c-app",
+    true,
+    NULL
+  };
+  uint64_t glean = glean_initialize(&cfg);
   uint64_t store1 = glean_new_ping_type("store1", true);
   glean_register_ping_type(glean, store1);
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::redundant_closure)]
 
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::os::raw::c_char;
 
 use ffi_support::{
@@ -198,6 +199,10 @@ pub extern "C" fn glean_enable_logging() {
     }
 }
 
+/// Configuration over FFI.
+///
+/// **CAUTION**: This must match _exactly_ the definition on the Kotlin side.
+/// If this side is changed, the Kotlin side need to be changed, too.
 #[repr(C)]
 pub struct FfiConfiguration<'a> {
     data_dir: FfiStr<'a>,
@@ -206,17 +211,10 @@ pub struct FfiConfiguration<'a> {
     max_events: Option<&'a i64>,
 }
 
-#[derive(Debug)]
-pub struct GleanConfiguration {
-    upload_enabled: bool,
-    data_path: String,
-    application_id: String,
-    max_events: Option<usize>,
-}
-
-use std::convert::TryFrom;
-impl TryFrom<&FfiConfiguration<'_>> for GleanConfiguration {
+/// Convert the FFI-compatible configuration object into the proper Rust configuration object.
+impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
     type Error = glean_core::Error;
+
     fn try_from(cfg: &FfiConfiguration) -> Result<Self, Self::Error> {
         let data_path = cfg
             .data_dir
@@ -246,12 +244,12 @@ pub unsafe extern "C" fn glean_initialize(cfg: *const FfiConfiguration) -> u64 {
     assert!(!cfg.is_null());
 
     GLEAN.insert_with_log(|| {
-        let glean_cfg = GleanConfiguration::try_from(&*cfg)?;
-        let glean = Glean::new(
-            &glean_cfg.data_path,
-            &glean_cfg.application_id,
-            glean_cfg.upload_enabled,
-        )?;
+        // We can create a reference to the FfiConfiguration struct:
+        // 1. We did a null check
+        // 2. We're not holding on to it beyond this function
+        //    and we copy out all data when needed.
+        let glean_cfg = glean_core::Configuration::try_from(&*cfg)?;
+        let glean = Glean::new(glean_cfg)?;
         log::info!("Glean initialized");
         Ok(glean)
     })

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![allow(clippy::redundant_closure)]
-
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::os::raw::c_char;
@@ -239,7 +237,6 @@ impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
 }
 
 #[no_mangle]
-#[allow(clippy::let_unit_value)]
 pub unsafe extern "C" fn glean_initialize(cfg: *const FfiConfiguration) -> u64 {
     assert!(!cfg.is_null());
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -208,7 +208,7 @@ pub struct FfiConfiguration<'a> {
     data_dir: FfiStr<'a>,
     package_name: FfiStr<'a>,
     upload_enabled: u8,
-    max_events: Option<&'a i64>,
+    max_events: Option<&'a i32>,
 }
 
 /// Convert the FFI-compatible configuration object into the proper Rust configuration object.

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -132,7 +132,7 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
         let tmpname = dir.path().display().to_string();
 
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
         (glean, dir)
     }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -3,8 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #![deny(missing_docs)]
-#![allow(clippy::new_without_default)]
-#![allow(clippy::redundant_closure)]
 
 //! Glean is a modern approach for recording and sending Telemetry data.
 //!

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -272,7 +272,7 @@ mod test {
     pub fn new_glean() -> (Glean, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let tmpname = dir.path().display().to_string();
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
         (glean, dir)
     }
 

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -205,7 +205,7 @@ mod test {
     fn test_experiments_json_serialization() {
         let t = tempfile::tempdir().unwrap();
         let name = t.path().display().to_string();
-        let glean = Glean::new(&name, "org.mozilla.glean", true).unwrap();
+        let glean = Glean::with_options(&name, "org.mozilla.glean", true).unwrap();
 
         let extra: HashMap<String, String> = [("test-key".into(), "test-value".into())]
             .iter()

--- a/glean-core/tests/boolean.rs
+++ b/glean-core/tests/boolean.rs
@@ -17,8 +17,15 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 #[test]
 fn boolean_serializer_should_correctly_serialize_boolean() {
     let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let metric = BooleanMetric::new(CommonMetricData {
             name: "boolean_metric".into(),
@@ -42,7 +49,7 @@ fn boolean_serializer_should_correctly_serialize_boolean() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -49,7 +49,13 @@ pub fn new_glean() -> (Glean, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
 
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+    let glean = Glean::new(cfg).unwrap();
 
     (glean, dir)
 }

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -20,8 +20,15 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 #[test]
 fn counter_serializer_should_correctly_serialize_counters() {
     let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let metric = CounterMetric::new(CommonMetricData {
             name: "counter_metric".into(),
@@ -45,7 +52,7 @@ fn counter_serializer_should_correctly_serialize_counters() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/datetime.rs
+++ b/glean-core/tests/datetime.rs
@@ -19,8 +19,15 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 fn datetime_serializer_should_correctly_serialize_datetime() {
     let expected_value = "1983-04-13T12:09+00:00";
     let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let metric = DatetimeMetric::new(
             CommonMetricData {
@@ -51,7 +58,7 @@ fn datetime_serializer_should_correctly_serialize_datetime() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -9,14 +9,13 @@ use std::collections::HashMap;
 use std::fs;
 
 use glean_core::metrics::*;
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 #[test]
 fn record_properly_records_without_optional_arguments() {
-    let (_t, tmpname) = tempdir();
     let store_names = vec!["store1".into(), "store2".into()];
 
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+    let (glean, _t) = new_glean();
 
     let metric = EventMetric::new(
         CommonMetricData {
@@ -42,11 +41,9 @@ fn record_properly_records_without_optional_arguments() {
 
 #[test]
 fn record_properly_records_with_optional_arguments() {
-    let (_t, tmpname) = tempdir();
+    let (glean, _t) = new_glean();
 
     let store_names = vec!["store1".into(), "store2".into()];
-
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
     let metric = EventMetric::new(
         CommonMetricData {
@@ -84,9 +81,7 @@ fn record_properly_records_with_optional_arguments() {
 
 #[test]
 fn snapshot_returns_none_if_nothing_is_recorded_in_the_store() {
-    let (_t, tmpname) = tempdir();
-
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+    let (glean, _t) = new_glean();
 
     assert!(glean
         .event_storage()
@@ -96,11 +91,9 @@ fn snapshot_returns_none_if_nothing_is_recorded_in_the_store() {
 
 #[test]
 fn snapshot_correctly_clears_the_stores() {
-    let (_t, tmpname) = tempdir();
+    let (glean, _t) = new_glean();
 
     let store_names = vec!["store1".into(), "store2".into()];
-
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
     let metric = EventMetric::new(
         CommonMetricData {
@@ -151,11 +144,9 @@ fn snapshot_correctly_clears_the_stores() {
 
 #[test]
 fn test_sending_of_event_ping_when_it_fills_up() {
-    let (_t, tmpname) = tempdir();
+    let (mut glean, _t) = new_glean();
 
     let store_names: Vec<String> = vec!["events".into()];
-
-    let mut glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
     for store_name in &store_names {
         glean.register_ping_type(&PingType::new(store_name.clone(), true));
@@ -204,11 +195,9 @@ fn test_sending_of_event_ping_when_it_fills_up() {
 
 #[test]
 fn extra_keys_must_be_recorded_and_truncated_if_needed() {
-    let (_t, tmpname) = tempdir();
+    let (glean, _t) = new_glean();
 
     let store_names: Vec<String> = vec!["store1".into()];
-
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
     let test_event = EventMetric::new(
         CommonMetricData {

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -319,7 +319,16 @@ fn dynamic_labels_regex_allowed() {
 
 #[test]
 fn seen_labels_get_reloaded_from_disk() {
-    let (glean, dir) = new_glean();
+    let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
+    let glean = Glean::new(cfg.clone()).unwrap();
+
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -357,8 +366,7 @@ fn seen_labels_get_reloaded_from_disk() {
 
     // Force a reload
     {
-        let tmpname = dir.path().display().to_string();
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         // Try to store another label
         labeled.get(&glean, "new_label").add(&glean, 40);

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -13,7 +13,13 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 
 fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
     let (t, tmpname) = tempdir();
-    let mut glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+    let mut glean = Glean::new(cfg).unwrap();
     let ping_maker = PingMaker::new();
     let ping_type = PingType::new("store1", true);
     glean.register_ping_type(&ping_type);

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -18,8 +18,15 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 #[test]
 fn string_serializer_should_correctly_serialize_strings() {
     let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let metric = StringMetric::new(CommonMetricData {
             name: "string_metric".into(),
@@ -43,7 +50,7 @@ fn string_serializer_should_correctly_serialize_strings() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -44,8 +44,16 @@ fn list_can_store_multiple_items() {
 #[test]
 fn stringlist_serializer_should_correctly_serialize_stringlists() {
     let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
+
         let metric = StringListMetric::new(CommonMetricData {
             name: "string_list_metric".into(),
             category: "telemetry.test".into(),
@@ -57,7 +65,7 @@ fn stringlist_serializer_should_correctly_serialize_stringlists() {
     }
 
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -19,11 +19,17 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 #[test]
 fn serializer_should_correctly_serialize_timespans() {
     let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
 
     let duration = 60;
 
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let mut metric = TimespanMetric::new(
             CommonMetricData {
@@ -48,7 +54,7 @@ fn serializer_should_correctly_serialize_timespans() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -21,8 +21,15 @@ fn serializer_should_correctly_serialize_timing_distribution() {
     let duration = 60;
     let time_unit = TimeUnit::Nanosecond;
 
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let mut metric = TimingDistributionMetric::new(
             CommonMetricData {
@@ -48,7 +55,7 @@ fn serializer_should_correctly_serialize_timing_distribution() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -99,12 +106,10 @@ fn set_value_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn timing_distributions_must_not_accumulate_negative_values() {
-    let (_t, tmpname) = tempdir();
+    let (glean, _t) = new_glean();
 
     let duration = 60;
     let time_unit = TimeUnit::Nanosecond;
-
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
     let mut metric = TimingDistributionMetric::new(
         CommonMetricData {
@@ -138,9 +143,7 @@ fn timing_distributions_must_not_accumulate_negative_values() {
 
 #[test]
 fn the_accumulate_samples_api_correctly_stores_timing_values() {
-    let (_t, tmpname) = tempdir();
-
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+    let (glean, _t) = new_glean();
 
     let mut metric = TimingDistributionMetric::new(
         CommonMetricData {
@@ -182,9 +185,7 @@ fn the_accumulate_samples_api_correctly_stores_timing_values() {
 
 #[test]
 fn the_accumulate_samples_api_correctly_handles_negative_values() {
-    let (_t, tmpname) = tempdir();
-
-    let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+    let (glean, _t) = new_glean();
 
     let mut metric = TimingDistributionMetric::new(
         CommonMetricData {

--- a/glean-core/tests/uuid.rs
+++ b/glean-core/tests/uuid.rs
@@ -42,8 +42,15 @@ fn uuid_serializer_should_correctly_serialize_uuids() {
     let value = uuid::Uuid::new_v4();
 
     let (_t, tmpname) = tempdir();
+    let cfg = glean_core::Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+    };
+
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
 
         let metric = UuidMetric::new(CommonMetricData {
             name: "uuid_metric".into(),
@@ -67,7 +74,7 @@ fn uuid_serializer_should_correctly_serialize_uuids() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::new(cfg.clone()).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();


### PR DESCRIPTION
This is a first draft/PoC of using a structure passed over FFI.

Notable:
* We need to ensure Kotlin and Rust use the same (C-compatible) structure
* Kotlin/JNA does the conversions, I'm not sure how heavy that is, then again we convert the configuration once.
* Passing null over is a bit tricky, but JNA has helpers (LongByReference)
* We still need to convert from the C-compatible types (`FfiStr`, ~~`*const i64`~~) to usable Rust types
* This currently does not use the defaults. The Glean constructor should take `Options` where it can provide a default (or we write the builder pattern, though that's a bit more code for a single use)
