### PR TITLE
1585333 - Add BooleansStorageEngine to AC data migration

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/GleanACDataMigrator.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/GleanACDataMigrator.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
+import mozilla.telemetry.glean.acmigration.engines.BooleansStorageEngine
 import mozilla.telemetry.glean.acmigration.engines.DatetimesStorageEngine
 import mozilla.telemetry.glean.acmigration.engines.UuidsStorageEngine
 import mozilla.telemetry.glean.private.Lifetime
@@ -43,6 +44,7 @@ internal class GleanACDataMigrator(
     }
 
     // The storage engines data is migrated from.
+    private val booleanStorageEngine by lazy { BooleansStorageEngine(applicationContext) }
     private val uuidStorageEngine by lazy { UuidsStorageEngine(applicationContext) }
     private val dateTimeStorageEngine by lazy { DatetimesStorageEngine(applicationContext) }
 
@@ -170,6 +172,7 @@ internal class GleanACDataMigrator(
      * Migrate all the metrics that have User lifetime.
      */
     fun migrateUserLifetimeMetrics() {
+        booleanStorageEngine.migrateToGleanCore(Lifetime.User)
         uuidStorageEngine.migrateToGleanCore(Lifetime.User)
         dateTimeStorageEngine.migrateToGleanCore(Lifetime.User)
     }
@@ -178,6 +181,7 @@ internal class GleanACDataMigrator(
      * Migrate all the metrics that have Ping lifetime.
      */
     fun migratePingLifetimeMetrics() {
+        booleanStorageEngine.migrateToGleanCore(Lifetime.Ping)
         uuidStorageEngine.migrateToGleanCore(Lifetime.Ping)
         dateTimeStorageEngine.migrateToGleanCore(Lifetime.Ping)
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/engines/BooleansStorageEngine.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/acmigration/engines/BooleansStorageEngine.kt
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.acmigration.engines
+
+import android.content.Context
+import mozilla.telemetry.glean.private.BooleanMetricType
+import mozilla.telemetry.glean.private.Lifetime
+
+internal class BooleansStorageEngine(
+    applicationContext: Context
+) : GenericStorageEngine<Boolean>() {
+
+    init {
+        this.applicationContext = applicationContext
+    }
+
+    override fun deserializeSingleMetric(metricName: String, value: Any?): Boolean? {
+        return value as? Boolean
+    }
+
+    /**
+     * Perform the data migration.
+     */
+    override fun migrateToGleanCore(lifetime: Lifetime) {
+        super.migrateToGleanCore(lifetime)
+
+        // Get the stored data.
+        val storedData = dataStores[lifetime.ordinal]
+        for ((storeName, data) in storedData) {
+            // Get each storage for the specified lifetime
+            for ((metricId, metricData) in data) {
+                // HACK HACK HACK HACK! Hic sunt leones!
+                // It would be tricky to break apart the category and the name of each metric,
+                // given that categories might contain dots themselves. Just leave the category
+                // blank and provide the full metric identifier through the "name".
+                val metric = BooleanMetricType(
+                    name = metricId,
+                    category = "",
+                    sendInPings = listOf(storeName),
+                    lifetime = lifetime,
+                    disabled = false
+                )
+
+                if (lifetime == Lifetime.User) {
+                    // User lifetime metrics are migrated very early: we don't want them
+                    // to be batched but, rather, set immediately.
+                    metric.setSync(metricData)
+                } else {
+                    metric.set(metricData)
+                }
+            }
+        }
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -75,6 +75,25 @@ class BooleanMetricType internal constructor(
     }
 
     /**
+     * Set a boolean value synchronously.
+     *
+     * This is only to be used for the glean-ac to glean-core data migration.
+     *
+     * @param value This is a user defined boolean value.
+     */
+    internal fun setSync(value: Boolean) {
+        if (disabled) {
+            return
+        }
+
+        LibGleanFFI.INSTANCE.glean_boolean_set(
+            Glean.handle,
+            this@BooleanMetricType.handle,
+            value.toByte()
+        )
+    }
+
+    /**
      * Tests whether a value is stored for the metric for testing purposes only. This function will
      * attempt to await the last task (if any) writing to the the metric's storage engine before
      * returning a value.


### PR DESCRIPTION
This adds the BooleansStorageEngine to the migration engines for the AC -> Glean-core migration.