### PR TITLE
Bug 1576857 - Remove dependency on android-components support-base

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -164,7 +164,6 @@ android {
 dependencies {
     api "org.mozilla.components:concept-fetch:$versions.android_components"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:$versions.android_components"
-    implementation "org.mozilla.components:support-base:$versions.android_components"
     implementation "org.mozilla.components:support-ktx:$versions.android_components"
 
     jnaForTest "net.java.dev.jna:jna:$versions.jna@jar"

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -30,7 +30,7 @@ internal object Dispatchers {
         internal val taskQueue: ConcurrentLinkedQueue<suspend CoroutineScope.() -> Unit> = ConcurrentLinkedQueue()
 
         companion object {
-            private const val LOG_TAG = "Dispatchers"
+            private const val LOG_TAG = "glean/Dispatchers"
 
             // This value was chosen in order to allow several tasks to be queued for execution but
             // still be conservative of memory. This queue size is important for cases where

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -48,7 +48,7 @@ typealias GleanTimerId = Long
 @Suppress("TooManyFunctions")
 open class GleanInternalAPI internal constructor () {
     companion object {
-        private val LOG_TAG: String = "glean/Glean"
+        private const val LOG_TAG: String = "glean/Glean"
         internal const val GLEAN_DATA_DIR: String = "glean_data"
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
@@ -21,7 +21,7 @@ import mozilla.telemetry.glean.Glean
  */
 class GleanDebugActivity : Activity() {
     companion object {
-        private const val LOG_TAG = "GleanDebugActivity"
+        private const val LOG_TAG = "glean/DebugActivity"
 
         // This is a list of the currently accepted commands
         /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
@@ -6,8 +6,8 @@ package mozilla.telemetry.glean.debug
 
 import android.app.Activity
 import android.os.Bundle
+import android.util.Log
 import mozilla.telemetry.glean.Glean
-import mozilla.components.support.base.log.logger.Logger
 
 /**
  * Debugging activity exported by Glean to allow easier debugging.
@@ -20,9 +20,9 @@ import mozilla.components.support.base.log.logger.Logger
  * https://developer.android.com/studio/command-line/adb#am
  */
 class GleanDebugActivity : Activity() {
-    private val logger = Logger("glean/GleanDebugActivity")
-
     companion object {
+        private const val LOG_TAG = "GleanDebugActivity"
+
         // This is a list of the currently accepted commands
         /**
          * Sends the ping with the given name immediately
@@ -55,7 +55,7 @@ class GleanDebugActivity : Activity() {
         super.onCreate(savedInstanceState)
 
         if (!Glean.isInitialized()) {
-            logger.error(
+            Log.e(LOG_TAG,
                 "Glean is not initialized. " +
                 "It may be disabled by the application."
             )
@@ -64,7 +64,7 @@ class GleanDebugActivity : Activity() {
         }
 
         if (intent.extras == null) {
-            logger.error("No debugging option was provided, doing nothing.")
+            Log.e(LOG_TAG, "No debugging option was provided, doing nothing.")
             finish()
             return
         }
@@ -77,7 +77,7 @@ class GleanDebugActivity : Activity() {
         intent.extras?.let {
             it.keySet().forEach { cmd ->
                 if (!supportedCommands.contains(cmd)) {
-                    logger.error("Unknown command '$cmd'.")
+                    Log.e(LOG_TAG, "Unknown command '$cmd'.")
                 }
             }
 
@@ -88,7 +88,7 @@ class GleanDebugActivity : Activity() {
             // Validate the ping tag against the regex pattern
             pingTag?.let {
                 if (!pingTagPattern.matches(it)) {
-                    logger.error("tagPings value $it does not match accepted pattern $pingTagPattern")
+                    Log.e(LOG_TAG, "tagPings value $it does not match accepted pattern $pingTagPattern")
                     pingTag = null
                 }
             }
@@ -100,7 +100,7 @@ class GleanDebugActivity : Activity() {
 
             // Finally set the default configuration before starting
             // the real product's activity.
-            logger.info("Setting debug config $debugConfig")
+            Log.i(LOG_TAG, "Setting debug config $debugConfig")
             Glean.configuration = debugConfig
 
             intent.getStringExtra(SEND_PING_EXTRA_KEY)?.let {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -46,7 +46,7 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
     }
 
     companion object {
-        private const val LOG_TAG = "MetricsPingScheduler"
+        private const val LOG_TAG = "glean/MetricsPingSched"
         const val LAST_METRICS_PING_SENT_DATETIME = "last_metrics_ping_iso_datetime"
         const val DUE_HOUR_OF_THE_DAY = 4
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -323,7 +323,7 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
  */
 internal class MetricsPingWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
     companion object {
-        private const val LOG_TAG = "MetricsPingWorker"
+        private const val LOG_TAG = "glean/MetricsPingWorker"
         const val TAG = "mozac_service_glean_metrics_ping_tick"
     }
 

--- a/glean-core/android/src/test/java/android/util/Log.java
+++ b/glean-core/android/src/test/java/android/util/Log.java
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package android.util;
+
+/**
+ * The purpose of this class is to avoid the "android.util.Log not mocked" exception when running
+ * tests with the Android Log utility.
+ *
+ * This solution can be attributed to this Stack Overflow answer:
+ * https://stackoverflow.com/a/46793567
+ */
+public class Log {
+    public static int d(String tag, String msg) {
+        System.out.println("DEBUG: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int i(String tag, String msg) {
+        System.out.println("INFO: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int w(String tag, String msg) {
+        System.out.println("WARN: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int e(String tag, String msg) {
+        System.out.println("ERROR: " + tag + ": " + msg);
+        return 0;
+    }
+}


### PR DESCRIPTION
This required switching all of our logging over to use Android.util.Log and also required a little hack to get mocked objects that used the Log to work.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
