### PR TITLE
Disable beta builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,8 @@ workflows:
   run-tests:
     jobs:
       - Rust tests - stable
-      - Rust tests - beta
+      # FIXME: Disabled due to failing to often, bug 1574424
+      #- Rust tests - beta
       - Rust tests - minimum version
       - Android tests
       - C tests


### PR DESCRIPTION
They are currently mostly failing due to out of memory issues.
Disabling to not waste resources.
We will re-enable them once we figure out what's going on.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
