### PR TITLE
Build carthage binary snapshots for each build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,39 @@ jobs:
           root: build/
           paths: docs/swift
       - run:
+          name: Build Carthage archive
+          no_output_timeout: 20m
+          command: |
+            if [ -z "${CIRCLE_TAG}" ]; then
+              # XCode tests build in Debug configuration, save us a full
+              # Rust rebuild in Release mode by forcing Debug mode on
+              # non-release builds.
+              bash bin/build-carthage.sh Glean Debug
+            else
+              bash bin/build-carthage.sh Glean
+            fi
+      - run:
+          name: "Create Carthage bin-only project specification"
+          command: |
+            ZIP_URL=https://circleci.com/api/v1.1/project/github/mozilla/glean/$CIRCLE_BUILD_NUM/artifacts/0/dist/Glean.framework.zip
+            echo "{\"0.0.1\":\"$ZIP_URL\"}" > mozilla.glean.json
+      - store_artifacts:
+          path: Glean.framework.zip
+          destination: dist/Glean.framework.zip
+      - store_artifacts:
+          path: mozilla.glean.json
+          destination: dist/mozilla.glean.json
+      - run:
+          name: "Carthage binary snapshot URL"
+          command: |
+            JSON_URL=https://circleci.com/api/v1.1/project/github/mozilla/glean/$CIRCLE_BUILD_NUM/artifacts/0/dist/mozilla.glean.json
+            echo "Add the following line to your Cartfile:"
+            echo "binary \"$JSON_URL\" ~> 0.0.1-snapshot # mozilla/glean@$CIRCLE_SHA1"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - Glean.framework.zip
+      - run:
           name: Create and upload code coverage
           command: |
               curl -L https://codecov.io/bash > codecov.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,10 @@ jobs:
       - checkout
       - run:
           name: Install lint tools
-          command: brew install swiftlint swiftformat
+          command: |
+            # do not update brew (might takes ages)
+            export HOMEBREW_NO_AUTO_UPDATE=1
+            brew install swiftlint swiftformat
       - run:
           name: Run swiftlint
           command: swiftlint --strict

--- a/bin/build-carthage.sh
+++ b/bin/build-carthage.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euvx
+
+FRAMEWORK_NAME="${1:-Glean}"
+CONFIGURATION="${2:-Release}"
+
+set -o pipefail && \
+    carthage build --archive --platform iOS --cache-builds --verbose --configuration "${CONFIGURATION}" "${FRAMEWORK_NAME}" | \
+    xcpretty


### PR DESCRIPTION
Step 1 of getting full binary releases.

See "Carthage binary snapshot URL" in https://circleci.com/gh/mozilla/glean/24984

```
Add the following line to your Cartfile:
binary "https://circleci.com/api/v1.1/project/github/mozilla/glean/24984/artifacts/0/dist/mozilla.glean.json" ~> 0.0.1-snapshot # mozilla/glean@036dd574ff6bb25126f0c9220740afa75898d447
```

I can do the "do that at release time and add it to the GitHub release" in a followup