### PR TITLE
WIP: Use DefaultLifecycleObserver interface, rather than lifecycle annotations

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -175,6 +175,7 @@ dependencies {
 
     implementation "androidx.annotation:annotation:$versions.androidx_annotation"
     implementation "androidx.lifecycle:lifecycle-extensions:$versions.androidx_lifecycle_extensions"
+    implementation "androidx.lifecycle:lifecycle-common-java8:$versions.androidx_lifecycle_extensions"
     implementation "androidx.work:work-runtime-ktx:$versions.androidx_work"
 
     // We need a compileOnly dependency on the following block of testing

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
@@ -4,9 +4,8 @@
 
 package mozilla.telemetry.glean.scheduler
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
 
@@ -14,12 +13,11 @@ import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
  * Connects process lifecycle events from Android to Glean's handleEvent
  * functionality (where the actual work of sending pings is done).
  */
-internal class GleanLifecycleObserver : LifecycleObserver {
+internal class GleanLifecycleObserver : DefaultLifecycleObserver {
     /**
      * Calls the "background" event when entering the background.
      */
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun onEnterBackground() {
+    override fun onStop(owner: LifecycleOwner) {
         // We're going to background, so store how much time we spent
         // on foreground.
         GleanBaseline.duration.stop()
@@ -34,8 +32,7 @@ internal class GleanLifecycleObserver : LifecycleObserver {
      *
      * https://developer.android.com/reference/android/app/Activity.html#onStart()
      */
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun onEnterForeground() {
+    override fun onStart(owner: LifecycleOwner) {
         // Note that this is sending the length of the last foreground session
         // because it belongs to the baseline ping and that ping is sent every
         // time the app goes to background.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -9,9 +9,8 @@ import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import android.text.format.DateUtils
 import android.util.Log
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
@@ -44,7 +43,7 @@ import java.util.concurrent.TimeUnit as AndroidTimeUnit
 internal class MetricsPingScheduler(
     private val applicationContext: Context,
     migratedLastSentDate: String? = null
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
     internal val sharedPreferences: SharedPreferences by lazy {
         applicationContext.getSharedPreferences(this.javaClass.canonicalName, Context.MODE_PRIVATE)
     }
@@ -312,8 +311,7 @@ internal class MetricsPingScheduler(
     /**
      * Update flag to show we are no longer in the foreground.
      */
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun onEnterBackground() {
+    override fun onStop(owner: LifecycleOwner) {
         isInForeground = false
     }
 
@@ -321,8 +319,7 @@ internal class MetricsPingScheduler(
      * Update the flag to indicate we are moving to the foreground, and if Glean is initialized we
      * will check to see if the metrics ping needs to be scheduled for collection.
      */
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun onEnterForeground() {
+    override fun onStart(owner: LifecycleOwner) {
         isInForeground = true
 
         // We check for the metrics ping schedule here because the app could have been in the

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -6,6 +6,7 @@ package mozilla.telemetry.glean.scheduler
 
 import android.content.Context
 import android.os.SystemClock
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -458,14 +459,14 @@ class MetricsPingSchedulerTest {
         // Initialize Glean
         resetGlean(clearStores = true)
         val mpsSpy = mock(MetricsPingScheduler::class.java)
-        `when`(mpsSpy.onEnterForeground()).thenCallRealMethod()
+        `when`(mpsSpy.onStart(ProcessLifecycleOwner.get())).thenCallRealMethod()
         Glean.metricsPingScheduler = mpsSpy
 
         // Make sure schedule() has not been called
         verify(mpsSpy, times(0)).schedule()
 
         // Simulate returning to the foreground with Glean initialized.
-        Glean.metricsPingScheduler.onEnterForeground()
+        Glean.metricsPingScheduler.onStart(ProcessLifecycleOwner.get())
 
         // Verify that schedule has been called once
         verify(mpsSpy, times(1)).schedule()


### PR DESCRIPTION
The official docs say that using the `androidx.lifecycle` API [requires adding](https://developer.android.com/jetpack/androidx/releases/lifecycle#declaring_dependencies) an `annotationProcessor` (Java) or `kapt` processor (Kotlin) in order to correctly handle the `@OnLifecycleEvent` annotation.

Some random components in a-c that use lifecycles do this, fwiw, but glean, both here and in a-c, does not.

It's not clear from the docs what happens if you don't do that, however [this StackOverflow question](https://stackoverflow.com/questions/49602410/when-should-we-use-android-arch-lifecyclecompiler-or-android-arch-lifecycleco) in the last, non-upvoted answer (I know how that must sound) says:

```
Lifecycle runtime will do one of 2 things:

    - Use reflection to look up the annotated methods,
    - or use generated adapters if you enabled the lifecycle-compiler annotation processor.
```

So, if we don't use the processor, it will use reflection.  We know reflection is flaky and we should avoid it, particularly with proguard.  It seems like if reflection were to fail, it would fail always, but :meh:.

I tried adding the processor as instructed, however, that doesn't work on our code base.  It raises a bunch of build errors of the form:

```
e: /home/mdboom/Work/builds/glean/glean.rs/glean-core/android/build/tmp/kapt3/stubs/debug/mozilla/telemetry/glean/GleanInternalAPI.java:24: error: <identifier> expected                      
    private final java.util.Set<mozilla.telemetry.glean.private.PingType> pingTypeQueue = null;                                                                                              
                                                        ^                                                                                                                                     
e: /home/mdboom/Work/builds/glean/glean.rs/glean-core/android/build/tmp/kapt3/stubs/debug/mozilla/telemetry/glean/GleanInternalAPI.java:24: error: <identifier> expected                      
    private final java.util.Set<mozilla.telemetry.glean.private.PingType> pingTypeQueue = null; 
                                                                        ^                                                                                                                     
e: /home/mdboom/Work/builds/glean/glean.rs/glean-core/android/build/tmp/kapt3/stubs/debug/mozilla/telemetry/glean/GleanInternalAPI.java:24: error: <identifier> expected
    private final java.util.Set<mozilla.telemetry.glean.private.PingType> pingTypeQueue = null;                                                                                               
```

As far as I can tell, this is generating Java code from the Kotlin code as part of this processing step, but since it contains the keyword `private`, it is not valid Java.  Resolving this probably involves refactoring a good chunk of our code base to rename `private` to something else, which would require `glean_parser` changes and the whole lot of it.  (There might be some clever way to "escape" this keyword, but I couldn't find it.)

Therefore, I propose this solution, which is to override the [DefaultLifecycleObserver](https://developer.android.com/reference/androidx/lifecycle/DefaultLifecycleObserver.html) interface.  This feels good because it just uses interfaces that have been in Java forever, and doesn't use any magical features like reflection or annotation processing.

I'm not 100% certain this will solve the baseline issue (since we can't reproduce locally and it only seems to happen "at scale"), but it seems like a worthwhile thing to avoid reflection in any event.