### PR TITLE
Add the GleanTestLocalServer to glean-core

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -576,6 +576,26 @@ open class GleanInternalAPI internal constructor () {
     }
 
     /**
+     * TEST ONLY FUNCTION.
+     * Sets the server endpoint to a local address for ingesting test pings.
+     *
+     * The endpoint will be set as "http://localhost:<port>".
+     *
+     * @param port the local address to send pings to
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal fun testSetLocalEndpoint(port: Int) {
+        Glean.enableTestingMode()
+
+        // We can't set the configuration unless we're initialized.
+        assert(isInitialized())
+
+        val endpointUrl = "http://localhost:$port"
+
+        Glean.configuration = configuration.copy(serverEndpoint = endpointUrl)
+    }
+
+    /**
      * Test-only method to destroy the owned glean-core handle.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestLocalServer.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestLocalServer.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.testing
+
+import androidx.annotation.VisibleForTesting
+import mozilla.components.service.glean.Glean
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * This implements a JUnit rule for writing tests for Glean SDK metrics.
+ *
+ * The rule takes care of sending Glean SDK pings to a local server, at the
+ * address: "http://localhost:<port>".
+ *
+ * This is useful for Android instrumented tests, where we don't want to
+ * initialize Glean more than once but still want to send pings to a local
+ * server for validation.
+ *
+ * Example usage:
+ *
+ * ```
+ * // Add the following lines to you test class.
+ * @get:Rule
+ * val gleanRule = GleanTestLocalServer(3785)
+ * ```
+ *
+ * @param localPort the port of the local ping server
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+class GleanTestLocalServer(
+    private val localPort: Int
+) : TestWatcher() {
+    override fun starting(description: Description?) {
+        Glean.testSetLocalEndpoint(localPort)
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestLocalServer.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestLocalServer.kt
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.service.glean.testing
+package mozilla.telemetry.glean.testing
 
 import androidx.annotation.VisibleForTesting
-import mozilla.components.service.glean.Glean
+import mozilla.telemetry.glean.Glean
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 


### PR DESCRIPTION
This is importing just the rule from mozilla-mobile/android-components#4786