### PR TITLE
1585021: Fix ordering of events at startup to prevent negative timestamps

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -177,8 +177,13 @@ internal object Dispatchers {
         /**
          * Helper function to execute the task as either an synchronous or asynchronous operation,
          * depending on whether [testingMode] is true.
+         *
+         * WARNING: THIS SHOULD ALMOST NEVER BE USED. IF IN DOUBT, USE [launch] INSTEAD.
+         *
+         * This has internal visibility only so that it can be called directly to
+         * send queued events immediately at startup before any metric recording.
          */
-        private fun executeTask(block: suspend CoroutineScope.() -> Unit): Job? {
+        internal fun executeTask(block: suspend CoroutineScope.() -> Unit): Job? {
             return when {
                 testingMode -> {
                     runBlocking {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -180,6 +180,11 @@ internal object Dispatchers {
          *
          * WARNING: THIS SHOULD ALMOST NEVER BE USED. IF IN DOUBT, USE [launch] INSTEAD.
          *
+         * [launch] is useful for running tasks that might be called before initialization, but
+         * need to actually run after initialization (which is true for most tasks in Glean).
+         * This should only be called directly for tasks that must run immediately after
+         * initialization.
+         *
          * This has internal visibility only so that it can be called directly to
          * send queued events immediately at startup before any metric recording.
          */

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -186,9 +186,12 @@ open class GleanInternalAPI internal constructor () {
         initializeCoreMetrics(applicationContext)
 
         // Deal with any pending events so we can start recording new ones
-        val pingSent = LibGleanFFI.INSTANCE.glean_on_ready_to_send_pings(this.handle).toBoolean()
-        if (pingSent) {
-            PingUploadWorker.enqueueWorker()
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.executeTask {
+            val pingSent = LibGleanFFI.INSTANCE.glean_on_ready_to_send_pings(this@GleanInternalAPI.handle).toBoolean()
+            if (pingSent) {
+                PingUploadWorker.enqueueWorker()
+            }
         }
 
         // Set up information and scheduling for Glean owned pings. Ideally, the "metrics"

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -279,6 +279,7 @@ class EventMetricTypeTest {
 
     // Moved from EventsStorageEngineTest.kt in glean-ac
     @kotlinx.coroutines.ObsoleteCoroutinesApi
+    @Suppress("LongMethod")
     @Test
     fun `flush queued events on startup and correctly handle pre-init events`() {
         val server = getMockWebServer()


### PR DESCRIPTION
This is basically a port of https://github.com/mozilla-mobile/android-components/pull/4595 to glean-core.

glean-core didn't actually have the same underlying bug, however, it was loading queued pings from disk on the main thread.  (Oh noes, I/O on the main thread!!!)  That has been fixed so it does this on an "early" (non-queued) task just as on glean-ac.

The other changes to glean-ac were not required, since everything is already internally synchronous on the Rust side when `sendPings` is called.