### PR TITLE
Record new error type "invalid state" to accurately describe the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v19.0.0...master)
 
 * Fixed a crash calling `start` on a timing distribution metric before Glean is initialized.
-  Timings are always measured, but only recorded when upload is enabled.
-* BUGFIX: When the Debug Activity is used to log pings, each ping is now logged only once.
+  Timings are always measured, but only recorded when upload is enabled ([#400](https://github.com/mozilla/glean/pull/400))
+* BUGFIX: When the Debug Activity is used to log pings, each ping is now logged only once ([#407](https://github.com/mozilla/glean/pull/407))
 * New `invalid state` error, used in timespan recording ([#230](https://github.com/mozilla/glean/pull/230))
 
 # v19.0.0 (2019-10-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Fixed a crash calling `start` on a timing distribution metric before Glean is initialized.
   Timings are always measured, but only recorded when upload is enabled.
-  
 * BUGFIX: When the Debug Activity is used to log pings, each ping is now logged only once.
+* New `invalid state` error, used in timespan recording ([#230](https://github.com/mozilla/glean/pull/230))
 
 # v19.0.0 (2019-10-22)
 

--- a/docs/user/metrics/timespan.md
+++ b/docs/user/metrics/timespan.md
@@ -152,6 +152,7 @@ HistorySync.setRawNanos(duration)
 
 * `invalid_value`
     * If recording a negative timespan.
+* `invalid_state`
     * If starting a timer while a previous timer is running.
     * If stopping a timer while it is not running.
     * If trying to set a raw timespan while a timer is running.

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -27,6 +27,8 @@ pub enum ErrorType {
     InvalidValue,
     /// For when the label of a labeled metric does not match the restrictions
     InvalidLabel,
+    /// For when the metric caught an invalid state while recording
+    InvalidState,
 }
 
 impl ErrorType {
@@ -35,6 +37,7 @@ impl ErrorType {
         match self {
             ErrorType::InvalidValue => "invalid_value",
             ErrorType::InvalidLabel => "invalid_label",
+            ErrorType::InvalidState => "invalid_state",
         }
     }
 }

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -56,7 +56,7 @@ impl TimespanMetric {
             record_error(
                 glean,
                 &self.meta,
-                ErrorType::InvalidValue,
+                ErrorType::InvalidState,
                 "Timespan already started",
                 None,
             );
@@ -74,7 +74,7 @@ impl TimespanMetric {
             record_error(
                 glean,
                 &self.meta,
-                ErrorType::InvalidValue,
+                ErrorType::InvalidState,
                 "Timespan not running",
                 None,
             );
@@ -113,7 +113,7 @@ impl TimespanMetric {
             record_error(
                 glean,
                 &self.meta,
-                ErrorType::InvalidValue,
+                ErrorType::InvalidState,
                 "Timespan already running. Raw value not recorded.",
                 None,
             );
@@ -142,7 +142,7 @@ impl TimespanMetric {
             record_error(
                 glean,
                 &self.meta,
-                ErrorType::InvalidValue,
+                ErrorType::InvalidState,
                 "Timespan value already recorded. New value discarded.",
                 None,
             );

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -119,7 +119,7 @@ fn second_timer_run_is_skipped() {
 
     // No error should be recorded here: we had no prior value stored.
     assert!(
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None).is_err()
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None).is_err()
     );
 
     let first_value = metric.test_get_value(&glean, "store1").unwrap();
@@ -135,7 +135,7 @@ fn second_timer_run_is_skipped() {
     // new measurement was dropped.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None)
     );
 }
 
@@ -284,6 +284,6 @@ fn set_raw_time_does_nothing_when_timer_running() {
     // Make sure that the error has been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None)
     );
 }


### PR DESCRIPTION
CAUTION: This might change error reporting for existing metrics.
We should decide if we want that.
That will only apply once we drop Glean AC (or we would need to also backport this)