### PR TITLE
Preparation for UI/Integration tests

### DIFF
--- a/glean-core/ios/Glean/Config/Configuration.swift
+++ b/glean-core/ios/Glean/Config/Configuration.swift
@@ -55,9 +55,10 @@ public struct Configuration {
     ///     This will be sent along with all the pings, in the `client_info` section.
     public init(
         maxEvents: Int32? = nil,
-        channel: String? = nil
+        channel: String? = nil,
+        serverEndpoint: String? = nil
     ) {
-        self.serverEndpoint = Constants.defaultTelemetryEndpoint
+        self.serverEndpoint = serverEndpoint ?? Constants.defaultTelemetryEndpoint
         self.userAgent = Constants.defaultUserAgent
         self.logPings = Constants.defaultLogPings
         self.maxEvents = maxEvents

--- a/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
+++ b/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
@@ -19,6 +19,9 @@ class GleanLifecycleObserver {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
+
+        // On init we start the duration, as we won't get the enter-foreground notification.
+        GleanBaseline.duration.start()
     }
 
     @objc func appWillEnterForeground(notification _: NSNotification) {


### PR DESCRIPTION
Due to the way the sample app works with Carthage, I need to land this on master first:

* Allow defining the endpoint at initialization time
* fixing the baseline duration, which is not started when the app is opened the first time as it doesn't get a foreground notification.