### PR TITLE
Update integration docs to be more appropriate for glean-ac

### DIFF
--- a/docs/user/adding-glean-to-your-project.md
+++ b/docs/user/adding-glean-to-your-project.md
@@ -11,16 +11,26 @@ Products using the Glean SDK to collect telemetry **must**:
 
 ## Usage
 
-### Setting up the dependency
+### Integrating with your project
+
+There are currently two implementations of Glean: an Android-only implementation that is part of Mozilla's [android-components](https://github.com/mozilla-mobile/android-components) project, and a [cross-platform implementation in Rust](https://github.com/mozilla/glean).
+
+This section describes integrating with the Android-only implementation.  The other implementation is still a work in progress and does not make release builds available.
+
+#### Setting up the dependency
 
 Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/)
-([Setup repository](../../../README.md#maven-repository)):
+([Setup repository](../../../README.md#maven-repository)) by adding the following to
+your Gradle configuration:
 
 ```Groovy
 implementation "org.mozilla.components:service-glean:{latest-version}"
 ```
 
-### Integrating with the build system
+The Glean SDK is released as part of [android-components](https://github.com/mozilla-mobile/android-components).  Therefore, it follows android-components' versions.
+The [android-components release page](https://github.com/mozilla-mobile/android-components/releases/) can be used to determine the latest version.
+
+#### Integrating with the build system
 
 In order for the Glean SDK to generate an API for your metrics, a Python environment must be accessible at build time.
 This is done automatically by the [`com.jetbrains.python.envs`](https://github.com/JetBrains/gradle-python-envs/) plugin.
@@ -36,14 +46,14 @@ Right before the end of the same file, the Glean SDK build script must be includ
 This script can be referenced directly from the GitHub repo, as shown below:
 
 ```Groovy
-apply from: 'https://github.com/mozilla/glean/raw/v{latest-version}/glean-core/android/sdk_generator.gradle'
+apply from: 'https://github.com/mozilla-mobile/android-components/raw/v{latest-version}/components/service/scripts/sdk_generator.gradle'
 ```
 
 > **Important:** the `{latest-version}` placeholder in the above link should be replaced with the version number of the Glean SDK used by the project.
-For example, if version *0.34.2* is used, then the include directive becomes:
+For example, if version *6.0.2* is used, then the include directive becomes:
 
 ```Groovy
-apply from: 'https://github.com/mozilla/glean/raw/v0.34.2/glean-core/android/sdk_generator.gradle'
+apply from: 'https://github.com/mozilla-mobile/android-components/raw/v6.0.2/components/service/scripts/sdk_generator.gradle'
 ```
 
 ### Adding new metrics

--- a/docs/user/adding-glean-to-your-project.md
+++ b/docs/user/adding-glean-to-your-project.md
@@ -13,15 +13,9 @@ Products using the Glean SDK to collect telemetry **must**:
 
 ### Integrating with your project
 
-There are currently two implementations of Glean: an Android-only implementation that is part of Mozilla's [android-components](https://github.com/mozilla-mobile/android-components) project, and a [cross-platform implementation in Rust](https://github.com/mozilla/glean).
-
-This section describes integrating with the Android-only implementation.  The other implementation is still a work in progress and does not make release builds available.
-
 #### Setting up the dependency
 
-Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/)
-([Setup repository](../../../README.md#maven-repository)) by adding the following to
-your Gradle configuration:
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](https://github.com/mozilla-mobile/android-components/blob/master/README.md#maven-repository)) by adding the following to your Gradle configuration:
 
 ```Groovy
 implementation "org.mozilla.components:service-glean:{latest-version}"


### PR DESCRIPTION
Based on feedback from support provided by @travis79.

This updates the "integrating in your project" docs to be accurate for `glean-ac`.  It also clarifies how you would find version numbers for `glean-ac`.  

We don't really have supported releases for `glean-core` yet, so it's probably only confusing to document things about that now and it's all pretty TBD how that all will work, so best to keep this only documenting the things that are working and available now.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
