### PR TITLE
Enable bors on the repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,7 +603,7 @@ workflows:
       - Lint Python
       - Rust FFI header check
       - Lint YAML with yamllint
-  ci:
+  test:
     jobs:
       - Rust tests - stable
       - Rust code coverage
@@ -631,7 +631,7 @@ workflows:
             - docs-linkcheck
           filters:
             branches:
-              only: master
+              only: staging
 
   release:
     jobs:

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,18 @@
+status = [
+  "check-formatting",
+  "lint",
+  "test"
+]
+block_labels = [
+  "needs:data-review",
+  "blocked",
+  "work in progress"
+]
+required_approvals = 1
+use_codeowners = true
+delete_merged_branches = true
+cut_body_after = "---"
+
+[committer]
+name = "glean-bors"
+email = "glean-team@mozilla.com"


### PR DESCRIPTION
This is the configuration enabling bors (https://bors.tech) to work on
this repository.

It will require enabling GitHub checks and removing the
review-required-on-PRs protection (which will now be enforced by bors
instead).

Currently known downsides:

* "Build succeeded/failed" messages will not contain a link to CI anymore.
It's a known issue and might get fixed: https://github.com/bors-ng/bors-ng/issues/569
* `bors try` works and runs, but for some reason bors does not get the notification that something is done.

---

Here's where I played around with it: https://github.com/badboy/glean-test-tc/pull/2

Steps to land this:

* [ ] Set up GitHub checks for this repository
* [ ] Enable this repository on https://bors.tech 