### PR TITLE
Upgrade `WorkManager` to version 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         androidx_junit: '1.1.1',
         androidx_lifecycle_extensions: '2.1.0',
         androidx_test: '1.2.0',
-        androidx_work: '2.0.1',
+        androidx_work: '2.2.0',
     ]
 
     ext.build = [

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
         androidx_core: '1.0.0',
         androidx_espresso: '3.2.0',
         androidx_junit: '1.1.1',
+        androidx_lifecycle_extensions: '2.1.0',
         androidx_test: '1.2.0',
         androidx_work: '2.0.1',
     ]

--- a/build.gradle
+++ b/build.gradle
@@ -11,16 +11,16 @@ buildscript {
     // changing them. Please note that, for using in Android-Components, the
     // versions below must match the ones in that repository.
     ext.versions = [
-        android_components: '5.0.0',
+        android_components: '15.0.0',
         android_gradle_plugin: '3.4.1',
         android_maven_publish_plugin: '3.6.2',
-        coroutines: '1.2.2',
+        coroutines: '1.3.0',
         dokka: '0.9.17',
         jna: '5.2.0',
         junit: '4.12',
         mockito: '2.24.5',
         mockwebserver: '3.10.0',
-        kotlin: '1.3.40',
+        kotlin: '1.3.50',
         robolectric: '4.2.1', // This is different than a-c, but we're fine, it's only tests.
         rust_android_plugin: '0.8.1',
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ buildscript {
 }
 
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("1.0.0-RC16")
+    id("io.gitlab.arturbosch.detekt").version("1.0.1")
 }
 
 allprojects {
@@ -172,8 +172,6 @@ ext.cargoExec = { spec, toolchain ->
 }
 
 detekt {
-    // The version number is duplicated, please refer to plugins block for more details
-    toolVersion = "1.0.0-RC14"
     input = files("${projectDir}/glean-core", "${projectDir}/samples/android", "buildSrc")
     filters = ".*test.*,.*/resources/.*,.*/tmp/.*,.*/build/.*"
     failFast = false

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ buildscript {
         rust_android_plugin: '0.8.1',
 
         // Android X dependencies
-        androidx_annotation: '1.0.2',
-        androidx_appcompat: '1.0.0',
-        androidx_browser: '1.0.0',
-        androidx_core: '1.0.0',
+        androidx_annotation: '1.1.0',
+        androidx_appcompat: '1.1.0',
+        androidx_browser: '1.2.0-alpha07',
+        androidx_core: '1.1.0',
         androidx_espresso: '3.2.0',
         androidx_junit: '1.1.1',
         androidx_lifecycle_extensions: '2.1.0',

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -118,9 +118,9 @@ afterEvaluate {
         def javaDebugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
         def mainSrc = "$project.projectDir/src/main/java"
 
-        sourceDirectories = files([mainSrc])
-        classDirectories = files([kotlinDebugTree, javaDebugTree])
-        executionData = fileTree(dir: project.buildDir, includes: [
+        sourceDirectories.from = files([mainSrc])
+        classDirectories.from = files([kotlinDebugTree, javaDebugTree])
+        executionData.from = fileTree(dir: project.buildDir, includes: [
                 'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
         ])
     }

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -170,6 +170,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.coroutines"
 
     implementation "androidx.annotation:annotation:$versions.androidx_annotation"
+    implementation "androidx.lifecycle:lifecycle-extensions:$versions.androidx_lifecycle_extensions"
     implementation "androidx.work:work-runtime-ktx:$versions.androidx_work"
 
     // We need a compileOnly dependency on the following block of testing

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -64,6 +64,19 @@ android {
     // Uncomment to include debug symbols in native library builds.
     // packagingOptions { doNotStrip "**/*.so" }
 
+    // This is required to support new AndroidX support libraries.
+    // See mozilla-mobile/android-components#842
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
+
     testOptions {
         unitTests.all {
             testLogging {
@@ -71,6 +84,10 @@ android {
             }
 
             maxHeapSize = "1024m"
+        }
+
+        unitTests {
+            includeAndroidResources = true
         }
     }
 }
@@ -151,14 +168,6 @@ configurations {
     // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
     // Success!
     jnaForTest
-}
-
-android {
-  testOptions {
-    unitTests {
-      includeAndroidResources = true
-    }
-  }
 }
 
 dependencies {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -187,7 +187,7 @@ open class GleanInternalAPI internal constructor () {
         Dispatchers.API.executeTask {
             val pingSent = LibGleanFFI.INSTANCE.glean_on_ready_to_send_pings(this@GleanInternalAPI.handle).toBoolean()
             if (pingSent) {
-                PingUploadWorker.enqueueWorker()
+                PingUploadWorker.enqueueWorker(applicationContext)
             }
         }
 
@@ -264,8 +264,8 @@ open class GleanInternalAPI internal constructor () {
                     // Cancel any pending workers here so that we don't accidentally upload or
                     // collect data after the upload has been disabled.
                     if (!enabled) {
-                        MetricsPingScheduler.cancel()
-                        PingUploadWorker.cancel()
+                        MetricsPingScheduler.cancel(applicationContext)
+                        PingUploadWorker.cancel(applicationContext)
                     }
                 }
 
@@ -533,7 +533,7 @@ open class GleanInternalAPI internal constructor () {
         ).toBoolean()
 
         if (sentPing) {
-            PingUploadWorker.enqueueWorker()
+            PingUploadWorker.enqueueWorker(applicationContext)
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -59,8 +59,8 @@ internal class MetricsPingScheduler(
         /**
          * Function to cancel any pending metrics ping workers
          */
-        internal fun cancel() {
-            WorkManager.getInstance().cancelUniqueWork(MetricsPingWorker.TAG)
+        internal fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(MetricsPingWorker.TAG)
         }
     }
 
@@ -115,7 +115,7 @@ internal class MetricsPingScheduler(
         // - Glean restarts;
         // - the ping is overdue and is immediately collected at startup;
         // - a new work is scheduled for the next calendar day.
-        WorkManager.getInstance().enqueueUniqueWork(
+        WorkManager.getInstance(applicationContext).enqueueUniqueWork(
             MetricsPingWorker.TAG,
             ExistingWorkPolicy.REPLACE,
             workRequest)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -66,9 +66,11 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
 
         /**
          * Function to aid in properly enqueuing the worker in [WorkManager]
+         *
+         * @param context the application [Context] to get the [WorkManager] instance for
          */
-        internal fun enqueueWorker() {
-            WorkManager.getInstance().enqueueUniqueWork(
+        internal fun enqueueWorker(context: Context) {
+            WorkManager.getInstance(context).enqueueUniqueWork(
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
                 buildWorkRequest())
@@ -84,9 +86,11 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
 
         /**
          * Function to cancel any pending ping upload workers
+         *
+         * @param context the application [Context] to get the [WorkManager] instance for
          */
-        internal fun cancel() {
-            WorkManager.getInstance().cancelUniqueWork(PING_WORKER_TAG)
+        internal fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(PING_WORKER_TAG)
         }
 
         /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/acmigration/GleanDataMigrationTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/acmigration/GleanDataMigrationTest.kt
@@ -171,7 +171,7 @@ class GleanDataMigrationTest {
 
         // Trigger a baseline and a metrics ping.
         Pings.baseline.send()
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         // Check that we received the expected sequence number for the baseline ping.
         val baselineJson = waitForSpecificPing(pingServer, "baseline")
@@ -249,7 +249,7 @@ class GleanDataMigrationTest {
 
         // Trigger a baseline and a metrics ping.
         Pings.baseline.send()
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         // Check that we received the expected sequence number for the baseline ping.
         val baselineJson = waitForSpecificPing(pingServer, "baseline")

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -129,7 +129,8 @@ class GleanDebugActivityTest {
     fun `pings are sent using sendPing`() {
         val server = getMockWebServer()
 
-        resetGlean(config = Glean.configuration.copy(
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port
         ))
 
@@ -159,7 +160,7 @@ class GleanDebugActivityTest {
             serverEndpoint = "http://" + server.hostName + ":" + server.port
         )
 
-        triggerWorkManager()
+        triggerWorkManager(context)
         val request = server.takeRequest(10L, TimeUnit.SECONDS)
 
         assertTrue(
@@ -173,7 +174,8 @@ class GleanDebugActivityTest {
     fun `tagPings filters ID's that don't match the pattern`() {
         val server = getMockWebServer()
 
-        resetGlean(config = Glean.configuration.copy(
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port
         ))
 
@@ -202,7 +204,7 @@ class GleanDebugActivityTest {
         assertEquals("Server endpoint must be reset if tag didn't pass regex",
             "http://" + server.hostName + ":" + server.port, Glean.configuration.serverEndpoint)
 
-        triggerWorkManager()
+        triggerWorkManager(context)
         val request = server.takeRequest(10L, TimeUnit.SECONDS)
 
         assertTrue(
@@ -223,7 +225,8 @@ class GleanDebugActivityTest {
         val pingTag = "test-debug-ID"
 
         // Use the test client in the Glean configuration
-        resetGlean(config = Glean.configuration.copy(
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        resetGlean(context, Glean.configuration.copy(
             httpClient = TestPingTagClient(debugHeaderValue = pingTag)
         ))
 
@@ -249,6 +252,6 @@ class GleanDebugActivityTest {
 
         // This will trigger the call to `fetch()` in the TestPingTagClient which is where the
         // test assertions will occur
-        triggerWorkManager()
+        triggerWorkManager(context)
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -232,7 +232,8 @@ class EventMetricTypeTest {
     fun `flush queued events on startup`() {
         val server = getMockWebServer()
 
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+        val context = getContextWithMockedInfo()
+        resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
             logPings = true
         ))
@@ -251,7 +252,7 @@ class EventMetricTypeTest {
 
         // Start a new Glean instance to trigger the sending of "stale" events
         resetGlean(
-            getContextWithMockedInfo(),
+            context,
             Glean.configuration.copy(
                 serverEndpoint = "http://" + server.hostName + ":" + server.port,
                 logPings = true
@@ -259,7 +260,7 @@ class EventMetricTypeTest {
             clearStores = false
         )
 
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         val request = server.takeRequest(1L, TimeUnit.SECONDS)
         assertEquals("POST", request.method)
@@ -284,7 +285,8 @@ class EventMetricTypeTest {
     fun `flush queued events on startup and correctly handle pre-init events`() {
         val server = getMockWebServer()
 
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+        val context = getContextWithMockedInfo()
+        resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
             logPings = true
         ))
@@ -305,7 +307,7 @@ class EventMetricTypeTest {
         event.record(extra = mapOf(SomeExtraKeys.SomeExtra to "pre-init"))
 
         resetGlean(
-            getContextWithMockedInfo(),
+            context,
             Glean.configuration.copy(
                 serverEndpoint = "http://" + server.hostName + ":" + server.port,
                 logPings = true
@@ -316,7 +318,7 @@ class EventMetricTypeTest {
         event.record(extra = mapOf(SomeExtraKeys.SomeExtra to "post-init"))
 
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         var request = server.takeRequest(20L, TimeUnit.SECONDS)
         var pingJsonData = request.body.readUtf8()
@@ -337,7 +339,7 @@ class EventMetricTypeTest {
         Glean.sendPingsByName(listOf("events"))
 
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         request = server.takeRequest(20L, TimeUnit.SECONDS)
         pingJsonData = request.body.readUtf8()

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -36,7 +36,8 @@ class PingTypeTest {
     fun `test sending of custom pings`() {
         val server = getMockWebServer()
 
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+        val context = getContextWithMockedInfo()
+        resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
             logPings = true
         ))
@@ -59,7 +60,7 @@ class PingTypeTest {
 
         customPing.send()
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         val docType = request.path.split("/")[3]
@@ -74,7 +75,8 @@ class PingTypeTest {
     fun `test sending of custom pings without client_id`() {
         val server = getMockWebServer()
 
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+        val context = getContextWithMockedInfo()
+        resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
             logPings = true
         ))
@@ -97,7 +99,7 @@ class PingTypeTest {
 
         customPing.send()
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         val docType = request.path.split("/")[3]
@@ -120,7 +122,8 @@ class PingTypeTest {
             sendInPings = listOf("unknown")
         )
 
-        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+        val context = getContextWithMockedInfo()
+        resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
             logPings = true
         ))
@@ -131,7 +134,7 @@ class PingTypeTest {
         Glean.sendPingsByName(listOf("unknown"))
 
         assertFalse("We shouldn't have any pings scheduled",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued
         )
     }
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -9,6 +9,7 @@ import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
+import mozilla.components.support.test.any
 import mozilla.telemetry.glean.getContextWithMockedInfo
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.private.Lifetime
@@ -30,7 +31,6 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.doReturn
@@ -45,17 +45,6 @@ import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class MetricsPingSchedulerTest {
-    private fun <T> kotlinFriendlyAny(): T {
-        // This is required to work around the Kotlin/ArgumentMatchers problem with using
-        // `verify` on non-nullable arguments (since `any` may return null). See
-        // https://github.com/nhaarman/mockito-kotlin/issues/241
-        ArgumentMatchers.any<T>()
-        // This weird cast was suggested as part of https://youtrack.jetbrains.com/issue/KT-8135 .
-        // See the related issue for why this is needed in mocks.
-        @Suppress("UNCHECKED_CAST")
-        return null as T
-    }
-
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
@@ -230,7 +219,7 @@ class MetricsPingSchedulerTest {
         // prior to |collectPingAndReschedule|.
         verify(mpsSpy, times(0)).updateSentDate(anyString())
         verify(mpsSpy, times(0)).schedulePingCollection(
-            kotlinFriendlyAny(),
+            any(),
             anyBoolean()
         )
 
@@ -239,7 +228,7 @@ class MetricsPingSchedulerTest {
         // Verify that we correctly called in the methods.
         verify(mpsSpy, times(1)).updateSentDate(anyString())
         verify(mpsSpy, times(1)).schedulePingCollection(
-            kotlinFriendlyAny(),
+            any(),
             anyBoolean()
         )
     }
@@ -311,7 +300,7 @@ class MetricsPingSchedulerTest {
 
         MetricsPingScheduler.isInForeground = true
 
-        verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny())
+        verify(mpsSpy, never()).collectPingAndReschedule(any())
 
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
@@ -342,7 +331,7 @@ class MetricsPingSchedulerTest {
             spy(MetricsPingScheduler(context))
         mpsSpy.updateSentDate(getISOTimeString(fakeNow, truncateTo = TimeUnit.Day))
 
-        verify(mpsSpy, never()).schedulePingCollection(kotlinFriendlyAny(), anyBoolean())
+        verify(mpsSpy, never()).schedulePingCollection(any(), anyBoolean())
 
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
@@ -353,7 +342,7 @@ class MetricsPingSchedulerTest {
         // Verify that we're scheduling for the next day and not collecting immediately.
         verify(mpsSpy, times(1)).schedulePingCollection(fakeNow, sendTheNextCalendarDay = true)
         verify(mpsSpy, never()).schedulePingCollection(fakeNow, sendTheNextCalendarDay = false)
-        verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny())
+        verify(mpsSpy, never()).collectPingAndReschedule(any())
     }
 
     @Test
@@ -376,7 +365,7 @@ class MetricsPingSchedulerTest {
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
 
-        verify(mpsSpy, never()).schedulePingCollection(kotlinFriendlyAny(), anyBoolean())
+        verify(mpsSpy, never()).schedulePingCollection(any(), anyBoolean())
 
         // Trigger the startup check.
         mpsSpy.schedule()
@@ -384,7 +373,7 @@ class MetricsPingSchedulerTest {
         // Verify that we're scheduling for today, but not collecting immediately.
         verify(mpsSpy, times(1)).schedulePingCollection(fakeNow, sendTheNextCalendarDay = false)
         verify(mpsSpy, never()).schedulePingCollection(fakeNow, sendTheNextCalendarDay = true)
-        verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny())
+        verify(mpsSpy, never()).collectPingAndReschedule(any())
     }
 
     @Test
@@ -399,7 +388,7 @@ class MetricsPingSchedulerTest {
             spy(MetricsPingScheduler(context))
         mpsSpy.sharedPreferences.edit().clear().apply()
 
-        verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny())
+        verify(mpsSpy, never()).collectPingAndReschedule(any())
 
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
@@ -424,7 +413,7 @@ class MetricsPingSchedulerTest {
             spy(MetricsPingScheduler(context))
         mpsSpy.sharedPreferences.edit().clear().apply()
 
-        verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny())
+        verify(mpsSpy, never()).collectPingAndReschedule(any())
 
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.telemetry.glean.scheduler
 
+import android.content.Context
 import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -55,18 +56,19 @@ class MetricsPingSchedulerTest {
         return null as T
     }
 
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @Before
     fun setup() {
-        WorkManagerTestInitHelper.initializeTestWorkManager(
-            ApplicationProvider.getApplicationContext())
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
         Glean.enableTestingMode()
     }
 
     @Test
     fun `milliseconds until the due time must be correctly computed`() {
-        val metricsPingScheduler = MetricsPingScheduler(
-            ApplicationProvider.getApplicationContext())
+        val metricsPingScheduler = MetricsPingScheduler(context)
 
         val fakeNow = Calendar.getInstance()
         fakeNow.clear()
@@ -104,7 +106,7 @@ class MetricsPingSchedulerTest {
 
     @Test
     fun `getDueTimeForToday must correctly return the due time for the current day`() {
-        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        val mps = MetricsPingScheduler(context)
 
         val fakeNow = Calendar.getInstance()
         fakeNow.clear()
@@ -123,7 +125,7 @@ class MetricsPingSchedulerTest {
 
     @Test
     fun `isAfterDueTime must report false before the due time on the same calendar day`() {
-        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        val mps = MetricsPingScheduler(context)
 
         val fakeNow = Calendar.getInstance()
         fakeNow.clear()
@@ -143,7 +145,7 @@ class MetricsPingSchedulerTest {
 
     @Test
     fun `isAfterDueTime must report true after the due time on the same calendar day`() {
-        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        val mps = MetricsPingScheduler(context)
 
         val fakeNow = Calendar.getInstance()
         fakeNow.clear()
@@ -155,7 +157,7 @@ class MetricsPingSchedulerTest {
 
     @Test
     fun `getLastCollectedDate must report null when no stored date is available`() {
-        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        val mps = MetricsPingScheduler(context)
         mps.sharedPreferences.edit().clear().apply()
 
         assertNull(
@@ -166,7 +168,7 @@ class MetricsPingSchedulerTest {
 
     @Test
     fun `getLastCollectedDate must report null when the stored date is corrupted`() {
-        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        val mps = MetricsPingScheduler(context)
         mps.sharedPreferences
             .edit()
             .putLong(MetricsPingScheduler.LAST_METRICS_PING_SENT_DATETIME, 123L)
@@ -194,7 +196,7 @@ class MetricsPingSchedulerTest {
     fun `getLastCollectedDate must report the migrated a-c date, if available`() {
         val testDate = "2018-12-19T12:36:00-06:00"
         val mps = MetricsPingScheduler(
-            ApplicationProvider.getApplicationContext(),
+            context,
             testDate
         )
 
@@ -208,7 +210,7 @@ class MetricsPingSchedulerTest {
     @Test
     fun `getLastCollectedDate must report the stored last collected date, if available`() {
         val testDate = "2018-12-19T12:36:00-06:00"
-        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        val mps = MetricsPingScheduler(context)
         mps.updateSentDate(testDate)
 
         val expectedDate = parseISOTimeString(testDate)!!
@@ -222,7 +224,7 @@ class MetricsPingSchedulerTest {
     @Test
     fun `collectMetricsPing must update the last sent date and reschedule the collection`() {
         val mpsSpy = spy(
-            MetricsPingScheduler(ApplicationProvider.getApplicationContext()))
+            MetricsPingScheduler(context))
 
         // Ensure we have the right assumptions in place: the methods were not called
         // prior to |collectPingAndReschedule|.
@@ -247,7 +249,8 @@ class MetricsPingSchedulerTest {
         // Setup a test server and make Glean point to it.
         val server = getMockWebServer()
 
-        resetGlean(getContextWithMockedInfo(), Configuration(
+        val context = getContextWithMockedInfo()
+        resetGlean(context, Configuration(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
             logPings = true
         ))
@@ -270,7 +273,7 @@ class MetricsPingSchedulerTest {
             Glean.metricsPingScheduler.collectPingAndReschedule(Calendar.getInstance())
 
             // Trigger worker task to upload the pings in the background
-            triggerWorkManager()
+            triggerWorkManager(context)
 
             // Fetch the ping from the server and decode its JSON body.
             val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)
@@ -302,7 +305,7 @@ class MetricsPingSchedulerTest {
 
         // Set the last sent date to a previous day, so that today's ping is overdue.
         val mpsSpy =
-            spy(MetricsPingScheduler(ApplicationProvider.getApplicationContext()))
+            spy(MetricsPingScheduler(context))
         val overdueTestDate = "2015-07-05T12:36:00-06:00"
         mpsSpy.updateSentDate(overdueTestDate)
 
@@ -336,7 +339,7 @@ class MetricsPingSchedulerTest {
 
         // Set the last sent date to now.
         val mpsSpy =
-            spy(MetricsPingScheduler(ApplicationProvider.getApplicationContext()))
+            spy(MetricsPingScheduler(context))
         mpsSpy.updateSentDate(getISOTimeString(fakeNow, truncateTo = TimeUnit.Day))
 
         verify(mpsSpy, never()).schedulePingCollection(kotlinFriendlyAny(), anyBoolean())
@@ -363,7 +366,7 @@ class MetricsPingSchedulerTest {
 
         // Set the last sent date to yesterday.
         val mpsSpy =
-            spy(MetricsPingScheduler(ApplicationProvider.getApplicationContext()))
+            spy(MetricsPingScheduler(context))
 
         val fakeYesterday = Calendar.getInstance()
         fakeYesterday.time = fakeNow.time
@@ -393,7 +396,7 @@ class MetricsPingSchedulerTest {
 
         // Clear the last sent date.
         val mpsSpy =
-            spy(MetricsPingScheduler(ApplicationProvider.getApplicationContext()))
+            spy(MetricsPingScheduler(context))
         mpsSpy.sharedPreferences.edit().clear().apply()
 
         verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny())
@@ -418,7 +421,7 @@ class MetricsPingSchedulerTest {
 
         // Clear the last sent date.
         val mpsSpy =
-            spy(MetricsPingScheduler(ApplicationProvider.getApplicationContext()))
+            spy(MetricsPingScheduler(context))
         mpsSpy.sharedPreferences.edit().clear().apply()
 
         verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny())
@@ -446,17 +449,17 @@ class MetricsPingSchedulerTest {
     fun `schedulePingCollection must correctly append a work request to the WorkManager`() {
         // Replacing the singleton's metricsPingScheduler here since doWork() refers to it when
         // the worker runs, otherwise we can get a lateinit property is not initialized error.
-        Glean.metricsPingScheduler = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        Glean.metricsPingScheduler = MetricsPingScheduler(context)
         MetricsPingScheduler.isInForeground = true
 
         // No work should be enqueued at the beginning of the test.
-        assertFalse(getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+        assertFalse(getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
 
         // Manually schedule a collection task for today.
         Glean.metricsPingScheduler.schedulePingCollection(Calendar.getInstance(), sendTheNextCalendarDay = false)
 
         // We expect the worker to be scheduled.
-        assertTrue(getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+        assertTrue(getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
 
         resetGlean(clearStores = true)
     }
@@ -481,20 +484,21 @@ class MetricsPingSchedulerTest {
 
     @Test
     fun `cancel() correctly cancels worker`() {
-        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val mps = MetricsPingScheduler(context)
 
         mps.schedulePingCollection(Calendar.getInstance(), true)
 
         // Verify that the worker is enqueued
         assertTrue("MetricsPingWorker is enqueued",
-            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
 
         // Cancel the worker
-        MetricsPingScheduler.cancel()
+        MetricsPingScheduler.cancel(context)
 
         // Verify worker has been cancelled
         assertFalse("MetricsPingWorker is not enqueued",
-            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
     }
 
     // @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
@@ -24,10 +24,12 @@ class PingUploadWorkerTest {
 
     private var pingUploadWorker: PingUploadWorker? = null
 
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @Before
     @Throws(Exception::class)
     fun setUp() {
-        val context: Context = ApplicationProvider.getApplicationContext()
         MockitoAnnotations.initMocks(this)
         resetGlean(context, config = Configuration().copy(logPings = true))
         pingUploadWorker = PingUploadWorker(context, workerParams!!)
@@ -54,17 +56,17 @@ class PingUploadWorkerTest {
 
     @Test
     fun `cancel() correctly cancels worker`() {
-        PingUploadWorker.enqueueWorker()
+        PingUploadWorker.enqueueWorker(context)
 
         // Verify that the worker is enqueued
         Assert.assertTrue("PingUploadWorker is enqueued",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
 
         // Cancel the worker
-        PingUploadWorker.cancel()
+        PingUploadWorker.cancel(context)
 
         // Verify worker has been cancelled
         Assert.assertFalse("PingUploadWorker is not enqueued",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 }


### PR DESCRIPTION
This was a bit less trivial than expected: the new version required a version upgrade of some other dependencies as well, so I ended up upgrading them all. We are now matching the [same version that Android Components is using](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Dependencies.kt).

This allowed to simplify the code in a few places: see the 'BONUS' commits.