### PR TITLE
 Bug 1548535 - Cancel any pending workers when ping upload disabled

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -201,6 +201,13 @@ open class GleanInternalAPI internal constructor () {
                 // iterating over and deleting the pings doesn't happen at the same time.
                 synchronized(PingUploader.pingQueueLock) {
                     LibGleanFFI.INSTANCE.glean_set_upload_enabled(handle, enabled.toByte())
+
+                    // Cancel any pending workers here so that we don't accidentally upload or
+                    // collect data after the upload has been disabled.
+                    if (!enabled) {
+                        MetricsPingScheduler.cancel()
+                        PingUploadWorker.cancel()
+                    }
                 }
 
                 if (!originalEnabled && getUploadEnabled()) {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -51,6 +51,13 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
         const val DUE_HOUR_OF_THE_DAY = 4
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal var isInForeground = false
+
+        /**
+         * Function to cancel any pending metrics ping workers
+         */
+        internal fun cancel() {
+            WorkManager.getInstance().cancelUniqueWork(MetricsPingWorker.TAG)
+        }
     }
 
     init {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -64,6 +64,13 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
          * @return true if process was successful
          */
         internal fun uploadPings(): Boolean = HttpPingUploader().process()
+
+        /**
+         * Function to cancel any pending ping upload workers
+         */
+        internal fun cancel() {
+            WorkManager.getInstance().cancelUniqueWork(PING_WORKER_TAG)
+        }
     }
 
     /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -464,6 +464,24 @@ class MetricsPingSchedulerTest {
         verify(mpsSpy, times(1)).schedule()
     }
 
+    @Test
+    fun `cancel() correctly cancels worker`() {
+        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+
+        mps.schedulePingCollection(Calendar.getInstance(), true)
+
+        // Verify that the worker is enqueued
+        assertTrue("MetricsPingWorker is enqueued",
+            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+
+        // Cancel the worker
+        MetricsPingScheduler.cancel()
+
+        // Verify worker has been cancelled
+        assertFalse("MetricsPingWorker is not enqueued",
+            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+    }
+
     // @Test
     // fun `Glean should close the measurement window for overdue pings before recording new data`() {
     //     // This test is a bit tricky: we want to make sure that, when our metrics ping is overdue

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
@@ -7,6 +7,7 @@ import androidx.work.BackoffPolicy
 import androidx.work.NetworkType
 import androidx.work.WorkerParameters
 import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.getWorkerStatus
 import mozilla.telemetry.glean.resetGlean
 import org.junit.Assert
 import org.junit.Before
@@ -49,5 +50,21 @@ class PingUploadWorkerTest {
     fun testDoWorkSuccess() {
         val result = pingUploadWorker!!.doWork()
         Assert.assertTrue(result.toString().contains("Success"))
+    }
+
+    @Test
+    fun `cancel() correctly cancels worker`() {
+        PingUploadWorker.enqueueWorker()
+
+        // Verify that the worker is enqueued
+        Assert.assertTrue("PingUploadWorker is enqueued",
+            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+
+        // Cancel the worker
+        PingUploadWorker.cancel()
+
+        // Verify worker has been cancelled
+        Assert.assertFalse("PingUploadWorker is not enqueued",
+            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 }


### PR DESCRIPTION
This cancels any pending `PingUploadWorkers` or `MetricsPingWorkers` when upload is disabled.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
