### PR TITLE
Clear stores in tests by toggling upload

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -520,15 +520,10 @@ open class GleanInternalAPI internal constructor () {
     ) {
         Glean.enableTestingMode()
 
-        // TODO: this will be addressed in bug 1570247
-        /*if (clearStores) {
+        if (isInitialized() && clearStores) {
             // Clear all the stored data.
-            val storageManager = StorageEngineManager(applicationContext = context)
-            storageManager.clearAllStores()
-            // The experiments storage engine needs to be cleared manually as it's not listed
-            // in the `StorageEngineManager`.
-            ExperimentsStorageEngine.clearAllStores()
-        }*/
+            LibGleanFFI.INSTANCE.glean_test_clear_all_stores(handle)
+        }
 
         // Init Glean.
         Glean.testDestroyGleanHandle()

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -69,6 +69,8 @@ internal interface LibGleanFFI : Library {
 
     fun glean_initialize(cfg: FfiConfiguration): Long
 
+    fun glean_test_clear_all_stores(handle: Long)
+
     fun glean_destroy_glean(handle: Long, error: RustError.ByReference)
 
     fun glean_on_ready_to_send_pings(handle: Long)

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -303,6 +303,8 @@ char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, Ffi
 
 uint8_t glean_string_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
 
+void glean_test_clear_all_stores(uint64_t glean_handle);
+
 uint8_t glean_test_has_ping_type(uint64_t glean_handle, FfiStr ping_name);
 
 void glean_timespan_cancel(uint64_t metric_id);

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -212,5 +212,10 @@ pub extern "C" fn glean_experiment_test_get_data(
     })
 }
 
+#[no_mangle]
+pub extern "C" fn glean_test_clear_all_stores(glean_handle: u64) {
+    GLEAN.call_infallible(glean_handle, |glean| glean.test_clear_all_stores());
+}
+
 define_handle_map_deleter!(GLEAN, glean_destroy_glean);
 define_string_destructor!(glean_str_free);

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -502,6 +502,17 @@ impl Glean {
         let metric = metrics::ExperimentMetric::new(experiment_id);
         metric.test_get_value_as_json_string(&self)
     }
+
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Delete all stored metrics.
+    /// Note that this also includes the ping sequence numbers, so it has
+    /// the effect of resetting those to their initial values.
+    pub fn test_clear_all_stores(&self) {
+        self.data_store.clear_all();
+        // We don't care about this failing, maybe the data does just not exist.
+        let _ = self.event_data_store.clear_all();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
So for this I actually have 2 different variants: this in here or [introducing a new FFI function](https://github.com/mozilla/glean/compare/clear-stores-2).

I considered this because I felt introducing all that FFI shenangigans for it wasn't worth it and it's _just_ a test API.

I await your judgement on either solution. 
