### PR TITLE
Build dependencies in Debug mode for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,10 @@ jobs:
       - run:
           name: Build sample app
           command: |
+            # Build in Debug mode to speed it all up
+            pushd samples/ios/app
+            carthage bootstrap --platform iOS --no-use-binaries --cache-builds --configuration Debug --verbose
+            popd
             bash bin/run-ios-sample-app-build.sh
       - store_artifacts:
           path: raw_sample_xcodebuild.log


### PR DESCRIPTION
Looks like this might speed it up from previously 12 minutes total time to now 8 minutes.