### PR TITLE
CLEANUP: Remove test for preinit timing distribution recording

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
@@ -13,9 +13,7 @@ import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.config.Configuration
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
@@ -70,23 +70,4 @@ class AccumulationsBeforeGleanInitTest {
 
         assertEquals(1, labeledCounterMetric["label1"].testGetValue())
     }
-
-    @Ignore("FIXME(bug 1588452): Timing distributions currently depend on a valid Glean instance to start")
-    @Test
-    fun `TimingDistributionMetricType must allow accumulation before Glean inits`() {
-        val timingDistribution = TimingDistributionMetricType(
-            disabled = false,
-            category = "test.telemetry",
-            lifetime = Lifetime.Application,
-            name = "pre_init_counter",
-            sendInPings = listOf("metrics")
-        )
-
-        val id = timingDistribution.start()
-        timingDistribution.stopAndAccumulate(id)
-
-        forceInitGlean()
-
-        assertTrue(timingDistribution.testHasValue())
-    }
 }


### PR DESCRIPTION
I missed this as part of #400.  It is now fully covered by the tests added
there.

Also \o/ last `@Ignore`d test!