### PR TITLE
Bug 1596762 - Fix for public header export

### DIFF
--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1F6A8FF2233C068A007837D5 /* BooleanMetricTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6A8FF1233C068A007837D5 /* BooleanMetricTypeTest.swift */; };
 		1F6A8FF4233C0A91007837D5 /* DatetimeMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6A8FF3233C0A91007837D5 /* DatetimeMetric.swift */; };
 		1F6A8FF6233C1555007837D5 /* DatetimeMetricTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6A8FF5233C1555007837D5 /* DatetimeMetricTypeTests.swift */; };
+		1F6F8A0B238336AB00B6ABB9 /* Glean.h in Headers */ = {isa = PBXBuildFile; fileRef = BF3DE3942243A2F20018E23F /* Glean.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F70B786232995A9007395FB /* Dispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F70B785232995A9007395FB /* Dispatchers.swift */; };
 		1F70B788232A81A4007395FB /* DispatchersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F70B787232A81A4007395FB /* DispatchersTest.swift */; };
 		1FB70AEF23301C1D00C7CF09 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB70AEE23301C1D00C7CF09 /* Logger.swift */; };
@@ -58,7 +59,7 @@
 		BFFE18382350A5F50068D97B /* TimingDistributionMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE18372350A5F50068D97B /* TimingDistributionMetric.swift */; };
 		BFFE183A2350A61F0068D97B /* TimingDistributionMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE18392350A61F0068D97B /* TimingDistributionMetricTests.swift */; };
 		BFFE183C2350A9CC0068D97B /* DistributionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE183B2350A9CC0068D97B /* DistributionData.swift */; };
-		BFFE33A92328F4EF005348FE /* GleanFfi.h in Headers */ = {isa = PBXBuildFile; fileRef = BFFE33A82328F4EF005348FE /* GleanFfi.h */; };
+		BFFE33A92328F4EF005348FE /* GleanFfi.h in Headers */ = {isa = PBXBuildFile; fileRef = BFFE33A82328F4EF005348FE /* GleanFfi.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFFE33AB232927C3005348FE /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE33AA232927C3005348FE /* Utils.swift */; };
 /* End PBXBuildFile section */
 
@@ -354,6 +355,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F6F8A0B238336AB00B6ABB9 /* Glean.h in Headers */,
 				BFFE33A92328F4EF005348FE /* GleanFfi.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/glean-core/ios/base.xcconfig
+++ b/glean-core/ios/base.xcconfig
@@ -2,4 +2,3 @@
 
 INFOPLIST_FILE = Glean/Info.plist
 LIBRARY_SEARCH_PATHS = "../../target/universal/$(buildvariant)"
-SWIFT_OBJC_BRIDGING_HEADER = Glean/Glean.h


### PR DESCRIPTION
Turns out I didn't get this quite right the first time.  Having `Glean.h` set as the Objective-C bridging header was preventing it from being exported publicly.  It also turns out that we didn't need to mark that as the bridging header, so removing it allowed me to properly export the public header.  

This ultimately fixes a warning seen in the lockwise-iOS integration about implicitly importing "Glean.h" through module "Glean".