### PR TITLE
Use lld for linking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,10 +173,13 @@ jobs:
                 circleci-agent step halt
             fi
       - run:
+          name: Install LLVM lld
+          command: sudo apt install -y lld
+      - run:
           name: Setup custom environment variables
           command: |
               echo "export CARGO_INCREMENTAL=0" >> $BASH_ENV
-              echo "export RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'" >> $BASH_ENV
+              echo "export RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads -C link-arg=-fuse-ld=lld'" >> $BASH_ENV
       - rust-tests:
           rust-version: "nightly"
       - run:


### PR DESCRIPTION
This hopefully reduces memory usage and thus makes the build pass again.
This is fine without looking further into whether lld is a good fit for
us, because it's only used for the coverage step.