### PR TITLE
Don't release glean-gradle-plugin with unspecified version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,8 @@ jobs:
             PKGDIR=./build/package
             # Collect all files into a single directory
             mkdir -p ${PKGDIR}
+            # The glean-gradle-plugin also creates releases with an "unspecified" version
+            # when used internally. We don't need to ship those.
             find ./build/maven/org/mozilla/telemetry/ \( \( -name "*.aar*" -or -name "*.jar*" -or -name "*.pom*" \) -and -not -name "*unspecified*" \) \
               -exec cp {} ${PKGDIR} \;
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,7 @@ jobs:
             PKGDIR=./build/package
             # Collect all files into a single directory
             mkdir -p ${PKGDIR}
-            find ./build/maven/org/mozilla/telemetry/ \( -name "*.aar*" -or -name "*.jar*" -or -name "*.pom*" \) \
+            find ./build/maven/org/mozilla/telemetry/ \( \( -name "*.aar*" -or -name "*.jar*" -or -name "*.pom*" \) -and -not -name "*unspecified*" \) \
               -exec cp {} ${PKGDIR} \;
 
             # Bundle all release files up into a single zip file


### PR DESCRIPTION
Due to how we use the glean-gradle-plugin both as an external Maven package and internally as a script, it ends up getting published once in the correct way (with a version number) and again with an unspecified version (since it doesn't use the publishing metadata we've set up).  This results in two copies of the plugin being published to releases, for example [see the 20.2.0 release](https://github.com/mozilla/glean/releases/tag/v20.2.0).

This filters the unnecessary ones out when making a release.