### PR TITLE
1588062: Add metrics usage documentation for Java.

### DIFF
--- a/docs/user/metrics/boolean.md
+++ b/docs/user/metrics/boolean.md
@@ -41,6 +41,28 @@ assertTrue(Flags.a11yEnabled.testGetValue())
 
 </div>
 
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Flags
+
+Flags.INSTANCE.getA11yEnabled.set(System.isAccesibilityEnabled())
+```
+
+There are test APIs available too:
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Flags
+
+// Was anything recorded?
+assertTrue(Flags.INSTANCE.getA11yEnabled.testHasValue())
+// Does it have the expected value?
+assertTrue(Flags.INSTANCE.getA11yEnabled.testGetValue())
+```
+
+</div>
+
+
 <div data-lang="Swift" class="tab">
 
 ```Swift

--- a/docs/user/metrics/counter.md
+++ b/docs/user/metrics/counter.md
@@ -45,6 +45,32 @@ assertEquals(
 
 </div>
 
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Controls
+
+Controls.INSTANCE.getRefreshPressed.add() // Adds 1 to the counter.
+Controls.INSTANCE.getRefreshPressed.add(5) // Adds 5 to the counter.
+```
+
+There are test APIs available too:
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Controls
+
+// Was anything recorded?
+assertTrue(Controls.INSTANCE.getRefreshPressed.testHasValue())
+// Does the counter have the expected value?
+assertEquals(6, Controls.INSTANCE.getRefreshPressed.testGetValue())
+// Did the counter record an negative value?
+assertEquals(
+    1, Controls.INSTANCE.getRefreshPressed.testGetNumRecordedErrors(ErrorType.InvalidValue)
+)
+```
+
+</div>
+
 <div data-lang="Swift" class="tab">
 
 ```Swift

--- a/docs/user/metrics/datetime.md
+++ b/docs/user/metrics/datetime.md
@@ -72,7 +72,7 @@ Install.INSTANCE.getFirstRun.set() // Records "now"
 Install.INSTANCE.getFirstRun.set(Calendar(2019, 3, 25)) // Records a custom datetime
 ```
 
-There are test APIs available too.INSTANCE.get
+There are test APIs available too:
 
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.Install

--- a/docs/user/metrics/datetime.md
+++ b/docs/user/metrics/datetime.md
@@ -63,6 +63,32 @@ assertEquals(1, Install.firstRun.testGetNumRecordedErrors(ErrorType.InvalidValue
 
 </div>
 
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Install
+
+Install.INSTANCE.getFirstRun.set() // Records "now"
+Install.INSTANCE.getFirstRun.set(Calendar(2019, 3, 25)) // Records a custom datetime
+```
+
+There are test APIs available too.INSTANCE.get
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Install
+
+// Was anything recorded?
+assertTrue(Install.INSTANCE.getFirstRun.testHasValue())
+// Was it the expected value?
+// NOTE: Datetimes always include a timezone offset from UTC, hence the
+// "-05:00" suffix.
+assertEquals("2019-03-25-05:00", Install.INSTANCE.getFirstRun.testGetValueAsString())
+// Was the value invalid?
+assertEquals(1, Install.INSTANCE.getFirstRun.testGetNumRecordedErrors(ErrorType.InvalidValue))
+```
+
+</div>
+
 <div data-lang="Swift" class="tab">
 
 ```Swift

