### PR TITLE
Migrate sequence numbers

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -26,6 +26,7 @@ import mozilla.telemetry.glean.rust.toByte
 import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
 import mozilla.telemetry.glean.GleanMetrics.GleanInternalMetrics
 import mozilla.telemetry.glean.GleanMetrics.Pings
+import mozilla.telemetry.glean.acmigration.GleanACDataMigrator
 import mozilla.telemetry.glean.net.BaseUploader
 import mozilla.telemetry.glean.private.PingType
 import mozilla.telemetry.glean.private.RecordedExperimentData
@@ -130,12 +131,34 @@ open class GleanInternalAPI internal constructor () {
             maxEvents = this.configuration.maxEvents
         )
 
-        handle = LibGleanFFI.INSTANCE.glean_initialize(cfg)
+        // Start the migration from glean-ac, if needed.
+        val migrator = GleanACDataMigrator(applicationContext)
+
+        // TODO: like we do in glean-ac, we should check if we already have a client id.
+        // If we don't, then we don't need to go through migration and this is likely a new
+        // client.
+        val newSequenceNums = if (migrator.shouldMigrateData()) {
+            migrator.getACMetadata().toFfi()
+        } else {
+            Triple(null, null, 0)
+        }
+
+        handle = LibGleanFFI.INSTANCE.glean_initialize_migration(
+            cfg,
+            newSequenceNums.first,
+            newSequenceNums.second,
+            newSequenceNums.third
+        )
 
         // If initialization of Glean fails we bail out and don't initialize further.
         if (handle == 0L) {
             return
         }
+
+        // TODO:
+        // - mark as migrated.
+        // - land a patch on a-c soon-ish to set wasMigrated to false, so that if we
+        //   need to roll back, we can restart the migration again.
 
         // If any pings were registered before initializing, do so now
         this.pingTypeQueue.forEach { this.registerPingType(it) }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -155,10 +155,9 @@ open class GleanInternalAPI internal constructor () {
             return
         }
 
