### PR TITLE
Allow easy migration of pending pings from glean-ac

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -33,7 +33,8 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
         // Since ping file names are UUIDs, this matches UUIDs for filtering purposes
         private const val FILE_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
         private const val LOG_TAG = "glean/PingUploadWorker"
-        internal const val PINGS_DIR = "pings"
+        // NOTE: The `PINGS_DIR` must be kept in sync with the one in the Rust implementation.
+        internal const val PINGS_DIR = "pending_pings"
         // A lock to prevent simultaneous writes in the ping queue directory.
         // In particular, there are issues if the pings are cleared (as part of
         // disabling telemetry), while the ping uploader is trying to upload queued pings.

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -98,7 +98,7 @@ class GleanTest {
 
         Glean.handleBackgroundEvent()
         // Make sure the file is on the disk
-        val pingPath = File(context.applicationInfo.dataDir, "glean_data/pings")
+        val pingPath = File(Glean.getDataDir(), PingUploadWorker.PINGS_DIR)
         // Only the baseline ping should have been written
         assertEquals(1, pingPath.listFiles()?.size)
 

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -13,7 +13,8 @@ public class HttpPingUploader {
         // Since ping file names are UUIDs, this matches UUIDs for filtering purposes
         static let filePattern = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
         static let logTag = "glean/HttpPingUploader"
-        static let pingsDir = "pings"
+        // NOTE: The `PINGS_DIR` must be kept in sync with the one in the Rust implementation.
+        static let pingsDir = "pending_pings"
         static let connectionTimeout = 10000
     }
 

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -214,7 +214,7 @@ impl PingMaker {
     /// The directory will be created inside the `data_path`.
     /// The `pings` directory (and its parents) is created if it does not exist.
     fn get_pings_dir(&self, data_path: &Path) -> std::io::Result<PathBuf> {
-        let pings_dir = data_path.join("pings");
+        let pings_dir = data_path.join("pending_pings");
         create_dir_all(&pings_dir)?;
         Ok(pings_dir)
     }

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -87,7 +87,7 @@ pub fn iso8601_to_chrono(datetime: &iso8601::DateTime) -> chrono::DateTime<chron
 /// `url` is the endpoint the ping will go to, and `json_data` is the JSON
 /// payload.
 pub fn get_queued_pings(data_path: &Path) -> Result<Vec<(String, JsonValue)>> {
-    let pings_dir = data_path.join("pings");
+    let pings_dir = data_path.join("pending_pings");
     let entries = read_dir(&pings_dir)?;
     Ok(entries
         .filter_map(|entry| entry.ok())

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -10,7 +10,7 @@ use glean_core::CommonMetricData;
 
 #[test]
 fn write_ping_to_disk() {
-    let (mut glean, temp) = new_glean();
+    let (mut glean, _temp) = new_glean();
 
     let ping = PingType::new("metrics", true);
     glean.register_ping_type(&ping);
@@ -26,14 +26,7 @@ fn write_ping_to_disk() {
 
     assert!(ping.send(&glean, true).unwrap());
 
-    let path = temp.path().join("pings");
-
-    let mut count = 0;
-    for entry in std::fs::read_dir(path).unwrap() {
-        assert!(entry.unwrap().path().is_file());
-        count += 1;
-    }
-    assert_eq!(1, count);
+    assert_eq!(1, get_queued_pings(glean.get_data_path()).unwrap().len());
 }
 
 #[test]


### PR DESCRIPTION
This changes the location glean-core stores pending pings to. It's changing from `pings` to `pending_pings`, which is the same location being used by [glean-ac](https://github.com/mozilla-mobile/android-components/blob/914091cebc92046dbc71742ddc8aefa7d7880371/components/service/glean/src/main/java/mozilla/components/service/glean/storages/PingStorageEngine.kt#L50).

