### PR TITLE
Retry codecov upload 2 times in case of failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,8 @@ jobs:
               chmod +x codecov.sh;
               zip -0 ccov.zip `find . \( -name "glean*.gc*" \) -print`
               ./grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" --ignore-dir "glean-core/ffi/*" -o lcov.info
-              ./codecov.sh -f lcov.info;
+              CODECOV_CMD="./codecov.sh -f lcov.info"
+              $CODECOV_CMD || (sleep 5 && $CODECOV_CMD) || (sleep 5 && $CODECOV_CMD)
   iOS build and test:
     macos:
       xcode: "11.0.0"
@@ -243,7 +244,8 @@ jobs:
           command: |
               curl -L https://codecov.io/bash > codecov.sh;
               chmod +x codecov.sh;
-              ./codecov.sh -f glean-core/android/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+              CODECOV_CMD="./codecov.sh -f glean-core/android/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+              $CODECOV_CMD || (sleep 5 && $CODECOV_CMD) || (sleep 5 && $CODECOV_CMD)
       - store_artifacts:
           path: glean-core/android/build/reports/tests
 


### PR DESCRIPTION
codecov upload occasionally fails due to network issues.
Most of the time this is solved by rerunning the task again.
Instead of that, let's just try 3 times total.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
