### PR TITLE
Move collecting and storing multiple pings at once into Rust core

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -83,9 +83,12 @@ internal interface LibGleanFFI : Library {
 
     fun glean_ping_collect(glean_handle: Long, ping_type_handle: Long): Pointer?
 
-    fun glean_send_ping(glean_handle: Long, ping_type_handle: Long, log_ping: Byte): Byte
-
-    fun glean_send_ping_by_name(glean_handle: Long, ping_name: String, log_ping: Byte): Byte
+    fun glean_send_pings_by_name(
+        glean_handle: Long,
+        ping_names: StringArray,
+        ping_names_len: Int,
+        log_ping: Byte
+    ): Byte
 
     fun glean_set_experiment_active(
         glean_handle: Long,

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -389,6 +389,11 @@ class GleanTest {
 
         val server = getMockWebServer()
 
+        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ))
+
         val pingName = "custom_ping_1"
         val ping = PingType(
             name = pingName,
@@ -401,11 +406,6 @@ class GleanTest {
             name = "string_metric",
             sendInPings = listOf(pingName)
         )
-
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
-            serverEndpoint = "http://" + server.hostName + ":" + server.port,
-            logPings = true
-        ))
 
         // This test relies on testing mode to be disabled, since we need to prove the
         // real-world async behaviour of this. We don't need to care about clearing it,

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -36,6 +36,11 @@ class PingTypeTest {
     fun `test sending of custom pings`() {
         val server = getMockWebServer()
 
+        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ))
+
         val customPing = PingType(
             name = "custom",
             includeClientId = true
@@ -48,11 +53,6 @@ class PingTypeTest {
             name = "counter",
             sendInPings = listOf("custom")
         )
-
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
-            serverEndpoint = "http://" + server.hostName + ":" + server.port,
-            logPings = true
-        ))
 
         counter.add()
         assertTrue(counter.testHasValue())
@@ -74,6 +74,11 @@ class PingTypeTest {
     fun `test sending of custom pings without client_id`() {
         val server = getMockWebServer()
 
+        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ))
+
         val customPing = PingType(
             name = "custom",
             includeClientId = false
@@ -86,11 +91,6 @@ class PingTypeTest {
             name = "counter",
             sendInPings = listOf("custom")
         )
-
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
-            serverEndpoint = "http://" + server.hostName + ":" + server.port,
-            logPings = true
-        ))
 
         counter.add()
         assertTrue(counter.testHasValue())

--- a/glean-core/ffi/examples/glean.h
+++ b/glean-core/ffi/examples/glean.h
@@ -262,9 +262,10 @@ char *glean_ping_collect(uint64_t glean_handle, uint64_t ping_type_handle);
 
 void glean_register_ping_type(uint64_t glean_handle, uint64_t ping_type_handle);
 
-uint8_t glean_send_ping(uint64_t glean_handle, uint64_t ping_type_handle, uint8_t log_ping);
-
-uint8_t glean_send_ping_by_name(uint64_t glean_handle, FfiStr ping_name, uint8_t log_ping);
+uint8_t glean_send_pings_by_name(uint64_t glean_handle,
+                                 RawStringArray ping_names,
+                                 int32_t ping_names_len,
+                                 uint8_t log_ping);
 
 void glean_set_experiment_active(uint64_t glean_handle,
                                  FfiStr experiment_id,

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -132,22 +132,17 @@ pub extern "C" fn glean_set_upload_enabled(glean_handle: u64, flag: u8) {
 }
 
 #[no_mangle]
-pub extern "C" fn glean_send_ping(glean_handle: u64, ping_type_handle: u64, log_ping: u8) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        PING_TYPES.call_with_log(ping_type_handle, |ping_type| {
-            glean.send_ping(ping_type, log_ping != 0)
-        })
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn glean_send_ping_by_name(
+pub extern "C" fn glean_send_pings_by_name(
     glean_handle: u64,
-    ping_name: FfiStr,
+    ping_names: RawStringArray,
+    ping_names_len: i32,
     log_ping: u8,
 ) -> u8 {
     GLEAN.call_with_log(glean_handle, |glean| {
-        glean.send_ping_by_name(ping_name.as_str(), log_ping != 0)
+        let log_ping = log_ping != 0;
+        let pings = from_raw_string_array(ping_names, ping_names_len)?;
+
+        Ok(glean.send_pings_by_name(&pings, log_ping))
     })
 }
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -396,6 +396,25 @@ impl Glean {
         }
     }
 
+    /// Send a list of pings by name.
+    ///
+    /// See `send_ping` for detailed information.
+    ///
+    /// Returns true if at least one ping was assembled and queued, false otherwise.
+    pub fn send_pings_by_name(&self, ping_names: &[String], log_ping: bool) -> bool {
+        // TODO: 1553813: glean-ac collects and stores pings in parallel and then joins them all before queueing the worker.
+        // This here is writing them out sequentially.
+
+        let mut result = false;
+
+        for ping_name in ping_names {
+            if let Ok(true) = self.send_ping_by_name(ping_name, log_ping) {
+                result = true;
+            }
+        }
+        result
+    }
+
     /// Send a ping by name.
     ///
     /// The ping content is assembled as soon as possible, but upload is not


### PR DESCRIPTION
This should enable storing pings concurrently eventually.

This is in part to address [bug 1553813](https://bugzilla.mozilla.org/show_bug.cgi?id=1553813), though it does nothing in parallel yet.
We don't know if that's an actuall bottleneck and right now I think we would just run into lock contention on the database anyway (plus right now we send _at most_ 2 pings at once)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
