### PR TITLE
1568034 - Update Dispatchers to queue tasks before Glean is initialized

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
+import mozilla.components.support.base.log.logger.Logger
+import java.util.concurrent.ConcurrentLinkedQueue
 
 @ObsoleteCoroutinesApi
 internal object Dispatchers {
@@ -18,24 +20,44 @@ internal object Dispatchers {
         // When true, jobs will be run synchronously
         internal var testingMode = false
 
+        // When true, jobs will be queued and not ran until triggered by calling
+        // flushQueuedInitialTasks()
+        @Volatile
+        private var queueInitialTasks = true
+
+        // Use a [ConcurrentLinkedQueue] to take advantage of it's thread safety and no locking
+        internal val taskQueue: ConcurrentLinkedQueue<() -> Unit> = ConcurrentLinkedQueue()
+
+        private val logger = Logger("glean/Dispatchers")
+
+        companion object {
+            // This value was chosen in order to allow several tasks to be queued for execution but
+            // still be conservative of memory. This queue size is important for cases where
+            // setUploadEnabled(false) is not called so that we don't continue to queue tasks and
+            // waste memory.
+            const val MAX_QUEUE_SIZE = 100
+        }
+
         /**
-         * Launch a block of work asyncronously.
+         * Launch a block of work asynchronously.
+         *
+         * * If [queueInitialTasks] is true, then the work will be queued and executed when
+         * [flushQueuedInitialTasks] is called.
          *
          * If [setTestingMode] has enabled testing mode, the work will run
          * synchronously.
          *
-         * @return [Job], or null if run synchronously.
+         * @return [Job], or null if queued or run synchronously.
          */
         fun launch(
             block: suspend CoroutineScope.() -> Unit
         ): Job? {
-            return if (testingMode) {
-                runBlocking {
-                    block()
+            return when {
+                queueInitialTasks -> {
+                    addTaskToQueue(block)
+                    null
                 }
-                null
-            } else {
-                coroutineScope.launch(block = block)
+                else -> executeTask(block)
             }
         }
 
@@ -64,6 +86,79 @@ internal object Dispatchers {
         @VisibleForTesting(otherwise = VisibleForTesting.NONE)
         fun setTestingMode(enabled: Boolean) {
             testingMode = enabled
+        }
+
+        /**
+         * Enable queueing mode, which causes tasks to be queued until launched by calling
+         * [flushQueuedInitialTasks].
+         *
+         * @param enabled whether or not to enable the testing mode
+         */
+        @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+        fun setTaskQueueing(enabled: Boolean) {
+            queueInitialTasks = enabled
+        }
+
+        /**
+         * Stops queueing tasks and processes any tasks in the queue. Since [queueInitialTasks] is
+         * set to false prior to processing the queue, newly launched tasks should be executed
+         * on the couroutine scope rather than added to the queue.
+         */
+        internal fun flushQueuedInitialTasks() {
+            // Setting this to false first should cause any new tasks to just be executed (see
+            // launch() above) making it safer to process the queue.
+            //
+            // NOTE: This has the potential for causing a task to execute out of order in certain
+            // situations. If a library or thread that runs before init happens to record
+            // between when the queueInitialTasks is set to false and the taskQueue finishing
+            // launching, then that task could be executed out of the queued order. See the bugzilla
+            // bug tracking this for more info: https://bugzilla.mozilla.org/show_bug.cgi?id=1568503
+            queueInitialTasks = false
+            taskQueue.forEach { task ->
+                task.invoke()
+            }
+            taskQueue.clear()
+        }
+
+        /**
+         * Helper function to add task to queue as either a synchronous or asynchronous operation,
+         * depending on whether [testingMode] is true.
+         */
+        private fun addTaskToQueue(block: suspend CoroutineScope.() -> Unit) {
+            if (taskQueue.size >= MAX_QUEUE_SIZE) {
+                logger.error("Exceeded maximum queue size, discarding task")
+                return
+            }
+
+            if (testingMode) {
+                logger.info("Task queued for execution in test mode")
+                taskQueue.add {
+                    runBlocking {
+                        block()
+                    }
+                }
+            } else {
+                logger.info("Task queued for execution and delayed until flushed")
+                taskQueue.add {
+                    coroutineScope.launch(block = block)
+                }
+            }
+        }
+
+        /**
+         * Helper function to execute the task as either an synchronous or asynchronous operation,
+         * depending on whether [testingMode] is true.
+         */
+        private fun executeTask(block: suspend CoroutineScope.() -> Unit): Job? {
+            return when {
+                testingMode -> {
+                    runBlocking {
+                        block()
+                    }
+                    null
+                }
+                else -> coroutineScope.launch(block = block)
+            }
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -136,6 +136,10 @@ open class GleanInternalAPI internal constructor () {
         // metricsPingScheduler = MetricsPingScheduler(applicationContext)
         // metricsPingScheduler.startupCheck()
 
+        // Signal Dispatcher that init is complete
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.flushQueuedInitialTasks()
+
         // At this point, all metrics and events can be recorded.
         ProcessLifecycleOwner.get().lifecycle.addObserver(gleanLifecycleObserver)
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -26,6 +26,7 @@ import mozilla.telemetry.glean.rust.toBoolean
  */
 class BooleanMetricType internal constructor(
     private var handle: Long,
+    private val disabled: Boolean,
     private val sendInPings: List<String>
 ) {
 
@@ -38,7 +39,7 @@ class BooleanMetricType internal constructor(
         lifetime: Lifetime,
         name: String,
         sendInPings: List<String>
-    ) : this(handle = 0, sendInPings = sendInPings) {
+    ) : this(handle = 0, disabled = disabled, sendInPings = sendInPings) {
         val ffiPingsList = StringArray(sendInPings.toTypedArray(), "utf-8")
         this.handle = LibGleanFFI.INSTANCE.glean_new_boolean_metric(
                 category = category,
@@ -56,22 +57,13 @@ class BooleanMetricType internal constructor(
         }
     }
 
-    private fun shouldRecord(): Boolean {
-        // Don't record metrics if we aren't initialized
-        if (!Glean.isInitialized()) {
-            return false
-        }
-
-        return LibGleanFFI.INSTANCE.glean_boolean_should_record(Glean.handle, this.handle).toBoolean()
-    }
-
     /**
      * Set a boolean value.
      *
      * @param value This is a user defined boolean value.
      */
     fun set(value: Boolean) {
-        if (!shouldRecord()) {
+        if (disabled) {
             return
         }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -23,7 +23,7 @@ import mozilla.telemetry.glean.rust.toByte
  * individual storage engines and rearrange them correctly in the ping.
  */
 class LabeledMetricType<T>(
-    disabled: Boolean,
+    private val disabled: Boolean,
     category: String,
     lifetime: Lifetime,
     name: String,
@@ -79,15 +79,15 @@ class LabeledMetricType<T>(
         return when (subMetric) {
             is CounterMetricType -> {
                 val handle = LibGleanFFI.INSTANCE.glean_labeled_counter_metric_get(Glean.handle, this.handle, label)
-                CounterMetricType(handle = handle, sendInPings = sendInPings) as T
+                CounterMetricType(handle = handle, disabled = disabled, sendInPings = sendInPings) as T
             }
             is BooleanMetricType -> {
                 val handle = LibGleanFFI.INSTANCE.glean_labeled_boolean_metric_get(Glean.handle, this.handle, label)
-                BooleanMetricType(handle = handle, sendInPings = sendInPings) as T
+                BooleanMetricType(handle = handle, disabled = disabled, sendInPings = sendInPings) as T
             }
             is StringMetricType -> {
                 val handle = LibGleanFFI.INSTANCE.glean_labeled_string_metric_get(Glean.handle, this.handle, label)
-                StringMetricType(handle = handle, sendInPings = sendInPings) as T
+                StringMetricType(handle = handle, disabled = disabled, sendInPings = sendInPings) as T
             }
             else -> throw IllegalStateException(
                 "Can not create a labeled version of this metric type"

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -18,6 +18,7 @@ import org.json.JSONArray
 
 class StringListMetricType(
     private var handle: Long,
+    private val disabled: Boolean,
     private val sendInPings: List<String>
 ) {
     /**
@@ -29,7 +30,7 @@ class StringListMetricType(
         lifetime: Lifetime,
         name: String,
         sendInPings: List<String>
-    ) : this(handle = 0, sendInPings = sendInPings) {
+    ) : this(handle = 0, disabled = disabled, sendInPings = sendInPings) {
         val ffiPingsList = StringArray(sendInPings.toTypedArray(), "utf-8")
         this.handle = LibGleanFFI.INSTANCE.glean_new_string_list_metric(
             category = category,
@@ -49,15 +50,6 @@ class StringListMetricType(
         // It is expected to only ever error if this.handle's invalid.
     }
 
-    private fun shouldRecord(): Boolean {
-        // Don't record metrics if Glean isn't initialized.
-        if (!Glean.isInitialized()) {
-            return false
-        }
-
-        return LibGleanFFI.INSTANCE.glean_string_list_should_record(Glean.handle, this.handle).toBoolean()
-    }
-
     /**
      * Appends a string value to one or more string list metric stores.  If the string exceeds the
      * maximum string length or if the list exceeds the maximum length it will be truncated.
@@ -66,7 +58,7 @@ class StringListMetricType(
      *              this string is [MAX_STRING_LENGTH].
      */
     fun add(value: String) {
-        if (!shouldRecord()) {
+        if (disabled) {
             return
         }
 
@@ -86,7 +78,7 @@ class StringListMetricType(
      * @param value This is a user defined string list.
      */
     fun set(value: List<String>) {
-        if (!shouldRecord()) {
+        if (disabled) {
             return
         }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -28,6 +28,7 @@ import mozilla.telemetry.glean.rust.toBoolean
  */
 class StringMetricType internal constructor(
     private var handle: Long,
+    private val disabled: Boolean,
     private val sendInPings: List<String>
 ) {
     /**
@@ -39,7 +40,7 @@ class StringMetricType internal constructor(
         lifetime: Lifetime,
         name: String,
         sendInPings: List<String>
-    ) : this(handle = 0, sendInPings = sendInPings) {
+    ) : this(handle = 0, disabled = disabled, sendInPings = sendInPings) {
         val ffiPingsList = StringArray(sendInPings.toTypedArray(), "utf-8")
         this.handle = LibGleanFFI.INSTANCE.glean_new_string_metric(
                 category = category,
@@ -57,15 +58,6 @@ class StringMetricType internal constructor(
         }
     }
 
-    private fun shouldRecord(): Boolean {
-        // Don't record metrics if we aren't initialized
-        if (!Glean.isInitialized()) {
-            return false
-        }
-
-        return LibGleanFFI.INSTANCE.glean_string_should_record(Glean.handle, this.handle).toBoolean()
-    }
-
     /**
      * Set a string value.
      *
@@ -73,7 +65,7 @@ class StringMetricType internal constructor(
      *              the maximum length, it will be truncated.
      */
     fun set(value: String) {
-        if (!shouldRecord()) {
+        if (disabled) {
             return
         }
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
@@ -11,17 +11,17 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 
+@Suppress("EXPERIMENTAL_API_USAGE")
 class DispatchersTest {
 
     @Test
     fun `API scope runs off the main thread`() {
         val mainThread = Thread.currentThread()
         var threadCanary = false
-        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.setTestingMode(false)
+        Dispatchers.API.setTaskQueueing(false)
 
         runBlocking {
-            @Suppress("EXPERIMENTAL_API_USAGE")
             Dispatchers.API.launch {
                 assertNotSame(mainThread, Thread.currentThread())
                 // Use the canary bool to make sure this is getting called before
@@ -31,9 +31,33 @@ class DispatchersTest {
             }!!.join()
         }
 
-        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.setTestingMode(true)
         assertEquals(true, threadCanary)
         assertSame(mainThread, Thread.currentThread())
+    }
+
+    @Test
+    fun `launch correctly adds tests to queue if queueTasks is true`() {
+        var threadCanary = 0
+
+        Dispatchers.API.setTestingMode(true)
+        Dispatchers.API.setTaskQueueing(true)
+
+        // Add 3 tasks to queue each one setting threadCanary to true to indicate if any task has ran
+        repeat(3) {
+            Dispatchers.API.launch {
+                threadCanary += 1
+            }
+        }
+
+        assertEquals("Task queue contains the correct number of tasks",
+            3, Dispatchers.API.taskQueue.size)
+        assertEquals("Tasks have not run while in queue", 0, threadCanary)
+
+        // Now trigger execution to ensure the tasks fired
+        Dispatchers.API.flushQueuedInitialTasks()
+
+        assertEquals("Tasks have executed", 3, threadCanary)
+        assertEquals("Task queue is cleared", 0, Dispatchers.API.taskQueue.size)
     }
 }


### PR DESCRIPTION
Keeping things in sync with glean-ac.  This was a little more problematic on the implementation side of things than glean-ac, mostly due to needing the Rust side of Glean initialized to be able to determine if upload is enabled and if a metric is disabled (in the `shouldRecord` methods).  I ended up just keeping parallel variables on the Kotlin side to eliminate/reduce the need to query across the FFI boundary.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
