### PR TITLE
Fixup cargo fmt on the latest version of Rust

### DIFF
--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -166,6 +166,11 @@ char *glean_experiment_test_get_data(uint64_t glean_handle, FfiStr experiment_id
 
 uint8_t glean_experiment_test_is_active(uint64_t glean_handle, FfiStr experiment_id);
 
+/**
+ * # Safety
+ *
+ * A valid and non-null configuration object is required for this function.
+ */
 uint64_t glean_initialize(const FfiConfiguration *cfg);
 
 uint8_t glean_is_upload_enabled(uint64_t glean_handle);

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -122,6 +122,9 @@ impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
     }
 }
 
+/// # Safety
+///
+/// A valid and non-null configuration object is required for this function.
 #[no_mangle]
 pub unsafe extern "C" fn glean_initialize(cfg: *const FfiConfiguration) -> u64 {
     assert!(!cfg.is_null());
@@ -138,6 +141,9 @@ pub unsafe extern "C" fn glean_initialize(cfg: *const FfiConfiguration) -> u64 {
     })
 }
 
+/// # Safety
+///
+/// A valid and non-null configuration object is required for this function.
 #[no_mangle]
 pub unsafe extern "C" fn glean_initialize_migration(
     cfg: *const FfiConfiguration,

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -166,6 +166,11 @@ char *glean_experiment_test_get_data(uint64_t glean_handle, FfiStr experiment_id
 
 uint8_t glean_experiment_test_is_active(uint64_t glean_handle, FfiStr experiment_id);
 
+/**
+ * # Safety
+ *
+ * A valid and non-null configuration object is required for this function.
+ */
 uint64_t glean_initialize(const FfiConfiguration *cfg);
 
 uint8_t glean_is_upload_enabled(uint64_t glean_handle);

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -147,7 +147,9 @@ impl Metric {
             Metric::Quantity(q) => json!(q),
             Metric::String(s) => json!(s),
             Metric::StringList(v) => json!(v),
-            Metric::Timespan(time, time_unit) => json!({"value": time_unit.duration_convert(*time), "time_unit": time_unit}),
+            Metric::Timespan(time, time_unit) => {
+                json!({"value": time_unit.duration_convert(*time), "time_unit": time_unit})
+            }
             Metric::TimingDistribution(hist) => json!(timing_distribution::snapshot(hist)),
             Metric::Uuid(s) => json!(s),
             Metric::MemoryDistribution(hist) => json!(memory_distribution::snapshot(hist)),


### PR DESCRIPTION
This fixes the formatting that is breaking the tree.