### PR TITLE
Add `carthage bootstrap` command to iOS glean-sample-app

### DIFF
--- a/samples/ios/app/glean-sample-app.xcodeproj/project.pbxproj
+++ b/samples/ios/app/glean-sample-app.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/usr/local/bin/carthage bootstrap --platform iOS --no-use-binaries --cache-builds\n/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
On a fresh clone, the glean-sample-app would not build until the `carthage bootstrap` command was run.  This adds the command to the build phases in order to simplify building from a fresh clone.