### PR TITLE
Fix the `targetSdkVersion` of the glean sample app

### DIFF
--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         applicationId "org.mozilla.samples.gleancore"
         minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Our sample app is using the wrong field as the target version. 