### PR TITLE
1582447 - Fix delayed ping uploading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ data/
 glean-core/data
 glean_app*
 !glean_app.c
+
+samples/ios/app/.venv/

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -26,7 +26,6 @@ public class Glean {
     private var uploadEnabled: Bool = true
     private var configuration: Configuration?
     private var observer: GleanLifecycleObserver?
-    static var backgroundTaskId = UIBackgroundTaskIdentifier.invalid
 
     // This struct is used for organizational purposes to keep the class constants in a single place
     struct Constants {
@@ -189,14 +188,6 @@ public class Glean {
 
     /// Handle background event and send appropriate pings
     func handleBackgroundEvent() {
-        // This asks the OS for more time when going to background to perform critical tasks.
-        // This will be signaled complete when `sendPingsByName` is done.
-        Glean.backgroundTaskId = UIApplication.shared.beginBackgroundTask(withName: "Glean Upload Task") {
-            // End the task if time expires
-            UIApplication.shared.endBackgroundTask(Glean.backgroundTaskId)
-            Glean.backgroundTaskId = UIBackgroundTaskIdentifier.invalid
-        }
-
         self.sendPingsByName(pingNames: ["baseline", "events"])
     }
 
@@ -240,10 +231,6 @@ public class Glean {
                     }
                 }
             }
-
-            // End background task assertion to let the OS know we are done with our tasks
-            UIApplication.shared.endBackgroundTask(Glean.backgroundTaskId)
-            Glean.backgroundTaskId = UIBackgroundTaskIdentifier.invalid
         }
     }
 

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -51,7 +51,7 @@ public class HttpPingUploader {
         // Build the request and create an async upload operation and launch it through the
         // Dispatchers
         if let request = buildRequest(path: path, data: data) {
-            let uploadOperation = PingUploadOperation(request: request, callback: callback)
+            let uploadOperation = PingUploadOperation(request: request, data: Data(data.utf8), callback: callback)
             Dispatchers.shared.launchConcurrent(operation: uploadOperation)
         }
     }


### PR DESCRIPTION
This fixes the delayed uploading of pings.  Due to a combination of factors, including using the wrong URLSessionTask and not using the extended background operation properly, the pings would sometimes not be sent when going to background.