### PR TITLE
Make the Glean SDK general API to be callable from Java

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -98,6 +98,7 @@ open class GleanInternalAPI internal constructor () {
      * @param configuration A Glean [Configuration] object with global settings.
      */
     @Suppress("ReturnCount")
+    @JvmOverloads
     @Synchronized
     fun initialize(
         applicationContext: Context,
@@ -250,6 +251,7 @@ open class GleanInternalAPI internal constructor () {
      * @param branch The experiment branch (maximum 30 bytes)
      * @param extra Optional metadata to output with the ping
      */
+    @JvmOverloads
     fun setExperimentActive(
         experimentId: String,
         branch: String,

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -61,6 +61,7 @@ internal class FfiConfiguration(
  */
 data class Configuration internal constructor(
     val serverEndpoint: String,
+    val channel: String? = null,
     val userAgent: String = DEFAULT_USER_AGENT,
     val maxEvents: Int? = null,
     val logPings: Boolean = DEFAULT_LOG_PINGS,
@@ -68,28 +69,31 @@ data class Configuration internal constructor(
     // default values for the lines below are ever changed, they are required
     // to change in the public constructor below.
     val httpClient: PingUploader = HttpURLConnectionUploader(),
-    val pingTag: String? = null,
-    val channel: String? = null
+    val pingTag: String? = null
 ) {
     /**
      * Configuration for Glean.
      *
-     * @param maxEvents the number of events to store before the events ping is sent
-     * @param httpClient The HTTP client implementation to use for uploading pings.
+     * @property serverEndpoint the server pings are sent to. Please note that this is
+     *           is only meant to be changed for tests.
      * @param channel the release channel the application is on, if known. This will be
      *           sent along with all the pings, in the `client_info` section.
+     * @param maxEvents the number of events to store before the events ping is sent
+     * @param httpClient The HTTP client implementation to use for uploading pings.
      */
     // This is the only public constructor this class should have. It should only
     // expose things we want to allow external applications to change. Every test
     // only or internal configuration option should be added to the above primary internal
     // constructor and only initialized with a proper default when calling the primary
     // constructor from the secondary, public one, below.
+    @JvmOverloads
     constructor(
+        serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
+        channel: String? = null,
         maxEvents: Int? = null,
-        httpClient: PingUploader = HttpURLConnectionUploader(),
-        channel: String? = null
+        httpClient: PingUploader = HttpURLConnectionUploader()
     ) : this (
-        serverEndpoint = DEFAULT_TELEMETRY_ENDPOINT,
+        serverEndpoint = serverEndpoint,
         userAgent = DEFAULT_USER_AGENT,
         maxEvents = maxEvents,
         logPings = DEFAULT_LOG_PINGS,


### PR DESCRIPTION
This is the glean-core companion to mozilla-mobile/android-components#4454 . In addition to
what's done in the other PR, this allows to change the HTTP endpoint in the constructor. That change was not backported to glean-core.