### PR TITLE
Use glean-core specific full path for debug activity in the docs

### DIFF
--- a/docs/user/debugging.md
+++ b/docs/user/debugging.md
@@ -3,7 +3,7 @@
 The Glean SDK exports the `GleanDebugActivity` that can be used to toggle debugging features on or off.
 Users can invoke this special activity, at run-time, using the following [`adb`](https://developer.android.com/studio/command-line/adb) command:
 
-`adb shell am start -n [applicationId]/mozilla.components.service.glean.debug.GleanDebugActivity [extra keys]`
+`adb shell am start -n [applicationId]/mozilla.telemetry.glean.debug.GleanDebugActivity [extra keys]`
 
 In the above:
 
@@ -21,7 +21,7 @@ In the above:
 For example, to direct a release build of the Glean sample application to (1) dump pings to logcat, (2) tag the ping with the `test-metrics-ping` tag, and (3) send the "metrics" ping immediately, the following command can be used:
 
 ```
-adb shell am start -n org.mozilla.samples.glean/mozilla.components.service.glean.debug.GleanDebugActivity \
+adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.GleanDebugActivity \
   --ez logPings true \
   --es sendPing metrics \
   --es tagPings test-metrics-ping

--- a/docs/user/debugging.md
+++ b/docs/user/debugging.md
@@ -5,6 +5,11 @@ Users can invoke this special activity, at run-time, using the following [`adb`]
 
 `adb shell am start -n [applicationId]/mozilla.telemetry.glean.debug.GleanDebugActivity [extra keys]`
 
+> **Note:** In previous versions of Glean the activity was available with the name `mozilla.components.service.glean.debug.GleanDebugActivity`.
+>
+> If you're debugging an old build, try running:
+> `adb shell am start -n [applicationId]/mozilla.components.service.glean.debug.GleanDebugActivity [extra keys]`
+
 In the above:
 
 - `[applicationId]` is the product's application id as defined in the manifest file and/or build script. For the Glean sample application, this is `org.mozilla.samples.glean` for a release build and `org.mozilla.samples.glean.debug` for a debug build.
@@ -26,6 +31,16 @@ adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.Gl
   --es sendPing metrics \
   --es tagPings test-metrics-ping
 ```
+
+> **Note:** In previous versions of Glean the activity was available with the name `mozilla.components.service.glean.debug.GleanDebugActivity`.
+>
+> If you're debugging an old build, try running:
+> ```
+> adb shell am start -n org.mozilla.samples.glean/mozilla.components.service.glean.debug.GleanDebugActivity \
+>   --ez logPings true \
+>   --es sendPing metrics \
+>   --es tagPings test-metrics-ping
+> ```
 
 ### Important GleanDebugActivity notes!
 


### PR DESCRIPTION
Probably shouldn't land before we land glean-core in a-c.

BREAKING CHANGE:

When used through Android Components,
previously users had to use the `mozilla.components.service.glean.debug.GleanDebugActivity` name.

It's now required to use `mozilla.telemetry.glean.debug.GleanDebugActivity``