### PR TITLE
1586736 - Add Glean-iOS debug functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ samples/ios/app/.venv/
 .mypy_cache/
 .coverage
 htmlcov/
+*.log

--- a/docs/user/debugging.md
+++ b/docs/user/debugging.md
@@ -1,4 +1,24 @@
-# Debugging products using the Glean SDK for Android
+# Debugging products using the Glean SDK
+
+## Contents
+
+1. [Debugging the Glean SDK in Android](#debugging-the-glean-sdk-in-android)
+2. [Debugging the Glean SDK in iOS](#debugging-the-glean-sdk-in-ios)
+
+### Important considerations when using Glean SDK debug tools
+
+- Options that are set using the adb flags are not immediately reset and will persist until the application is closed or manually reset.
+
+- There are a couple different ways in which to send pings using the Glean SDK debug tools.
+    1. You can tag pings using the debug tools and trigger them manually using the UI.  This should always produce a ping with all required fields.
+    2. You can tag _and_ send pings using the debug tools.  This has the side effect of potentially sending a ping which does not include all fields because `sendPings` triggers pings to be sent before certain application behaviors can occur which would record that information.  For example, `duration` is not calculated or included in a baseline ping sent with `sendPing` because it forces the ping to be sent before the `duration` metric has been recorded.  Keep in mind that there may be nothing to send, in which case no ping is generated.
+    3. You can trigger a command while the instrumented application is still running.  This is useful for toggling commands or for triggering pings that have schedules that are difficult to trigger manually.  This is especially useful if you need to trigger a ping submission after some activity within the application, such as with the metrics ping.
+
+### Glean Log messages
+
+Glean logs warnings and errors through the platform-specific logging frameworks.  See the platform-specific instructions for information on how to view the logs.
+
+## Debugging the Glean SDK in Android
 
 The Glean SDK exports the `GleanDebugActivity` that can be used to toggle debugging features on or off.
 Users can invoke this special activity, at run-time, using the following [`adb`](https://developer.android.com/studio/command-line/adb) command:
@@ -25,7 +45,7 @@ In the above:
 
 For example, to direct a release build of the Glean sample application to (1) dump pings to logcat, (2) tag the ping with the `test-metrics-ping` tag, and (3) send the "metrics" ping immediately, the following command can be used:
 
-```
+```shell
 adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.GleanDebugActivity \
   --ez logPings true \
   --es sendPing metrics \
@@ -35,27 +55,19 @@ adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.Gl
 > **Note:** In previous versions of Glean the activity was available with the name `mozilla.components.service.glean.debug.GleanDebugActivity`.
 >
 > If you're debugging an old build, try running:
-> ```
+>
+> ```shell
 > adb shell am start -n org.mozilla.samples.glean/mozilla.components.service.glean.debug.GleanDebugActivity \
 >   --ez logPings true \
 >   --es sendPing metrics \
 >   --es tagPings test-metrics-ping
 > ```
 
-### Important GleanDebugActivity notes!
+### Glean Log messages
 
-- Options that are set using the adb flags are not immediately reset and will persist until the application is closed or manually reset.
-
-- There are a couple different ways in which to send pings through the GleanDebugActivity.
-    1. You can use the `GleanDebugActivity` in order to tag pings and trigger them manually using the UI.  This should always produce a ping with all required fields.
-    2. You can use the `GleanDebugActivity` to tag _and_ send pings.  This has the side effect of potentially sending a ping which does not include all fields because `sendPings` triggers pings to be sent before certain application behaviors can occur which would record that information.  For example, `duration` is not calculated or included in a baseline ping sent with `sendPing` because it forces the ping to be sent before the `duration` metric has been recorded.
-
-## Glean Log messages
-
-Glean logs warnings and errors through the Android logging framework.
 When running a Glean-powered app in the Android emulator or on a device connected to your computer via cable, there are several ways to read the log output.
 
-### Android Studio
+#### Android Studio
 
 Android Studio can show the logs of a connected emulator or device.
 To display the log messages for an app:
@@ -71,28 +83,143 @@ More information can be found in the [View Logs with Logcat][] help article.
 
 [View Logs with Logcat]: https://developer.android.com/studio/debug/am-logcat
 
-### Command line
+#### Command line
 
 On the command line you can show all of the log output using:
 
-```
+```shell
 adb logcat
 ```
 
 This is the unfiltered output of all log messages.
 You can match for `glean` using grep:
 
-```
+```shell
 adb logcat | grep -i glean
 ```
 
 A simple way to filter for only the application that is being debugged is by using [pidcat][], a wrapper around `adb`, which adds colors and proper filtering by application ID and log level.
 Run it like this to filter for an application:
 
-```
+```shell
 pidcat [applicationId]
 ```
 
 In the above `[applicationId]` is the product's application id as defined in the manifest file and/or build script. For the Glean sample application, this is `org.mozilla.samples.glean` for a release build and `org.mozilla.samples.glean.debug` for a debug build.
 
 [pidcat]: https://github.com/JakeWharton/pidcat
+
+## Debugging the Glean SDK in iOS
+
+For debugging and validation purposes on iOS, Glean makes use of a custom URL scheme which is implemented _within the application_ that is consuming Glean.  Glean provides some convenience functions to facilitate this, but it's up to the consuming application to enable this functionality.  Applications that enable this Glean SDK feature will be able to launch the application from a URL with the Glean debug commands embedded in the URL itself.
+
+### Available commands and query format
+
+There are 3 available commands that you can use with the Glean SDK debug tools
+
+- `logPings`: This is either true or false and will cause pings that are submitted to also be echoed to the device's log
+- `tagPings`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters.
+- `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
+
+The structure of the custom URL uses the following format:
+
+`<protocol>://glean?<command 1>=<paramter 1>&<command 2>=<parameter 2> ...`
+
+Where:
+
+- `<protocol>` is the "Url Scheme" that has been added for your app (see Instrumenting the application below), such as `glean-sample-app`.
+- This is followed by `://` and then `glean` which is required for the Glean SDK to recognize the command is meant for it to process.
+- Following standard URL query format, the next character after `glean` is the `?` indicating the beginning of the query.
+- This is followed by one or more queries in the form of `<command>=<parameter>`, where the command is one of the commands listed above, followed by an `=` and then the value or parameter to be used with the command.
+
+There are a few things to consider when creating the custom URL:  
+
+- Invalid commands will log an error and cause the entire url to be ignored.
+- Not all commands are required to be encoded in the URL, you can mix and match the commands that you need.
+- Multiple instances of commands are not allowed in the same url and, if present, will cause the entire url to be ignored.
+
+### Instrumenting the application for Glean debug functionality
+
+In order to enable the debugging features in a Glean SDK consuming iOS application, it is necessary to add some information to the application's `Info.plist`, and add a line and possibly an override for a function in the `AppDelegate.swift`.
+
+#### Register custom URL scheme in `Info.plist`
+
+> **Note:** If your application already has a custom URL scheme implemented, there is no need to implement a second scheme, you can simply use that and skip to the next section about adding the convenience method.  If the app doesn't have a custom URL scheme implemented, then you will need to perform the following instructions to register your app to recieve custom URLs.
+
+Find and open the application's `Info.plist` and right click any blank area and select `Add Row` to create a new key.
+
+You will be prompted to select a key from a drop-down menu, scroll down to and select `URL types`.  This creates an array item, which can be expanded by clicking the triangle disclosure icon.
+
+Select `Item 0`, click on it and click the disclosure icon to expand it and show the `URL identifier` line.  Double-click the value field and fill in your identifier, typically the same as the bundle ID.
+
+Right-click on `Item 0` and select `Add Row` from the context menu.  In the dropdown menu, select `URL Schemes` to add the item.
+
+Click on the disclosure icon of `URL Schemes` to expand the item, double-click the value field of `Item 0` and key in the value for your application's custom scheme.  For instance, the Glean sample app uses `glean-sample-app`, which allows for custom URL's to be crafted using that as a protocol, for example: `glean-sample-app://glean?logPings=true`
+
+#### Add the `Glean.handleCustomUrl()` convenience function and necessary overrides
+
+In order to handle the incoming Glean SDK debug commands, it is necessary to implement the override in the application's `AppDelegate.swift` file.  Within that function, you can make use of the convenience function provided in Glean `handleCustomUrl(url: URL)`.  
+
+An example of a simple implementation of this would look like this:
+
+```Swift
+func application(_: UIApplication,
+                 open url: URL,
+                 options _: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    // ...
+
+    // This does nothing if the url isn't meant for Glean.
+    Glean.shared.handleCustomUrl(url: url)
+
+    // ...
+
+    return true
+}
+```
+
+If you need additional help setting up a custom URL scheme in your application, please refer to [Apple's documentation](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app).
+
+### Invoking the Glean-iOS debug commands
+
+Now that the app has the Glean SDK debug functionality enabled, there are a few ways in which we can invoke the debug commands.
+
+#### Using a web browser
+
+Perhaps the simplest way to invoke the Glean SDK debug functionality is to open a web browser and type/paste the custom URL into the address bar.  This is especially useful on an actual device because there isn't a good way to launch from the command line and process the URL for an actual device.
+
+Using the glean-sample-app as an example: to activate ping logging, tag the pings to go to the Glean Debug View, and force the `events` ping to be sent, enter the following URL in a web browser on the iOS device:
+
+```shell
+glean-sample-app://glean?logPings=true&tagPings=My-ping-tag&sendPing=events
+```
+
+This should cause iOS to prompt you with a dialog asking if you want to open the URL in the Glean Sample App, and if you select "Okay" then it will launch (or resume if it's already running) the application with the indicated commands and parameters and immediately force the collection and submission of the events ping.
+
+> **Note:** This method does not work if the browser you are using to input the command is the same application you are attempting to pass the Glean debug commands to.  So, you couldn't use Firefox for iOS to trigger commands within Firefox for iOS.
+
+It is also possible to encode the URL into a 2D barcode or QR code and launch the app via the camera app.  After scanning the encoded URL, the dialog prompting to launch the app should appear as if the URL were entered into the browser address bar.
+
+#### Using the command line
+
+This method is useful for testing via the Simulator, which typically requires a Mac with Xcode installed, including the Xcode command line tools.  In order to perform the same command as above with using the browser to input the URL, you can use the following command in the command line terminal of the Mac:
+
+```shell
+xcrun simctl openurl booted "glean-sample-app://glean?logPings=true&tagPings=My-ping-tag&sendPing=events"
+```
+
+This will launch the simulator and again prompt the user with a dialog box asking if you want to open the URL in the Glean Sample App (or whichever app you are instrumenting and testing).
+
+### Glean log messages
+
+If debugging in the simulator, the logging messages can be seen in the console window within Xcode.
+
+When running a Glean-powered app in the iOS Simulator or on a device connected to your computer via cable, the following steps will help in getting the logs:
+
+1. Plug in the device and open Xcode
+2. Choose Window -> Devices from the menu bar
+3. Under the DEVICES section in the left column, choose the device
+4. To see the device console, click the up-triangle at the bottom left of the right hand panel
+
+> **Note:** It is helpful to filter the console window by adding the keyword "glean" to the filter box.  This will allow you to see only messages generated by the Glean SDK.
+
+You can refer to [this Apple technical Q&A](https://developer.apple.com/library/archive/qa/qa1747/_index.html) for more information about debugging deployed iOS apps.

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F39E7B0239F0505009B13B3 /* GleanDebugTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F39E7AF239F0505009B13B3 /* GleanDebugTools.swift */; };
+		1F39E7B3239F0777009B13B3 /* GleanDebugUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F39E7B2239F0777009B13B3 /* GleanDebugUtilityTests.swift */; };
 		1F6058932314863400307A9F /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6058922314863400307A9F /* Configuration.swift */; };
 		1F605895231489AB00307A9F /* HttpPingUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F605894231489AB00307A9F /* HttpPingUploader.swift */; };
 		1F60589723148BF800307A9F /* GleanLifecycleObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F60589623148BF800307A9F /* GleanLifecycleObserver.swift */; };
@@ -75,6 +77,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F39E7AF239F0505009B13B3 /* GleanDebugTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanDebugTools.swift; sourceTree = "<group>"; };
+		1F39E7B2239F0777009B13B3 /* GleanDebugUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanDebugUtilityTests.swift; sourceTree = "<group>"; };
 		1F6058922314863400307A9F /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		1F605894231489AB00307A9F /* HttpPingUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpPingUploader.swift; sourceTree = "<group>"; };
 		1F60589623148BF800307A9F /* GleanLifecycleObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanLifecycleObserver.swift; sourceTree = "<group>"; };
@@ -159,6 +163,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F39E7AE239F04D3009B13B3 /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				1F39E7AF239F0505009B13B3 /* GleanDebugTools.swift */,
+			);
+			path = Debug;
+			sourceTree = "<group>";
+		};
+		1F39E7B1239F0741009B13B3 /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				1F39E7B2239F0777009B13B3 /* GleanDebugUtilityTests.swift */,
+			);
+			path = Debug;
+			sourceTree = "<group>";
+		};
 		1F60588D231483D600307A9F /* Scheduler */ = {
 			isa = PBXGroup;
 			children = (
@@ -249,6 +269,7 @@
 		BF3DE3932243A2F20018E23F /* Glean */ = {
 			isa = PBXGroup;
 			children = (
+				1F39E7AE239F04D3009B13B3 /* Debug */,
 				97C5C1A223708C1E00B79C93 /* Testing */,
 				1F6058912314861B00307A9F /* Config */,
 				BF3227D723336CF800CD0111 /* Generated */,
@@ -269,6 +290,7 @@
 		BF3DE39E2243A2F20018E23F /* GleanTests */ = {
 			isa = PBXGroup;
 			children = (
+				1F39E7B1239F0741009B13B3 /* Debug */,
 				1FB8F8392326EBA500618E47 /* Config */,
 				BF43A8CB232A613100545310 /* Metrics */,
 				BF80AA5923992FFB00A8B172 /* Net */,
@@ -572,6 +594,7 @@
 				BF30FDC4233260B500840607 /* TimespanMetric.swift in Sources */,
 				BFE1CDCE233B989A0019EE47 /* GleanMetrics.swift in Sources */,
 				BF6C53B2232F870C00E3B43A /* Ping.swift in Sources */,
+				1F39E7B0239F0505009B13B3 /* GleanDebugTools.swift in Sources */,
 				BFB59A9F2342A24000F40CA8 /* GleanInternalMetrics.swift in Sources */,
 				97C5C1A423708C6700B79C93 /* ErrorType.swift in Sources */,
 				BF10007E23548AF400064051 /* MemoryUnit.swift in Sources */,
@@ -585,6 +608,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F39E7B3239F0777009B13B3 /* GleanDebugUtilityTests.swift in Sources */,
 				BFAED50A2369752400DF293D /* StringListMetricTests.swift in Sources */,
 				BF890561232BC227003CA2BA /* StringMetricTests.swift in Sources */,
 				1FD4527723395EEB00F4C7E8 /* UuidMetricTests.swift in Sources */,

--- a/glean-core/ios/Glean/Config/Configuration.swift
+++ b/glean-core/ios/Glean/Config/Configuration.swift
@@ -7,9 +7,9 @@
 public struct Configuration {
     let serverEndpoint: String
     let userAgent: String
-    let logPings: Bool
+    var logPings: Bool
     let maxEvents: Int32?
-    let pingTag: String?
+    var pingTag: String?
     let channel: String?
 
     struct Constants {

--- a/glean-core/ios/Glean/Debug/GleanDebugTools.swift
+++ b/glean-core/ios/Glean/Debug/GleanDebugTools.swift
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/// This class is meant to encapsulate the Glean debug functionality.
+class GleanDebugUtility {
+    // This struct is used for organizational purposes to keep the class constants in a single place
+    struct Constants {
+        static let logTag = "glean/GleanDebugUtility"
+        // Since ping tags are transmitted via HTTP in a header, and since they are displayed to the
+        // user on the Glean Debug View, we need to constrain the tag to a safe character set and
+        // limit the length to prevent possible attack vectors.
+        static let pingTagRegexPattern = "^[a-zA-Z0-9-]{1,20}$"
+    }
+
+    private static let logger = Logger(tag: Constants.logTag)
+
+    /// When applications are launched using the custom URL scheme, this helper function will process
+    /// the URL and parse the debug commands
+    ///
+    /// - parameters:
+    ///     * url: A `URL` object containing the Glean debug commands as query parameters
+    ///
+    /// There are 3 available commands that you can use with the Glean SDK debug tools
+    ///
+    /// - `logPings`: If "true", will cause pings that are submitted to also be echoed to the device's log
+    /// - `tagPings`:  This command expects a string to tag the pings with and redirects them to the Glean Debug View
+    /// - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
+    ///
+    /// The structure of the custom URL uses the following format:
+    ///
+    /// `<protocol>://glean?<command 1>=<paramter 1>&<command 2>=<parameter 2> ...`
+    ///
+    /// Where:
+    ///
+    /// - `<protocol>://` is the "Url Scheme" that has been added for the app and doesn't matter to Glean.
+    /// - `glean` is required for the Glean SDK to recognize the command is meant for it to process.
+    /// - `?` indicating the beginning of the query.
+    /// - `<command>=<parameter>` are instances of the commands listed above  separated by `&`.
+    ///
+    /// There are a few things to consider when creating the custom URL:
+    ///
+    /// - Invalid commands will trigger an error and be ignored.
+    /// - Not all commands are requred to be encoded in the URL, you can mix and match the commands that you need.
+    /// - Special characters should be properly URL encoded and escaped since this needs to represent a valid URL.
+    static func handleCustomUrl(url: URL) {
+        guard url.host?.removingPercentEncoding == "glean" else {
+            return
+        }
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+            let params = components.queryItems else {
+            logger.error("Error parsing query parameters, aborting Glean debugging tools")
+            return
+        }
+
+        if let parsedCommands = processCustomUrlQuery(urlQueryItems: params) {
+            if let tag = parsedCommands.pingTag {
+                Glean.shared.configuration?.pingTag = tag
+                logger.debug("Pings tagged with: \(tag)")
+            }
+
+            if let logPings = parsedCommands.logPings {
+                Glean.shared.configuration?.logPings = logPings
+                logger.debug("Log pings set to: \(logPings)")
+            }
+
+            if let pingName = parsedCommands.pingNameToSend {
+                Glean.shared.sendPingsByName(pingNames: [pingName])
+                logger.debug("Glean debug tools triggered ping: \(pingName)")
+            }
+        }
+    }
+
+    /// A simple struct to represent the commands parsed from the custom URL
+    private struct ParsedQueryCommands {
+        let pingTag: String?
+        let logPings: Bool?
+        let pingNameToSend: String?
+    }
+
+    /// Helper function to process parameters passed as a query to the custom URL processed by `handleCustomUrl`
+    ///
+    /// - parameters:
+    ///     * urlQueryItems: A `URLQueryItem` representing the commands passed to Glean
+    ///
+    /// - returns: A tuple containing the values of the parameters `pingTag`, `logPings`, `pingNamesToSend` or nil
+    ///     when invalid or duplicated commands are detected.
+    private static func processCustomUrlQuery(urlQueryItems: [URLQueryItem]) -> ParsedQueryCommands? {
+        var pingTagName: String?
+        var willLogPings: Bool?
+        var pingToSend: String?
+
+        for param in urlQueryItems {
+            if param.value == nil {
+                logger.error("Empty values are unsupported, aborting Glean debug tools")
+                return nil
+            }
+
+            switch param.name {
+            case "tagPings":
+                if pingTagName != nil {
+                    logger.error(
+                        "Multiple `tagPings` commands not allowed, aborting Glean debug tools")
+                    return nil
+                }
+
+                if !param.value!.matches(Constants.pingTagRegexPattern) {
+                    logger.error("Invalid ping tag name, aborting Glean debug tools")
+                    return nil
+                }
+
+                pingTagName = param.value
+            case "logPings":
+                if willLogPings != nil {
+                    logger.error("Multiple `logPings` commands not allowed, aborting Glean debug tools")
+                    return nil
+                }
+
+                // If param.value is any string other than "true" or "false", the result is nil.
+                // This initializer is case sensitive. See Apple docs for more info at:
+                // https://developer.apple.com/documentation/swift/bool
+                willLogPings = Bool(param.value!)
+            case "sendPing":
+                if pingToSend != nil {
+                    logger.error("Multiple `sendPing` commands not allowed, aborting Glean debug tools")
+                    return nil
+                }
+
+                pingToSend = param.value
+            default:
+                logger.error("Unknown parameter passed to Glean.handleCustomUrl, aborting Glean debug tools")
+                return nil
+            }
+        }
+
+        return ParsedQueryCommands(
+            pingTag: pingTagName,
+            logPings: willLogPings,
+            pingNameToSend: pingToSend
+        )
+    }
+}

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -25,7 +25,7 @@ public class Glean {
 
     var handle: UInt64 = 0
     private var uploadEnabled: Bool = true
-    private var configuration: Configuration?
+    var configuration: Configuration?
     private var observer: GleanLifecycleObserver?
 
     // This struct is used for organizational purposes to keep the class constants in a single place
@@ -280,6 +280,38 @@ public class Glean {
         } else {
             glean_register_ping_type(self.handle, pingType.handle)
         }
+    }
+
+    /// When applications are launched using the custom URL scheme, this helper function will process
+    /// the URL and parse the debug commands
+    ///
+    /// - parameters:
+    ///     * url: A `URL` object containing the Glean debug commands as query parameters
+    ///
+    /// There are 3 available commands that you can use with the Glean SDK debug tools
+    ///
+    /// - `logPings`: If "true", will cause pings that are submitted to also be echoed to the device's log
+    /// - `tagPings`:  This command expects a string to tag the pings with and redirects them to the Glean Debug View
+    /// - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
+    ///
+    /// The structure of the custom URL uses the following format:
+    ///
+    /// `<protocol>://glean?<command 1>=<paramter 1>&<command 2>=<parameter 2> ...`
+    ///
+    /// Where:
+    ///
+    /// - `<protocol>://` is the "Url Scheme" that has been added for the app and doesn't matter to Glean.
+    /// - `glean` is required for the Glean SDK to recognize the command is meant for it to process.
+    /// - `?` indicating the beginning of the query.
+    /// - `<command>=<parameter>` are instances of the commands listed above  separated by `&`.
+    ///
+    /// There are a few things to consider when creating the custom URL:
+    ///
+    /// - Invalid commands will trigger an error and be ignored.
+    /// - Not all commands are requred to be encoded in the URL, you can mix and match the commands that you need.
+    /// - Special characters should be properly URL encoded and escaped since this needs to represent a valid URL.
+    public func handleCustomUrl(url: URL) {
+        GleanDebugUtility.handleCustomUrl(url: url)
     }
 
     /// PUBLIC TEST ONLY FUNCTION.

--- a/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
+++ b/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Glean
+import OHHTTPStubs
+import XCTest
+
+class GleanDebugUtilityTests: XCTestCase {
+    var expectation: XCTestExpectation?
+
+    override func setUp() {
+        Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
+    }
+
+    override func tearDown() {
+        Glean.shared.setUploadEnabled(true)
+    }
+
+    private func setupHttpResponseStub(statusCode: Int32 = 200) {
+        expectation = expectation(description: "Ping sent")
+        // This function will be handling one each of baseline, events, and metrics pings
+        // so we set the expected count to 3 and set it to assert for overfulfill in order
+        // to test that unknown pings aren't being sent.
+        expectation!.expectedFulfillmentCount = 3
+        expectation!.assertForOverFulfill = true
+        let host = URL(string: Configuration.Constants.defaultTelemetryEndpoint)!.host!
+        stub(condition: isHost(host)) { data in
+            let body = (data as NSURLRequest).ohhttpStubs_HTTPBody()
+            let json = try! JSONSerialization.jsonObject(with: body!, options: []) as? [String: Any]
+            XCTAssert(json != nil)
+            let pingType = (json?["ping_info"] as? [String: Any])!["ping_type"] as? String
+            XCTAssertTrue(Glean.shared.testHasPingType(pingType!))
+
+            self.expectation!.fulfill()
+
+            return OHHTTPStubsResponse(
+                jsonObject: [],
+                statusCode: statusCode,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+    }
+
+    func testHandleCustomUrlTagPings() {
+        // Check invalid tags: This should have the configuration keep the
+        // default value of nil because they don't match the accepted
+        // regex for ping tag names.
+        var url = URL(string: "test://glean?tagPings=This-tag-is-not-valid-because-it-is-too-long")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertNil(Glean.shared.configuration?.pingTag)
+
+        url = URL(string: "test://glean?tagPings=Invalid_Chars@!!$")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertNil(Glean.shared.configuration?.pingTag)
+
+        // Check valid tag: This should update the pingTag value of the
+        // configuration object.
+        url = URL(string: "test://glean?tagPings=Glean-Ping")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertEqual("Glean-Ping", Glean.shared.configuration?.pingTag)
+    }
+
+    func testHandleCustomUrlLogPings() {
+        // Test initial state
+        XCTAssertFalse(Glean.shared.configuration!.logPings)
+
+        // Test toggle true
+        var url = URL(string: "test://glean?logPings=true")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertTrue(Glean.shared.configuration!.logPings)
+
+        // Test invalid value doesn't cause setting to toggle
+        var previousValue = Glean.shared.configuration?.logPings
+        url = URL(string: "test://glean?logPings=Not-a-bool")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertEqual(previousValue, Glean.shared.configuration!.logPings)
+
+        // Test toggle false
+        url = URL(string: "test://glean?logPings=false")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertFalse(Glean.shared.configuration!.logPings)
+
+        // Test invalid value doesn't cause setting to toggle
+        previousValue = Glean.shared.configuration?.logPings
+        url = URL(string: "test://glean?logPings=Not-a-bool")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertEqual(previousValue, Glean.shared.configuration!.logPings)
+    }
+
+    func testHandleCustomUrlWrongHost() {
+        // This should NOT set the logPings to true or false because it doesn't
+        // match the required host "glean".
+        let url = URL(string: "test://not-glean?logPings=true")
+        Glean.shared.handleCustomUrl(url: url!)
+        XCTAssertEqual(false, Glean.shared.configuration?.logPings)
+    }
+
+    func testHandleCustomUrlSendPing() {
+        setupHttpResponseStub()
+
+        // Create a dummy event and a dummy metric so that the
+        // respective pings will be sent
+        let event = EventMetricType<ClickKeys>(
+            category: "ui",
+            name: "click",
+            sendInPings: ["events"],
+            lifetime: .ping,
+            disabled: false,
+            allowedExtraKeys: ["object_id", "other"]
+        )
+        event.record()
+
+        let metric = CounterMetricType(
+            category: "telemetry",
+            name: "counter_metric",
+            sendInPings: ["metrics"],
+            lifetime: .application,
+            disabled: false
+        )
+        metric.add()
+
+        // Send the baseline ping via the custom URL
+        var url = URL(string: "test://glean?sendPing=baseline")
+        Glean.shared.handleCustomUrl(url: url!)
+
+        // Send the events ping via the custom URL
+        url = URL(string: "test://glean?sendPing=events")
+        Glean.shared.handleCustomUrl(url: url!)
+
+        // Send the metrics ping via the custom URL
+        url = URL(string: "test://glean?sendPing=metrics")
+        Glean.shared.handleCustomUrl(url: url!)
+
+        // Sending a non-registered ping does nothing, if it did it would cause
+        // the assert on overfulfull to trigger
+        url = URL(string: "test://glean?sendPing=no-such-ping")
+        Glean.shared.handleCustomUrl(url: url!)
+
+        waitForExpectations(timeout: 5.0) { error in
+            XCTAssertNil(error, "Test timed out waiting for baseline ping: \(error!)")
+        }
+    }
+}

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -3,11 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @testable import Glean
+import OHHTTPStubs
 import XCTest
 
 class GleanTests: XCTestCase {
     override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
     }
 
     override func tearDown() {
@@ -15,10 +17,8 @@ class GleanTests: XCTestCase {
     }
 
     func testInitializeGlean() {
-        let glean = Glean.shared
-
-        glean.initialize()
-        XCTAssert(glean.isInitialized(), "Glean should be initialized")
-        XCTAssert(glean.getUploadEnabled(), "Upload is enabled by default")
+        // Glean is already initialized by the `setUp()` function
+        XCTAssert(Glean.shared.isInitialized(), "Glean should be initialized")
+        XCTAssert(Glean.shared.getUploadEnabled(), "Upload is enabled by default")
     }
 }

--- a/samples/ios/app/glean-sample-app/AppDelegate.swift
+++ b/samples/ios/app/glean-sample-app/AppDelegate.swift
@@ -13,11 +13,10 @@ typealias Pings = GleanMetrics.Pings
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
+    let glean = Glean.shared
 
     // swiftlint:disable line_length
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        let glean = Glean.shared
-
         glean.registerPings(Pings.shared)
         glean.setUploadEnabled(true)
 
@@ -35,6 +34,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Set a sample value for a metric.
         Basic.os.set("iOS")
+
+        return true
+    }
+
+    func application(_: UIApplication,
+                     open url: URL,
+                     options _: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        // This does nothing if the url isn't meant for Glean.
+        glean.handleCustomUrl(url: url)
 
         return true
     }

--- a/samples/ios/app/glean-sample-app/Info.plist
+++ b/samples/ios/app/glean-sample-app/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>glean-sample-app</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>org.mozilla.glean-sample-app</string>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
This adds CLI handling for the `sendPing`, `tagPings`, and `logPings` commands by using the UserDefaults API to receive and parse launch arguments.