### PR TITLE
Take DST into account when converting a calendar into its items

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
@@ -95,7 +95,7 @@ class DatetimeMetricType internal constructor(
             second = cal.get(Calendar.SECOND),
             nano = AndroidTimeUnit.MILLISECONDS.toNanos(cal.get(Calendar.MILLISECOND).toLong()),
             offset_seconds = AndroidTimeUnit.MILLISECONDS.toSeconds(
-                cal.get(Calendar.ZONE_OFFSET).toLong()
+                cal.get(Calendar.ZONE_OFFSET).toLong() + cal.get(Calendar.DST_OFFSET)
             ).toInt()
         )
     }
@@ -127,7 +127,7 @@ class DatetimeMetricType internal constructor(
                 second = value.get(Calendar.SECOND),
                 nano = AndroidTimeUnit.MILLISECONDS.toNanos(value.get(Calendar.MILLISECOND).toLong()),
                 offset_seconds = AndroidTimeUnit.MILLISECONDS.toSeconds(
-                        value.get(Calendar.ZONE_OFFSET).toLong()
+                        value.get(Calendar.ZONE_OFFSET).toLong() + value.get(Calendar.DST_OFFSET)
                 ).toInt()
             )
         }


### PR DESCRIPTION
ZONE_OFFSET only provides the default offset from UTC without DST considerations.
DST_OFFSET needs to be added to get the full offset for the calendar instance.

There's a _very small_ hint in the deprecated `Date` class that one
needs to do this[1].

Neither the docs for ZONE_OFFSET[2] nor the ones for DST_OFFSET[3]
mention this explicitly.
I guess the existence of both fields is the only indicator there.

[1]: https://docs.oracle.com/javase/7/docs/api/java/util/Date.html#getTimezoneOffset()
[2]: https://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#ZONE_OFFSET
[3]: https://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#DST_OFFSET