### PR TITLE
Check if Timespans are allowed to record at stop

### DIFF
--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -70,6 +70,10 @@ impl TimespanMetric {
     ///
     /// This will record an error if no `start` was called.
     pub fn set_stop(&mut self, glean: &Glean, stop_time: u64) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         if self.start_time.is_none() {
             record_error(
                 glean,


### PR DESCRIPTION
This ensures that no error is recorded if a product disables upload and 'baseline.duration' is attempted
to be recorded when going to background. Without this change, it would record an error if upload was disabled at startup, when coming to foreground.

This check was present in [glean-ac](https://github.com/mozilla-mobile/android-components/blob/594be62732d9f4cacca3b2841cca299064709822/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt#L67-L69).

Is this a bug or did we remove it for some reason?

**Note**: we do have the same problem in the `TimingDistirbutionMetricType`, where we don't check if we're allowed to record at startup