### PR TITLE
Log the same actions as glean AC

### DIFF
--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -38,11 +38,11 @@ impl Database {
     /// Creates the storage directories and inits rkv.
     fn open_rkv(path: &str) -> Result<Rkv> {
         let path = std::path::Path::new(path);
-        log::info!("Path is: {:?}", path.display());
+        log::debug!("Database path: {:?}", path.display());
         fs::create_dir_all(&path)?;
 
         let rkv = Rkv::new(path)?;
-        log::info!("Rkv done. We are initialized!");
+        log::info!("Database initialized");
         Ok(rkv)
     }
 

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -134,7 +134,7 @@ impl EventDatabase {
         for store_name in store_names {
             if let Err(err) = glean.send_ping_by_name(&store_name, false) {
                 log::error!(
-                    "Error flushing existing events to the {} ping: {}",
+                    "Error flushing existing events to the '{}' ping: {}",
                     store_name,
                     err
                 );
@@ -212,7 +212,7 @@ impl EventDatabase {
             .open(self.path.join(store_name))
             .and_then(|mut file| writeln!(file, "{}", event_json))
         {
-            log::error!("Error writing event to store {}: {}", store_name, err);
+            log::error!("IO error writing event to store '{}': {}", store_name, err);
         }
     }
 
@@ -236,6 +236,7 @@ impl EventDatabase {
                         store.iter().map(|e| e.serialize_relative(first_timestamp)),
                     ))
                 } else {
+                    log::error!("Unexpectly got empty event store for '{}'", store_name);
                     None
                 }
             })
@@ -253,7 +254,7 @@ impl EventDatabase {
                     std::io::ErrorKind::NotFound => {
                         // silently drop this error, the file was already non-existing
                     }
-                    _ => log::error!("Error removing events queue file {}: {}", store_name, err),
+                    _ => log::error!("Error removing events queue file '{}': {}", store_name, err),
                 }
             }
         }


### PR DESCRIPTION
This also tries to unify the wording of log messages where appropriate.

This is all I found right now.

I'm a bit torn about 2 occasions where I do `let Err(e) = ...` just to log and rethrow the error (at which point the actual error will still bubble up and get logged at the FFI boundary I think).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
