### PR TITLE
1569603 - Remove `glean_*_should_record` functions from FFI

### DIFF
--- a/docs/dev/core/new-metric-type.md
+++ b/docs/dev/core/new-metric-type.md
@@ -150,7 +150,6 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 define_metric!(CounterMetric => COUNTER_METRICS {
     new           -> glean_new_counter_metric(),
     destroy       -> glean_destroy_counter_metric,
-    should_record -> glean_counter_should_record,
 
     add -> glean_counter_add(amount: i32),
 });
@@ -185,7 +184,6 @@ For Kotlin this is in `glean-core/android/src/main/java/mozilla/telemetry/glean/
 fun glean_new_counter_metric(category: String, name: String, send_in_pings: StringArray, send_in_pings_len: Int, lifetime: Int, disabled: Byte): Long
 fun glean_destroy_counter_metric(handle: Long, error: RustError.ByReference)
 fun glean_counter_add(glean_handle: Long, metric_id: Long, amount: Int)
-fun glean_counter_should_record(glean_handle: Long, metric_id: Long): Byte
 ```
 
 Finally, create a platform-specific metric type wrapper.
@@ -217,15 +215,6 @@ class CounterMetricType(
             val error = RustError.ByReference()
             LibGleanFFI.INSTANCE.glean_destroy_counter_metric(this.handle, error)
         }
