### PR TITLE
 Bug 1556995 - Fix Glean storing/sending of empty StringListMetricType

### DIFF
--- a/docs/user/metrics/string_list.md
+++ b/docs/user/metrics/string_list.md
@@ -49,6 +49,8 @@ assertEquals(listOf("Google", "DuckDuckGo"), Search.engines.testGetValue())
 
 ## Limits
 
+* Empty string lists are not accepted by the `set()` method. Attempting to record an empty string list will result in an `invalid_value` error and nothing being recorded.
+
 * Fixed maximum string length: 50. Longer strings are truncated. For the original Kotlin implementation of the Glean SDK, this is measured in Unicode characters. For the Rust implementation, this is measured in the number of bytes when the string is encoded in UTF-8.
 
 * Fixed maximum list length: 20 items. Additional strings are dropped.
@@ -58,6 +60,8 @@ assertEquals(listOf("Google", "DuckDuckGo"), Search.engines.testGetValue())
 * The names of the enabled search engines.
 
 ## Recorded errors
+
+* `invalid_value`: if an empty list is passed to `set()`
 
 * `invalid_value`: if the string is too long
 

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -90,10 +90,17 @@ impl StringListMetric {
     ///
     /// ## Notes
     ///
+    /// If passed an empty list, records an error and returns.
     /// Truncates the list if it is longer than `MAX_LIST_LENGTH` and logs an error.
     /// Truncates any value in the list if it is longer than `MAX_STRING_LENGTH` and logs an error.
     pub fn set(&self, glean: &Glean, value: Vec<String>) {
         if !self.should_record(glean) {
+            return;
+        }
+
+        if value.is_empty() {
+            let msg = "Attempt to set empty list to StringList";
+            record_error(glean, &self.meta, ErrorType::InvalidValue, msg, None);
             return;
         }
 


### PR DESCRIPTION
This prevents `StringListMetricType` from accepting empty lists to the `set()` method.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
