### PR TITLE
HACK: Fix up missing libtinfo.so.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,12 @@ commands:
           name: Install missing Android SDK
           command: |
               sdkmanager 'build-tools;21.0.0'
+      # The Debian container in use is shipping libtinfo.so.6, but the Clang deployed in the NDK requires v5.
+      # We hack around that by symlinking the new to the old version, they seem to be mostly compatible.
+      - run:
+          name: "HACK: Fix up missing libtinfo.so.5"
+          command: |
+              sudo ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.5
 
 jobs:
   Check Rust formatting:


### PR DESCRIPTION
The Debian container in use is shipping libtinfo.so.6, but the Clang deployed in the NDK requires v5.
We hack around that by symlinking the new to the old version, they seem to be mostly compatible.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
