### PR TITLE
Prepare for next release cycle

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 19.0.0
+libraryVersion: 20.0.0-SNAPSHOT
 groupId: org.mozilla.telemetry
 projects:
   glean-core:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "19.0.0"
+version = "20.0.0-alpha.0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -257,12 +257,12 @@ dependencies = [
 
 [[package]]
 name = "glean-ffi"
-version = "19.0.0"
+version = "20.0.0-alpha.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 19.0.0",
+ "glean-core 20.0.0-alpha.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/docs/dev/cut-a-new-release.md
+++ b/docs/dev/cut-a-new-release.md
@@ -20,7 +20,10 @@ These are the steps needed to cut a new release from latest master.
 
     2. Add a new `# Unreleased Changes` on top
 
-2. Bump `libraryVersion` in the top-level [.buildconfig.yml](https://github.com/mozilla/glean/blob/master/.buildconfig.yml) file. Be sure you're following semver, and if in doubt, ask.
+2. Bump the versions
+    * Rust crates: Bump `version` in [`glean-core/Cargo.toml`](https://github.com/mozilla/glean/blob/master/glean-core/Cargo.toml) and [`glean-core/Cargo.toml`](https://github.com/mozilla/glean/blob/master/glean-core/ffi/Cargo.toml).
+    * Kotlin package: Bump `libraryVersion` in the top-level [.buildconfig.yml](https://github.com/mozilla/glean/blob/master/.buildconfig.yml) file.
+    * Be sure you're following semver, and if in doubt, ask.
 3. Land the commits that perform the steps above. This takes a PR, typically, because of branch protection on master.
 4. Cut the actual release.
     1. Click "Releases", and then "Draft a New Release" in the github UI.
@@ -28,3 +31,6 @@ These are the steps needed to cut a new release from latest master.
     3. Under the description, paste the contents of the release notes from `CHANGELOG.md`.
     4. Note that the release is not available until the CI build completes for that tag.
         - You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla/glean).
+5. After the release, bump the versions to the next pre-release:
+    * Rust crates: Use the next major version and append `-alpha.1`
+    * Kotlin package: Use the next major version and append `-SNAPSHOT`

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "19.0.0"
+version = "20.0.0-alpha.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "glean-ffi"
-edition = "2018"
-version = "19.0.0"
+version = "20.0.0-alpha.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
+description = "FFI layer for Glean, a modern Telemetry library"
+repository = "https://github.com/mozilla/glean"
+readme = "README.md"
+license = "MPL-2.0"
+edition = "2018"
 
 [lib]
 name = "glean_ffi"


### PR DESCRIPTION
For local development and easy testing in a-c and Fenix we should have a version number bigger than the released one.

The gradle/maven way is to `major+1` + `-SNAPSHOT`.
The Rust/semver way is to `major+1` + `-alpha.0` (less relevant, as we don't push to crates.io just yet).

I would totally expect that we go `19.1.0` next first, but that's for the release to decide. 