### PR TITLE
Bug 1595211 - Makes GleanDebugActivity launch as a `singleInstance` Activity.

### DIFF
--- a/glean-core/android/src/main/AndroidManifest.xml
+++ b/glean-core/android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="mozilla.telemetry.glean" >
     <application>
         <activity android:name=".debug.GleanDebugActivity"
+            android:launchMode="singleInstance"
             android:exported="true" />
     </application>
 </manifest>


### PR DESCRIPTION
This makes the `GleanDebugActivity` launch as a [`singleInstance` Activity](https://developer.android.com/guide/topics/manifest/activity-element.html#lmode).  This causes the `GleanDebugActivity` to correctly handle additional `Intents` if the application was launched with a `GleanDebugActivity` `Intent` using the `adb` command.