### PR TITLE
Add support for Python code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ glean_app*
 
 samples/ios/app/.venv/
 .mypy_cache/
+.coverage
+htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -147,3 +147,9 @@ rust-coverage: ## Generate code coverage information for Rust code
 	grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" --ignore "glean-core/ffi/*" -o lcov.info
 	genhtml -o report/ --show-details --highlight --ignore-errors source --legend lcov.info
 .PHONY: rust-coverage
+
+python-coverage: build-python ## Generate a code coverage report for Python
+	cd glean-core/python
+	$(GLEAN_PYENV)/bin/python3 -m coverage run --source glean -m pytest
+	$(GLEAN_PYENV)/bin/python3 -m coverage html
+.PHONY: python-coverage

--- a/docs/code_coverage.md
+++ b/docs/code_coverage.md
@@ -65,3 +65,17 @@ report/index.html
 
 Xcode automatically generates code coverage when running tests.
 You can find the report in the Report Navigator (`View -> Navigators -> Show Report Navigator -> Coverage`).
+
+## Generating Python reports locally
+
+Python code coverage is determined using the [coverage.py](https://coverage.readthedocs.io/en/latest/) library.
+
+Run
+
+```bash
+make python-coverage
+```
+
+to generate code coverage reports in the Glean virtual environment.
+
+After running, the report will be in `htmlcov`.


### PR DESCRIPTION
This just adds instructions for generating it.

Adding to CI will be a follow-on task.