### PR TITLE
Add instrumented tests to sample app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
         androidx_lifecycle_extensions: '2.1.0',
         androidx_test: '1.2.0',
         androidx_work: '2.2.0',
+        androidx_uiautomator: '2.2.0',
     ]
 
     ext.build = [

--- a/samples/android/app/README.md
+++ b/samples/android/app/README.md
@@ -2,6 +2,14 @@
 
 A simple app showcasing the Glean SDK.
 
+## Running tests
+
+1. [Setup the Android Build Environment](https://mozilla.github.io/glean/book/dev/android/setup-android-build-environment.html?highlight=android#setup-the-android-build-environment)
+2. Run `./gradlew :glean-sample-app:connectedAndroidTest`
+
+Since the tests are instrumented they need a connected device or emulator
+present to complete.
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -20,7 +20,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "org.mozilla.samples.gleancore.GleanTestRunner"
     }
 
     buildTypes {
@@ -38,6 +38,15 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$rootProject.versions.androidx_appcompat"
     implementation "androidx.browser:browser:$rootProject.versions.androidx_browser"
+
+    androidTestImplementation "androidx.test:core-ktx:$rootProject.versions.androidx_test"
+    androidTestImplementation "androidx.test:runner:$rootProject.versions.androidx_test"
+    androidTestImplementation "androidx.test:rules:$rootProject.versions.androidx_test"
+    androidTestImplementation "androidx.test.ext:junit:$rootProject.versions.androidx_junit"
+    androidTestImplementation "androidx.test.uiautomator:uiautomator:$rootProject.versions.androidx_uiautomator"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.versions.androidx_espresso"
+    androidTestImplementation "androidx.work:work-testing:$rootProject.versions.androidx_work"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:$rootProject.versions.mockwebserver"
 }
 
 ext.gleanNamespace = "mozilla.telemetry.glean"

--- a/samples/android/app/metrics.yaml
+++ b/samples/android/app/metrics.yaml
@@ -8,20 +8,92 @@
 
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
+browser.engagement:
+  click:
+    type: event
+    description: >
+      Just testing events
+    bugs:
+      - https://bugzilla.mozilla.org/123456789
+    data_reviews:
+      - N/A 
+    notification_emails:
+      - CHANGE-ME@example.com
+    extra_keys:
+      key1:
+        description: "This is key one"
+      key2:
+        description: "This is key two"
+    expires: 2100-01-01 
+    
+  event_no_keys:
+    type: event
+    description: >
+      Just testing events without keys
+    bugs:
+      - https://bugzilla.mozilla.org/123456789
+    data_reviews:
+      - N/A 
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
+basic:
+  os:
+    type: string
+    description: >
+      The name of the os
+    bugs:
+      - https://bugzilla.mozilla.org/123456789
+    data_reviews:
+      - N/A 
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
 test:
-  test_counter:
+  string_list:
+    type: string_list
+    description: >
+      Testing StringList ping
+    send_in_pings:
+      - test_string_list
+    lifetime: user
+    bugs:
+      - https://bugzilla.mozilla.org/123456789
+    data_reviews:
+      - N/A 
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
+  counter:
     type: counter
     description: >
       Testing counter
     send_in_pings:
-      - baseline
+      - test_string_list
     lifetime: user
     bugs:
-      - https://bugzilla.mozilla.org/1234567890
+      - https://bugzilla.mozilla.org/123456789
     data_reviews:
-      - N/A
+      - N/A 
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
+  timespan:
+    type: timespan
+    description: >
+      Testing a timespan
+    time_unit: microsecond
+    lifetime: application
+    bugs:
+      - https://bugzilla.mozilla.org/1508948
+    data_reviews:
+      - N/A 
+    notification_emails:
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
   is_started:
@@ -33,6 +105,22 @@ test:
     lifetime: application
     bugs:
       - https://bugzilla.mozilla.org/1234567890
+    data_reviews:
+      - N/A
+    notification_emails:
+      - CHANGE-ME@test-only.com
+    expires: 2100-01-01
+
+custom:
+  counter:
+    type: counter
+    description: >
+      A custom counter that goes on a custom ping
+    lifetime: ping
+    send_in_pings:
+      - sample
+    bugs:
+      - https://bugzilla.mozilla.org/1547330
     data_reviews:
       - N/A
     notification_emails:

--- a/samples/android/app/pings.yaml
+++ b/samples/android/app/pings.yaml
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the built-in pings that are recorded by glean telemetry. They are
+# automatically converted to Kotlin code at build time using the `glean_parser`
+# PyPI package.
+
+$schema: moz://mozilla.org/schemas/glean/pings/1-0-0
+
+sample:
+  description: |
+    A sample custom ping.
+  include_client_id: true
+  bugs:
+    - https://bugzilla.mozilla.org/123456789
+  data_reviews:
+    - N/A
+  notification_emails:
+    - CHANGE-ME@example.com

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/GleanTestRunner.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/GleanTestRunner.kt
@@ -38,14 +38,14 @@ internal fun getPingServer(): MockWebServer {
 }
 
 /**
- * Returns the address the local ping server is listening to.
+ * Returns the port the local ping server is listening to.
  *
- * @return a `String` containing the server address.
+ * @return a `Int` containing the server address.
  */
 @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-internal fun getPingServerAddress(): String {
+internal fun getPingServerPort(): Int {
     val testRunner: GleanTestRunner = InstrumentationRegistry.getInstrumentation() as GleanTestRunner
-    return testRunner.pingServerAddress!!
+    return testRunner.pingServerPort!!
 }
 
 /**
@@ -57,7 +57,7 @@ class GleanTestRunner : AndroidJUnitRunner() {
     // Add a lazy ping server to the app runner. This is only initialized once
     // since the `Application` object is re-used.
     internal val pingServer: MockWebServer by lazy { createMockWebServer() }
-    internal var pingServerAddress: String? = null
+    internal var pingServerPort: Int? = null
 
     init {
         // We need to start the server off the main thread, otherwise
@@ -65,7 +65,7 @@ class GleanTestRunner : AndroidJUnitRunner() {
         // a thread and joining seems fine.
         val thread = Thread {
             pingServer.start()
-            pingServerAddress = "http://${pingServer.hostName}:${pingServer.port}"
+            pingServerPort = pingServer.port
         }
         thread.start()
         thread.join()

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/GleanTestRunner.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/GleanTestRunner.kt
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.gleancore
+
+import androidx.annotation.VisibleForTesting
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnitRunner
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+
+/**
+ * Create a mock webserver that accepts all requests and replies with "OK".
+ * @return a [MockWebServer] instance
+ */
+private fun createMockWebServer(): MockWebServer {
+    val server = MockWebServer()
+    server.setDispatcher(object : Dispatcher() {
+        override fun dispatch(request: RecordedRequest): MockResponse {
+            return MockResponse().setBody("OK")
+        }
+    })
+    return server
+}
+
+/**
+ * Returns the currently active instance of the ping server.
+ *
+ * @return the active [MockWebServer] instance
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+internal fun getPingServer(): MockWebServer {
+    val testRunner: GleanTestRunner = InstrumentationRegistry.getInstrumentation() as GleanTestRunner
+    return testRunner.pingServer
+}
+
+/**
+ * Returns the address the local ping server is listening to.
+ *
+ * @return a `String` containing the server address.
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+internal fun getPingServerAddress(): String {
+    val testRunner: GleanTestRunner = InstrumentationRegistry.getInstrumentation() as GleanTestRunner
+    return testRunner.pingServerAddress!!
+}
+
+/**
+ * The test runner to be used in the instrumentation tests for the Glean SDK
+ * sample app in order to point it to a local ping server.
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+class GleanTestRunner : AndroidJUnitRunner() {
+    // Add a lazy ping server to the app runner. This is only initialized once
+    // since the `Application` object is re-used.
+    internal val pingServer: MockWebServer by lazy { createMockWebServer() }
+    internal var pingServerAddress: String? = null
+
+    init {
+        // We need to start the server off the main thread, otherwise
+        // Android will throw a `NetworkOnMainThreadException`. Spawning
+        // a thread and joining seems fine.
+        val thread = Thread {
+            pingServer.start()
+            pingServerAddress = "http://${pingServer.hostName}:${pingServer.port}"
+        }
+        thread.start()
+        thread.join()
+    }
+
+    /**
+     * Called before the application code runs, this starts the ping server.
+     */
+    override fun onStart() {
+        super.onStart()
+        pingServer.start()
+    }
+
+    /**
+     * Called after the application code cleans up, this stops the ping server.
+     */
+    override fun onDestroy() {
+        super.onDestroy()
+        pingServer.shutdown()
+    }
+}

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/MainActivityTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/MainActivityTest.kt
@@ -4,14 +4,11 @@
 
 package org.mozilla.samples.gleancore
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
-import mozilla.telemetry.glean.config.Configuration
-import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.mozilla.samples.gleancore.GleanMetrics.Test as GleanTestMetrics
@@ -25,26 +22,22 @@ class MainActivityTest {
     @get:Rule
     val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(MainActivity::class.java)
 
-    @get:Rule
-    val gleanRule = GleanTestRule(
-        ApplicationProvider.getApplicationContext(),
-        Configuration(serverEndpoint = getPingServerAddress())
-    )
-
     @Test
     fun checkGleanClickData() {
+        // We don't reset the storage in this test as the GleanTestRule does not
+        // work nicely in instrumented test. Just check the current value, increment
+        // by one and make it the expected value.
+        val expectedValue = if (GleanTestMetrics.counter.testHasValue()) {
+            GleanTestMetrics.counter.testGetValue() + 1
+        } else {
+            1
+        }
+
         // Simulate a click on the button.
         onView(withId(R.id.buttonGenerateData)).perform(click())
 
         // Use the Glean testing API to check if the expected data was recorded.
         assertTrue(GleanTestMetrics.counter.testHasValue())
-        assertEquals(1, GleanTestMetrics.counter.testGetValue())
-    }
-
-    @Test
-    fun checkGleanClickDataAgain() {
-        // Repeat the same test as above: this will fail if the GleanTestRule fails to
-        // clear the Glean SDK state.
-        checkGleanClickData()
+        assertEquals(expectedValue, GleanTestMetrics.counter.testGetValue())
     }
 }

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/MainActivityTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/MainActivityTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.gleancore
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.testing.GleanTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.mozilla.samples.gleancore.GleanMetrics.Test as GleanTestMetrics
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @get:Rule
+    val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(MainActivity::class.java)
+
+    @get:Rule
+    val gleanRule = GleanTestRule(
+        ApplicationProvider.getApplicationContext(),
+        Configuration(serverEndpoint = getPingServerAddress())
+    )
+
+    @Test
+    fun checkGleanClickData() {
+        // Simulate a click on the button.
+        onView(withId(R.id.buttonGenerateData)).perform(click())
+
+        // Use the Glean testing API to check if the expected data was recorded.
+        assertTrue(GleanTestMetrics.counter.testHasValue())
+        assertEquals(1, GleanTestMetrics.counter.testGetValue())
+    }
+
+    @Test
+    fun checkGleanClickDataAgain() {
+        // Repeat the same test as above: this will fail if the GleanTestRule fails to
+        // clear the Glean SDK state.
+        checkGleanClickData()
+    }
+}

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BaselinePingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BaselinePingTest.kt
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.gleancore.pings
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import org.junit.Assert.assertEquals
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.samples.gleancore.MainActivity
+import org.mozilla.samples.gleancore.getPingServer
+import androidx.test.uiautomator.UiDevice
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.testing.GleanTestRule
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.mozilla.samples.gleancore.getPingServerAddress
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class BaselinePingTest {
+    @get:Rule
+    val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(MainActivity::class.java)
+
+    @get:Rule
+    val gleanRule = GleanTestRule(
+        ApplicationProvider.getApplicationContext(),
+        Configuration(serverEndpoint = getPingServerAddress())
+    )
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun clearWorkManager() {
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+    }
+
+    private fun waitForPingContent(
+        pingName: String,
+        maxAttempts: Int = 3
+    ): JSONObject?
+    {
+        val server = getPingServer()
+
+        var attempts = 0
+        do {
+            attempts += 1
+            val request = server.takeRequest(20L, TimeUnit.SECONDS)
+            val docType = request.path.split("/")[3]
+            if (pingName == docType) {
+                return JSONObject(request.body.readUtf8())
+            }
+        } while (attempts < maxAttempts)
+
+        return null
+    }
+
+    /**
+     * Sadly, the WorkManager still requires us to manually trigger the upload job.
+     * This function goes through all the active jobs by Glean (there should only be
+     * one!) and triggers them.
+     */
+    private fun triggerEnqueuedUpload() {
+        // The tag is really internal to PingUploadWorker, but we can't do much more
+        // than copy-paste unless we want to increase our API surface.
+        val tag = "mozac_service_glean_ping_upload_worker"
+        val reasonablyHighCITimeoutMs = 5000L
+
+        runBlocking {
+            withTimeout(reasonablyHighCITimeoutMs) {
+                do {
+                    val workInfoList = WorkManager.getInstance(context).getWorkInfosByTag(tag).get()
+                    workInfoList.forEach { workInfo ->
+                        if (workInfo.state === WorkInfo.State.ENQUEUED) {
+                            // Trigger WorkManager using TestDriver
+                            val testDriver = WorkManagerTestInitHelper.getTestDriver(context)
+                            testDriver?.setAllConstraintsMet(workInfo.id)
+                            return@withTimeout
+                        }
+                    }
+                } while (true)
+            }
+        }
+    }
+
+    @Test
+    fun validateBaselinePing() {
+        // Wait for the app to be idle/ready.
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.waitForIdle()
+
+        // Wait for 1 second: this should guarantee we have some valid duration in the
+        // ping.
+        Thread.sleep(1000)
+
+        // Move it to background.
+        device.pressHome()
+
+        // Wait for the upload job to be present and trigger it.
+        Thread.sleep(1000) // FIXME: for some reason, without this, WorkManager won't find the job
+        triggerEnqueuedUpload()
+
+        // Validate the received data.
+        val baselinePing = waitForPingContent("baseline")!!
+        assertEquals("baseline", baselinePing.getJSONObject("ping_info")["ping_type"])
+
+        val metrics = baselinePing.getJSONObject("metrics")
+
+        // Make sure we have a 'duration' field with a reasonable value: it should be >= 1, since
+        // we slept for 1000ms.
+        val timespans = metrics.getJSONObject("timespan")
+        assertTrue(timespans.getJSONObject("glean.baseline.duration").getLong("value") >= 1L)
+
+        // Make sure there's no errors.
+        val errors = metrics.optJSONObject("labeled_counter")?.keys()
+        errors?.forEach {
+            assertFalse(it.startsWith("glean.error."))
+        }
+    }
+}

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BaselinePingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BaselinePingTest.kt
@@ -22,13 +22,12 @@ import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import mozilla.telemetry.glean.config.Configuration
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestLocalServer
 import org.json.JSONObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.mozilla.samples.gleancore.getPingServerAddress
