### PR TITLE
Fix Gradle plugin usage with AndroidStudio

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -7,15 +7,6 @@
 
 import groovy.json.JsonOutput
 
-// Include the glean-gradle-plugin. This is slightly different than what is
-// recommended for external users since we are loading it from the same root Gradle
-// build.
-buildscript {
-    dependencies {
-        classpath "org.mozilla.telemetry.glean-gradle-plugin:gradle-plugin"
-    }
-}
-
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -250,20 +241,22 @@ task docs(type: org.jetbrains.dokka.gradle.DokkaAndroidTask, overwrite: true) {
 // Generate markdown docs for the collected metrics.
 ext.gleanGenerateMarkdownDocs = true
 ext.gleanDocsDirectory = "$rootDir/docs/user/collected-metrics"
-apply plugin: 'org.mozilla.telemetry.glean-gradle-plugin'
+// Include the glean-gradle-plugin. This is slightly different than what is
+// recommended for external users since we are loading it from the same root Gradle
+// build.
+apply from: '../../gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy'
+ext.glean_plugin.apply(project)
 
 // Store the path to the Glean Miniconda installation in a buildConfigField
 // so that unit tests can validate JSON schema.
-pluginManager.withPlugin('org.mozilla.telemetry.glean-gradle-plugin') {
-    android {
-        defaultConfig {
-            buildConfigField(
-                "String",
-                "GLEAN_MINICONDA_DIR",
-                // Carefully escape the string here so it will support `\` in
-                // Windows paths correctly.
-                JsonOutput.toJson(project.ext.gleanCondaDir.path)
-            )
-        }
+android {
+    defaultConfig {
+        buildConfigField(
+            "String",
+            "GLEAN_MINICONDA_DIR",
+            // Carefully escape the string here so it will support `\` in
+            // Windows paths correctly.
+            JsonOutput.toJson(project.ext.gleanCondaDir.path)
+        )
     }
 }

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -353,3 +353,5 @@ subprocess.check_call([
         }
     }
 }
+
+ext.glean_plugin = new GleanPlugin()

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -354,4 +354,7 @@ subprocess.check_call([
     }
 }
 
+// Put an instance of the plugin in ext so it can be used from the outside
+// by Glean's own projects. This is not used by third-parties when using the
+// plugin.
 ext.glean_plugin = new GleanPlugin()

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -2,12 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-buildscript {
-    dependencies {
-        classpath "org.mozilla.telemetry.glean-gradle-plugin:gradle-plugin"
-    }
-}
-
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -57,4 +51,8 @@ dependencies {
 
 ext.gleanNamespace = "mozilla.telemetry.glean"
 
-apply plugin: 'org.mozilla.telemetry.glean-gradle-plugin'
+// Include the glean-gradle-plugin. This is slightly different than what is
+// recommended for external users since we are loading it from the same root Gradle
+// build.
+apply from: '../../../gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy'
+ext.glean_plugin.apply(project)

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,12 +12,6 @@ buildscript {
     }
 }
 
-// All projects in this repo need the gradle-plugin to be available as
-// a build dependency. This means we build the plugin twice: once for
-// internal use and once to publish for external use, but there doesn't
-// seem to be any way around that.
-includeBuild "gradle-plugin"
-
 // See https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:deferred_configuration.
 enableFeaturePreview('STABLE_PUBLISHING')
 


### PR DESCRIPTION
This works for me.

I can:

1) Sync the IDE to get autocompletion and the "build" button working
2) Build from the commandline
3) Publish to local maven, and the plugin is there
4) This plugin can be used to build Fenix