### PR TITLE
Expose testGetNumRecordedErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v19.1.0...master)
 
+* In Kotlin, metrics that can record errors now have a new testing method,
+  `testGetNumRecordedErrors`.
+
 # v19.1.0 (2019-10-29)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v19.0.0...v19.1.0)

--- a/docs/user/metrics/counter.md
+++ b/docs/user/metrics/counter.md
@@ -37,6 +37,8 @@ import org.mozilla.yourApplication.GleanMetrics.Controls
 assertTrue(Controls.refreshPressed.testHasValue())
 // Does the counter have the expected value?
 assertEquals(6, Controls.refreshPressed.testGetValue())
+// Did the counter record an negative value?
+assertEquals(1, Controls.refreshPressed.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>
@@ -73,7 +75,7 @@ XCTAssertEqual(6, try Controls.refreshPressed.testGetValue())
 
 ## Recorded errors
 
-* None.
+* If the counter is incremented by a non-positive value.
 
 ## Reference
 

--- a/docs/user/metrics/custom_distribution.md
+++ b/docs/user/metrics/custom_distribution.md
@@ -68,6 +68,9 @@ assertEquals(11, snapshot.sum)
 
 // Usually you don't know the exact timing values, but how many should have been recorded.
 assertEquals(2L, snapshot.count())
+
+/// Did the metric receive a negative value?
+assertEquals(1, Graphics.checkerboardPeak.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 ## Limits

--- a/docs/user/metrics/datetime.md
+++ b/docs/user/metrics/datetime.md
@@ -57,6 +57,8 @@ assertTrue(Install.firstRun.testHasValue())
 // NOTE: Datetimes always include a timezone offset from UTC, hence the
 // "-05:00" suffix.
 assertEquals("2019-03-25-05:00", Install.firstRun.testGetValueAsString())
+// Was the value invalid?
+assertEquals(1, Install.firstRun.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>

--- a/docs/user/metrics/event.md
+++ b/docs/user/metrics/event.md
@@ -46,6 +46,8 @@ val snapshot = Views.loginOpened.testGetValue()
 assertEquals(2, snapshot.size)
 val first = snapshot.single()
 assertEquals("login_opened", first.name)
+// Check that no errors were recorded
+assertEquals(0, Views.loginOpened.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>

--- a/docs/user/metrics/memory_distribution.md
+++ b/docs/user/metrics/memory_distribution.md
@@ -56,6 +56,9 @@ assertEquals(11, snapshot.sum)
 
 // Usually you don't know the exact memory values, but how many should have been recorded.
 assertEquals(2L, snapshot.count)
+
+// Did this record a negative value?
+assertEquals(1, Memory.heapAllocated.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>

--- a/docs/user/metrics/quantity.md
+++ b/docs/user/metrics/quantity.md
@@ -39,6 +39,8 @@ import org.mozilla.yourApplication.GleanMetrics.Gfx
 assertTrue(Gfx.displayWidth.testHasValue())
 // Does the quantity have the expected value?
 assertEquals(6, Gfx.displayWidth.testGetValue())
+// Did it record an error due to a negative value?
+assertEquals(1, Gfx.displayWidth.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 ## Limits

--- a/docs/user/metrics/string.md
+++ b/docs/user/metrics/string.md
@@ -45,6 +45,8 @@ assertTrue(SearchDefault.name.testHasValue())
 // Does the string metric have the expected value?
 // IMPORTANT: It may have been truncated -- see "Limits" below
 assertEquals("wikipedia", SearchDefault.name.testGetValue())
+// Was the string truncated, and an error reported?
+assertEquals(1, SearchDefault.name.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>

--- a/docs/user/metrics/string_list.md
+++ b/docs/user/metrics/string_list.md
@@ -50,6 +50,8 @@ assertTrue(Search.engines.testHasValue())
 // Does it have the expected value?
 // IMPORTANT: It may have been truncated -- see "Limits" below
 assertEquals(listOf("Google", "DuckDuckGo"), Search.engines.testGetValue())
+// Were any of the values too long, and thus an error was recorded?
+assertEquals(1, Search.engines.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>

--- a/docs/user/metrics/timespan.md
+++ b/docs/user/metrics/timespan.md
@@ -66,6 +66,8 @@ import org.mozilla.yourApplication.GleanMetrics.Auth
 assertTrue(Auth.loginTime.testHasValue())
 // Does the timer have the expected value
 assertTrue(Auth.loginTime.testGetValue() > 0)
+// Was the timing recorded incorrectly?
+assertEquals(1, Auth.loginTime.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>

--- a/docs/user/metrics/timing_distribution.md
+++ b/docs/user/metrics/timing_distribution.md
@@ -70,6 +70,9 @@ assertEquals(11, snapshot.sum)
 
 // Usually you don't know the exact timing values, but how many should have been recorded.
 assertEquals(2L, snapshot.count)
+
+// Was an error recorded?
+assertEquals(1, pages.pageLoad.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -6,12 +6,12 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
-
-import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 
 /**
  * This implements the developer facing API for recording counter metrics.
@@ -136,5 +136,24 @@ class CounterMetricType internal constructor(
             throw NullPointerException()
         }
         return LibGleanFFI.INSTANCE.glean_counter_test_get_value(Glean.handle, this.handle, pingName)
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_counter_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -4,14 +4,15 @@
 
 package mozilla.telemetry.glean.private
 
-import com.sun.jna.StringArray
 import androidx.annotation.VisibleForTesting
-import mozilla.telemetry.glean.Glean
-import mozilla.telemetry.glean.rust.getAndConsumeRustString
-import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
+import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.rust.LibGleanFFI
+import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 
 /**
  * This implements the developer facing API for recording custom distribution metrics.
@@ -139,5 +140,24 @@ data class CustomDistributionMetricType(
                 pingName)!!
 
         return DistributionData.fromJsonString(ptr.getAndConsumeRustString())!!
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_custom_distribution_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
@@ -6,16 +6,17 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
-import mozilla.telemetry.glean.utils.parseISOTimeString
-import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
-import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
-import mozilla.telemetry.glean.rust.getAndConsumeRustString
-import mozilla.telemetry.glean.rust.toBoolean
 import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.rust.LibGleanFFI
+import mozilla.telemetry.glean.rust.getAndConsumeRustString
+import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
+import mozilla.telemetry.glean.utils.parseISOTimeString
 
 /**
  * This implements the developer facing API for recording datetime metrics.
@@ -195,5 +196,24 @@ class DatetimeMetricType internal constructor(
     @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): Date {
         return parseISOTimeString(testGetValueAsString(pingName))!!
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_datetime_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
@@ -13,6 +13,7 @@ import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
 import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -229,5 +230,24 @@ class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>> internal constructor(
             result.add(deserializeEvent(jsonRes.getJSONObject(i)))
         }
         return result
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_event_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -6,12 +6,13 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
-import mozilla.telemetry.glean.Glean
-import mozilla.telemetry.glean.rust.getAndConsumeRustString
-import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
 import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.rust.LibGleanFFI
+import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 
 /**
  * This implements the developer facing API for recording memory distribution metrics.
@@ -145,5 +146,24 @@ class MemoryDistributionMetricType internal constructor(
                 pingName)!!
 
         return DistributionData.fromJsonString(ptr.getAndConsumeRustString())!!
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_memory_distribution_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -6,12 +6,12 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
-
-import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 
 /**
  * This implements the developer facing API for recording quantity metrics.
@@ -112,5 +112,24 @@ class QuantityMetricType internal constructor(
             throw NullPointerException()
         }
         return LibGleanFFI.INSTANCE.glean_quantity_test_get_value(Glean.handle, this.handle, pingName)
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_quantity_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -8,10 +8,11 @@ import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
-import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.LibGleanFFI
+import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
 import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.utils.toList
 import org.json.JSONArray
 
@@ -176,5 +177,24 @@ class StringListMetricType(
             throw NullPointerException()
         }
         return jsonRes.toList()
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_string_list_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -6,13 +6,13 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
-
-import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 
 /**
  * This implements the developer facing API for recording string metrics.
@@ -122,5 +122,24 @@ class StringMetricType internal constructor(
         }
         val ptr = LibGleanFFI.INSTANCE.glean_string_test_get_value(Glean.handle, this.handle, pingName)!!
         return ptr.getAndConsumeRustString()
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_string_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -4,15 +4,15 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.annotation.VisibleForTesting
 import android.os.SystemClock
+import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
-
-import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 
 /**
  * This implements the developer facing API for recording timespans.
@@ -172,5 +172,24 @@ class TimespanMetricType internal constructor(
             throw NullPointerException()
         }
         return LibGleanFFI.INSTANCE.glean_timespan_test_get_value(Glean.handle, this.handle, pingName)
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_timespan_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -4,16 +4,17 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.annotation.VisibleForTesting
 import android.os.SystemClock
+import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.GleanTimerId
-import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
-import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
+import mozilla.telemetry.glean.testing.ErrorType
 
 /**
  * This implements the developer facing API for recording timing distribution metrics.
@@ -204,5 +205,24 @@ class TimingDistributionMetricType internal constructor(
                 pingName)!!
 
         return DistributionData.fromJsonString(ptr.getAndConsumeRustString())!!
+    }
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.assertInTestingMode()
+
+        return LibGleanFFI.INSTANCE.glean_timing_distribution_test_get_num_recorded_errors(
+            Glean.handle, this.handle, errorType.ordinal, pingName
+        )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -159,6 +159,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_counter_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
+    fun glean_counter_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
+
     // Quantity
 
     fun glean_new_quantity_metric(
@@ -178,6 +185,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_quantity_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
 
+    fun glean_quantity_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
+
     // String
 
     fun glean_new_string_metric(
@@ -196,6 +210,13 @@ internal interface LibGleanFFI : Library {
     fun glean_string_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Pointer?
 
     fun glean_string_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+
+    fun glean_string_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
 
     // Datetime
 
@@ -228,6 +249,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_datetime_test_get_value_as_string(glean_handle: Long, metric_id: Long, storage_name: String): Pointer?
 
+    fun glean_datetime_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
+
     // String list
 
     fun glean_new_string_list_metric(
@@ -252,6 +280,13 @@ internal interface LibGleanFFI : Library {
         metric_id: Long,
         storage_name: String
     ): Pointer?
+
+    fun glean_string_list_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
 
     // UUID
 
@@ -298,6 +333,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_timespan_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Long
 
+    fun glean_timespan_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
+
     // TimingDistribution
 
     fun glean_new_timing_distribution_metric(
@@ -333,6 +375,13 @@ internal interface LibGleanFFI : Library {
         storage_name: String
     ): Pointer?
 
+    fun glean_timing_distribution_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
+
     // MemoryDistribution
 
     fun glean_new_memory_distribution_metric(
@@ -358,6 +407,13 @@ internal interface LibGleanFFI : Library {
         metric_id: Long,
         storage_name: String
     ): Pointer?
+
+    fun glean_memory_distribution_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
 
     // CustomDistribution
 
@@ -385,6 +441,13 @@ internal interface LibGleanFFI : Library {
         metric_id: Long,
         storage_name: String
     ): Pointer?
+
+    fun glean_custom_distribution_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
 
     // Event
 
@@ -415,6 +478,13 @@ internal interface LibGleanFFI : Library {
         handle: Long,
         storage_Name: String
     ): Pointer?
+
+    fun glean_event_test_get_num_recorded_errors(
+        glean_handle: Long,
+        metric_id: Long,
+        error_type: Int,
+        storage_name: String
+    ): Int
 
     // Labeled Counter
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/ErrorType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/ErrorType.kt
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.testing
+
+enum class ErrorType {
+    // For when the value to be recorded does not match the metric-specific restrictions
+    InvalidValue,
+    // For when the label of a labeled metric does not match the restrictions
+    InvalidLabel,
+    // For when timings are recorded incorrectly
+    InvalidState
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CounterMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CounterMetricTypeTest.kt
@@ -12,6 +12,8 @@ package mozilla.telemetry.glean.private
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.lang.NullPointerException
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,7 +21,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.NullPointerException
 
 @RunWith(AndroidJUnit4::class)
 class CounterMetricTypeTest {
@@ -153,5 +154,6 @@ class CounterMetricTypeTest {
         // Check that count was NOT incremented.
         assertTrue(counterMetric.testHasValue("store1"))
         assertEquals(1, counterMetric.testGetValue("store1"))
+        assertEquals(1, counterMetric.testGetNumRecordedErrors(ErrorType.InvalidValue))
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/MemoryDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/MemoryDistributionMetricTypeTest.kt
@@ -5,17 +5,18 @@
 package mozilla.telemetry.glean.private
 
 import androidx.test.core.app.ApplicationProvider
+import java.lang.NullPointerException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
@@ -78,6 +79,8 @@ class MemoryDistributionMetricTypeTest {
         assertEquals(1L shl 40, snapshot.sum)
         // Check that the 1L fell into 1TB bucket
         assertEquals(1L, snapshot.values[(1L shl 40) - 1])
+        // Check that an error was recorded
+        assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidValue))
     }
 
     @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/QuantityMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/QuantityMetricTypeTest.kt
@@ -12,6 +12,8 @@ package mozilla.telemetry.glean.private
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.lang.NullPointerException
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,7 +21,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.NullPointerException
 
 @RunWith(AndroidJUnit4::class)
 class QuantityMetricTypeTest {
@@ -142,7 +143,6 @@ class QuantityMetricTypeTest {
         assertFalse(quantityMetric.testHasValue("store1"))
 
         // Make sure that the errors have been recorded
-        // TODO(bug 1556963)
-        // assertEquals(1, testGetNumRecordedErrors(quantityMetric, ErrorType.InvalidValue))
+        assertEquals(1, quantityMetric.testGetNumRecordedErrors(ErrorType.InvalidValue))
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringListMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringListMetricTypeTest.kt
@@ -12,14 +12,15 @@ package mozilla.telemetry.glean.private
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.lang.NullPointerException
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.NullPointerException
 
 @RunWith(AndroidJUnit4::class)
 class StringListMetricTypeTest {
@@ -191,5 +192,26 @@ class StringListMetricTypeTest {
         assertEquals("other1", snapshot2[0])
         assertEquals("other2", snapshot2[1])
         assertEquals("other3", snapshot2[2])
+    }
+
+    @Test
+    fun `Long string lists are truncated`() {
+        // Define a 'stringMetric' string metric, which will be stored in "store1" and "store2"
+        val stringListMetric = StringListMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "string_list_metric",
+            sendInPings = listOf("store1")
+        )
+
+        for (x in 0..20) {
+            stringListMetric.add("value$x")
+        }
+
+        val snapshot = stringListMetric.testGetValue("store1")
+        assertEquals(20, snapshot.size)
+
+        assertEquals(1, stringListMetric.testGetNumRecordedErrors(ErrorType.InvalidValue))
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringMetricTypeTest.kt
@@ -12,6 +12,8 @@ package mozilla.telemetry.glean.private
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.lang.NullPointerException
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,7 +21,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.NullPointerException
 
 @RunWith(AndroidJUnit4::class)
 class StringMetricTypeTest {
@@ -104,5 +105,21 @@ class StringMetricTypeTest {
         // Check that data was properly recorded in the second ping.
         assertTrue(stringMetric.testHasValue("store2"))
         assertEquals("overriddenValue", stringMetric.testGetValue("store2"))
+    }
+
+    @Test
+    fun `Setting a long string records an error`() {
+        // Define a 'stringMetric' string metric, which will be stored in "store1" and "store2"
+        val stringMetric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "string_metric",
+            sendInPings = listOf("store1", "store2")
+        )
+
+        stringMetric.set("0123456789".repeat(11))
+
+        assertEquals(1, stringMetric.testGetNumRecordedErrors(ErrorType.InvalidValue))
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
@@ -8,15 +8,16 @@ package mozilla.telemetry.glean.private
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.lang.NullPointerException
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
-import org.junit.Test
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.NullPointerException
 
 @RunWith(AndroidJUnit4::class)
 class TimespanMetricTypeTest {
@@ -89,8 +90,7 @@ class TimespanMetricTypeTest {
         // Check that data was not recorded.
         assertFalse("The API should not record a counter if metric is cancelled",
             metric.testHasValue())
-        // TODO(bug 1556963)
-        // assertEquals(1, testGetNumRecordedErrors(metric, ErrorType.InvalidValue))
+        assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidState))
     }
 
     @Test(expected = NullPointerException::class)
@@ -147,8 +147,7 @@ class TimespanMetricTypeTest {
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))
         assertTrue(metric.testGetValue("store2") >= 0)
-        // TODO(bug 1556963)
-        // assertEquals(1, testGetNumRecordedErrors(metric, ErrorType.InvalidValue))
+        assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidState))
     }
 
     @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
@@ -7,18 +7,19 @@ package mozilla.telemetry.glean.private
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.lang.NullPointerException
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.NullPointerException
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.spy
 
 @RunWith(AndroidJUnit4::class)
 class TimingDistributionMetricTypeTest {
@@ -217,5 +218,20 @@ class TimingDistributionMetricTypeTest {
         Glean.initialize(context)
 
         metric.testGetValue().sum >= 0
+    }
+
+    @Test
+    fun `Stopping a non-existent timer records an error`() {
+        val metric = TimingDistributionMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "timing_distribution_samples",
+            sendInPings = listOf("store1"),
+            timeUnit = TimeUnit.Second
+        )
+
+        metric.stopAndAccumulate(-1)
+        assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidValue))
     }
 }

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -49,6 +49,11 @@ uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
 
 void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
 
+int32_t glean_counter_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                   uint64_t metric_id,
+                                                   int32_t error_type,
+                                                   FfiStr storage_name);
+
 int32_t glean_counter_test_get_value(uint64_t glean_handle,
                                      uint64_t metric_id,
                                      FfiStr storage_name);
@@ -61,6 +66,11 @@ void glean_custom_distribution_accumulate_samples(uint64_t glean_handle,
                                                   uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
+
+int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                               uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 char *glean_custom_distribution_test_get_value_as_json_string(uint64_t glean_handle,
                                                               uint64_t metric_id,
@@ -80,6 +90,11 @@ void glean_datetime_set(uint64_t glean_handle,
                         uint32_t second,
                         int64_t nano,
                         int32_t offset_seconds);
+
+int32_t glean_datetime_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                    uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
 
 char *glean_datetime_test_get_value_as_string(uint64_t glean_handle,
                                               uint64_t metric_id,
@@ -136,6 +151,11 @@ void glean_event_record(uint64_t glean_handle,
                         RawStringArray extra_values,
                         int32_t extra_len);
 
+int32_t glean_event_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                 uint64_t metric_id,
+                                                 int32_t error_type,
+                                                 FfiStr storage_name);
+
 char *glean_event_test_get_value_as_json_string(uint64_t glean_handle,
                                                 uint64_t metric_id,
                                                 FfiStr storage_name);
@@ -173,6 +193,11 @@ void glean_memory_distribution_accumulate_samples(uint64_t glean_handle,
                                                   uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
+
+int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                               uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 char *glean_memory_distribution_test_get_value_as_json_string(uint64_t glean_handle,
                                                               uint64_t metric_id,
@@ -320,6 +345,11 @@ char *glean_ping_collect(uint64_t glean_handle, uint64_t ping_type_handle);
 
 void glean_quantity_set(uint64_t glean_handle, uint64_t metric_id, int64_t value);
 
+int32_t glean_quantity_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                    uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
+
 int64_t glean_quantity_test_get_value(uint64_t glean_handle,
                                       uint64_t metric_id,
                                       FfiStr storage_name);
@@ -357,6 +387,11 @@ void glean_string_list_set(uint64_t glean_handle,
                            RawStringArray values,
                            int32_t values_len);
 
+int32_t glean_string_list_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                       uint64_t metric_id,
+                                                       int32_t error_type,
+                                                       FfiStr storage_name);
+
 char *glean_string_list_test_get_value_as_json_string(uint64_t glean_handle,
                                                       uint64_t metric_id,
                                                       FfiStr storage_name);
@@ -366,6 +401,11 @@ uint8_t glean_string_list_test_has_value(uint64_t glean_handle,
                                          FfiStr storage_name);
 
 void glean_string_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+
+int32_t glean_string_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                  uint64_t metric_id,
+                                                  int32_t error_type,
+                                                  FfiStr storage_name);
 
 char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
 
@@ -385,6 +425,11 @@ void glean_timespan_set_start(uint64_t glean_handle, uint64_t metric_id, uint64_
 
 void glean_timespan_set_stop(uint64_t glean_handle, uint64_t metric_id, uint64_t stop_time);
 
+int32_t glean_timespan_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                    uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
+
 uint64_t glean_timespan_test_get_value(uint64_t glean_handle,
                                        uint64_t metric_id,
                                        FfiStr storage_name);
@@ -400,13 +445,17 @@ void glean_timing_distribution_accumulate_samples(uint64_t glean_handle,
 
 void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
 
-TimerId glean_timing_distribution_set_start(uint64_t metric_id,
-                                            uint64_t start_time);
+TimerId glean_timing_distribution_set_start(uint64_t metric_id, uint64_t start_time);
 
 void glean_timing_distribution_set_stop_and_accumulate(uint64_t glean_handle,
                                                        uint64_t metric_id,
                                                        TimerId timer_id,
                                                        uint64_t stop_time);
+
+int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                               uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 char *glean_timing_distribution_test_get_value_as_json_string(uint64_t glean_handle,
                                                               uint64_t metric_id,

--- a/glean-core/ffi/src/counter.rs
+++ b/glean-core/ffi/src/counter.rs
@@ -8,6 +8,7 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
 define_metric!(CounterMetric => COUNTER_METRICS {
     new           -> glean_new_counter_metric(),
+    test_get_num_recorded_errors -> glean_counter_test_get_num_recorded_errors,
     destroy       -> glean_destroy_counter_metric,
 
     add -> glean_counter_add(amount: i32),

--- a/glean-core/ffi/src/custom_distribution.rs
+++ b/glean-core/ffi/src/custom_distribution.rs
@@ -12,6 +12,7 @@ use crate::{
 
 define_metric!(CustomDistributionMetric => CUSTOM_DISTRIBUTION_METRICS {
     new           -> glean_new_custom_distribution_metric(range_min: u64, range_max: u64, bucket_count: u64, histogram_type: i32),
+    test_get_num_recorded_errors -> glean_custom_distribution_test_get_num_recorded_errors,
     destroy       -> glean_destroy_custom_distribution_metric,
 });
 

--- a/glean-core/ffi/src/datetime.rs
+++ b/glean-core/ffi/src/datetime.rs
@@ -10,6 +10,7 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
 define_metric!(DatetimeMetric => DATETIME_METRICS {
     new           -> glean_new_datetime_metric(time_unit: i32),
+    test_get_num_recorded_errors -> glean_datetime_test_get_num_recorded_errors,
     destroy       -> glean_destroy_datetime_metric,
 });
 

--- a/glean-core/ffi/src/event.rs
+++ b/glean-core/ffi/src/event.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 define_metric!(EventMetric => EVENT_METRICS {
+    test_get_num_recorded_errors -> glean_event_test_get_num_recorded_errors,
     destroy       -> glean_destroy_event_metric,
 });
 

--- a/glean-core/ffi/src/memory_distribution.rs
+++ b/glean-core/ffi/src/memory_distribution.rs
@@ -12,6 +12,7 @@ use crate::{
 
 define_metric!(MemoryDistributionMetric => MEMORY_DISTRIBUTION_METRICS {
     new           -> glean_new_memory_distribution_metric(memory_unit: i32),
+    test_get_num_recorded_errors -> glean_memory_distribution_test_get_num_recorded_errors,
     destroy       -> glean_destroy_memory_distribution_metric,
     accumulate    -> glean_memory_distribution_accumulate(sample: u64),
 });

--- a/glean-core/ffi/src/quantity.rs
+++ b/glean-core/ffi/src/quantity.rs
@@ -8,6 +8,7 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
 define_metric!(QuantityMetric => QUANTITY_METRICS {
     new           -> glean_new_quantity_metric(),
+    test_get_num_recorded_errors -> glean_quantity_test_get_num_recorded_errors,
     destroy       -> glean_destroy_quantity_metric,
 
     set -> glean_quantity_set(value: i64),

--- a/glean-core/ffi/src/string.rs
+++ b/glean-core/ffi/src/string.rs
@@ -12,6 +12,7 @@ use crate::{
 
 define_metric!(StringMetric => STRING_METRICS {
     new           -> glean_new_string_metric(),
+    test_get_num_recorded_errors -> glean_string_test_get_num_recorded_errors,
     destroy       -> glean_destroy_string_metric,
 });
 

--- a/glean-core/ffi/src/string_list.rs
+++ b/glean-core/ffi/src/string_list.rs
@@ -13,6 +13,7 @@ use crate::{
 
 define_metric!(StringListMetric => STRING_LIST_METRICS {
     new           -> glean_new_string_list_metric(),
+    test_get_num_recorded_errors -> glean_string_list_test_get_num_recorded_errors,
     destroy       -> glean_destroy_string_list_metric,
 });
 

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -10,6 +10,7 @@ use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
 
 define_metric!(TimespanMetric => TIMESPAN_METRICS {
     new           -> glean_new_timespan_metric(time_unit: i32),
+    test_get_num_recorded_errors -> glean_timespan_test_get_num_recorded_errors,
     destroy       -> glean_destroy_timespan_metric,
 });
 

--- a/glean-core/ffi/src/timing_distribution.rs
+++ b/glean-core/ffi/src/timing_distribution.rs
@@ -13,6 +13,7 @@ use glean_core::metrics::TimerId;
 
 define_metric!(TimingDistributionMetric => TIMING_DISTRIBUTION_METRICS {
     new           -> glean_new_timing_distribution_metric(time_unit: i32),
+    test_get_num_recorded_errors -> glean_timing_distribution_test_get_num_recorded_errors,
     destroy       -> glean_destroy_timing_distribution_metric,
 });
 

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -49,6 +49,11 @@ uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
 
 void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
 
+int32_t glean_counter_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                   uint64_t metric_id,
+                                                   int32_t error_type,
+                                                   FfiStr storage_name);
+
 int32_t glean_counter_test_get_value(uint64_t glean_handle,
                                      uint64_t metric_id,
                                      FfiStr storage_name);
@@ -61,6 +66,11 @@ void glean_custom_distribution_accumulate_samples(uint64_t glean_handle,
                                                   uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
+
+int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                               uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 char *glean_custom_distribution_test_get_value_as_json_string(uint64_t glean_handle,
                                                               uint64_t metric_id,
@@ -80,6 +90,11 @@ void glean_datetime_set(uint64_t glean_handle,
                         uint32_t second,
                         int64_t nano,
                         int32_t offset_seconds);
+
+int32_t glean_datetime_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                    uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
 
 char *glean_datetime_test_get_value_as_string(uint64_t glean_handle,
                                               uint64_t metric_id,
@@ -136,6 +151,11 @@ void glean_event_record(uint64_t glean_handle,
                         RawStringArray extra_values,
                         int32_t extra_len);
 
+int32_t glean_event_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                 uint64_t metric_id,
+                                                 int32_t error_type,
+                                                 FfiStr storage_name);
+
 char *glean_event_test_get_value_as_json_string(uint64_t glean_handle,
                                                 uint64_t metric_id,
                                                 FfiStr storage_name);
@@ -173,6 +193,11 @@ void glean_memory_distribution_accumulate_samples(uint64_t glean_handle,
                                                   uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
+
+int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                               uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 char *glean_memory_distribution_test_get_value_as_json_string(uint64_t glean_handle,
                                                               uint64_t metric_id,
@@ -320,6 +345,11 @@ char *glean_ping_collect(uint64_t glean_handle, uint64_t ping_type_handle);
 
 void glean_quantity_set(uint64_t glean_handle, uint64_t metric_id, int64_t value);
 
+int32_t glean_quantity_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                    uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
+
 int64_t glean_quantity_test_get_value(uint64_t glean_handle,
                                       uint64_t metric_id,
                                       FfiStr storage_name);
@@ -357,6 +387,11 @@ void glean_string_list_set(uint64_t glean_handle,
                            RawStringArray values,
                            int32_t values_len);
 
+int32_t glean_string_list_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                       uint64_t metric_id,
+                                                       int32_t error_type,
+                                                       FfiStr storage_name);
+
 char *glean_string_list_test_get_value_as_json_string(uint64_t glean_handle,
                                                       uint64_t metric_id,
                                                       FfiStr storage_name);
@@ -366,6 +401,11 @@ uint8_t glean_string_list_test_has_value(uint64_t glean_handle,
                                          FfiStr storage_name);
 
 void glean_string_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+
+int32_t glean_string_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                  uint64_t metric_id,
+                                                  int32_t error_type,
+                                                  FfiStr storage_name);
 
 char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
 
@@ -384,6 +424,11 @@ void glean_timespan_set_raw_nanos(uint64_t glean_handle,
 void glean_timespan_set_start(uint64_t glean_handle, uint64_t metric_id, uint64_t start_time);
 
 void glean_timespan_set_stop(uint64_t glean_handle, uint64_t metric_id, uint64_t stop_time);
+
+int32_t glean_timespan_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                    uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
 
 uint64_t glean_timespan_test_get_value(uint64_t glean_handle,
                                        uint64_t metric_id,
@@ -406,6 +451,11 @@ void glean_timing_distribution_set_stop_and_accumulate(uint64_t glean_handle,
                                                        uint64_t metric_id,
                                                        TimerId timer_id,
                                                        uint64_t stop_time);
+
+int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
+                                                               uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 char *glean_timing_distribution_test_get_value_as_json_string(uint64_t glean_handle,
                                                               uint64_t metric_id,

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -12,8 +12,10 @@
 //! but are not actually used directly, since the `send_in_pings` value needs to match the pings of the metric that is erroring (plus the "metrics" ping),
 //! not some constant value that we could define in `metrics.yaml`.
 
+use std::convert::TryFrom;
 use std::fmt::Display;
 
+use crate::error::{Error, ErrorKind};
 use crate::metrics::CounterMetric;
 use crate::metrics::{combine_base_identifier_and_label, strip_label};
 use crate::CommonMetricData;
@@ -38,6 +40,19 @@ impl ErrorType {
             ErrorType::InvalidValue => "invalid_value",
             ErrorType::InvalidLabel => "invalid_label",
             ErrorType::InvalidState => "invalid_state",
+        }
+    }
+}
+
+impl TryFrom<i32> for ErrorType {
+    type Error = Error;
+
+    fn try_from(value: i32) -> Result<ErrorType, Self::Error> {
+        match value {
+            0 => Ok(ErrorType::InvalidValue),
+            1 => Ok(ErrorType::InvalidLabel),
+            2 => Ok(ErrorType::InvalidState),
+            e => Err(ErrorKind::Lifetime(e).into()),
         }
     }
 }


### PR DESCRIPTION
This is an (incomplete) approach to exposing `testGetNumRecordedErrors` across the FFI.

As you can see, it's going to require quite a bit of busy work across all of the metric types (at least the ones that can record errors).

An alternative approach would be to dynamically upcast to the `MetricType` trait and get a `CommonMetricData` object to pass that to the underlying `test_get_num_recorded_errors` function in `error_recording.rs`.  I think in that event, we'd still need to write an FFI function for every metric type to get a handle to a `CommonMetricData` instance, and all of the ownership complications of having a handle to a part of an object...

Another alternative would be to use a single ConcurrentHandleMap for all metrics that stores `MetricType`, and then dynamically downcast that when making type-specific calls...

Thoughts?  All of these options seem awfully big for the feature...