+import org.mozilla.samples.gleancore.getPingServerPort
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
@@ -37,10 +36,7 @@ class BaselinePingTest {
     val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(MainActivity::class.java)
 
     @get:Rule
-    val gleanRule = GleanTestRule(
-        ApplicationProvider.getApplicationContext(),
-        Configuration(serverEndpoint = getPingServerAddress())
-    )
+    val gleanRule = GleanTestLocalServer(getPingServerPort())
 
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()

--- a/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -7,6 +7,10 @@ package org.mozilla.samples.gleancore
 import android.app.Application
 import android.util.Log
 import mozilla.telemetry.glean.Glean
+import org.mozilla.samples.gleancore.GleanMetrics.Basic
+import org.mozilla.samples.gleancore.GleanMetrics.Test
+import org.mozilla.samples.gleancore.GleanMetrics.Custom
+import org.mozilla.samples.gleancore.GleanMetrics.Pings
 
 private const val TAG = "Glean"
 
@@ -15,9 +19,20 @@ class GleanApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // Register the sample application's custom pings.
+        Glean.registerPings(Pings)
+
         // Initialize the Glean library. Ideally, this is the first thing that
         // must be done right after enabling logging.
         Glean.initialize(applicationContext)
+
+        Test.timespan.start()
+
+        Custom.counter.add()
+
+        // Set a sample value for a metric.
+        Basic.os.set("Android")
+
         Log.i(TAG, "Glean initialized")
     }
 }