-    }
-
-    fun shouldRecord(): Boolean {
-        // Don't record metrics if we aren't initialized
-        if (!Glean.isInitialized()) {
-            return false
-        }
-
-        return LibGleanFFI.INSTANCE.glean_counter_should_record(Glean.handle, this.handle).toBoolean()
     }
 
     fun add(amount: Int = 1) {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -125,8 +125,6 @@ internal interface LibGleanFFI : Library {
 
     fun glean_boolean_set(glean_handle: Long, metric_id: Long, value: Byte)
 
-    fun glean_boolean_should_record(glean_handle: Long, metric_id: Long): Byte
-
     fun glean_boolean_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
     fun glean_boolean_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
@@ -146,8 +144,6 @@ internal interface LibGleanFFI : Library {
 
     fun glean_counter_add(glean_handle: Long, metric_id: Long, amount: Int)
 
-    fun glean_counter_should_record(glean_handle: Long, metric_id: Long): Byte
-
     fun glean_counter_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Int
 
     fun glean_counter_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
@@ -166,8 +162,6 @@ internal interface LibGleanFFI : Library {
     fun glean_destroy_string_metric(handle: Long, error: RustError.ByReference)
 
     fun glean_string_set(glean_handle: Long, metric_id: Long, value: String)
-
-    fun glean_string_should_record(glean_handle: Long, metric_id: Long): Byte
 
     fun glean_string_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Pointer?
 
@@ -200,8 +194,6 @@ internal interface LibGleanFFI : Library {
         offset_seconds: Int
     )
 
-    fun glean_datetime_should_record(glean_handle: Long, metric_id: Long): Byte
-
     fun glean_datetime_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
     fun glean_datetime_test_get_value_as_string(glean_handle: Long, metric_id: Long, storage_name: String): Pointer?
@@ -218,8 +210,6 @@ internal interface LibGleanFFI : Library {
     ): Long
 
     fun glean_destroy_string_list_metric(handle: Long, error: RustError.ByReference)
-
-    fun glean_string_list_should_record(glean_handle: Long, metric_id: Long): Byte
 
     fun glean_string_list_add(glean_handle: Long, metric_id: Long, value: String)
 
@@ -246,8 +236,6 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_uuid_metric(handle: Long, error: RustError.ByReference)
 
-    fun glean_uuid_should_record(glean_handle: Long, metric_id: Long): Byte
-
     fun glean_uuid_set(glean_handle: Long, metric_id: Long, value: String)
 
     fun glean_uuid_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
@@ -267,8 +255,6 @@ internal interface LibGleanFFI : Library {
     ): Long
 
     fun glean_destroy_timespan_metric(handle: Long, error: RustError.ByReference)
-
-    fun glean_timespan_should_record(glean_handle: Long, metric_id: Long): Byte
 
     fun glean_timespan_set_start(glean_handle: Long, metric_id: Long, start_time: Long)
 
@@ -295,8 +281,6 @@ internal interface LibGleanFFI : Library {
     ): Long
 
     fun glean_destroy_timing_distribution_metric(handle: Long, error: RustError.ByReference)
-
-    fun glean_timing_distribution_should_record(glean_handle: Long, metric_id: Long): Byte
 
     fun glean_timing_distribution_set_start(glean_handle: Long, metric_id: Long, start_time: Long): GleanTimerId
 
@@ -331,8 +315,6 @@ internal interface LibGleanFFI : Library {
         allowed_extra_keys: StringArray?,
         allowed_extra_keys_len: Int
     ): Long
-
-    fun glean_event_should_record(glean_handle: Long, metric_id: Long): Byte
 
     fun glean_event_record(
         glean_handle: Long,

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -38,8 +38,6 @@ typedef const int64_t *RawInt64Array;
 
 void glean_boolean_set(uint64_t glean_handle, uint64_t metric_id, uint8_t value);
 
-uint8_t glean_boolean_should_record(uint64_t glean_handle, uint64_t metric_id);
-
 uint8_t glean_boolean_test_get_value(uint64_t glean_handle,
                                      uint64_t metric_id,
                                      FfiStr storage_name);
@@ -49,8 +47,6 @@ uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
                                      FfiStr storage_name);
 
 void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
-
-uint8_t glean_counter_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 int32_t glean_counter_test_get_value(uint64_t glean_handle,
                                      uint64_t metric_id,
@@ -70,8 +66,6 @@ void glean_datetime_set(uint64_t glean_handle,
                         uint32_t second,
                         int64_t nano,
                         int32_t offset_seconds);
-
-uint8_t glean_datetime_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 char *glean_datetime_test_get_value_as_string(uint64_t glean_handle,
                                               uint64_t metric_id,
@@ -121,8 +115,6 @@ void glean_event_record(uint64_t glean_handle,
                         RawIntArray extra_keys,
                         RawStringArray extra_values,
                         int32_t extra_len);
-
-uint8_t glean_event_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 char *glean_event_test_get_value_as_json_string(uint64_t glean_handle,
                                                 uint64_t metric_id,
@@ -292,8 +284,6 @@ void glean_string_list_set(uint64_t glean_handle,
                            RawStringArray values,
                            int32_t values_len);
 
-uint8_t glean_string_list_should_record(uint64_t glean_handle, uint64_t metric_id);
-
 char *glean_string_list_test_get_value_as_json_string(uint64_t glean_handle,
                                                       uint64_t metric_id,
                                                       FfiStr storage_name);
@@ -303,8 +293,6 @@ uint8_t glean_string_list_test_has_value(uint64_t glean_handle,
                                          FfiStr storage_name);
 
 void glean_string_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
-
-uint8_t glean_string_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
 
@@ -321,8 +309,6 @@ void glean_timespan_set_raw_nanos(uint64_t glean_handle,
 void glean_timespan_set_start(uint64_t glean_handle, uint64_t metric_id, uint64_t start_time);
 
 void glean_timespan_set_stop(uint64_t glean_handle, uint64_t metric_id, uint64_t stop_time);
-
-uint8_t glean_timespan_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 uint64_t glean_timespan_test_get_value(uint64_t glean_handle,
                                        uint64_t metric_id,
@@ -348,8 +334,6 @@ void glean_timing_distribution_set_stop_and_accumulate(uint64_t glean_handle,
                                                        TimerId timer_id,
                                                        uint64_t stop_time);
 
-uint8_t glean_timing_distribution_should_record(uint64_t glean_handle, uint64_t metric_id);
-
 char *glean_timing_distribution_test_get_value_as_json_string(uint64_t glean_handle,
                                                               uint64_t metric_id,
                                                               FfiStr storage_name);
@@ -359,8 +343,6 @@ uint8_t glean_timing_distribution_test_has_value(uint64_t glean_handle,
                                                  FfiStr storage_name);
 
 void glean_uuid_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
-
-uint8_t glean_uuid_should_record(uint64_t glean_handle, uint64_t metric_id);
 
 char *glean_uuid_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
 

--- a/glean-core/ffi/src/boolean.rs
+++ b/glean-core/ffi/src/boolean.rs
@@ -9,7 +9,6 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 define_metric!(BooleanMetric => BOOLEAN_METRICS {
     new           -> glean_new_boolean_metric(),
     destroy       -> glean_destroy_boolean_metric,
-    should_record -> glean_boolean_should_record,
 });
 
 #[no_mangle]

--- a/glean-core/ffi/src/counter.rs
+++ b/glean-core/ffi/src/counter.rs
@@ -9,7 +9,6 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 define_metric!(CounterMetric => COUNTER_METRICS {
     new           -> glean_new_counter_metric(),
     destroy       -> glean_destroy_counter_metric,
-    should_record -> glean_counter_should_record,
 
     add -> glean_counter_add(amount: i32),
 });

--- a/glean-core/ffi/src/datetime.rs
+++ b/glean-core/ffi/src/datetime.rs
@@ -11,7 +11,6 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 define_metric!(DatetimeMetric => DATETIME_METRICS {
     new           -> glean_new_datetime_metric(time_unit: i32),
     destroy       -> glean_destroy_datetime_metric,
-    should_record -> glean_datetime_should_record,
 });
 
 #[no_mangle]

--- a/glean-core/ffi/src/event.rs
+++ b/glean-core/ffi/src/event.rs
@@ -18,7 +18,6 @@ use crate::{
 
 define_metric!(EventMetric => EVENT_METRICS {
     destroy       -> glean_destroy_event_metric,
-    should_record -> glean_event_should_record,
 });
 
 #[no_mangle]

--- a/glean-core/ffi/src/string.rs
+++ b/glean-core/ffi/src/string.rs
@@ -11,7 +11,6 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 define_metric!(StringMetric => STRING_METRICS {
     new           -> glean_new_string_metric(),
     destroy       -> glean_destroy_string_metric,
-    should_record -> glean_string_should_record,
 
     set -> glean_string_set(value: FfiStr),
 });

--- a/glean-core/ffi/src/string_list.rs
+++ b/glean-core/ffi/src/string_list.rs
@@ -13,7 +13,6 @@ use crate::{
 define_metric!(StringListMetric => STRING_LIST_METRICS {
     new           -> glean_new_string_list_metric(),
     destroy       -> glean_destroy_string_list_metric,
-    should_record -> glean_string_list_should_record,
 
     add -> glean_string_list_add(value: FfiStr),
 });

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -11,7 +11,6 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 define_metric!(TimespanMetric => TIMESPAN_METRICS {
     new           -> glean_new_timespan_metric(time_unit: i32),
     destroy       -> glean_destroy_timespan_metric,
-    should_record -> glean_timespan_should_record,
 });
 
 #[no_mangle]

--- a/glean-core/ffi/src/timing_distribution.rs
+++ b/glean-core/ffi/src/timing_distribution.rs
@@ -14,7 +14,6 @@ use glean_core::metrics::TimerId;
 define_metric!(TimingDistributionMetric => TIMING_DISTRIBUTION_METRICS {
     new           -> glean_new_timing_distribution_metric(time_unit: i32),
     destroy       -> glean_destroy_timing_distribution_metric,
-    should_record -> glean_timing_distribution_should_record,
 });
 
 #[no_mangle]

--- a/glean-core/ffi/src/uuid.rs
+++ b/glean-core/ffi/src/uuid.rs
@@ -11,7 +11,6 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 define_metric!(UuidMetric => UUID_METRICS {
     new           -> glean_new_uuid_metric(),
     destroy       -> glean_destroy_uuid_metric,
-    should_record -> glean_uuid_should_record,
 });
 
 #[no_mangle]


### PR DESCRIPTION
This removes the `should_record` functions from the FFI since they are no longer used.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