--- a/docs/user/metrics/string.md
+++ b/docs/user/metrics/string.md
@@ -51,6 +51,38 @@ assertEquals(1, SearchDefault.name.testGetNumRecordedErrors(ErrorType.InvalidVal
 
 </div>
 
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault
+
+// Record a value into the metric.
+SearchDefault.INSTANCE.getName.set("duck duck go")
+// If it changed later, you can record the new value:
+SearchDefault.INSTANCE.getName.set("wikipedia")
+```
+
+There are test APIs available too:
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault
+
+// Was anything recorded?
+assertTrue(SearchDefault.INSTANCE.getName.testHasValue())
+// Does the string metric have the expected value?
+// IMPORTANT: It may have been truncated -- see "Limits" below
+assertEquals("wikipedia", SearchDefault.INSTANCE.getName.testGetValue())
+// Was the string truncated, and an error reported?
+assertEquals(
+    1, 
+    SearchDefault.INSTANCE.getName.testGetNumRecordedErrors(
+        ErrorType.InvalidValue
+    )
+)
+```
+
+</div>
+
 <div data-lang="Swift" class="tab">
 
 ```Swift

--- a/docs/user/metrics/timespan.md
+++ b/docs/user/metrics/timespan.md
@@ -72,6 +72,49 @@ assertEquals(1, Auth.loginTime.testGetNumRecordedErrors(ErrorType.InvalidValue))
 
 </div>
 
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Auth
+
+fun onShowLogin() {
+    Auth.INSTANCE.getLoginTime.start()
+    // ...
+}
+
+fun onLogin() {
+    Auth.INSTANCE.getLoginTime.stop()
+    // ...
+}
+
+fun onLoginCancel() {
+    Auth.INSTANCE.getLoginTime.cancel()
+    // ...
+}
+```
+
+The time reported in the telemetry ping will be timespan recorded during the lifetime of the ping.
+
+There are test APIs available too:
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Auth
+
+// Was anything recorded?
+assertTrue(Auth.INSTANCE.getLoginTime.testHasValue())
+// Does the timer have the expected value
+assertTrue(Auth.INSTANCE.getLoginTime.testGetValue() > 0)
+// Was the timing recorded incorrectly?
+assertEquals(
+    1, 
+    Auth.INSTANCE.getLoginTime.testGetNumRecordedErrors(
+        ErrorType.InvalidValue
+    )
+)
+```
+
+</div>
+
 <div data-lang="Swift" class="tab">
 
 ```Swift

--- a/docs/user/metrics/timing_distribution.md
+++ b/docs/user/metrics/timing_distribution.md
@@ -77,6 +77,54 @@ assertEquals(1, pages.pageLoad.testGetNumRecordedErrors(ErrorType.InvalidValue))
 
 </div>
 
+<div data-lang="Java" class="tab">
+
+```Java
+import mozilla.components.service.glean.GleanTimerId
+import org.mozilla.yourApplication.GleanMetrics.Pages
+
+val timerId : GleanTimerId
+
+fun onPageStart(e: Event) {
+    timerId = Pages.INSTANCE.getPageLoad.start()
+}
+
+fun onPageLoaded(e: Event) {
+    Pages.INSTANCE.getPageLoad.stopAndAccumulate(timerId)
+}
+```
+
+There are test APIs available too.  For convenience, properties `sum` and `count` are exposed to facilitate validating that data was recorded correctly.
+
+Continuing the `pageLoad` example above, at this point the metric should have a `sum == 11` and a `count == 2`:
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Pages
+
+// Was anything recorded?
+assertTrue(pages.INSTANCE.getPageLoad.testHasValue())
+
+// Get snapshot.
+val snapshot = pages.INSTANCE.getPageLoad.testGetValue()
+
+// Does the sum have the expected value?
+assertEquals(11, snapshot.getSum)
+
+// Usually you don't know the exact timing values, but how many should have been recorded.
+assertEquals(2L, snapshot.getCount)
+
+// Was an error recorded?
+assertEquals(
+    1, 
+    pages.INSTANCE.getPageLoad.testGetNumRecordedErrors(
+        ErrorType.InvalidValue
+    )
+)
+```
+
+</div>
+
+
 <div data-lang="Swift" class="tab">
 
 ```Swift

--- a/docs/user/metrics/uuid.md
+++ b/docs/user/metrics/uuid.md
@@ -44,6 +44,29 @@ assertEquals(uuid, User.clientId.testGetValue())
 
 </div>
 
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.User
+
+User.INSTANCE.getClientId.generateAndSet() // Generate a new UUID and record it
+User.INSTANCE.getClientId.set(UUID.randomUUID())  // Set a UUID explicitly
+```
+
+There are test APIs available too.INSTANCE.get
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.User
+
+// Was anything recorded?
+assertTrue(User.INSTANCE.getClientId.testHasValue())
+// Was it the expected value?
+assertEquals(uuid, User.INSTANCE.getClientId.testGetValue())
+```
+
+</div>
+
+
 <div data-lang="Swift" class="tab">
 
 ```Swift

--- a/docs/user/metrics/uuid.md
+++ b/docs/user/metrics/uuid.md
@@ -53,7 +53,7 @@ User.INSTANCE.getClientId.generateAndSet() // Generate a new UUID and record it
 User.INSTANCE.getClientId.set(UUID.randomUUID())  // Set a UUID explicitly
 ```
 
-There are test APIs available too.INSTANCE.get
+There are test APIs available too:
 
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.User


### PR DESCRIPTION
This doesn't include metrics that are GV-only (since it's unlikely they'll
be needed from Java), and doesn't include event or string_list where the
conversion to Java is more complex and I'd need to fire up the compiler to
check my work.