--- a/samples/android/app/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -5,10 +5,10 @@
 package org.mozilla.samples.gleancore
 
 import android.os.Bundle
-import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
 import org.mozilla.samples.gleancore.GleanMetrics.Test
+import org.mozilla.samples.gleancore.GleanMetrics.BrowserEngagement
 
 private const val TAG = "Glean"
 
@@ -21,8 +21,30 @@ open class MainActivity : AppCompatActivity() {
 
         // Generate an event when user clicks on the button.
         buttonGenerateData.setOnClickListener {
-            Test.testCounter.add(1)
-            Log.i(TAG, "increment happened")
+            // These first two actions, adding to the string list and incrementing the counter are
+            // tied to a user lifetime metric which is persistent from launch to launch.
+
+            // Adds the EditText's text content as a new string in the string list metric from the
+            // metrics.yaml file.
+            Test.stringList.add(etStringListInput.text.toString())
+            // Clear current text to help indicate something happened
+            etStringListInput.setText("")
+
+            // Increments the test_counter metric from the metrics.yaml file.
+            Test.counter.add()
+
+            // This is referencing the event ping named 'click' from the metrics.yaml file. In
+            // order to illustrate adding extra information to the event, it is also adding to the
+            // 'extras' field a dictionary of values.  Note that the dictionary keys must be
+            // declared in the metrics.yaml file under the 'extra_keys' section of an event metric.
+            BrowserEngagement.click.record(
+                    mapOf(
+                        BrowserEngagement.clickKeys.key1 to "extra_value_1",
+                        BrowserEngagement.clickKeys.key2 to "extra_value_2"
+                    )
+            )
         }
+
+        Test.timespan.stop()
     }
 }


### PR DESCRIPTION
Related to [Bug 1570252](https://bugzilla.mozilla.org/show_bug.cgi?id=1570252)

I basically just copy pasted the tests from the sample app in android components, so they should do the same thing.

Unfortunately (or fortunately depending on how you look at it) this tests are failing, because while adding them to the project we found two bugs in the actual glean app.

@badboy reported one of them ([Bug 1588717](https://bugzilla.mozilla.org/show_bug.cgi?id=1588717)) and is still loking into the other one.

The one bug that is already reported is also happening for the instrumented tests in android-components. Which means that they are not probably run on CI there, as well.