### PR TITLE
Python: Remove unnecessary m2r dependency.

### DIFF
--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -2,7 +2,6 @@ auditwheel==2.1.1
 black
 coverage==4.5.2
 flake8==3.7.8
-m2r==0.2.1
 mypy==0.740
 pdoc3==0.7.2
 pip


### PR DESCRIPTION
m2r is a markdown-to-restructred text converter.

I copied this from glean_parser, which uses it for its doc generation, but it's
not needed here.