### PR TITLE
1588451, 1530733: Handle dynamic labels in coroutine tasks

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -6,7 +6,6 @@ package mozilla.telemetry.glean.private
 
 import com.sun.jna.StringArray
 
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toByte
 
@@ -78,15 +77,15 @@ class LabeledMetricType<T>(
     operator fun get(label: String): T {
         return when (subMetric) {
             is CounterMetricType -> {
-                val handle = LibGleanFFI.INSTANCE.glean_labeled_counter_metric_get(Glean.handle, this.handle, label)
+                val handle = LibGleanFFI.INSTANCE.glean_labeled_counter_metric_get(this.handle, label)
                 CounterMetricType(handle = handle, disabled = disabled, sendInPings = sendInPings) as T
             }
             is BooleanMetricType -> {
-                val handle = LibGleanFFI.INSTANCE.glean_labeled_boolean_metric_get(Glean.handle, this.handle, label)
+                val handle = LibGleanFFI.INSTANCE.glean_labeled_boolean_metric_get(this.handle, label)
                 BooleanMetricType(handle = handle, disabled = disabled, sendInPings = sendInPings) as T
             }
             is StringMetricType -> {
-                val handle = LibGleanFFI.INSTANCE.glean_labeled_string_metric_get(Glean.handle, this.handle, label)
+                val handle = LibGleanFFI.INSTANCE.glean_labeled_string_metric_get(this.handle, label)
                 StringMetricType(handle = handle, disabled = disabled, sendInPings = sendInPings) as T
             }
             else -> throw IllegalStateException(

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -430,7 +430,7 @@ internal interface LibGleanFFI : Library {
         label_count: Int
     ): Long
 
-    fun glean_labeled_counter_metric_get(glean_handle: Long, handle: Long, label: String): Long
+    fun glean_labeled_counter_metric_get(handle: Long, label: String): Long
 
     // Labeled Boolean
 
@@ -445,7 +445,7 @@ internal interface LibGleanFFI : Library {
         label_count: Int
     ): Long
 
-    fun glean_labeled_boolean_metric_get(glean_handle: Long, handle: Long, label: String): Long
+    fun glean_labeled_boolean_metric_get(handle: Long, label: String): Long
 
     // Labeled string
 
@@ -460,7 +460,7 @@ internal interface LibGleanFFI : Library {
         label_count: Int
     ): Long
 
-    fun glean_labeled_string_metric_get(glean_handle: Long, handle: Long, label: String): Long
+    fun glean_labeled_string_metric_get(handle: Long, label: String): Long
 
     // Misc
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -4,10 +4,14 @@
 
 package mozilla.telemetry.glean.private
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.collectAndCheckPingSchema
 import mozilla.telemetry.glean.GleanMetrics.Pings
+import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,6 +22,8 @@ import org.junit.Rule
 
 @RunWith(AndroidJUnit4::class)
 class LabeledMetricTypeTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
 
     @get:Rule
     val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
@@ -187,6 +193,47 @@ class LabeledMetricTypeTest {
                 .getJSONObject("telemetry.labeled_counter_metric")
                 .get("__other__")
         )
+    }
+
+    @Test
+    fun `test __other__ label without predefined labels before Glean initialization`() {
+        val counterMetric = CounterMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "labeled_counter_metric",
+            sendInPings = listOf("metrics")
+        )
+
+        val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "labeled_counter_metric",
+            sendInPings = listOf("metrics"),
+            subMetric = counterMetric
+        )
+
+        // Make sure Glean isn't initialized, and turn task queueing on
+        Glean.testDestroyGleanHandle()
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.setTaskQueueing(true)
+
+        for (i in 0..20) {
+            labeledCounterMetric["label_$i"].add(1)
+        }
+        // Go back and record in one of the real labels again
+        labeledCounterMetric["label_0"].add(1)
+
+        // Initialize glean
+        val config = Configuration()
+        Glean.initialize(context, config)
+
+        assertEquals(2, labeledCounterMetric["label_0"].testGetValue())
+        for (i in 1..15) {
+            assertEquals(1, labeledCounterMetric["label_$i"].testGetValue())
+        }
+        assertEquals(5, labeledCounterMetric["__other__"].testGetValue())
     }
 
     @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -226,8 +226,7 @@ class LabeledMetricTypeTest {
         labeledCounterMetric["label_0"].add(1)
 
         // Initialize glean
-        val config = Configuration()
-        Glean.initialize(context, config)
+        Glean.initialize(context)
 
         assertEquals(2, labeledCounterMetric["label_0"].testGetValue())
         for (i in 1..15) {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -11,7 +11,6 @@ import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.collectAndCheckPingSchema
 import mozilla.telemetry.glean.GleanMetrics.Pings
-import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -153,17 +153,17 @@ uint8_t glean_is_upload_enabled(uint64_t glean_handle);
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
-uint64_t glean_labeled_boolean_metric_get(uint64_t glean_handle, uint64_t handle, FfiStr label);
+uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
 
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
-uint64_t glean_labeled_counter_metric_get(uint64_t glean_handle, uint64_t handle, FfiStr label);
+uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
 
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
-uint64_t glean_labeled_string_metric_get(uint64_t glean_handle, uint64_t handle, FfiStr label);
+uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
 
 void glean_memory_distribution_accumulate(uint64_t glean_handle,
                                           uint64_t metric_id,

--- a/glean-core/ffi/src/event.rs
+++ b/glean-core/ffi/src/event.rs
@@ -46,6 +46,7 @@ pub extern "C" fn glean_new_event_metric(
                 send_in_pings,
                 lifetime,
                 disabled: disabled != 0,
+                ..Default::default()
             },
             extra_keys,
         ))

--- a/glean-core/ffi/src/labeled.rs
+++ b/glean-core/ffi/src/labeled.rs
@@ -67,6 +67,7 @@ macro_rules! impl_labeled_metric {
                         send_in_pings,
                         lifetime,
                         disabled: disabled != 0,
+                        ..Default::default()
                     }),
                     labels,
                 ))
