### PR TITLE
Allow to use the `GleanTimerId` from Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v20.1.0...master)
 
+* The `GleanTimerId` can now be accessed in Java and is no longer a `typealias`.
+
 # v20.2.0 (2019-11-11)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v20.0.0...v20.1.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -41,7 +41,7 @@ import org.json.JSONObject
  * Public exported type identifying individual timers for
  * [TimingDistributionMetricType][mozilla.telemetry.glean.private.TimingDistributionMetricType].
  */
-typealias GleanTimerId = Long
+data class GleanTimerId internal constructor(internal val id: Long)
 
 /**
  * The main Glean API.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -82,10 +82,10 @@ class TimingDistributionMetricType internal constructor(
         val startTime = getElapsedTimeNanos()
 
         // No dispatcher, we need the return value
-        return LibGleanFFI.INSTANCE.glean_timing_distribution_set_start(
+        return GleanTimerId(LibGleanFFI.INSTANCE.glean_timing_distribution_set_start(
             this@TimingDistributionMetricType.handle,
             startTime
-        )
+        ))
     }
 
     /**
@@ -113,7 +113,7 @@ class TimingDistributionMetricType internal constructor(
             LibGleanFFI.INSTANCE.glean_timing_distribution_set_stop_and_accumulate(
                     Glean.handle,
                     this@TimingDistributionMetricType.handle,
-                    timerId,
+                    timerId.id,
                     stopTime)
         }
     }
@@ -132,7 +132,7 @@ class TimingDistributionMetricType internal constructor(
 
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
-            LibGleanFFI.INSTANCE.glean_timing_distribution_cancel(this@TimingDistributionMetricType.handle, timerId)
+            LibGleanFFI.INSTANCE.glean_timing_distribution_cancel(this@TimingDistributionMetricType.handle, timerId.id)
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -11,7 +11,6 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.StringArray
 import java.lang.reflect.Proxy
-import mozilla.telemetry.glean.GleanTimerId
 import mozilla.telemetry.glean.config.FfiConfiguration
 
 // Turn a boolean into its Byte (u8) representation
@@ -354,16 +353,16 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_timing_distribution_metric(handle: Long)
 
-    fun glean_timing_distribution_set_start(metric_id: Long, start_time: Long): GleanTimerId
+    fun glean_timing_distribution_set_start(metric_id: Long, start_time: Long): Long
 
     fun glean_timing_distribution_set_stop_and_accumulate(
         glean_handle: Long,
         metric_id: Long,
-        timer_id: GleanTimerId,
+        timer_id: Long,
         stop_time: Long
     )
 
-    fun glean_timing_distribution_cancel(metric_id: Long, timer_id: GleanTimerId)
+    fun glean_timing_distribution_cancel(metric_id: Long, timer_id: Long)
 
     fun glean_timing_distribution_accumulate_samples(glean_handle: Long, metric_id: Long, samples: LongArray?, len: Int)
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
@@ -49,4 +49,11 @@ public class GleanFromJavaTest {
                 experimentProperties
         );
     }
+
+    @Test
+    public void testCanAccessGleanTimerId() {
+        // Users are not really meant to instantiate this. Moreover, the constructor
+        // visibility is `internal`, but looks like Java ignores it.
+        GleanTimerId testId = new GleanTimerId(100);
+    }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
@@ -10,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.GleanTimerId
 import mozilla.telemetry.glean.testing.ErrorType
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
@@ -231,7 +232,7 @@ class TimingDistributionMetricTypeTest {
             timeUnit = TimeUnit.Second
         )
 
-        metric.stopAndAccumulate(-1)
+        metric.stopAndAccumulate(GleanTimerId(-1))
         assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidValue))
     }
 }


### PR DESCRIPTION
This also has the nice side effect of adding type safety to the `GleanTimerId` for Kotlin calls, making
it an opaque type for end users.