### PR TITLE
Make v21.0.0 release

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 21.0.0-SNAPSHOT
+libraryVersion: 21.0.0
 groupId: org.mozilla.telemetry
 projects:
   glean-core:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v20.1.0...master)
+[Full changelog](https://github.com/mozilla/glean/compare/v21.0.0...master)
 
-* The `GleanTimerId` can now be accessed in Java and is no longer a `typealias`.
-* Bumped `glean_parser` to version 1.11.0.
+# v21.0.0 (2019-11-18)
+
+[Full changelog](https://github.com/mozilla/glean/compare/v20.2.0...v21.0.0)
+
+* Android:
+
+  * The `GleanTimerId` can now be accessed in Java and is no longer a `typealias`.
+
+  * Fixed a bug where the metrics ping was getting scheduled twice on startup.
+* All platforms
+
+  * Bumped `glean_parser` to version 1.11.0.
 
 # v20.2.0 (2019-11-11)
 
-[Full changelog](https://github.com/mozilla/glean/compare/v20.0.0...v20.1.0)
+[Full changelog](https://github.com/mozilla/glean/compare/v20.1.0...v20.2.0)
 
 * In earlier 20.x.x releases, the version of glean-ffi was incorrectly built
   against the wrong version of glean-core.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "21.0.0-alpha.1"
+version = "21.0.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -320,12 +320,12 @@ dependencies = [
 
 [[package]]
 name = "glean-ffi"
-version = "21.0.0-alpha.1"
+version = "21.0.0"
 dependencies = [
  "android_logger 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 21.0.0-alpha.1",
+ "glean-core 21.0.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "21.0.0-alpha.1"
+version = "21.0.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-ffi"
-version = "21.0.0-alpha.1"
+version = "21.0.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "FFI layer for Glean, a modern Telemetry library"
 repository = "https://github.com/mozilla/glean"
@@ -34,7 +34,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 
 [dependencies.glean-core]
 path = ".."
-version = "21.0.0-alpha.1"
+version = "21.0.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = { version = "0.8.5", default-features = false }

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -367,7 +367,7 @@ subprocess.check_call([
     }
 
     void apply(Project project) {
-        project.ext.glean_version = "21.0.0-SNAPSHOT"
+        project.ext.glean_version = "21.0.0"
 
         File condaDir = setupPythonEnvironmentTasks(project)
         project.ext.set("gleanCondaDir", condaDir)


### PR DESCRIPTION
We need this so we can properly deploy the glean-gradle-plugin see [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1597239)