@@ -75,23 +76,11 @@ macro_rules! impl_labeled_metric {
 
         /// Create a new instance of the sub-metric of this labeled metric.
         #[no_mangle]
-        pub extern "C" fn $get_name(glean_handle: u64, handle: u64, label: FfiStr) -> u64 {
-            // If Glean is not yet initialized on the platform side (no handle available),
-            // let's not crash, but let the core handle it by ignoring previously stored dynamic
-            // labels.
-            if glean_handle == 0 {
-                $global.call_infallible_mut(handle, |labeled| {
-                    let metric = labeled.get(None, label.as_str());
-                    $metric_global.insert_with_log(|| Ok(metric))
-                })
-            } else {
-                GLEAN.call_infallible(glean_handle, |glean| {
-                    $global.call_infallible_mut(handle, |labeled| {
-                        let metric = labeled.get(Some(glean), label.as_str());
-                        $metric_global.insert_with_log(|| Ok(metric))
-                    })
-                })
-            }
+        pub extern "C" fn $get_name(handle: u64, label: FfiStr) -> u64 {
+            $global.call_infallible_mut(handle, |labeled| {
+                let metric = labeled.get(label.as_str());
+                $metric_global.insert_with_log(|| Ok(metric))
+            })
         }
     };
 }

--- a/glean-core/ffi/src/macros.rs
+++ b/glean-core/ffi/src/macros.rs
@@ -73,6 +73,7 @@ macro_rules! define_metric {
                     send_in_pings,
                     lifetime,
                     disabled: disabled != 0,
+                    ..Default::default()
                 }, $($new_argname),*))
             })
         }

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -153,17 +153,17 @@ uint8_t glean_is_upload_enabled(uint64_t glean_handle);
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
-uint64_t glean_labeled_boolean_metric_get(uint64_t glean_handle, uint64_t handle, FfiStr label);
+uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
 
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
-uint64_t glean_labeled_counter_metric_get(uint64_t glean_handle, uint64_t handle, FfiStr label);
+uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
 
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
-uint64_t glean_labeled_string_metric_get(uint64_t glean_handle, uint64_t handle, FfiStr label);
+uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
 
 void glean_memory_distribution_accumulate(uint64_t glean_handle,
                                           uint64_t metric_id,

--- a/glean-core/ios/Glean/Metrics/LabeledMetric.swift
+++ b/glean-core/ios/Glean/Metrics/LabeledMetric.swift
@@ -24,6 +24,7 @@ public class LabeledMetricType<T> {
     /// The public constructor used by automatically generated metrics.
     ///
     /// Supports the following types as sub-metrics:
+    /// * `BooleanMetricType`
     /// * `CounterMetricType`
     /// * `StringMetricType`
     ///
@@ -109,13 +110,13 @@ public class LabeledMetricType<T> {
 
         switch self.subMetric {
         case is CounterMetricType:
-            let handle = glean_labeled_counter_metric_get(Glean.shared.handle, self.handle, label)
+            let handle = glean_labeled_counter_metric_get(self.handle, label)
             return CounterMetricType(withHandle: handle, disabled: self.disabled, sendInPings: self.sendInPings) as! T
         case is BooleanMetricType:
-            let handle = glean_labeled_boolean_metric_get(Glean.shared.handle, self.handle, label)
+            let handle = glean_labeled_boolean_metric_get(self.handle, label)
             return BooleanMetricType(withHandle: handle, disabled: self.disabled, sendInPings: self.sendInPings) as! T
         case is StringMetricType:
-            let handle = glean_labeled_string_metric_get(Glean.shared.handle, self.handle, label)
+            let handle = glean_labeled_string_metric_get(self.handle, label)
             return StringMetricType(withHandle: handle, disabled: self.disabled, sendInPings: self.sendInPings) as! T
         default:
             // The constructor will already throw an exception on an unhandled sub-metric type

--- a/glean-core/src/common_metric_data.rs
+++ b/glean-core/src/common_metric_data.rs
@@ -92,7 +92,7 @@ impl CommonMetricData {
     ///
     /// If `category` is empty, it's ommitted.
     /// Otherwise, it's the combination of the metric's `category` and `name`.
-    pub fn base_identifier(&self) -> String {
+    pub(crate) fn base_identifier(&self) -> String {
         if self.category.is_empty() {
             self.name.clone()
         } else {
@@ -104,7 +104,7 @@ impl CommonMetricData {
     ///
     /// If `category` is empty, it's ommitted.
     /// Otherwise, it's the combination of the metric's `category`, `name` and `label`.
-    pub fn identifier(&self, glean: &Glean) -> String {
+    pub(crate) fn identifier(&self, glean: &Glean) -> String {
         let base_identifier = self.base_identifier();
 
         if let Some(label) = &self.dynamic_label {

--- a/glean-core/src/common_metric_data.rs
+++ b/glean-core/src/common_metric_data.rs
@@ -66,8 +66,10 @@ pub struct CommonMetricData {
     ///
     /// Disabled metrics are never recorded.
     pub disabled: bool,
-    /// Dynamic label. These need to be looked up in the database to make sure
-    /// we aren't storing too many. (Static labels are stored as part of name).
+    /// Dynamic label.
+    /// When a LabeledMetric<T> factory creates the specific metric to be
+    /// recorded to, dynamic labels are stored in the specific label so that we
+    /// can validate them when the Glean singleton is available.
     pub dynamic_label: Option<String>,
 }
 
@@ -106,11 +108,7 @@ impl CommonMetricData {
         let base_identifier = self.base_identifier();
 
         if let Some(label) = &self.dynamic_label {
-            format!(
-                "{}/{}",
-                base_identifier,
-                dynamic_label(glean, self, &base_identifier, label)
-            )
+            dynamic_label(glean, self, &base_identifier, label)
         } else {
             base_identifier
         }

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -67,8 +67,21 @@ impl Database {
         }
     }
 
-    /// Iterates with the provided transaction function on the data from
-    /// the given storage.
+    /// Iterates with the provided transaction function over the requested data
+    /// from the given storage.
+    ///
+    /// ## Arguments
+    ///
+    /// * `lifetime`: The metric lifetime to iterate over.
+    /// * `storage_name`: The storage name to iterate over.
+    /// * `metric_key`: The metric key to iterate over. All metrics iterated over
+    ///   will have this prefix. For example, if `metric_key` is of the form `{category}.`,
+    ///   it will iterate over all metrics in the given category. If the `metric_key` is of the
+    ///   form `{category}.{name}/`, the iterator will iterate over all specific metrics for
+    ///   a given labeled metric. If not provided, the entire storage for the given lifetime
+    ///   will be iterated over.
+    /// * `transaction_fn`: Called for each entry being iterated over. It is
+    ///   passed two arguments: `(metric_name: &[u8], metric: &Metric)`.
     pub fn iter_store_from<F>(
         &self,
         lifetime: Lifetime,
@@ -115,9 +128,20 @@ impl Database {
         }
     }
 
-    /// Returns `True` if the storage has the given metric.
-    pub fn has_metric(&self, lifetime: Lifetime, storage_name: &str, metric_key: &str) -> bool {
-        let key = Self::get_storage_key(storage_name, Some(metric_key));
+    /// Determine if the storage has the given metric.
+    ///
+    /// ## Arguments
+    ///
+    /// * `lifetime`: The lifetime of the metric.
+    /// * `storage_name`: The storage name to look in.
+    /// * `metric_identifier`: The metric identifier.
+    pub fn has_metric(
+        &self,
+        lifetime: Lifetime,
+        storage_name: &str,
+        metric_identifier: &str,
+    ) -> bool {
+        let key = Self::get_storage_key(storage_name, Some(metric_identifier));
 
         // Lifetime::Application data is not persisted to disk
         if lifetime == Lifetime::Application {

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -19,6 +19,7 @@ impl CoreMetrics {
                 send_in_pings: vec!["glean_client_info".into()],
                 lifetime: Lifetime::User,
                 disabled: false,
+                dynamic_label: None,
             }),
 
             first_run_date: DatetimeMetric::new(
@@ -28,6 +29,7 @@ impl CoreMetrics {
                     send_in_pings: vec!["glean_client_info".into()],
                     lifetime: Lifetime::User,
                     disabled: false,
+                    dynamic_label: None,
                 },
                 TimeUnit::Day,
             ),

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -44,7 +44,7 @@ impl BooleanMetric {
         }
 
         let value = Metric::Boolean(value);
-        glean.storage().record(&self.meta, &value)
+        glean.storage().record(glean, &self.meta, &value)
     }
 
     /// **Test-only API (exported for FFI purposes).**
@@ -53,8 +53,11 @@ impl BooleanMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<bool> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::Boolean(b)) => Some(b),
             _ => None,
         }

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -62,7 +62,7 @@ impl CounterMetric {
 
         glean
             .storage()
-            .record_with(&self.meta, |old_value| match old_value {
+            .record_with(glean, &self.meta, |old_value| match old_value {
                 Some(Metric::Counter(old_value)) => {
                     Metric::Counter(old_value.saturating_add(amount))
                 }
@@ -76,8 +76,11 @@ impl CounterMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<i32> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::Counter(i)) => Some(i),
             _ => None,
         }

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -111,7 +111,7 @@ impl CustomDistributionMetric {
             (num_negative_samples, metric(hist))
         }
 
-        glean.storage().record_with(&self.meta, |old_value| {
+        glean.storage().record_with(glean, &self.meta, |old_value| {
             let (num_negative, hist) = match self.histogram_type {
                 HistogramType::Linear => {
                     let hist = if let Some(Metric::CustomDistributionLinear(hist)) = old_value {
@@ -166,8 +166,11 @@ impl CustomDistributionMetric {
         glean: &Glean,
         storage_name: &str,
     ) -> Option<Histogram<Box<dyn Bucketing>>> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             // Boxing the value, in order to return either of the possible buckets
             Some(Metric::CustomDistributionExponential(hist)) => Some(hist.boxed()),
             Some(Metric::CustomDistributionLinear(hist)) => Some(hist.boxed()),

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -108,7 +108,7 @@ impl DatetimeMetric {
 
         let value = value.unwrap_or_else(local_now_with_offset);
         let value = Metric::Datetime(value, self.time_unit);
-        glean.storage().record(&self.meta, &value)
+        glean.storage().record(glean, &self.meta, &value)
     }
 
     /// Get the stored datetime value.
@@ -129,7 +129,7 @@ impl DatetimeMetric {
         match StorageManager.snapshot_metric(
             glean.storage(),
             storage_name,
-            &self.meta().identifier(),
+            &self.meta().identifier(glean),
         ) {
             Some(Metric::Datetime(dt, _)) => Some(dt),
             _ => None,
@@ -144,8 +144,11 @@ impl DatetimeMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value_as_string(&self, glean: &Glean, storage_name: &str) -> Option<String> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::Datetime(d, tu)) => Some(get_iso_time_string(d, tu)),
             _ => None,
         }

--- a/glean-core/src/metrics/experiment.rs
+++ b/glean-core/src/metrics/experiment.rs
@@ -179,7 +179,7 @@ impl ExperimentMetric {
             branch: truncated_branch,
             extra: truncated_extras,
         });
-        glean.storage().record(&self.meta, &value)
+        glean.storage().record(glean, &self.meta, &value)
     }
 
     /// Record an experiment as inactive.
@@ -209,7 +209,7 @@ impl ExperimentMetric {
         match StorageManager.snapshot_metric(
             glean.storage(),
             INTERNAL_STORAGE,
-            &self.meta.identifier(),
+            &self.meta.identifier(glean),
         ) {
             Some(Metric::Experiment(e)) => Some(json!(e).to_string()),
             _ => None,

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -2,15 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::HashSet;
-
+//! Module documentation
 use lazy_static::lazy_static;
 use regex::Regex;
 
+use crate::common_metric_data::CommonMetricData;
 use crate::error_recording::{record_error, ErrorType};
 use crate::metrics::{Metric, MetricType};
 use crate::Glean;
-use crate::Lifetime;
 
 const MAX_LABELS: usize = 16;
 const OTHER_LABEL: &str = "__other__";
@@ -38,30 +37,6 @@ lazy_static! {
     static ref LABEL_REGEX: Regex = Regex::new("^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$").unwrap();
 }
 
-/// Validate a label against the restrictions.
-///
-/// * Shorter than the allowed `MAX_LABEL_LENGTH`.
-/// * Matches the label regex (only alphanumeric characters and dots, underscores, hyphens)
-///
-/// Returns an error message to be reported through Glean.
-fn validate_label(label: &str) -> Result<&str, String> {
-    if label.len() > MAX_LABEL_LENGTH {
-        let msg = format!(
-            "label length {} exceeds maximum of {}",
-            label.len(),
-            MAX_LABEL_LENGTH
-        );
-        return Err(msg);
-    }
-
-    if !LABEL_REGEX.is_match(label) {
-        let msg = format!("label must be snake_case, got '{}'", label);
-        return Err(msg);
-    }
-
-    Ok(label)
-}
-
 /// A labeled metric.
 ///
 /// Labeled metrics allow to record multiple sub-metrics of the same type under different string labels.
@@ -71,8 +46,6 @@ pub struct LabeledMetric<T> {
     /// Type of the underlying metric
     /// We hold on to an instance of it, which is cloned to create new modified instances.
     submetric: T,
-
-    seen_labels: HashSet<String>,
 }
 
 impl<T> LabeledMetric<T>
@@ -83,16 +56,18 @@ where
     ///
     /// See [`get`](#method.get) for information on how static or dynamic labels are handled.
     pub fn new(submetric: T, labels: Option<Vec<String>>) -> LabeledMetric<T> {
-        LabeledMetric {
-            labels,
-            submetric,
-            seen_labels: HashSet::new(),
-        }
+        LabeledMetric { labels, submetric }
     }
 
     fn new_metric_with_name(&self, name: String) -> T {
         let mut t = self.submetric.clone();
         t.meta_mut().name = name;
+        t
+    }
+
+    fn new_metric_with_dynamic_label(&self, label: String) -> T {
+        let mut t = self.submetric.clone();
+        t.meta_mut().dynamic_label = Some(label);
         t
     }
 
@@ -115,64 +90,6 @@ where
         }
     }
 
-    /// Create a dynamic label
-    ///
-    /// Checkes the requested label against limitations, such as the label length and allowed
-    /// characters.
-    ///
-    /// ## Arguments
-    ///
-    /// * `label` - The requested label
-    ///
-    /// ## Return value
-    ///
-    /// Returns the valid label if within the limitations,
-    /// or `OTHER_LABEL` on any errors.
-    /// The errors are logged.
-    fn dynamic_label<'a>(&mut self, glean: &Glean, label: &'a str) -> &'a str {
-        if self.seen_labels.is_empty() && self.submetric.meta().lifetime != Lifetime::Application {
-            // Fetch all labels that are already stored by iterating through existing data.
-
-            let prefix = format!("{}/", self.submetric.meta().identifier());
-            let seen_labels = &mut self.seen_labels;
-            let mut snapshotter = |metric_name: &[u8], _: &Metric| {
-                let metric_name = String::from_utf8_lossy(metric_name);
-                if metric_name.starts_with(&prefix) {
-                    let label = metric_name.splitn(2, '/').nth(1).unwrap(); // safe unwrap, we know it contains a slash
-                    seen_labels.insert(label.into());
-                }
-            };
-
-            let lifetime = self.submetric.meta().lifetime;
-            for store in &self.submetric.meta().send_in_pings {
-                glean
-                    .storage()
-                    .iter_store_from(lifetime, store, &mut snapshotter);
-            }
-        }
-
-        if !self.seen_labels.contains(label) {
-            if self.seen_labels.len() >= MAX_LABELS {
-                return OTHER_LABEL;
-            } else {
-                if let Err(msg) = validate_label(label) {
-                    record_error(
-                        glean,
-                        &self.submetric.meta(),
-                        ErrorType::InvalidLabel,
-                        msg,
-                        None,
-                    );
-                    return OTHER_LABEL;
-                }
-
-                self.seen_labels.insert(label.into());
-            }
-        }
-
-        label
-    }
-
     /// Get a specific metric for a given label.
     ///
     /// If a set of acceptable labels were specified in the `metrics.yaml` file,
@@ -184,32 +101,82 @@ where
     ///
     /// Labels must be `snake_case` and less than 30 characters.
     /// If an invalid label is used, the metric will be recorded in the special `OTHER_LABEL` label.
-    pub fn get<'a, G: Into<Option<&'a Glean>>>(&mut self, glean: G, label: &str) -> T {
-        // We have 3 scenarios to consider:
+    pub fn get(&mut self, label: &str) -> T {
+        // We have 2 scenarios to consider:
         // * Static labels. No database access needed. We just look at what is in memory.
-        // * Dynamic labels, initialized Glean. We look up in the database all previously stored
-        //   labels in order to keep a maximum of allowed labels.
-        // * Dynamic labels, uninitialized Glean. We ignore potentially previously stored labels
-        //   and just take what the user passed in.
-        //   This potentially allows creating more than `MAX_LABELS` labels, but only before Glean
-        //   is initialized.
-        //   This behavior is not publicly documented and should not be abused/depended upon.
-        // The last case is buggy behavior, tracked in bug 1588451.
-        let glean = glean.into();
-        let label = match (&self.labels, glean) {
-            (Some(_), _) => self.static_label(label),
-            (None, Some(glean)) => self.dynamic_label(glean, label),
-            (None, None) => {
-                if let Ok(label) = validate_label(label) {
-                    label
-                } else {
-                    // We can't report any error, as we don't have a Glean instance.
-                    OTHER_LABEL
-                }
+        // * Dynamic labels. We look up in the database all previously stored
+        //   labels in order to keep a maximum of allowed labels. This is done later
+        //   when the specific metric is actually recorded, when we are guaranteed to have
+        //   an initialized Glean object.
+        match self.labels {
+            Some(_) => {
+                let label = self.static_label(label).to_string();
+                self.new_metric_with_name(format!("{}/{}", self.submetric.meta().name, label))
             }
-        };
-        let label = format!("{}/{}", self.submetric.meta().name, label);
-
-        self.new_metric_with_name(label)
+            None => self.new_metric_with_dynamic_label(label.to_string()),
+        }
     }
+}
+
+/// Correct a dynamic label
+///
+/// Checks the requested label against limitations, such as the label length and allowed
+/// characters.
+///
+/// ## Arguments
+///
+/// * `label` - The requested label
+///
+/// ## Return value
+///
+/// Returns the valid label if within the limitations,
+/// or `OTHER_LABEL` on any errors.
+/// The errors are logged.
+pub fn dynamic_label<'a>(
+    glean: &Glean,
+    meta: &CommonMetricData,
+    base_identifier: &'a str,
+    label: &'a str,
+) -> &'a str {
+    let key = format!("{}/{}", base_identifier, label);
+    for store in &meta.send_in_pings {
+        if glean.storage().has_metric(meta.lifetime, store, &key) {
+            return label;
+        }
+    }
+
+    let mut label_count = 0;
+    let prefix = &key[..=base_identifier.len()];
+    let mut snapshotter = |_: &[u8], _: &Metric| {
+        label_count += 1;
+    };
+
+    let lifetime = meta.lifetime;
+    for store in &meta.send_in_pings {
+        glean
+            .storage()
+            .iter_store_from(lifetime, store, Some(&prefix), &mut snapshotter);
+    }
+
+    if label_count >= MAX_LABELS {
+        return OTHER_LABEL;
+    } else {
+        if label.len() > MAX_LABEL_LENGTH {
+            let msg = format!(
+                "label length {} exceeds maximum of {}",
+                label.len(),
+                MAX_LABEL_LENGTH
+            );
+            record_error(glean, meta, ErrorType::InvalidLabel, msg, None);
+            return OTHER_LABEL;
+        }
+
+        if !LABEL_REGEX.is_match(label) {
+            let msg = format!("label must be snake_case, got '{}'", label);
+            record_error(glean, meta, ErrorType::InvalidLabel, msg, None);
+            return OTHER_LABEL;
+        }
+    }
+
+    label
 }

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -58,12 +58,19 @@ where
         LabeledMetric { labels, submetric }
     }
 
+    /// Creates a new metric with a specific label.
+    ///
+    /// This is used for static labels where we can just set the name to be `name/label`.
     fn new_metric_with_name(&self, name: String) -> T {
         let mut t = self.submetric.clone();
         t.meta_mut().name = name;
         t
     }
 
+    /// Creates a new metric with a specific label.
+    ///
+    /// This is used for dynamic labels where we have to actually validate and correct the
+    /// label later when we have a Glean object.
     fn new_metric_with_dynamic_label(&self, label: String) -> T {
         let mut t = self.submetric.clone();
         t.meta_mut().dynamic_label = Some(label);

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -116,7 +116,7 @@ where
         //   an initialized Glean object.
         match self.labels {
             Some(_) => {
-                let label = self.static_label(label).to_string();
+                let label = self.static_label(label);
                 self.new_metric_with_name(combine_base_identifier_and_label(
                     &self.submetric.meta().name,
                     &label,

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -95,7 +95,7 @@ impl MemoryDistributionMetric {
 
         glean
             .storage()
-            .record_with(&self.meta, |old_value| match old_value {
+            .record_with(glean, &self.meta, |old_value| match old_value {
                 Some(Metric::MemoryDistribution(mut hist)) => {
                     hist.accumulate(sample);
                     Metric::MemoryDistribution(hist)
@@ -135,7 +135,7 @@ impl MemoryDistributionMetric {
         let mut num_negative_samples = 0;
         let mut num_too_log_samples = 0;
 
-        glean.storage().record_with(&self.meta, |old_value| {
+        glean.storage().record_with(glean, &self.meta, |old_value| {
             let mut hist = match old_value {
                 Some(Metric::MemoryDistribution(hist)) => hist,
                 _ => Histogram::functional(LOG_BASE, BUCKETS_PER_MAGNITUDE),
@@ -194,8 +194,11 @@ impl MemoryDistributionMetric {
         glean: &Glean,
         storage_name: &str,
     ) -> Option<Histogram<Functional>> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::MemoryDistribution(hist)) => Some(hist),
             _ => None,
         }

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -42,7 +42,7 @@ pub use crate::histogram::HistogramType;
 pub use self::custom_distribution::CustomDistributionMetric;
 #[cfg(test)]
 pub(crate) use self::experiment::RecordedExperimentData;
-pub use self::labeled::LabeledMetric;
+pub use self::labeled::{dynamic_label, LabeledMetric};
 pub use self::memory_distribution::MemoryDistributionMetric;
 pub use self::memory_unit::MemoryUnit;
 pub use self::ping::PingType;

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -42,7 +42,9 @@ pub use crate::histogram::HistogramType;
 pub use self::custom_distribution::CustomDistributionMetric;
 #[cfg(test)]
 pub(crate) use self::experiment::RecordedExperimentData;
-pub use self::labeled::{dynamic_label, LabeledMetric};
+pub use self::labeled::{
+    combine_base_identifier_and_label, dynamic_label, strip_label, LabeledMetric,
+};
 pub use self::memory_distribution::MemoryDistributionMetric;
 pub use self::memory_unit::MemoryUnit;
 pub use self::ping::PingType;

--- a/glean-core/src/metrics/quantity.rs
+++ b/glean-core/src/metrics/quantity.rs
@@ -59,7 +59,9 @@ impl QuantityMetric {
             return;
         }
 
-        glean.storage().record(&self.meta, &Metric::Quantity(value))
+        glean
+            .storage()
+            .record(glean, &self.meta, &Metric::Quantity(value))
     }
 
     /// **Test-only API (exported for FFI purposes).**
@@ -68,8 +70,11 @@ impl QuantityMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<i64> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::Quantity(i)) => Some(i),
             _ => None,
         }

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -54,7 +54,7 @@ impl StringMetric {
         let s = truncate_string_at_boundary_with_error(glean, &self.meta, value, MAX_LENGTH_VALUE);
 
         let value = Metric::String(s);
-        glean.storage().record(&self.meta, &value)
+        glean.storage().record(glean, &self.meta, &value)
     }
 
     /// **Test-only API (exported for FFI purposes).**
@@ -63,8 +63,11 @@ impl StringMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<String> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::String(s)) => Some(s),
             _ => None,
         }

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -59,7 +59,7 @@ impl StringListMetric {
         let mut error = None;
         glean
             .storage()
-            .record_with(&self.meta, |old_value| match old_value {
+            .record_with(glean, &self.meta, |old_value| match old_value {
                 Some(Metric::StringList(mut old_value)) => {
                     if old_value.len() == MAX_LIST_LENGTH {
                         let msg = format!(
@@ -128,7 +128,7 @@ impl StringListMetric {
             .collect();
 
         let value = Metric::StringList(value);
-        glean.storage().record(&self.meta, &value);
+        glean.storage().record(glean, &self.meta, &value);
     }
 
     /// **Test-only API (exported for FFI purposes).**
@@ -137,8 +137,11 @@ impl StringListMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<Vec<String>> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::StringList(values)) => Some(values),
             _ => None,
         }

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -121,7 +121,7 @@ impl TimespanMetric {
         }
 
         let mut report_value_exists: bool = false;
-        glean.storage().record_with(&self.meta, |old_value| {
+        glean.storage().record_with(glean, &self.meta, |old_value| {
             if overwrite {
                 Metric::Timespan(elapsed, self.time_unit)
             } else {
@@ -155,8 +155,11 @@ impl TimespanMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<u64> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::Timespan(time, time_unit)) => Some(time_unit.duration_convert(time)),
             _ => None,
         }

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -185,7 +185,7 @@ impl TimingDistributionMetric {
 
         glean
             .storage()
-            .record_with(&self.meta, |old_value| match old_value {
+            .record_with(glean, &self.meta, |old_value| match old_value {
                 Some(Metric::TimingDistribution(mut hist)) => {
                     hist.accumulate(duration);
                     Metric::TimingDistribution(hist)
@@ -235,7 +235,7 @@ impl TimingDistributionMetric {
         let mut num_negative_samples = 0;
         let mut num_too_log_samples = 0;
 
-        glean.storage().record_with(&self.meta, |old_value| {
+        glean.storage().record_with(glean, &self.meta, |old_value| {
             let mut hist = match old_value {
                 Some(Metric::TimingDistribution(hist)) => hist,
                 _ => Histogram::functional(LOG_BASE, BUCKETS_PER_MAGNITUDE),
@@ -294,8 +294,11 @@ impl TimingDistributionMetric {
         glean: &Glean,
         storage_name: &str,
     ) -> Option<Histogram<Functional>> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::TimingDistribution(hist)) => Some(hist),
             _ => None,
         }

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -47,7 +47,7 @@ impl UuidMetric {
 
         let s = value.to_string();
         let value = Metric::Uuid(s);
-        glean.storage().record(&self.meta, &value)
+        glean.storage().record(glean, &self.meta, &value)
     }
 
     /// Generate a new random UUID and set the metric to it.
@@ -75,7 +75,7 @@ impl UuidMetric {
         match StorageManager.snapshot_metric(
             glean.storage(),
             storage_name,
-            &self.meta().identifier(),
+            &self.meta().identifier(glean),
         ) {
             Some(Metric::Uuid(uuid)) => Uuid::parse_str(&uuid).ok(),
             _ => None,
@@ -88,8 +88,11 @@ impl UuidMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<String> {
-        match StorageManager.snapshot_metric(glean.storage(), storage_name, &self.meta.identifier())
-        {
+        match StorageManager.snapshot_metric(
+            glean.storage(),
+            storage_name,
+            &self.meta.identifier(glean),
+        ) {
             Some(Metric::Uuid(s)) => Some(s),
             _ => None,
         }

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -88,7 +88,7 @@ impl PingMaker {
         let current_seq = match StorageManager.snapshot_metric(
             glean.storage(),
             INTERNAL_STORAGE,
-            &seq.meta().identifier(),
+            &seq.meta().identifier(glean),
         ) {
             Some(Metric::Counter(i)) => i,
             _ => 0,

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -94,9 +94,9 @@ impl StorageManager {
             }
         };
 
-        storage.iter_store_from(Lifetime::Ping, &store_name, &mut snapshotter);
-        storage.iter_store_from(Lifetime::Application, &store_name, &mut snapshotter);
-        storage.iter_store_from(Lifetime::User, &store_name, &mut snapshotter);
+        storage.iter_store_from(Lifetime::Ping, &store_name, None, &mut snapshotter);
+        storage.iter_store_from(Lifetime::Application, &store_name, None, &mut snapshotter);
+        storage.iter_store_from(Lifetime::User, &store_name, None, &mut snapshotter);
 
         if clear_store {
             storage.clear_ping_lifetime_storage(store_name);
@@ -137,9 +137,9 @@ impl StorageManager {
             }
         };
 
-        storage.iter_store_from(Lifetime::Ping, &store_name, &mut snapshotter);
-        storage.iter_store_from(Lifetime::Application, &store_name, &mut snapshotter);
-        storage.iter_store_from(Lifetime::User, &store_name, &mut snapshotter);
+        storage.iter_store_from(Lifetime::Ping, &store_name, None, &mut snapshotter);
+        storage.iter_store_from(Lifetime::Application, &store_name, None, &mut snapshotter);
+        storage.iter_store_from(Lifetime::User, &store_name, None, &mut snapshotter);
 
         snapshot
     }
@@ -183,7 +183,7 @@ impl StorageManager {
             }
         };
 
-        storage.iter_store_from(Lifetime::Application, store_name, &mut snapshotter);
+        storage.iter_store_from(Lifetime::Application, store_name, None, &mut snapshotter);
 
         if snapshot.is_empty() {
             None

--- a/glean-core/tests/boolean.rs
+++ b/glean-core/tests/boolean.rs
@@ -33,6 +33,7 @@ fn boolean_serializer_should_correctly_serialize_boolean() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::User,
+            ..Default::default()
         });
 
         metric.set(&glean, true);
@@ -71,6 +72,7 @@ fn set_properly_sets_the_value_in_all_stores() {
         send_in_pings: store_names.clone(),
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.set(&glean, true);

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -36,6 +36,7 @@ fn counter_serializer_should_correctly_serialize_counters() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::User,
+            ..Default::default()
         });
 
         metric.add(&glean, 1);
@@ -74,6 +75,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
         send_in_pings: store_names.clone(),
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.add(&glean, 1);
@@ -103,6 +105,7 @@ fn counters_must_not_increment_when_passed_zero_or_negative() {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::Application,
+        ..Default::default()
     });
 
     // Attempt to increment the counter with zero

--- a/glean-core/tests/custom_distribution.rs
+++ b/glean-core/tests/custom_distribution.rs
@@ -38,6 +38,7 @@ mod linear {
                     send_in_pings: vec!["store1".into()],
                     disabled: false,
                     lifetime: Lifetime::Ping,
+                    ..Default::default()
                 },
                 1,
                 100,
@@ -81,6 +82,7 @@ mod linear {
                 send_in_pings: store_names.clone(),
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,
@@ -120,6 +122,7 @@ mod linear {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,
@@ -167,6 +170,7 @@ mod linear {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,
@@ -214,6 +218,7 @@ mod linear {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,
@@ -252,6 +257,7 @@ mod exponential {
                     send_in_pings: vec!["store1".into()],
                     disabled: false,
                     lifetime: Lifetime::Ping,
+                    ..Default::default()
                 },
                 1,
                 100,
@@ -295,6 +301,7 @@ mod exponential {
                 send_in_pings: store_names.clone(),
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,
@@ -334,6 +341,7 @@ mod exponential {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,
@@ -381,6 +389,7 @@ mod exponential {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,
@@ -428,6 +437,7 @@ mod exponential {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             1,
             100,

--- a/glean-core/tests/datetime.rs
+++ b/glean-core/tests/datetime.rs
@@ -36,6 +36,7 @@ fn datetime_serializer_should_correctly_serialize_datetime() {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::User,
+                ..Default::default()
             },
             TimeUnit::Minute,
         );
@@ -81,6 +82,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -172,6 +174,7 @@ fn test_that_truncation_works() {
                 send_in_pings: vec![store_name.into()],
                 disabled: false,
                 lifetime: Lifetime::User,
+                ..Default::default()
             },
             t.desired_resolution,
         );

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -24,6 +24,7 @@ fn record_properly_records_without_optional_arguments() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         vec![],
     );
@@ -52,6 +53,7 @@ fn record_properly_records_with_optional_arguments() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         vec!["key1".into(), "key2".into()],
     );
@@ -102,6 +104,7 @@ fn snapshot_correctly_clears_the_stores() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         vec![],
     );
@@ -159,6 +162,7 @@ fn test_sending_of_event_ping_when_it_fills_up() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         vec!["test_event_number".into()],
     );
@@ -206,6 +210,7 @@ fn extra_keys_must_be_recorded_and_truncated_if_needed() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         vec!["extra1".into(), "truncatedExtra".into()],
     );

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -22,11 +22,12 @@ fn can_create_labeled_counter_metric() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         Some(vec!["label1".into()]),
     );
 
-    let metric = labeled.get(&glean, "label1");
+    let metric = labeled.get("label1");
     metric.add(&glean, 1);
 
     let snapshot = StorageManager
@@ -53,11 +54,12 @@ fn can_create_labeled_string_metric() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         Some(vec!["label1".into()]),
     );
 
-    let metric = labeled.get(&glean, "label1");
+    let metric = labeled.get("label1");
     metric.set(&glean, "text");
 
     let snapshot = StorageManager
@@ -84,11 +86,12 @@ fn can_create_labeled_bool_metric() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         Some(vec!["label1".into()]),
     );
 
-    let metric = labeled.get(&glean, "label1");
+    let metric = labeled.get("label1");
     metric.set(&glean, true);
 
     let snapshot = StorageManager
@@ -115,14 +118,15 @@ fn can_use_multiple_labels() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         None,
     );
 
-    let metric = labeled.get(&glean, "label1");
+    let metric = labeled.get("label1");
     metric.add(&glean, 1);
 
-    let metric = labeled.get(&glean, "label2");
+    let metric = labeled.get("label2");
     metric.add(&glean, 2);
 
     let snapshot = StorageManager
@@ -152,20 +156,21 @@ fn labels_are_checked_against_static_list() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         Some(vec!["label1".into(), "label2".into()]),
     );
 
-    let metric = labeled.get(&glean, "label1");
+    let metric = labeled.get("label1");
     metric.add(&glean, 1);
 
-    let metric = labeled.get(&glean, "label2");
+    let metric = labeled.get("label2");
     metric.add(&glean, 2);
 
     // All non-registed labels get mapped to the `other` label
-    let metric = labeled.get(&glean, "label3");
+    let metric = labeled.get("label3");
     metric.add(&glean, 3);
-    let metric = labeled.get(&glean, "label4");
+    let metric = labeled.get("label4");
     metric.add(&glean, 4);
 
     let snapshot = StorageManager
@@ -196,11 +201,12 @@ fn dynamic_labels_too_long() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         None,
     );
 
-    let metric = labeled.get(&glean, "this_string_has_more_than_thirty_characters");
+    let metric = labeled.get("this_string_has_more_than_thirty_characters");
     metric.add(&glean, 1);
 
     let snapshot = StorageManager
@@ -230,6 +236,7 @@ fn dynamic_labels_regex_mimsatch() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         None,
     );
@@ -245,7 +252,7 @@ fn dynamic_labels_regex_mimsatch() {
     let num_non_validating = labels_not_validating.len();
 
     for label in &labels_not_validating {
-        labeled.get(&glean, label).add(&glean, 1);
+        labeled.get(label).add(&glean, 1);
     }
 
     let snapshot = StorageManager
@@ -275,6 +282,7 @@ fn dynamic_labels_regex_allowed() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         None,
     );
@@ -291,7 +299,7 @@ fn dynamic_labels_regex_allowed() {
     ];
 
     for label in &labels_validating {
-        labeled.get(&glean, label).add(&glean, 1);
+        labeled.get(label).add(&glean, 1);
     }
 
     let snapshot = StorageManager
@@ -336,6 +344,7 @@ fn seen_labels_get_reloaded_from_disk() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         }),
         None,
     );
@@ -345,7 +354,7 @@ fn seen_labels_get_reloaded_from_disk() {
         // Set the maximum number of labels
         for i in 1..=16 {
             let label = format!("label{}", i);
-            labeled.get(&glean, &label).add(&glean, i);
+            labeled.get(&label).add(&glean, i);
         }
 
         let snapshot = StorageManager
@@ -369,7 +378,7 @@ fn seen_labels_get_reloaded_from_disk() {
         let glean = Glean::new(cfg.clone()).unwrap();
 
         // Try to store another label
-        labeled.get(&glean, "new_label").add(&glean, 40);
+        labeled.get("new_label").add(&glean, 40);
 
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", false)

--- a/glean-core/tests/memory_distribution.rs
+++ b/glean-core/tests/memory_distribution.rs
@@ -38,6 +38,7 @@ fn serializer_should_correctly_serialize_memory_distribution() {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             memory_unit,
         );
@@ -78,6 +79,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         MemoryUnit::Byte,
     );
@@ -114,6 +116,7 @@ fn the_accumulate_samples_api_correctly_stores_memory_values() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         MemoryUnit::Kilobyte,
     );
@@ -160,6 +163,7 @@ fn the_accumulate_samples_api_correctly_handles_negative_values() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         MemoryUnit::Kilobyte,
     );

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -31,6 +31,7 @@ fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::User,
+        ..Default::default()
     });
     metric.set(&glean, true);
 
@@ -103,6 +104,7 @@ fn seq_number_must_be_sequential() {
         send_in_pings: vec!["store2".into()],
         disabled: false,
         lifetime: Lifetime::User,
+        ..Default::default()
     });
     metric.set(&glean, true);
 
@@ -165,6 +167,7 @@ fn test_clear_pending_pings() {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::User,
+        ..Default::default()
     });
     metric.set(&glean, true);
 

--- a/glean-core/tests/quantity.rs
+++ b/glean-core/tests/quantity.rs
@@ -36,6 +36,7 @@ fn quantity_serializer_should_correctly_serialize_quantities() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::User,
+            ..Default::default()
         });
 
         metric.set(&glean, 1);
@@ -74,6 +75,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
         send_in_pings: store_names.clone(),
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.set(&glean, 1);
@@ -103,6 +105,7 @@ fn quantities_must_not_set_when_passed_negative() {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::Application,
+        ..Default::default()
     });
 
     // Attempt to set the quantity with negative

--- a/glean-core/tests/storage.rs
+++ b/glean-core/tests/storage.rs
@@ -48,6 +48,7 @@ fn snapshot_correctly_clears_the_stores() {
         send_in_pings: store_names.clone(),
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.add(&glean, 1);

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -34,6 +34,7 @@ fn string_serializer_should_correctly_serialize_strings() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::User,
+            ..Default::default()
         });
 
         metric.set(&glean, "test_string_value");
@@ -72,6 +73,7 @@ fn set_properly_sets_the_value_in_all_stores() {
         send_in_pings: store_names.clone(),
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.set(&glean, "test_string_value");
@@ -102,6 +104,7 @@ fn long_string_values_are_truncated() {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     let test_sting = "01234567890".repeat(20);

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -60,6 +60,7 @@ fn stringlist_serializer_should_correctly_serialize_stringlists() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::User,
+            ..Default::default()
         });
         metric.set(&glean, vec!["test_string_1".into(), "test_string_2".into()]);
     }
@@ -88,6 +89,7 @@ fn set_properly_sets_the_value_in_all_stores() {
         send_in_pings: store_names.clone(),
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.set(&glean, vec!["test_string_1".into(), "test_string_2".into()]);
@@ -114,6 +116,7 @@ fn long_string_values_are_truncated() {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     let test_string = "0123456789".repeat(20);
@@ -142,6 +145,7 @@ fn disabled_string_lists_dont_record() {
         send_in_pings: vec!["store1".into()],
         disabled: true,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.add(&glean, "test_string".repeat(20));
@@ -170,6 +174,7 @@ fn string_lists_dont_exceed_max_items() {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     for _n in 1..21 {
@@ -218,6 +223,7 @@ fn set_does_not_record_error_when_receiving_empty_list() {
         send_in_pings: vec!["store1".into()],
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.set(&glean, vec![]);

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -38,6 +38,7 @@ fn serializer_should_correctly_serialize_timespans() {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             TimeUnit::Nanosecond,
         );
@@ -77,6 +78,7 @@ fn single_elapsed_time_must_be_recorded() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -106,6 +108,7 @@ fn second_timer_run_is_skipped() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -147,6 +150,7 @@ fn recorded_time_conforms_to_resolution() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -158,6 +162,7 @@ fn recorded_time_conforms_to_resolution() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Minute,
     );
@@ -191,6 +196,7 @@ fn cancel_does_not_store() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -212,6 +218,7 @@ fn nothing_stored_before_stop() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -237,6 +244,7 @@ fn set_raw_time() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -259,6 +267,7 @@ fn set_raw_time_does_nothing_when_timer_running() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -40,6 +40,7 @@ fn serializer_should_correctly_serialize_timing_distribution() {
                 send_in_pings: vec!["store1".into()],
                 disabled: false,
                 lifetime: Lifetime::Ping,
+                ..Default::default()
             },
             time_unit,
         );
@@ -83,6 +84,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
             send_in_pings: store_names.clone(),
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -120,6 +122,7 @@ fn timing_distributions_must_not_accumulate_negative_values() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         time_unit,
     );
@@ -154,6 +157,7 @@ fn the_accumulate_samples_api_correctly_stores_timing_values() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Second,
     );
@@ -200,6 +204,7 @@ fn the_accumulate_samples_api_correctly_handles_negative_values() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );
@@ -243,6 +248,7 @@ fn large_nanoseconds_values() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::Ping,
+            ..Default::default()
         },
         TimeUnit::Nanosecond,
     );

--- a/glean-core/tests/uuid.rs
+++ b/glean-core/tests/uuid.rs
@@ -58,6 +58,7 @@ fn uuid_serializer_should_correctly_serialize_uuids() {
             send_in_pings: vec!["store1".into()],
             disabled: false,
             lifetime: Lifetime::User,
+            ..Default::default()
         });
 
         metric.set(&glean, value);
@@ -97,6 +98,7 @@ fn set_properly_sets_the_value_in_all_stores() {
         send_in_pings: store_names.clone(),
         disabled: false,
         lifetime: Lifetime::Ping,
+        ..Default::default()
     });
 
     metric.set(&glean, value);


### PR DESCRIPTION
At present, the determination of (a) whether there are too many dynamic labels
on a metric, or (b) the label is invalid, are handled synchronously in the
`get()` operator (in Kotlin, the bracket operator).

This requires the Glean object to already be initialized at metric recording
time -- both to see how many labels have already been used, and also to record
any errors.  This both means that labeled metrics can't be recorded prior to
initialization (even though most metrics now can), but more importantly,
blocking I/O is performed to determine how many labels have already been
recorded for the metric.

This PR changes how things work so the *requested* dynamic label is stored on
the specific labeled metric as a new field. This dynamic label is then converted
to its *actual* value later as part of the coroutine task, at which point we are
guaranteed to have an initialized Glean object.