### PR TITLE
Don't bundle FFI example in crate

### DIFF
--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -12,7 +12,6 @@ include = [
   "README.md",
   "LICENSE",
   "src/**/*",
-  "examples/**/*",
   "tests/**/*",
   "Cargo.toml",
   "cbindgen.toml",


### PR DESCRIPTION
The way it's currently build depends on being run from the workspace
anyway, so bundling it in the crate doesn't make sense.
Plus, if build, it might contain files we don't want to include (such as
the final binary)