### PR TITLE
 Bug 1572509 -  Fix PingUploadWorker loop if upload disabled

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -43,7 +43,7 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
          * @return [OneTimeWorkRequest] representing the task for the [WorkManager] to enqueue and run
          */
         internal fun buildWorkRequest(): OneTimeWorkRequest = OneTimeWorkRequestBuilder<PingUploadWorker>()
-            .addTag(PingUploadWorker.PING_WORKER_TAG)
+            .addTag(PING_WORKER_TAG)
             .setConstraints(buildConstraints())
             .build()
 
@@ -52,9 +52,9 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
          */
         internal fun enqueueWorker() {
             WorkManager.getInstance().enqueueUniqueWork(
-                PingUploadWorker.PING_WORKER_TAG,
+                PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
-                PingUploadWorker.buildWorkRequest())
+                buildWorkRequest())
         }
 
         /**
@@ -63,13 +63,7 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
          *
          * @return true if process was successful
          */
-        internal fun uploadPings(): Boolean {
-            return if (Glean.getUploadEnabled()) {
-                HttpPingUploader().process()
-            } else {
-                false
-            }
-        }
+        internal fun uploadPings(): Boolean = HttpPingUploader().process()
     }
 
     /**
@@ -85,10 +79,10 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
      * @return The [androidx.work.ListenableWorker.Result] of the computation
      */
     override fun doWork(): Result {
-        if (!uploadPings()) {
-            return Result.retry()
+        return when {
+            !Glean.getUploadEnabled() -> Result.failure()
+            !uploadPings() -> Result.retry()
+            else -> Result.success()
         }
-
-        return Result.success()
     }
 }


### PR DESCRIPTION
Fixes an issue that could cause the `PingUploadWorker` to loop forever if one were enqueued when upload was disabled.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
