### PR TITLE
Update the Glean ping schema revision to a recent version

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'jacoco'
  * created during unit testing.
  * This uses a specific version of the schema identified by a git commit hash.
  */
-String GLEAN_PING_SCHEMA_GIT_HASH = "64b852c"
+String GLEAN_PING_SCHEMA_GIT_HASH = "f13ae39"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/baseline/baseline.1.schema.json"
 
 // Set configuration for the glean_parser


### PR DESCRIPTION
I noticed that we were using a quite old version in our tests. I updated the version to the latest release.