### PR TITLE
 Bug 1574468 - Add experiments limits violations error reporting

### DIFF
--- a/docs/user/experiments-api.md
+++ b/docs/user/experiments-api.md
@@ -42,6 +42,8 @@ assertEquals(
 * `experimentId`, `branch`, and the keys of the 'extra' field are fixed at a maximum length of 30. Length for the values of the `extra` field is fixed at 50. Longer strings used as ids, keys, or values are truncated to their respective maximum length. For the original Kotlin implementation of the Glean SDK, this is measured in Unicode characters. For the Rust implementation, this is measured in the number of bytes when the string is encoded in UTF-8.
 * `extra` map is limited to 20 entries. If passed a map which contains more elements than this, it is truncated to 20 elements.  **WARNING** Which items are truncated is nondeterministic due to the unordered nature of maps and what's left may not necessarily be the first elements added.
 
+**NOTE:** Any truncation that occurs when recording to the Experiments API will result in an `invalid_value` error being recorded. See [Error Reporting](error-reporting.md) for more information about this type of error.
+
 ## Reference
 
 * [Kotlin API docs](../../javadoc/glean/mozilla.telemetry.glean/-glean.html).

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -474,7 +474,7 @@ impl Glean {
         branch: String,
         extra: Option<HashMap<String, String>>,
     ) {
-        let metric = metrics::ExperimentMetric::new(experiment_id);
+        let metric = metrics::ExperimentMetric::new(&self, experiment_id);
         metric.set_active(&self, branch, extra);
     }
 
@@ -484,7 +484,7 @@ impl Glean {
     ///
     /// * `experiment_id` - The id of the active experiment to deactivate (maximum 30 bytes).
     pub fn set_experiment_inactive(&self, experiment_id: String) {
-        let metric = metrics::ExperimentMetric::new(experiment_id);
+        let metric = metrics::ExperimentMetric::new(&self, experiment_id);
         metric.set_inactive(&self);
     }
 
@@ -518,7 +518,7 @@ impl Glean {
     /// { 'branch': 'the-branch-name', 'extra': {'key': 'value', ...}}
     /// Otherwise, None.
     pub fn test_get_experiment_data_as_json(&self, experiment_id: String) -> Option<String> {
-        let metric = metrics::ExperimentMetric::new(experiment_id);
+        let metric = metrics::ExperimentMetric::new(&self, experiment_id);
         metric.test_get_value_as_json_string(&self)
     }
 

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -212,7 +212,7 @@ mod test {
             .cloned()
             .collect();
 
-        let metric = ExperimentMetric::new("some-experiment".to_string());
+        let metric = ExperimentMetric::new(&glean, "some-experiment".to_string());
 
         metric.set_active(&glean, "test-branch".to_string(), Some(extra));
         let snapshot = StorageManager


### PR DESCRIPTION
This adds error reporting to the string truncation and extra truncation when it occurs in the experiments API.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
