### PR TITLE
1595548: Fix truncation of string list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   * The experiments API is no longer ignored before the Glean SDK initialized. Calls are
     recorded and played back once the Glean SDK is initialized.
 
+  * String list items were being truncated to 20, rather than 50, bytes when using
+    `.set()` (rather than `.add()`). This has been corrected, but it may result
+    in changes in the sent data if using string list items longer than 20 bytes.
+
 # v21.1.1 (2019-11-20)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v21.1.0...v21.1.1)

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -113,7 +113,7 @@ impl StringListMetric {
         let value = value
             .into_iter()
             .map(|elem| {
-                truncate_string_at_boundary_with_error(glean, &self.meta, elem, MAX_LIST_LENGTH)
+                truncate_string_at_boundary_with_error(glean, &self.meta, elem, MAX_STRING_LENGTH)
             })
             .collect();
 

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -133,6 +133,20 @@ fn long_string_values_are_truncated() {
         Ok(1),
         test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
     );
+
+    metric.set(&glean, vec![test_string.clone()]);
+
+    // Ensure the string was truncated to the proper length.
+    assert_eq!(
+        vec![test_string[..50].to_string()],
+        metric.test_get_value(&glean, "store1").unwrap()
+    );
+
+    // Ensure the error has been recorded.
+    assert_eq!(
+        Ok(2),
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Oops.  ¯\_(ツ)_/¯

This will affect analysis against previously collected data, since the old values will be truncated, but new values will not.  Thoughts about that?