### PR TITLE
 Report an error if Timespans are used twice before are cleared

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -79,8 +79,10 @@ class TimespanMetricType internal constructor(
 
     /**
      * Stop tracking time for the provided metric.
-     * Sets the metric to the elapsed time.
-     * This will record an error if no [start] was called.
+     * Sets the metric to the elapsed time, but does not overwrite an already
+     * existing value.
+     * This will record an error if no [start] was called or there is an already
+     * existing value.
      */
     fun stop() {
         if (disabled) {

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -114,6 +114,11 @@ fn second_timer_run_is_skipped() {
     metric.set_start(&glean, 0);
     metric.set_stop(&glean, duration);
 
+    // No error should be recorded here: we had no prior value stored.
+    assert!(
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None).is_err()
+    );
+
     let first_value = metric.test_get_value(&glean, "store1").unwrap();
     assert_eq!(duration, first_value);
 
@@ -122,6 +127,13 @@ fn second_timer_run_is_skipped() {
 
     let second_value = metric.test_get_value(&glean, "store1").unwrap();
     assert_eq!(second_value, first_value);
+
+    // Make sure that the error has been recorded: we had a stored value, the
+    // new measurement was dropped.
+    assert_eq!(
+        Ok(1),
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is related to mozilla-mobile/android-components#3970

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
