### PR TITLE
By default make `make` print helpful output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,23 @@
-default: test
+.PHONY: help
+help:
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	  sort | \
+	  awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 # All builds
 
 build: build-rust
 
-build-rust:
+build-rust: ## Build all Rust code
 	cargo build --all
 
-build-kotlin:
+build-kotlin: ## Build all Kotlin code
 	./gradlew build -x test
 
-build-swift:
+build-swift: ## Build all Swift code
 	bin/run-ios-build.sh
 
-build-apk:
+build-apk: ## Build an apk of the Glean sample app
 	./gradlew glean-core:build
 	./gradlew glean-sample-app:build
 
@@ -23,16 +27,16 @@ build-apk:
 
 test: test-rust
 
-test-rust:
+test-rust: ## Run all Rust tests
 	cargo test --all
 
-test-rust-with-logs:
+test-rust-with-logs: ## Run all Rust tests with debug logging and single-threaded
 	RUST_LOG=glean_core=debug cargo test --all -- --nocapture --test-threads=1
 
-test-kotlin:
+test-kotlin: ## Run all Kotlin tests
 	./gradlew test
 
-test-swift:
+test-swift: ## Run all Swift tests
 	bin/run-ios-tests.sh
 
 .PHONY: test test-rust test-rust-with-logs test-kotlin test-swift
@@ -41,13 +45,13 @@ test-swift:
 
 lint: clippy
 
-clippy:
+clippy: ## Run cargo-clippy to lint Rust code
 	cargo clippy --all --all-targets --all-features -- -D warnings
 
-ktlint:
+ktlint: ## Run ktlint to lint Kotlin code
 	./gradlew ktlint detekt
 
-swiftlint:
+swiftlint: ## Run swiftlint to lint Swift code
 	swiftlint --strict
 
 .PHONY: lint clippy ktlint swiftlint
@@ -56,47 +60,47 @@ swiftlint:
 
 fmt: rustfmt
 
-rustfmt:
+rustfmt: ## Format all Rust code
 	cargo fmt --all
 
-swiftfmt:
+swiftfmt: ## Format all Swift code
 	swiftformat glean-core/ios samples/ios --swiftversion 5 --verbose
 
 .PHONY: fmt rustfmt swiftfmt
 
 # Docs
 
-docs: rust-docs kotlin-docs
+docs: rust-docs kotlin-docs ## Build the Rust and Kotlin API documentation
 
-rust-docs:
+rust-docs: ## Build the Rust documentation
 	bin/build-rust-docs.sh
 
-kotlin-docs:
+kotlin-docs: ## Build the Kotlin documentation
 	./gradlew docs
 
-swift-docs:
+swift-docs: ## Build the Swift documentation
 	bin/build-swift-docs.sh
 
 .PHONY: docs rust-docs kotlin-docs swift-docs
 
-linkcheck: docs
+linkcheck: docs ## Run linkchecker on the generated docs
 	# Requires https://wummel.github.io/linkchecker/
 	linkchecker --ignore-url javadoc --ignore-url docs/glean_core build/docs
 .PHONY: linkcheck
 
 # Utilities
 
-android-emulator:
+android-emulator: ## Start the Android emulator with a predefined image
 	$(ANDROID_HOME)/emulator/emulator -avd Nexus_5X_API_P -netdelay none -netspeed full
 .PHONY: android-emulator
 
-cbindgen:
+cbindgen: ## Regenerate the FFI header file
 	RUSTUP_TOOLCHAIN=nightly \
 	cbindgen glean-core/ffi --lockfile Cargo.lock -o glean-core/ffi/glean.h
 	cp glean-core/ffi/glean.h glean-core/ios/Glean/GleanFfi.h
 .PHONY: cbindgen
 
-rust-coverage:
+rust-coverage: ## Generate code coverage information for Rust code
 	# Expects a Rust nightly toolchain to be available.
 	# Expects grcov and genhtml to be available in $PATH.
 	CARGO_INCREMENTAL=0 \


### PR DESCRIPTION
Stumbled upon this last night: https://jakemccrary.com/blog/2018/12/27/a-more-helpful-makefile/

Went ahead and implemented it. This will list all documented make commands like this:

```
$ make
android-emulator               Start the Android emulator with a predefined image
build-apk                      Build an apk of the Glean sample app
build-kotlin                   Build all Kotlin code
build-rust                     Build all Rust code
build-swift                    Build all Swift code
cbindgen                       Regenerate the FFI header file
clippy                         Run cargo-clippy to lint Rust code
docs                           Build the Rust and Kotlin API documentation
kotlin-docs                    Build the Kotlin documentation
ktlint                         Run ktlint to lint Kotlin code
linkcheck                      Run linkchecker on the generated docs
rust-coverage                  Generate code coverage information for Rust code
rust-docs                      Build the Rust documentation
rustfmt                        Format all Rust code
swift-docs                     Build the Swift documentation
swiftfmt                       Format all Swift code
swiftlint                      Run swiftlint to lint Swift code
test-kotlin                    Run all Kotlin tests
test-rust-with-logs            Run all Rust tests with debug logging and single-threaded
test-rust                      Run all Rust tests
test-swift                     Run all Swift tests
```