### PR TITLE
Make sure ProGuard doesn't remove Glean classes from the app

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -47,7 +47,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            consumerProguardFiles "$projectDir/proguard-rules-consumer-jna.pro"
+            consumerProguardFiles "$projectDir/proguard-rules-consumer.pro"
         }
 
         withoutLib {

--- a/glean-core/android/proguard-rules-consumer.pro
+++ b/glean-core/android/proguard-rules-consumer.pro
@@ -5,3 +5,6 @@
 -dontwarn java.awt.*
 -keep class com.sun.jna.* { *; }
 -keepclassmembers class * extends com.sun.jna.* { public *; }
+
+# Glean specific rules
+-keep class mozilla.telemetry.** { *; }


### PR DESCRIPTION
@badboy found that our QA build of Fenix was crashing due to Glean classes being optimized (= removed) by ProGuard.

**How did I test this?**
For some reason, I can't produce working builds of Fenix (locally!) due to GeckoView. In order to test that this was working, I did the following:

- Published glean from this branch to local Maven.
- Imported the local glean in Android Components and published a new build of A-C to the local Maven.
- Imported the local A-C build in Fenix. I added the `-printusage pro-guard-fenix-usage.txt` in `app/proguard-rules.pro` for Fenix. This generated a `pro-guard-fenix-usage.txt` file with a list of "optimized" stuff. Without this rule, the file contains `mozilla.telemetry.*` classes. With this rule, they are missing.