### PR TITLE
Update docs about calling Glean.initialize first

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -659,8 +659,6 @@ open class GleanInternalAPI internal constructor () {
 /**
  * The main Glean object.
  *
- * Before any data collection can take place, the Glean SDK **must** be initialized from the application.
- *
  * ```
  * Glean.setUploadEnabled(true)
  * Glean.initialize(applicationContext)

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -17,8 +17,6 @@ public typealias GleanTimerId = UInt64
 public class Glean {
     /// The main Glean object.
     ///
-    /// Before any data collection can take place, the Glean SDK **must** be initialized from the application.
-    ///
     /// ```swift
     /// Glean.shared.setUploadEnabled(true)
     /// Glean.shared.initialize()


### PR DESCRIPTION
As @hawkinsw pointed out, this is no longer true and potentially confusing...