### PR TITLE
Enable looking up labels by their index in LabeledMetricType

### DIFF
--- a/glean-core/android/sdk_generator.gradle
+++ b/glean-core/android/sdk_generator.gradle
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.ArtifactAttributes
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "1.4.2"
+String GLEAN_PARSER_VERSION = "1.6.1"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -27,7 +27,7 @@ class LabeledMetricType<T>(
     category: String,
     lifetime: Lifetime,
     name: String,
-    labels: Set<String>? = null,
+    private val labels: Set<String>? = null,
     private val sendInPings: List<String>,
     private val subMetric: T
 ) {
@@ -93,5 +93,26 @@ class LabeledMetricType<T>(
                 "Can not create a labeled version of this metric type"
             )
         }
+    }
+
+    /**
+     * Get the specific metric for a given label index.
+     *
+     * This only works if a set of acceptable labels were specified in the
+     * metrics.yaml file. If static labels were not defined in that file or
+     * the index of the given label is not in the set, it will be recorded under
+     * the special `OTHER_LABEL`.
+     *
+     * @param labelIndex The label
+     * @return The specific metric for that label
+     */
+    operator fun get(labelIndex: Int): T {
+        val actualLabel = if (labels != null && labelIndex < labels.size) {
+            labels.elementAt(labelIndex)
+        } else {
+            "__other__"
+        }
+
+        return this[actualLabel]
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -303,4 +303,40 @@ class LabeledMetricTypeTest {
 
     // SKIPPED `test seen labels get reloaded from disk`
     // REASON This is tested on the Rust side. The Kotlin side has no way to inject data into the database.
+
+    @Test
+    fun `test recording to static labels by label index`() {
+        val counterMetric = CounterMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "labeled_counter_metric",
+            sendInPings = listOf("metrics")
+        )
+
+        val labeledCounterMetric = LabeledMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "labeled_counter_metric",
+            sendInPings = listOf("metrics"),
+            subMetric = counterMetric,
+            labels = setOf("foo", "bar", "baz")
+        )
+
+        // Increment using a label name first.
+        labeledCounterMetric["foo"].add(2)
+
+        // Now only use label indices: "foo" first.
+        labeledCounterMetric[0].add(1)
+        // Then "bar".
+        labeledCounterMetric[1].add(1)
+        // Then some out of bound index: will go to "__other__".
+        labeledCounterMetric[100].add(100)
+
+        // Use the testing API to get the values for the labels.
+        assertEquals(3, labeledCounterMetric["foo"].testGetValue())
+        assertEquals(1, labeledCounterMetric["bar"].testGetValue())
+        assertEquals(100, labeledCounterMetric["__other__"].testGetValue())
+    }
 }


### PR DESCRIPTION
This is needed in order to accumulate to `labeled_counter`(s) when required by Gecko categorical histograms.

I went for the easiest solution here: we pay the cost of storing the list of strings on the Kotlin side instead of having a new FFI function for that. Would that be ok, as a short term solution for feature parity? I'm happy to file a bug and take on this after.

This is a port of mozilla-mobile/android-components#4439