### PR TITLE
Bug 1576774 - Removed android-components support-ktx dependency

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -164,7 +164,6 @@ android {
 dependencies {
     api "org.mozilla.components:concept-fetch:$versions.android_components"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:$versions.android_components"
-    implementation "org.mozilla.components:support-ktx:$versions.android_components"
 
     jnaForTest "net.java.dev.jna:jna:$versions.jna@jar"
     implementation "net.java.dev.jna:jna:$versions.jna@aar"

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DistributionData.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DistributionData.kt
@@ -5,16 +5,14 @@
 package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.utils.tryGetLong
 import org.json.JSONObject
-
-import mozilla.components.support.ktx.android.org.json.tryGetLong
 
 /**
  * This class represents the structure of a timing distribution according to the pipeline schema. It
  * is meant to help serialize and deserialize data to the correct format for transport and storage,
  * as well as including a helper function to calculate the bucket sizes.
  *
- * @param histogramType the [HistogramType] representing the bucket layout
  * @param values a map containing the bucket index mapped to the accumulated count
  * @param sum the accumulated sum of all the samples in the timing distribution
  */

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -6,7 +6,6 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
-import mozilla.components.support.ktx.android.org.json.toList
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
@@ -14,6 +13,7 @@ import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.RustError
 import mozilla.telemetry.glean.rust.toBoolean
 import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.utils.toList
 import org.json.JSONArray
 
 /**
@@ -153,6 +153,6 @@ class StringListMetricType(
         } catch (e: org.json.JSONException) {
             throw NullPointerException()
         }
-        return jsonRes.toList<String>()
+        return jsonRes.toList()
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/JsonUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/JsonUtils.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.utils
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Returns the value mapped by {@code key} if it exists, and
+ * if the value returned is not null. If it's null, it returns null
+ */
+fun JSONObject.tryGetLong(key: String): Long? = if (isNull(key)) null else getLong(key)
+
+/**
+ * Convenience method to convert a JSONArray into a sequence.
+ *
+ * @param getter callback to get the value for an index in the array.
+ */
+inline fun <V> JSONArray.asSequence(crossinline getter: JSONArray.(Int) -> V): Sequence<V> {
+    val indexRange = 0 until length()
+    return indexRange.asSequence().map { i -> getter(i) }
+}
+
+fun JSONArray.asSequence(): Sequence<Any> = asSequence { i -> get(i) }
+
+/**
+ * Convenience method to convert a JSONArray into a List
+ *
+ * @return list with the JSONArray values, or an empty list if the JSONArray was null
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> JSONArray?.toList(): List<T> {
+    val array = this ?: return emptyList()
+    return array.asSequence().map { it as T }.toList()
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -40,6 +40,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
+import org.robolectric.shadows.ShadowProcess
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -508,5 +509,18 @@ class GleanTest {
             getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
         assertFalse("MetricsPingWorker is not enqueued",
             getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+    }
+
+    @Test
+    fun `isMainProcess must only return true if we are in the main process`() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val myPid = Int.MAX_VALUE
+
+        assertTrue(Glean.isMainProcess(context))
+
+        ShadowProcess.setPid(myPid)
+        Glean.isMainProcess = null
+
+        assertFalse(Glean.isMainProcess(context))
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/JsonUtilsTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/JsonUtilsTest.kt
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class JsonUtilsTest {
+    private lateinit var testData2Elements: JSONArray
+
+    @Before
+    fun setUp() {
+        testData2Elements = JSONArray().apply {
+            put(JSONObject("""{"a": 1}"""))
+            put(JSONObject("""{"b": 2}"""))
+        }
+    }
+
+    @Test
+    fun tryGetLongNull() {
+        val jsonObject = JSONObject("""{"key":null}""")
+        assertNull(jsonObject.tryGetLong("key"))
+        assertNull(jsonObject.tryGetLong("another-key"))
+    }
+
+    @Test
+    fun tryGetLongNotNull() {
+        val jsonObject = JSONObject("""{"key":218728173837192717}""")
+        assertEquals(218728173837192717, jsonObject.tryGetLong("key"))
+    }
+
+    @Test
+    fun itCanBeIterated() {
+        val array = JSONArray("[1, 2, 3]")
+
+        val sum = array.asSequence()
+            .map { it as Int }
+            .sum()
+
+        assertEquals(6, sum)
+    }
+
+    @Test
+    fun toListNull() {
+        val jsonArray: JSONArray? = null
+        val list = jsonArray.toList<Any>()
+        assertEquals(0, list.size)
+    }
+
+    @Test
+    fun toListEmpty() {
+        val jsonArray = JSONArray()
+        val list = jsonArray.toList<Any>()
+        assertEquals(0, list.size)
+    }
+
+    @Test
+    fun toListNotEmpty() {
+        val jsonArray = JSONArray()
+        jsonArray.put("value")
+        jsonArray.put("another-value")
+        val list = jsonArray.toList<String>()
+        assertEquals(2, list.size)
+        assertTrue(list.contains("value"))
+        assertTrue(list.contains("another-value"))
+    }
+}


### PR DESCRIPTION
Inlining wasn't ideal in every case, so I went ahead and copied over the extension files for the JSON stuff from android-components to the /utils directory and added the extension for `Context` that detects the main process to the `Glean.kt` file.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
