### PR TITLE
Fix and disallow mdbook errors

### DIFF
--- a/bin/build-rust-docs.sh
+++ b/bin/build-rust-docs.sh
@@ -8,7 +8,13 @@ set -e
 CRATE_NAME=glean_core
 
 pushd docs &&
-    mdbook build &&
+    mdbook build |& grep "\[ERROR\]" &&
+    if [ $? -eq 0 ]
+    then
+        exit 1
+    else
+        exit 0
+    fi
     popd
 
 cargo doc --no-deps

--- a/docs/user/pings/custom.md
+++ b/docs/user/pings/custom.md
@@ -37,7 +37,7 @@ search:
 
 The Glean SDK build generates code from `pings.yaml` in a `Pings` object, which must be instantiated so Glean can send pings by name.
 
-{{#include ../tab_header.md}}
+{{#include ../../tab_header.md}}
 
 <div data-lang="Kotlin" class="tab">
 
@@ -67,7 +67,7 @@ pings = load_pings("pings.yaml")
 
 </div>
 
-{{#include ../tab_footer.md}}
+{{#include ../../tab_footer.md}}
 
 ## Sending metrics in a custom ping
 
@@ -99,7 +99,7 @@ To send a custom ping, call the `send` method on the `PingType` object that the 
 
 For example, to send the custom ping defined above:
 
-{{#include ../tab_header.md}}
+{{#include ../../tab_header.md}}
 
 <div data-lang="Kotlin" class="tab">
 
@@ -118,4 +118,4 @@ pings.search.send()
 
 </div>
 
-{{#include ../tab_footer.md}}
+{{#include ../../tab_footer.md}}


### PR DESCRIPTION
When `mdbook` reports errors, it doesn't actually return a UNIX error code.  So there were `include` directives inserted into the docs that were "broken" but still passed CI.

I filed this issue with mdbook: https://github.com/rust-lang/mdBook/issues/1094

In the meantime, we can use grep to detect errors and return an error code from CI.