-        // TODO:
-        // - mark as migrated.
-        // - land a patch on a-c soon-ish to set wasMigrated to false, so that if we
-        //   need to roll back, we can restart the migration again.
+        // TODO: uncomment the line below once all migration dependencies have landed.
+        // See bug 1583454.
+        // migrator.markAsMigrated()
 
         // If any pings were registered before initializing, do so now
         this.pingTypeQueue.forEach { this.registerPingType(it) }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/GleanACDataMigrator.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/GleanACDataMigrator.kt
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.acmigration
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.sun.jna.StringArray
+import java.lang.NullPointerException
+
+/**
+ * A class encapsulating the code used for migrating data from glean-ac
+ * to glean-core. This class, along with all the migration code, should be removed
+ * from this codebase 6 months after the last application was migrated to
+ * glean-core.
+ */
+internal class GleanACDataMigrator(
+    private val applicationContext: Context
+) {
+    companion object {
+        internal const val SEQUENCE_NUMBERS_FILENAME = "mozilla.components.service.glean.ping.PingMaker"
+        internal const val MIGRATION_PREFS_FILE = "mozilla.components.service.glean.GleanACDataMigrator"
+    }
+
+    internal val migrationPrefs: SharedPreferences? by lazy {
+        applicationContext.getSharedPreferences(
+            MIGRATION_PREFS_FILE,
+            Context.MODE_PRIVATE
+        )
+    }
+
+    /**
+     * A data class representing the metadata from glean-ac.
+     *
+     * @param alreadyMigrated whether or not migration was already performed; if true
+     *        the remaining metadata is not loaded and will be `null`.
+     * @param sequenceNumbers the mapping between AC storage names and their sequence
+     *        numbers.
+     * @return a [Triple] containing the keys and the values representing the sequence
+     *         numbers map, with the addition of the number of elements in the map.
+     */
+    internal data class ACMetadata(
+        val alreadyMigrated: Boolean,
+        val sequenceNumbers: Map<String, Int>
+    ) {
+        fun toFfi(): Triple<StringArray?, IntArray?, Int> {
+            // The Map is sent over FFI as a pair of arrays, one containing the
+            // keys, and the other containing the values.
+            // In Kotlin, Map.keys and Map.values are not guaranteed to return the entries
+            // in any particular order. Therefore, we iterate over the pairs together and
+            // create the keys and values arrays step-by-step.
+            val len = sequenceNumbers.size
+
+            if (len == 0) {
+                return Triple(null, null, 0)
+            }
+
+            val seqList = sequenceNumbers.toList()
+            val keys = StringArray(Array<String>(sequenceNumbers.size) { seqList[it].first }, "utf-8")
+            val values = IntArray(sequenceNumbers.size) { seqList[it].second }
+
+            return Triple(keys, values, len)
+        }
+    }
+
+    /**
+     * Get the metadata from glean-ac.
+     *
+     * @return an instance of [ACMetadata] with, at least, [ACMetadata.alreadyMigrated].
+     */
+    fun getACMetadata(): ACMetadata {
+        if (wasMigrated()) {
+            return ACMetadata(true, emptyMap())
+        }
+
+        return ACMetadata(
+            alreadyMigrated = false,
+            sequenceNumbers = getSequenceNumbers()
+        )
+    }
+
+    /**
+     * Load the sequence numbers that were stored in glean-ac [SharedPreferences].
+     *
+     * @return a `Map<String, Int>` in which entries are (`<ping_name>_seq`, nextSequenceNumber).
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun getSequenceNumbers(): Map<String, Int> {
+        val seqPrefs = applicationContext.getSharedPreferences(
+            SEQUENCE_NUMBERS_FILENAME,
+            Context.MODE_PRIVATE
+        )
+
+        @Suppress("TooGenericExceptionCaught")
+        return try {
+            // The code in this block might throw. It probably means the file
+            // does not exist or the data is corrupted. We try our best to recover
+            // most of the data, though.
+            seqPrefs
+                .all
+                .entries
+                .filter {
+                    it.key.endsWith("_seq") &&
+                    it.value is Int &&
+                    it.value as Int >= 0
+                }
+                .map {
+                    val seq = it.value as Int
+                    it.key to seq
+                }.toMap()
+        } catch (e: NullPointerException) {
+            emptyMap()
+        }
+    }
+
+    /**
+     * Mark the current client as migrated.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun markAsMigrated() {
+        migrationPrefs?.edit()?.putBoolean("wasMigrated", true)?.apply()
+    }
+
+    /**
+     * Get if the current client was migrated.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun wasMigrated(): Boolean {
+        val defaultValue = false
+        return try {
+            migrationPrefs?.getBoolean("wasMigrated", defaultValue) ?: defaultValue
+        } catch (e: ClassCastException) {
+            // If another pref in this file exists with a non boolean value,
+            // something probably went wrong in the migration. Let's try again?
+            defaultValue
+        }
+    }
+
+    /**
+     * Check if data migration should be performed.
+     *
+     * @return true if glean-ac data was found and needs to be moved over,
+     *         false otherwise.
+     */
+    internal fun shouldMigrateData(): Boolean {
+        if (wasMigrated()) {
+            return false
+        }
+
+        // TODO: check if we have any previous a-c data (i.e. client_id). If so, migrate.
+
+        return true
+    }
+
+    /**
+     * Clears any previously saved migration status.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun testResetMigrationStatus() {
+        migrationPrefs?.edit()?.clear()?.apply()
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/GleanACDataMigrator.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/GleanACDataMigrator.kt
@@ -118,8 +118,7 @@ internal class GleanACDataMigrator(
     /**
      * Mark the current client as migrated.
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun markAsMigrated() {
+    fun markAsMigrated() {
         migrationPrefs?.edit()?.putBoolean("wasMigrated", true)?.apply()
     }
 
@@ -150,6 +149,7 @@ internal class GleanACDataMigrator(
         }
 
         // TODO: check if we have any previous a-c data (i.e. client_id). If so, migrate.
+        // This will happen as part of bug 1582102.
 
         return true
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -69,6 +69,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_initialize(cfg: FfiConfiguration): Long
 
+    fun glean_initialize_migration(
+        cfg: FfiConfiguration,
+        seq_num_keys: StringArray?,
+        seq_num_values: IntArray?,
+        seq_num_len: Int
+    ): Long
+
     fun glean_test_clear_all_stores(handle: Long)
 
     fun glean_destroy_glean(handle: Long)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/acmigration/GleanACDataMigratorTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/acmigration/GleanACDataMigratorTest.kt
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.acmigration
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import java.lang.NullPointerException
+
+@RunWith(AndroidJUnit4::class)
+class GleanACDataMigratorTest {
+    @Test
+    fun `sequence numbers are correctly migrated`() {
+        val persistedSeq = mapOf(
+            "without_trailing_seq_but_valid" to 1,
+            "valid_ping_seq" to 3785,
+            "negative_ping_seq" to -3785,
+            "null_seq" to null,
+            "string_seq" to "test",
+            "bool_seq" to "test"
+        )
+
+        // Create a fake application context that will be used to load our data.
+        val context = mock(Context::class.java)
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        `when`(sharedPreferences.all).thenAnswer { persistedSeq }
+        `when`(context.getSharedPreferences(
+            ArgumentMatchers.eq(GleanACDataMigrator.SEQUENCE_NUMBERS_FILENAME),
+            ArgumentMatchers.eq(Context.MODE_PRIVATE)
+        )).thenReturn(sharedPreferences)
+
+        // Attempt a metadata migration.
+        val migrator = GleanACDataMigrator(context)
+        val migratedData = migrator.getSequenceNumbers()
+
+        assertNotNull(migratedData)
+        assertEquals(1, migratedData.size)
+        assertEquals(3785, migratedData["valid_ping_seq"])
+    }
+
+    @Test
+    fun `do not throw if the sequence number file does not exist`() {
+        val context = mock(Context::class.java)
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        `when`(sharedPreferences.all).thenThrow(NullPointerException())
+        `when`(context.getSharedPreferences(
+            ArgumentMatchers.eq(GleanACDataMigrator.SEQUENCE_NUMBERS_FILENAME),
+            ArgumentMatchers.eq(Context.MODE_PRIVATE)
+        )).thenReturn(sharedPreferences)
+
+        // Attempt a metadata migration.
+        val migrator = GleanACDataMigrator(context)
+        val migratedData = migrator.getSequenceNumbers()
+
+        // If SharedPreferences throws when we try to load, just return null.
+        assertEquals(0, migratedData.size)
+    }
+
+    @Test
+    fun `markAsMigrated correctly marks as migrated`() {
+        // Mark the client as migrated.
+        val writer = GleanACDataMigrator(ApplicationProvider.getApplicationContext())
+        assertFalse(writer.wasMigrated())
+        writer.markAsMigrated()
+
+        val reader = GleanACDataMigrator(ApplicationProvider.getApplicationContext())
+        assertTrue(reader.wasMigrated())
+    }
+
+    @Test
+    fun `migration status is false when data is of the wrong type`() {
+        val persistedStatus = mapOf(
+            "wasMigrated" to "true"
+        )
+
+        // Create a fake application context that will be used to load our data.
+        val context = mock(Context::class.java)
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        `when`(sharedPreferences.all).thenAnswer { persistedStatus }
+        `when`(context.getSharedPreferences(
+            ArgumentMatchers.eq(GleanACDataMigrator.SEQUENCE_NUMBERS_FILENAME),
+            ArgumentMatchers.eq(Context.MODE_PRIVATE)
+        )).thenReturn(sharedPreferences)
+
+        // Attempt a metadata migration.
+        val migrator = GleanACDataMigrator(context)
+        assertFalse(migrator.wasMigrated())
+    }
+
+    @Test
+    fun `migration status is false if the data file is empty`() {
+        val persistedStatus = emptyMap<String, Any>()
+
+        // Create a fake application context that will be used to load our data.
+        val context = mock(Context::class.java)
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        `when`(sharedPreferences.all).thenAnswer { persistedStatus }
+        `when`(context.getSharedPreferences(
+            ArgumentMatchers.eq(GleanACDataMigrator.SEQUENCE_NUMBERS_FILENAME),
+            ArgumentMatchers.eq(Context.MODE_PRIVATE)
+        )).thenReturn(sharedPreferences)
+
+        // Attempt a metadata migration.
+        val migrator = GleanACDataMigrator(context)
+        assertFalse(migrator.wasMigrated())
+    }
+
+    @Test
+    fun `getACMetadata does not load AC data if client was migrated`() {
+        val migrator =
+            spy<GleanACDataMigrator>(GleanACDataMigrator(ApplicationProvider.getApplicationContext()))
+        `when`(migrator.wasMigrated()).thenReturn(true)
+        val meta = migrator.getACMetadata()
+        assertTrue(meta.alreadyMigrated)
+        assertEquals(
+            "We must not reload the ac data if the client was migrated already",
+            0,
+            meta.sequenceNumbers.size
+        )
+    }
+
+    @Test
+    fun `getACMetadata loads AC data if client was not migrated`() {
+        val persistedSeq = mapOf(
+            "ping_one_seq" to 1,
+            "ping_two_seq" to 2,
+            "ping_three_seq" to 3
+        )
+
+        // Create a fake application context that will be used to load our data.
+        val context = mock(Context::class.java)
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        `when`(sharedPreferences.all).thenAnswer { persistedSeq }
+        `when`(context.getSharedPreferences(
+            ArgumentMatchers.eq(GleanACDataMigrator.SEQUENCE_NUMBERS_FILENAME),
+            ArgumentMatchers.eq(Context.MODE_PRIVATE)
+        )).thenReturn(sharedPreferences)
+
+        val migrator = GleanACDataMigrator(context)
+        // Mark the client as migrated.
+        migrator.markAsMigrated()
+
+        // Verify that the persisted sequence numbers are returned as part of
+        // the metadata.
+        val meta = migrator.getACMetadata()
+        assertFalse(meta.alreadyMigrated)
+        assertNotNull(meta.sequenceNumbers)
+        assertEquals(3, meta.sequenceNumbers.size)
+        assertEquals(1, meta.sequenceNumbers["ping_one_seq"])
+        assertEquals(2, meta.sequenceNumbers["ping_two_seq"])
+        assertEquals(3, meta.sequenceNumbers["ping_three_seq"])
+    }
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/acmigration/GleanDataMigrationTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/acmigration/GleanDataMigrationTest.kt
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.acmigration
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.testing.WorkManagerTestInitHelper
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.GleanMetrics.Pings
+import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.getMockWebServer
+import mozilla.telemetry.glean.triggerWorkManager
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class GleanDataMigrationTest {
+    // NOTE: do not use the Glean test rule in these tests, as they are testing
+    // part of the initialization sequence.
+
+    private fun setFakeSequenceNumber(context: Context, pingName: String, number: Int) {
+        val prefs = context.getSharedPreferences(
+            GleanACDataMigrator.SEQUENCE_NUMBERS_FILENAME,
+            Context.MODE_PRIVATE
+        )
+
+        prefs?.edit()?.putInt("${pingName}_seq", number)?.apply()
+    }
+
+    @Before
+    fun setup() {
+        // We're using the WorkManager in a bunch of places, and Glean will crash
+        // in tests without this line.
+        WorkManagerTestInitHelper.initializeTestWorkManager(
+            ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun `Glean triggers the migration sequence if needed`() {
+        val pingServer = getMockWebServer()
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // Make sure we did not migrate so that a new migration process starts.
+        val migrator = GleanACDataMigrator(context)
+        migrator.testResetMigrationStatus()
+
+        // Set a fake sequence number for the baseline ping.
+        setFakeSequenceNumber(context, "baseline", 37)
+
+        // Start Glean and point it to a local ping server.
+        Glean.resetGlean(
+            context,
+            Configuration().copy(
+                serverEndpoint = "http://" + pingServer.hostName + ":" + pingServer.port,
+                logPings = true
+            ),
+            true
+        )
+
+        // Trigger a baseline and a metrics ping.
+        Pings.baseline.send()
+        triggerWorkManager()
+
+        // Get the pending pings from the ping server.
+        val request = pingServer.takeRequest(20L, TimeUnit.SECONDS)
+
+        // Check that we received the expected sequence number for the baseline ping.
+        val baselineJson = JSONObject(request.body.readUtf8())
+        assertEquals("baseline", baselineJson.getJSONObject("ping_info")["ping_type"])
+        assertEquals(37, baselineJson.getJSONObject("ping_info")["seq"])
+    }
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.telemetry.glean.debug
 
 import android.content.Context

--- a/glean-core/ffi/cbindgen.toml
+++ b/glean-core/ffi/cbindgen.toml
@@ -15,6 +15,9 @@ typedef uint64_t TimerId;
 
 language = "C"
 
+[export]
+exclude = ["glean_initialize_migration"]
+
 [parse.expand]
 crates = ["glean-ffi"]
 

--- a/glean-core/ffi/cbindgen.toml
+++ b/glean-core/ffi/cbindgen.toml
@@ -16,6 +16,9 @@ typedef uint64_t TimerId;
 language = "C"
 
 [export]
+# The `glean_initialize_migration` symbol is only needed in the Kotlin
+# FFI layer to allow migrating data from glean-ac to glean-core. It does
+# not need to be exposed to all the platform: it's only needed on Android.
 exclude = ["glean_initialize_migration"]
 
 [parse.expand]

--- a/glean-core/ffi/src/from_raw.rs
+++ b/glean-core/ffi/src/from_raw.rs
@@ -110,6 +110,38 @@ pub fn from_raw_string_array_and_string_array(
     }
 }
 
+/// Create a HashMap<String, i32> from a pair of C string and int arrays.
+///
+/// Returns an error if any of the strings contain invalid UTF-8 characters.
+///
+/// ## Safety
+///
+/// * We check the array pointer for validity (non-null).
+/// * FfiStr checks each individual char pointer for validity (non-null).
+/// * We discard invalid char pointers (null pointer).
+/// * Invalid UTF-8 in any string will return an error from this function.
+pub fn from_raw_string_array_and_int_array(
+    keys: RawStringArray,
+    values: RawIntArray,
+    len: i32,
+) -> glean_core::Result<Option<HashMap<String, i32>>> {
+    unsafe {
+        if keys.is_null() || values.is_null() || len <= 0 {
+            return Ok(None);
+        }
+
+        let keys_ptrs = std::slice::from_raw_parts(keys, len as usize);
+        let values_ptrs = std::slice::from_raw_parts(values, len as usize);
+
+        let res: glean_core::Result<_> = keys_ptrs
+            .iter()
+            .zip(values_ptrs.iter())
+            .map(|(&k, &v)| FfiStr::from_raw(k).to_string_fallible().map(|s| (s, v)))
+            .collect();
+        res.map(Some)
+    }
+}
+
 /// Create a Vec<u32> from a raw C uint64 array.
 ///
 /// This will return an empty `Vec` if the input is empty.
@@ -336,6 +368,81 @@ mod test {
             let map = from_raw_string_array_and_string_array(
                 ptr_key_array.as_ptr(),
                 ptr_array.as_ptr(),
+                array.len() as i32,
+            );
+            assert!(map.is_err());
+        }
+    }
+
+    mod raw_string_int_array {
+        use super::*;
+
+        #[test]
+        fn parsing_valid_array() {
+            let mut expected_map = HashMap::new();
+            expected_map.insert("seven".to_string(), 7);
+            expected_map.insert("eight".to_string(), 8);
+
+            let int_array = vec![7, 8];
+            let str_array = vec![
+                CString::new("seven").unwrap(),
+                CString::new("eight").unwrap(),
+            ];
+            let ptr_array: Vec<*const _> = str_array.iter().map(|s| s.as_ptr()).collect();
+
+            let map = from_raw_string_array_and_int_array(
+                ptr_array.as_ptr(),
+                int_array.as_ptr(),
+                expected_map.len() as i32,
+            )
+            .unwrap();
+            assert_eq!(Some(expected_map), map);
+        }
+
+        #[test]
+        fn parsing_empty_array() {
+            // Testing a null pointer (length longer to ensure the null pointer is checked)
+            let result =
+                from_raw_string_array_and_int_array(std::ptr::null(), std::ptr::null(), 2).unwrap();
+            assert_eq!(None, result);
+
+            // Need a (filled) vector to obtain a valid pointer.
+            let int_array = vec![1];
+            let result =
+                from_raw_string_array_and_int_array(std::ptr::null(), int_array.as_ptr(), 2)
+                    .unwrap();
+            assert_eq!(None, result);
+
+            let array = vec![CString::new("glean").unwrap()];
+            let ptr_array: Vec<*const _> = array.iter().map(|s| s.as_ptr()).collect();
+            let result =
+                from_raw_string_array_and_int_array(ptr_array.as_ptr(), std::ptr::null(), 2)
+                    .unwrap();
+            assert_eq!(None, result);
+
+            // Check the length with valid pointers.
+            let result =
+                from_raw_string_array_and_int_array(ptr_array.as_ptr(), int_array.as_ptr(), 0)
+                    .unwrap();
+            assert_eq!(None, result);
+        }
+
+        #[test]
+        fn parsing_invalid_utf8_fails() {
+            // CAREFUL! We're manually constructing nul-terminated
+
+            // Need a (filled) vector to obtain a valid pointer.
+            let int_array = vec![1];
+            let array = vec![
+                // -1 is definitely an invalid UTF-8 codepoint
+                // Let's not break anything and append the nul terminator
+                vec![0x67, 0x6c, -1, 0x65, 0x61, 0x6e, 0x00],
+            ];
+            let ptr_array: Vec<*const _> = array.iter().map(|s| s.as_ptr()).collect();
+
+            let map = from_raw_string_array_and_int_array(
+                ptr_array.as_ptr(),
+                int_array.as_ptr(),
                 array.len() as i32,
             );
             assert!(map.is_err());

--- a/glean-core/src/ac_migration/mod.rs
+++ b/glean-core/src/ac_migration/mod.rs
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A module containing glean-core code for supporting data migration
+//! (i.e. sequence numbers) from glean-ac. This is a temporary module
+//! planned to be removed in 2020, after the transition from glean-ac
+//! is complete.
+
+use crate::util::truncate_string_at_boundary;
+use std::collections::HashMap;
+
+use super::Glean;
+use super::PingMaker;
+
+const GLEAN_AC_SEQUENCE_SUFFIX: &str = "_seq";
+
+/// The Glean A-C metadata migration object.
+#[derive(Debug, Clone)]
+pub struct ACMetadata {
+    /// A map in which entries are (`<ping_name>_seq`, nextSequenceNumber)..
+    pub sequence_numbers: HashMap<String, i32>,
+}
+
+/// Stores the sequence numbers from glean-ac in glean-core.
+pub(super) fn migrate_sequence_numbers(glean: &Glean, seq_numbers: HashMap<String, i32>) {
+    let ping_maker = PingMaker::new();
+
+    for (store_name_with_suffix, next_seq) in seq_numbers.into_iter() {
+        // Note: glean-ac stores the sequence numbers as '<ping_name>_seq',
+        // glean-core requires '<ping_name>#sequence'.
+        if !store_name_with_suffix.ends_with(GLEAN_AC_SEQUENCE_SUFFIX) {
+            continue;
+        }
+
+        // Negative or 0 counters are definitively not worth importing.
+        if next_seq <= 0 {
+            continue;
+        }
+
+        let truncated_len = store_name_with_suffix
+            .len()
+            .saturating_sub(GLEAN_AC_SEQUENCE_SUFFIX.len());
+        let store_name = truncate_string_at_boundary(store_name_with_suffix, truncated_len);
+
+        ping_maker.set_ping_seq(glean, &store_name, next_seq);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tests::new_glean;
+
+    #[test]
+    fn invalid_storage_names_must_not_be_migrated() {
+        let (glean, _) = new_glean();
+
+        let mut ac_seq_numbers = HashMap::new();
+        ac_seq_numbers.insert(String::from("control_seq"), 3);
+        ac_seq_numbers.insert(String::from("ignored_seq-lol"), 85);
+
+        let ping_maker = PingMaker::new();
+        migrate_sequence_numbers(&glean, ac_seq_numbers);
+
+        assert_eq!(3, ping_maker.get_ping_seq(&glean, "control"));
+        // The next one should not have been migrated, so we expect
+        // it to start from 0 instead of 85.
+        assert_eq!(0, ping_maker.get_ping_seq(&glean, "ignored"));
+    }
+
+    #[test]
+    fn invalid_sequence_numbers_must_not_be_migrated() {
+        let (glean, _) = new_glean();
+
+        let mut ac_seq_numbers = HashMap::new();
+        ac_seq_numbers.insert(String::from("control_seq"), 3);
+        ac_seq_numbers.insert(String::from("ignored_seq"), -85);
+
+        let ping_maker = PingMaker::new();
+        migrate_sequence_numbers(&glean, ac_seq_numbers);
+
+        assert_eq!(3, ping_maker.get_ping_seq(&glean, "control"));
+        // The next one should not have been migrated, so we expect
+        // it to start from 0 instead of 85.
+        assert_eq!(0, ping_maker.get_ping_seq(&glean, "ignored"));
+    }
+
+    #[test]
+    fn valid_sequence_numbers_must_be_migrated() {
+        let (glean, _) = new_glean();
+
+        let mut ac_seq_numbers = HashMap::new();
+        ac_seq_numbers.insert(String::from("custom_seq"), 3);
+        ac_seq_numbers.insert(String::from("other_seq"), 7);
+        ac_seq_numbers.insert(String::from("ignored_seq-lol"), 85);
+
+        let ping_maker = PingMaker::new();
+        migrate_sequence_numbers(&glean, ac_seq_numbers);
+
+        assert_eq!(3, ping_maker.get_ping_seq(&glean, "custom"));
+        assert_eq!(7, ping_maker.get_ping_seq(&glean, "other"));
+        // The next one should not have been migrated, so we expect
+        // it to start from 0 instead of 85.
+        assert_eq!(0, ping_maker.get_ping_seq(&glean, "ignored"));
+    }
+}

--- a/glean-core/src/ac_migration/mod.rs
+++ b/glean-core/src/ac_migration/mod.rs
@@ -15,13 +15,6 @@ use super::PingMaker;
 
 const GLEAN_AC_SEQUENCE_SUFFIX: &str = "_seq";
 
-/// The Glean A-C metadata migration object.
-#[derive(Debug, Clone)]
-pub struct ACMetadata {
-    /// A map in which entries are (`<ping_name>_seq`, nextSequenceNumber)..
-    pub sequence_numbers: HashMap<String, i32>,
-}
-
 /// Stores the sequence numbers from glean-ac in glean-core.
 pub(super) fn migrate_sequence_numbers(glean: &Glean, seq_numbers: HashMap<String, i32>) {
     let ping_maker = PingMaker::new();

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -37,11 +37,11 @@ impl Database {
 
     /// Creates the storage directories and inits rkv.
     fn open_rkv(path: &str) -> Result<Rkv> {
-        let path = std::path::Path::new(path);
+        let path = std::path::Path::new(path).join("db");
         log::debug!("Database path: {:?}", path.display());
         fs::create_dir_all(&path)?;
 
-        let rkv = Rkv::new(path)?;
+        let rkv = Rkv::new(&path)?;
         log::info!("Database initialized");
         Ok(rkv)
     }
@@ -298,7 +298,7 @@ mod test {
 
     #[test]
     fn test_panicks_if_fails_dir_creation() {
-        assert!(Database::new("").is_err());
+        assert!(Database::new("/!#\"'@#°ç").is_err());
     }
 
     #[test]

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -33,7 +33,6 @@ pub mod storage;
 mod util;
 
 use crate::ac_migration::migrate_sequence_numbers;
-pub use crate::ac_migration::ACMetadata;
 pub use crate::common_metric_data::{CommonMetricData, Lifetime};
 use crate::database::Database;
 pub use crate::error::{Error, Result};

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -19,6 +19,7 @@ use chrono::{DateTime, FixedOffset};
 use lazy_static::lazy_static;
 use uuid::Uuid;
 
+pub mod ac_migration;
 mod common_metric_data;
 mod database;
 mod error;
@@ -31,6 +32,8 @@ pub mod ping;
 pub mod storage;
 mod util;
 
+use crate::ac_migration::migrate_sequence_numbers;
+pub use crate::ac_migration::ACMetadata;
 pub use crate::common_metric_data::{CommonMetricData, Lifetime};
 use crate::database::Database;
 pub use crate::error::{Error, Result};
@@ -139,6 +142,39 @@ impl Glean {
             max_events: cfg.max_events.unwrap_or(DEFAULT_MAX_EVENTS),
         };
         glean.on_change_upload_enabled(cfg.upload_enabled);
+        Ok(glean)
+    }
+
+    /// Create and initialize a new Glean object.
+    ///
+    /// This will attempt to delete any previously existing database and
+    /// then create the necessary directories and files in `data_path`.
+    /// This will also initialize the core metrics.
+    ///
+    /// # Arguments
+    ///
+    /// * `cfg` - an instance of the Glean `Configuration`.
+    /// * `new_sequence_nums` - a map of ("<pingName>_seq", sequence number)
+    ///   used to initialize Glean with sequence numbers imported from glean-ac.
+    pub fn with_sequence_numbers(
+        cfg: Configuration,
+        new_sequence_nums: HashMap<String, i32>,
+    ) -> Result<Self> {
+        log::info!("Creating new Glean (migrating data)");
+
+        // Delete the database directory, if it exists. Bail out if there's
+        // errors, as I'm not sure what else could be done if we can't even
+        // delete a directory we own.
+        let db_path = Path::new(&cfg.data_path).join("db");
+        if db_path.exists() {
+            std::fs::remove_dir_all(db_path)?;
+        }
+
+        let glean = Self::new(cfg)?;
+
+        // Set sequence numbers coming through the FFI.
+        migrate_sequence_numbers(&glean, new_sequence_nums);
+
         Ok(glean)
     }
 

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -340,7 +340,7 @@ fn glean_inits_with_migration_when_no_db_dir_exists() {
     let tmpname = dir.path().display().to_string();
 
     let cfg = Configuration {
-        data_path: tmpname.into(),
+        data_path: tmpname,
         application_id: GLOBAL_APPLICATION_ID.to_string(),
         upload_enabled: false,
         max_events: None,

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -333,3 +333,23 @@ fn disabling_when_already_disabled_is_a_noop() {
 
     assert!(!glean.set_upload_enabled(false));
 }
+
+#[test]
+fn glean_inits_with_migration_when_no_db_dir_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+
+    let cfg = Configuration {
+        data_path: tmpname.into(),
+        application_id: GLOBAL_APPLICATION_ID.to_string(),
+        upload_enabled: false,
+        max_events: None,
+    };
+
+    let mut ac_seq_numbers = HashMap::new();
+    ac_seq_numbers.insert(String::from("custom_seq"), 3);
+
+    let mut glean = Glean::with_sequence_numbers(cfg, ac_seq_numbers).unwrap();
+
+    assert!(!glean.set_upload_enabled(false));
+}

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -48,7 +48,33 @@ impl PingMaker {
         Self
     }
 
-    fn get_ping_seq(&self, glean: &Glean, storage_name: &str) -> usize {
+    /// Set the next ping sequence number to the provided one.
+    ///
+    /// This function stores the next sequence number (the one that
+    /// will be returned next time `get_ping_seq` is called) in the
+    /// glean-core store. The main purpose of this function is to allow
+    /// overriding sequence numbers with migration data coming from
+    /// glean-ac.
+    pub(super) fn set_ping_seq(&self, glean: &Glean, storage_name: &str, next_seq: i32) {
+        // Sequence numbers are stored as a counter under a name that includes the storage name
+        let seq = CounterMetric::new(CommonMetricData {
+            name: format!("{}#sequence", storage_name),
+            // We don't need a category, the name is already unique
+            category: "".into(),
+            send_in_pings: vec![INTERNAL_STORAGE.into()],
+            lifetime: Lifetime::User,
+            ..Default::default()
+        });
+
+        // It's safe to add `next_seq` because the glean-ac migration code
+        // clears the glean-core database before the migration starts.
+        seq.add(glean, next_seq);
+    }
+
+    /// Get, and then increment, the sequence number for a given ping.
+    ///
+    /// This is crate-internal exclusively for enabling the migration tests.
+    pub(super) fn get_ping_seq(&self, glean: &Glean, storage_name: &str) -> usize {
         // Sequence numbers are stored as a counter under a name that includes the storage name
         let seq = CounterMetric::new(CommonMetricData {
             name: format!("{}#sequence", storage_name),
@@ -300,4 +326,16 @@ mod test {
         assert_eq!(1, ping_maker.get_ping_seq(&glean, "custom"));
     }
 
+    #[test]
+    fn set_ping_seq_must_correctly_set_sequence_numbers() {
+        let (glean, _) = new_glean();
+        let ping_maker = PingMaker::new();
+
+        ping_maker.set_ping_seq(&glean, "custom", 3);
+        assert_eq!(3, ping_maker.get_ping_seq(&glean, "custom"));
+
+        ping_maker.set_ping_seq(&glean, "other", 7);
+        assert_eq!(7, ping_maker.get_ping_seq(&glean, "other"));
+        assert_eq!(8, ping_maker.get_ping_seq(&glean, "other"));
+    }
 }

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -281,14 +281,7 @@ impl PingMaker {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    const GLOBAL_APPLICATION_ID: &str = "org.mozilla.glean.test.app";
-    pub fn new_glean() -> (Glean, tempfile::TempDir) {
-        let dir = tempfile::tempdir().unwrap();
-        let tmpname = dir.path().display().to_string();
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
-        (glean, dir)
-    }
+    use crate::tests::new_glean;
 
     #[test]
     fn sequence_numbers_should_be_reset_when_toggling_uploading() {


### PR DESCRIPTION
This PR enables the cross-platform Glean SDK to migrate sequence numbers from glean-ac.

This additionally adds initial test coverage for the migration process.