### PR TITLE
Include a `forUnitTests` package in the release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,8 +303,14 @@ jobs:
                echo "=================================================="
                exit 1
             fi
-            ARTIFACTS="./build/maven/org/mozilla/telemetry/glean/${RAWVERSION}/"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} ${ARTIFACTS}
+
+            PKGDIR=./build/package/
+            # Collect all files into a single directory
+            mkdir -p ${PKGDIR}
+            find ./build/maven/org/mozilla/telemetry/ \( -name "*.aar*" -or -name "*.jar*" -or -name "*.pom*" \) \
+              -exec cp {} ${PKGDIR} \;
+            # Upload to GitHub
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} ${PKGDIR}
 
   # via https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
   Generate Rust documentation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,16 +282,24 @@ jobs:
 
   android-release:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/rust:latest
     steps:
       - checkout
       - attach_workspace:
           at: .
       - run:
+          name: Get ghr release tool
+          command: |
+              GHR=ghr_v0.13.0_linux_amd64
+              GHR_SHA256=c428627270ae26e206cb526cb8c7bdfba475dd278f6691ddaf863355adadfa13
+              curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/tcnksm/ghr/releases/download/v0.13.0/${GHR}.tar.gz"
+              echo "${GHR_SHA256} *${GHR}.tar.gz" | shasum -a 256 -c -
+              tar -xf "${GHR}.tar.gz"
+              cp ./${GHR}/ghr ghr
+      - run:
           name: Publish a release on GitHub
           command: |
-            go get github.com/tcnksm/ghr
-            VERSION=$(git describe --tag)
+            VERSION="${CIRCLE_TAG}"
             RAWVERSION="${VERSION#v}"
             VERSIONFILE=.buildconfig.yml
             if ! grep -q "libraryVersion: ${RAWVERSION}" "${VERSIONFILE}"; then
@@ -310,7 +318,7 @@ jobs:
             find ./build/maven/org/mozilla/telemetry/ \( -name "*.aar*" -or -name "*.jar*" -or -name "*.pom*" \) \
               -exec cp {} ${PKGDIR} \;
             # Upload to GitHub
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} ${PKGDIR}
+            ./ghr ${VERSION} ${PKGDIR}
 
   # via https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
   Generate Rust documentation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,10 @@ jobs:
           path: glean-core/android/build/reports/tests
       - run:
           name: Package a release artifact
-          command: ./gradlew --no-daemon publish
+          command: |
+            ./gradlew --no-daemon assembleRelease
+            ./gradlew --no-daemon publish
+            ./gradlew --no-daemon checkMavenArtifacts
           environment:
             GRADLE_OPTS: -Xmx2048m
       - persist_to_workspace:

--- a/publish.gradle
+++ b/publish.gradle
@@ -23,6 +23,38 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
     def theArtifactId = project.ext.artifactId
     def theDescription = project.ext.description
 
+    task extractJnaResources(type: Sync) {
+        dependsOn jnaForTestConfiguration
+
+        from {
+            // Defer the resolution of the configuration.  This helps to
+            // avoid a nasty issue with the Android-Gradle plugin 3.2.1,
+            // like `Cannot change attributes of configuration
+            // ':PROJECT:kapt' after it has been resolved`.
+            zipTree(jnaForTestConfiguration.singleFile)
+        }
+
+        into "${buildDir}/jnaResources/"
+
+        eachFile { FileCopyDetails fcp ->
+            // The intention is to just keep the various `*jnidispatch.*` files.
+            if (fcp.relativePath.pathString.startsWith("META-INFO") || fcp.relativePath.pathString.endsWith(".class")) {
+                fcp.exclude()
+            }
+        }
+
+        includeEmptyDirs false
+    }
+
+    def forUnitTestsJarTask = task forUnitTestsJar(type: Jar) {
+        from extractJnaResources
+        from "$buildDir/rustJniLibs/desktop"
+    }
+
+    project.afterEvaluate {
+        forUnitTestsJarTask.dependsOn(tasks["cargoBuild"])
+    }
+
     task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs
         classifier = 'sources'
@@ -45,7 +77,7 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                     from components.findByName("androidRelease")
                 }
                 artifact sourcesJar
-                // Can't publish Javadoc yet: fxaclient isn't well behaved.
+                // Can't publish Javadoc yet: Glean isn't well behaved.
                 // artifact javadocJar
 
                 // If this goes haywire with
@@ -79,6 +111,41 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                         url = libUrl
                     }
                 }
+            }
+
+            forUnitTestsJar(MavenPublication) {
+                artifact tasks['forUnitTestsJar']
+                pom {
+                    groupId = theGroupId
+                    artifactId = "${theArtifactId}-forUnitTests"
+                    description = theDescription
+                    version = rootProject.ext.library.version
+                    packaging = "jar"
+
+                    licenses {
+                        license {
+                            name = libLicense
+                            url = libLicenseUrl
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            name = 'Mozilla Glean Team'
+                            email = 'glean-team@mozilla.com'
+                        }
+                    }
+
+                    scm {
+                        connection = libVcsUrl
+                        developerConnection = libVcsUrl
+                        url = libUrl
+                    }
+                }
+
+                // This is never the publication we want to use when publishing a
+                // parent project with us as a child `project()` dependency.
+                alias = true
             }
         }
     }


### PR DESCRIPTION
This will only include a Linux-compatible build for now.
Windows (the easier part) and macOS (the harder part) will follow eventually.	
