### PR TITLE
1589743: Don't log pings twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixed a crash calling `start` on a timing distribution metric before Glean is initialized.
   Timings are always measured, but only recorded when upload is enabled.
+  
+* BUGFIX: When the Debug Activity is used to log pings, each ping is now logged only once.
 
 # v19.0.0 (2019-10-22)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -524,8 +524,7 @@ open class GleanInternalAPI internal constructor () {
         val sentPing = LibGleanFFI.INSTANCE.glean_send_pings_by_name(
             handle,
             pingArray,
-            pingArrayLen,
-            (configuration.logPings).toByte()
+            pingArrayLen
         ).toBoolean()
 
         if (sentPing) {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -93,8 +93,7 @@ internal interface LibGleanFFI : Library {
     fun glean_send_pings_by_name(
         glean_handle: Long,
         ping_names: StringArray,
-        ping_names_len: Int,
-        log_ping: Byte
+        ping_names_len: Int
     ): Byte
 
     fun glean_set_experiment_active(

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -332,8 +332,7 @@ void glean_register_ping_type(uint64_t glean_handle, uint64_t ping_type_handle);
 
 uint8_t glean_send_pings_by_name(uint64_t glean_handle,
                                  RawStringArray ping_names,
-                                 int32_t ping_names_len,
-                                 uint8_t log_ping);
+                                 int32_t ping_names_len);
 
 void glean_set_experiment_active(uint64_t glean_handle,
                                  FfiStr experiment_id,

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -189,13 +189,11 @@ pub extern "C" fn glean_send_pings_by_name(
     glean_handle: u64,
     ping_names: RawStringArray,
     ping_names_len: i32,
-    log_ping: u8,
 ) -> u8 {
     GLEAN.call_with_log(glean_handle, |glean| {
-        let log_ping = log_ping != 0;
         let pings = from_raw_string_array(ping_names, ping_names_len)?;
 
-        Ok(glean.send_pings_by_name(&pings, log_ping))
+        Ok(glean.send_pings_by_name(&pings))
     })
 }
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -226,8 +226,7 @@ public class Glean {
                 let sentPing = glean_send_pings_by_name(
                     self.handle,
                     pingNames,
-                    Int32(pingNames?.count ?? 0),
-                    self.configuration!.logPings.toByte()
+                    Int32(pingNames?.count ?? 0)
                 )
 
                 if sentPing != 0 {

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -332,8 +332,7 @@ void glean_register_ping_type(uint64_t glean_handle, uint64_t ping_type_handle);
 
 uint8_t glean_send_pings_by_name(uint64_t glean_handle,
                                  RawStringArray ping_names,
-                                 int32_t ping_names_len,
-                                 uint8_t log_ping);
+                                 int32_t ping_names_len);
 
 void glean_set_experiment_active(uint64_t glean_handle,
                                  FfiStr experiment_id,

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -140,7 +140,7 @@ impl EventDatabase {
 
         let mut ping_sent = false;
         for store_name in store_names {
-            if let Err(err) = glean.send_ping_by_name(&store_name, false) {
+            if let Err(err) = glean.send_ping_by_name(&store_name) {
                 log::error!(
                     "Error flushing existing events to the '{}' ping: {}",
                     store_name,
@@ -199,7 +199,7 @@ impl EventDatabase {
         // If any of the event stores reached maximum size, send the pings
         // containing those events immediately.
         for store_name in stores_to_send {
-            if let Err(err) = glean.send_ping_by_name(store_name, false) {
+            if let Err(err) = glean.send_ping_by_name(store_name) {
                 log::error!(
                     "Got more than {} events, but could not send {} ping: {}",
                     glean.get_max_events(),

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -38,12 +38,11 @@ impl PingType {
     /// ## Arguments
     ///
     /// * `glean` - the Glean instance to use to send the ping.
-    /// * `log_ping` - whether to log the ping after assembly.
     ///
     /// ## Return value
     ///
     /// See [`Glean#send_ping`](../struct.Glean.html#method.send_ping) for details.
-    pub fn send(&self, glean: &Glean, log_ping: bool) -> Result<bool> {
-        glean.send_ping(self, log_ping)
+    pub fn send(&self, glean: &Glean) -> Result<bool> {
+        glean.send_ping(self)
     }
 }

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -24,7 +24,7 @@ fn write_ping_to_disk() {
     });
     counter.add(&glean, 1);
 
-    assert!(ping.send(&glean, true).unwrap());
+    assert!(ping.send(&glean).unwrap());
 
     assert_eq!(1, get_queued_pings(glean.get_data_path()).unwrap().len());
 }
@@ -45,7 +45,7 @@ fn disabling_upload_clears_pending_pings() {
     });
 
     counter.add(&glean, 1);
-    assert!(ping.send(&glean, true).unwrap());
+    assert!(ping.send(&glean).unwrap());
     assert_eq!(1, get_queued_pings(glean.get_data_path()).unwrap().len());
 
     glean.set_upload_enabled(false);
@@ -55,6 +55,6 @@ fn disabling_upload_clears_pending_pings() {
     assert_eq!(0, get_queued_pings(glean.get_data_path()).unwrap().len());
 
     counter.add(&glean, 1);
-    assert!(ping.send(&glean, true).unwrap());
+    assert!(ping.send(&glean).unwrap());
     assert_eq!(1, get_queued_pings(glean.get_data_path()).unwrap().len());
 }

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -171,7 +171,7 @@ fn test_clear_pending_pings() {
     });
     metric.set(&glean, true);
 
-    assert!(glean.send_ping(&ping_type, false).is_ok());
+    assert!(glean.send_ping(&ping_type).is_ok());
     assert_eq!(1, get_queued_pings(glean.get_data_path()).unwrap().len());
 
     assert!(ping_maker


### PR DESCRIPTION
This now matches the behavior of glean-ac (logging from the uploader)