### PR TITLE
[WIP] Automatically substitute glean's version in forUnitTest dependencies

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 20.0.0-SNAPSHOT
+libraryVersion: 20.0.0-TEST6
 groupId: org.mozilla.telemetry
 projects:
   glean-core:


### PR DESCRIPTION
This attempts to find the version of the Glean SDK currently being used in projects using the gradle plugin and to add that version as a constraint to any `forUnitTest` glean dependency available.

**Note** this is currently lacking the constraint part

Todo:

- [ ] Add a [dependency constraint](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.html) to enable using `forUnitTest` dependencies without a version number
- [ ] Remove the changes to `.buildconfig.yml`
- [ ] Add to the changelog