### PR TITLE
Include version in Glean plugin

### DIFF
--- a/docs/dev/cut-a-new-release.md
+++ b/docs/dev/cut-a-new-release.md
@@ -23,6 +23,7 @@ These are the steps needed to cut a new release from latest master.
 2. Bump the versions
     * Rust crates: Bump `version` in [`glean-core/Cargo.toml`](https://github.com/mozilla/glean/blob/master/glean-core/Cargo.toml) and [`glean-core/Cargo.toml`](https://github.com/mozilla/glean/blob/master/glean-core/ffi/Cargo.toml).
     * Kotlin package: Bump `libraryVersion` in the top-level [.buildconfig.yml](https://github.com/mozilla/glean/blob/master/.buildconfig.yml) file.
+    * Gradle plugin: Bump `project.ext.gleanVersion` in [`GleanGradlePlugin.groovy`](https://github.com/mozilla/glean/blob/master/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy).
     * Be sure you're following semver, and if in doubt, ask.
 3. Land the commits that perform the steps above. This takes a PR, typically, because of branch protection on master.
 4. Cut the actual release.

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -346,6 +346,8 @@ subprocess.check_call([
     }
 
     void apply(Project project) {
+        project.ext.glean_version = "20.0.0-SNAPSHOT"
+
         File condaDir = setupPythonEnvironmentTasks(project)
         project.ext.set("gleanCondaDir", condaDir)
 


### PR DESCRIPTION
This is required to make https://github.com/mozilla-mobile/fenix/pull/6476 work.

I tried using both of the following plugins to include the version in the build programatically:

https://plugins.gradle.org/plugin/com.github.gmazzo.buildconfig
https://github.com/mfuerstenau/gradle-buildconfig-plugin

(There is also a buildConfig feature as part of the Android gradle plugin, which doesn't work here because this is a Gradle plugin we are building, not an Android application).

Unfortunately, this doesn't work because the plugin needs to be used one way to build the plugin that we ship for third parties, and used as a script for use internally in this repo.  In the latter form, there is no chance for the buildConfig script to run, and worse, no way to import the configuration class that it produces.

At the end of the day, I'm not totally against the solution here.  This just means we have 3, rather than 2, locations that the Glean version number needs to be updated.  Perhaps there is a way to script the updating of the version number that would work here.  I recall @badboy has already been working on release automation and this might fit into that.