### PR TITLE
Update message on "test mode" assertions

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -77,8 +77,8 @@ internal object Dispatchers {
             assert(
                 testingMode
             ) {
-                "To use the testing API, Glean must be in testing mode by calling " +
-                "Glean.enableTestingMode() (for example, in a @Before method)."
+                "To use the testing API, apply the GleanTestRule to set up a disposable Glean " +
+                "instance. e.g. GleanTestRule(ApplicationProvider.getApplicationContext())"
             }
         }
 

--- a/glean-core/ios/Glean/Dispatchers.swift
+++ b/glean-core/ios/Glean/Dispatchers.swift
@@ -178,7 +178,7 @@ class Dispatchers {
     func assertInTestingMode() {
         assert(
             testingMode,
-            "To use the testing API, Glean must be in testing mode by calling Glean.shared.enableTestingMode()"
+            "To use the testing API, put the Glean SDK in testing mode. e.g. Glean.shared.resetGlean(clearStores: true)"
         )
     }
 


### PR DESCRIPTION
Fixes [Bug 1600005](https://bugzilla.mozilla.org/show_bug.cgi?id=1600005)

Messages to assert if Glean is in testing mode for both Kotlin
and Swift were referencing the old enableTestingMode API which
is deprecated. Both have been updated to mirror the new API.