### PR TITLE
Fix Python docstrings

### DIFF
--- a/glean-core/python/glean/config.py
+++ b/glean-core/python/glean/config.py
@@ -31,28 +31,28 @@ class Configuration:
     Configuration values for Glean.
     """
 
-    # The server pings are sent to.
     server_endpoint: str = DEFAULT_TELEMETRY_ENDPOINT
+    """The server pings are sent to."""
 
-    # The user agent used when sending pings.
     user_agent: Optional[str] = dataclasses.field(
         default_factory=_get_default_user_agent
     )
+    """The user agent used when sending pings."""
 
-    # The release channel the application is on, if known.
     channel: Optional[str] = None
+    """The release channel the application is on, if known."""
 
-    # The number of events to store before force-sending.
     max_events: int = DEFAULT_MAX_EVENTS
+    """The number of events to store before force-sending."""
 
-    # Whether to log ping contents to the console.
     log_pings: bool = False
+    """Whether to log ping contents to the console."""
 
-    # String tag to be applied to headers when uploading pings for debug view.
     ping_tag: Optional[str] = None
+    """String tag to be applied to headers when uploading pings for debug view."""
 
-    # The ping uploader implementation
     ping_uploader: net.BaseUploader = net.HttpClientUploader()
+    """The ping uploader implementation."""
 
 
 __all__ = ["Configuration"]

--- a/glean-core/python/glean/metrics/experiment.py
+++ b/glean-core/python/glean/metrics/experiment.py
@@ -13,13 +13,17 @@ class RecordedExperimentData:
     Deserialized experiment data.
     """
 
-    # The experiment's branch, as set through
-    # `glean.Glean.set_experiment_active`
     branch: str
+    """
+    The experiment's branch, as set through
+    `glean.Glean.set_experiment_active`.
+    """
 
-    # Any extra data associated with this experiment through
-    # `glean.Glean.set_experiment_active`
     extra: Dict[str, str]
+    """
+    And extra data associated with this experiment through
+    `glean.Glean.set_experiment_active`.
+    """
 
 
 __all__ = ["RecordedExperimentData"]


### PR DESCRIPTION
This just fixes the docstring formatting on dataclasses so they show up correctly in the generated docs.  (No content changes, just moving things around...)