### PR TITLE
Dispatch experiments asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v21.0.0...master)
 
+* All platforms
+
+  * The experiments API is no longer ignored before the Glean SDK initialized. Calls are
+    recorded and played back once the Glean SDK is initialized.
+
 # v21.0.0 (2019-11-18)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v20.2.0...v21.0.0)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -157,6 +157,29 @@ class GleanTest {
     }
 
     @Test
+    fun `test experiments recording before Glean inits`() {
+        // This test relies on Glean not being initialized and task queuing to be on.
+        Glean.testDestroyGleanHandle()
+        Dispatchers.API.setTaskQueueing(true)
+
+        Glean.setExperimentActive(
+            "experiment_set_preinit", "branch_a"
+        )
+
+        Glean.setExperimentActive(
+            "experiment_preinit_disabled", "branch_a"
+        )
+
+        Glean.setExperimentInactive("experiment_preinit_disabled")
+
+        // This will init glean and flush the dispatcher's queue.
+        resetGlean()
+
+        assertTrue(Glean.testIsExperimentActive("experiment_set_preinit"))
+        assertFalse(Glean.testIsExperimentActive("experiment_preinit_disabled"))
+    }
+
+    @Test
     fun `test sending of background pings`() {
         val server = getMockWebServer()
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -267,6 +267,7 @@ class Glean:
         Args:
             experiment_id (str): The id of the experiment to deactivate.
         """
+
         @Dispatcher.launch
         def set_experiment_inactive():
             _ffi.lib.glean_set_experiment_inactive(

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -242,24 +242,22 @@ class Glean:
             extra (dict of str -> str): Optional metadata to output with the
                 ping
         """
-        if not cls.is_initialized():
-            log.error("Please call Glean.initialize() before using this API.")
-            return
-
         if extra is None:
             keys: List[str] = []
             values: List[str] = []
         else:
             keys, values = zip(*extra.items())  # type: ignore
 
-        _ffi.lib.glean_set_experiment_active(
-            cls._handle,
-            _ffi.ffi_encode_string(experiment_id),
-            _ffi.ffi_encode_string(branch),
-            _ffi.ffi_encode_vec_string(keys),
-            _ffi.ffi_encode_vec_string(values),
-            len(keys),
-        )
+        @Dispatcher.launch
+        def set_experiment_active():
+            _ffi.lib.glean_set_experiment_active(
+                cls._handle,
+                _ffi.ffi_encode_string(experiment_id),
+                _ffi.ffi_encode_string(branch),
+                _ffi.ffi_encode_vec_string(keys),
+                _ffi.ffi_encode_vec_string(values),
+                len(keys),
+            )
 
     @classmethod
     def set_experiment_inactive(cls, experiment_id: str):
@@ -269,13 +267,11 @@ class Glean:
         Args:
             experiment_id (str): The id of the experiment to deactivate.
         """
-        if not cls.is_initialized():
-            log.error("Please call Glean.initialize() before using this API.")
-            return
-
-        _ffi.lib.glean_set_experiment_inactive(
-            cls._handle, _ffi.ffi_encode_string(experiment_id)
-        )
+        @Dispatcher.launch
+        def set_experiment_inactive():
+            _ffi.lib.glean_set_experiment_inactive(
+                cls._handle, _ffi.ffi_encode_string(experiment_id)
+            )
 
     @classmethod
     def test_is_experiment_active(cls, experiment_id: str) -> bool:

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -105,6 +105,23 @@ def test_experiments_recording():
     assert "value" == stored_data.extra["test_key"]
 
 
+def test_experiments_recording_before_glean_inits():
+    # This test relies on Glean not being initialized and task
+    # queuing to be on.
+    Glean.reset()
+
+    Glean.set_experiment_active("experiment_set_preinit", "branch_a")
+    Glean.set_experiment_active("experiment_preinit_disabled", "branch_a")
+
+    Glean.set_experiment_inactive("experiment_preinit_disabled")
+
+    # This will init Glean and flush the dispatcher's queue.
+    Glean.initialize(GLEAN_APP_ID, glean_version)
+
+    assert Glean.test_is_experiment_active("experiment_set_preinit")
+    assert not Glean.test_is_experiment_active("experiment_preinit_disabled")
+
+
 @pytest.mark.skip
 def test_sending_of_background_pings():
     pass


### PR DESCRIPTION
This guarantees that call to the API that happen before the Glean SDK is initialized don't get lost
and are played back once the Glean SDK is finally initialized.