### PR TITLE
Revert #418 - Use lld for linking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,13 +180,10 @@ jobs:
                 circleci-agent step halt
             fi
       - run:
-          name: Install LLVM lld
-          command: sudo apt install -y lld
-      - run:
           name: Setup custom environment variables
           command: |
               echo "export CARGO_INCREMENTAL=0" >> $BASH_ENV
-              echo "export RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads -C link-arg=-fuse-ld=lld'" >> $BASH_ENV
+              echo "export RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'" >> $BASH_ENV
       - rust-tests:
           rust-version: "nightly"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
     docker:
       - image: circleci/rust:latest
     # We have to use a machine with more RAM for tests so we don't run out of memory.
-    resource_class: "large"
+    resource_class: "xlarge"
     steps:
       - run:
           name: Check skip condition

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
       - run:
           name: Create and upload code coverage
           command: |
-              curl -L https://github.com/mozilla/grcov/releases/download/v0.5.4/grcov-linux-x86_64.tar.bz2 | tar jxf -
+              curl -L https://github.com/mozilla/grcov/releases/download/v0.5.5/grcov-linux-x86_64.tar.bz2 | tar jxf -
               curl -L https://codecov.io/bash > codecov.sh
               chmod +x codecov.sh
               zip -0 ccov.zip `find . \( -name "glean*.gc*" \) -print`

--- a/Makefile
+++ b/Makefile
@@ -103,14 +103,15 @@ cbindgen: ## Regenerate the FFI header file
 	cp glean-core/ffi/glean.h glean-core/ios/Glean/GleanFfi.h
 .PHONY: cbindgen
 
+rust-coverage: export CARGO_INCREMENTAL=0
+rust-coverage: export RUSTFLAGS=-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
+rust-coverage: export RUSTUP_TOOLCHAIN=nightly
 rust-coverage: ## Generate code coverage information for Rust code
 	# Expects a Rust nightly toolchain to be available.
 	# Expects grcov and genhtml to be available in $PATH.
-	CARGO_INCREMENTAL=0 \
-	RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads' \
-	RUSTUP_TOOLCHAIN=nightly \
-		cargo build
+	cargo build --verbose
+	cargo test --verbose
 	zip -0 ccov.zip `find . \( -name "glean*.gc*" \) -print`
-	grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" --ignore-dir "glean-core/ffi/*" -o lcov.info
+	grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" --ignore "glean-core/ffi/*" -o lcov.info
 	genhtml -o report/ --show-details --highlight --ignore-errors source --legend lcov.info
 .PHONY: rust-coverage


### PR DESCRIPTION
I'm not 100% sure why but:

* with LLD the coverage breaks
* ~~it now works again with the default linker~~ it doesn't, using a bigger instance now

I also updated the make command and upgraded to the latest version of grcov.

This is still flaky and at least I don't spend time looking at code coverage, so if this keeps braking I propose to remove it for now.