### PR TITLE
Refactor Android uploaders to share more code

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
@@ -40,7 +40,7 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
             WorkManager.getInstance(context).enqueueUniqueWork(
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
-                buildWorkRequest(PING_WORKER_TAG))
+                buildWorkRequest<DeletionPingUploadWorker>(PING_WORKER_TAG))
         }
 
         /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
@@ -5,22 +5,14 @@
 package mozilla.telemetry.glean.scheduler
 
 import android.content.Context
-import android.util.Log
-import androidx.annotation.VisibleForTesting
-import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
-import androidx.work.NetworkType
-import androidx.work.OneTimeWorkRequest
-import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import mozilla.telemetry.glean.Glean
-import java.io.BufferedReader
 import java.io.File
-import java.io.FileNotFoundException
-import java.io.FileReader
-import java.io.IOException
+
+private const val LOG_TAG = "glean/DeletionPing"
 
 /**
  * This class is the worker class used by [WorkManager] to handle uploading the ping to the server.
@@ -30,9 +22,6 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
     companion object {
         internal const val PING_WORKER_TAG = "mozac_service_glean_deletion_ping_upload_worker"
 
-        // Since ping file names are UUIDs, this matches UUIDs for filtering purposes
-        private const val FILE_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-        private const val LOG_TAG = "glean/DeletionPing"
         // NOTE: The `PINGS_DIR` must be kept in sync with the one in the Rust implementation.
         internal const val DELETION_PING_DIR = "deletion_request"
         // A lock to prevent simultaneous writes in the ping queue directory.
@@ -43,28 +32,6 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
         internal val pingQueueLock = Any()
 
         /**
-         * Build the constraints around which the worker can be run, such as whether network
-         * connectivity is required.
-         *
-         * @return [Constraints] object containing the required work constraints
-         */
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        fun buildConstraints(): Constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-
-        /**
-         * Build the [OneTimeWorkRequest] for enqueueing in the [WorkManager].  This also adds a tag
-         * by which enqueued requests can be identified.
-         *
-         * @return [OneTimeWorkRequest] representing the task for the [WorkManager] to enqueue and run
-         */
-        internal fun buildWorkRequest(): OneTimeWorkRequest = OneTimeWorkRequestBuilder<DeletionPingUploadWorker>()
-            .addTag(PING_WORKER_TAG)
-            .setConstraints(buildConstraints())
-            .build()
-
-        /**
          * Function to aid in properly enqueuing the worker in [WorkManager]
          *
          * @param context the application [Context] to get the [WorkManager] instance for
@@ -73,7 +40,7 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
             WorkManager.getInstance(context).enqueueUniqueWork(
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
-                buildWorkRequest())
+                buildWorkRequest(PING_WORKER_TAG))
         }
 
         /**
@@ -82,7 +49,6 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
          *
          * @return true if process was successful
          */
-        internal fun uploadPings(): Boolean = process()
 
         /**
          * Function to cancel any pending ping upload workers
@@ -101,73 +67,10 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
          * @return Boolean representing the success of the upload task. This may be the value bubbled up
          *         from the callback, or if there was an error reading the files.
          */
-        fun process(): Boolean {
-            // This function is from PingsStorageEngine in glean-ac
-
-            var success = true
-            // TODO: 1551694 Get this directory from the rust side
+        internal fun uploadPings(): Boolean {
             val storageDirectory = File(Glean.getDataDir(), DELETION_PING_DIR)
 
-            Log.d(LOG_TAG, "Processing persisted pings at ${storageDirectory.absolutePath}")
-
-            synchronized(pingQueueLock) {
-                storageDirectory.listFiles()?.forEach { file ->
-                    if (file.name.matches(Regex(FILE_PATTERN))) {
-                        Log.d(LOG_TAG, "Processing ping: ${file.name}")
-                        if (!processFile(file)) {
-                            Log.e(LOG_TAG, "Error processing ping file: ${file.name}")
-                            success = false
-                        }
-                    } else {
-                        // Delete files that don't match the UUID FILE_PATTERN regex
-                        Log.d(LOG_TAG, "Pattern mismatch. Deleting ${file.name}")
-                        file.delete()
-                    }
-                }
-            }
-
-            return success
-        }
-
-        /**
-         * This function encapsulates processing of a single ping file.
-         *
-         * @param file The [File] to process
-         *
-         */
-        @Suppress("ReturnCount")
-        private fun processFile(
-            file: File
-        ): Boolean {
-            // This function is from PingsStorageEngine in glean-ac
-
-            var processed = false
-            BufferedReader(FileReader(file)).use {
-                try {
-                    val path = it.readLine()
-                    val serializedPing = it.readLine()
-
-                    processed = serializedPing == null ||
-                        Glean.httpClient.doUpload(path, serializedPing, Glean.configuration)
-                } catch (e: FileNotFoundException) {
-                    // This shouldn't happen after we queried the directory.
-                    Log.e(LOG_TAG, "Could not find ping file ${file.name}")
-                    return false
-                } catch (e: IOException) {
-                    // Something is not right.
-                    Log.e(LOG_TAG, "IO Exception when reading file ${file.name}")
-                    return false
-                }
-            }
-
-            return if (processed) {
-                val fileWasDeleted = file.delete()
-                Log.d(LOG_TAG, "${file.name} was deleted: $fileWasDeleted")
-                true
-            } else {
-                // The callback couldn't process this file.
-                false
-            }
+            return processDirectory(pingQueueLock, storageDirectory)
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -22,6 +22,103 @@ import java.io.FileNotFoundException
 import java.io.FileReader
 import java.io.IOException
 
+// Since ping file names are UUIDs, this matches UUIDs for filtering purposes
+private const val FILE_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+private const val LOG_TAG = "glean/PingUploadWorker"
+
+/**
+ * Build the constraints around which the worker can be run, such as whether network
+ * connectivity is required.
+ *
+ * @return [Constraints] object containing the required work constraints
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+fun buildConstraints(): Constraints = Constraints.Builder()
+    .setRequiredNetworkType(NetworkType.CONNECTED)
+    .build()
+
+/**
+ * Build the [OneTimeWorkRequest] for enqueueing in the [WorkManager].  This also adds a tag
+ * by which enqueued requests can be identified.
+ *
+ * @return [OneTimeWorkRequest] representing the task for the [WorkManager] to enqueue and run
+ */
+internal fun buildWorkRequest(tag: String): OneTimeWorkRequest = OneTimeWorkRequestBuilder<PingUploadWorker>()
+    .addTag(tag)
+    .setConstraints(buildConstraints())
+    .build()
+
+/**
+ * This function encapsulates processing of a single ping file.
+ *
+ * @param file The [File] to process
+ *
+ */
+@Suppress("ReturnCount")
+private fun processFile(file: File): Boolean {
+    // This function is from PingsStorageEngine in glean-ac
+
+    var processed = false
+    BufferedReader(FileReader(file)).use {
+        try {
+            val path = it.readLine()
+            val serializedPing = it.readLine()
+
+            processed = serializedPing == null ||
+                Glean.httpClient.doUpload(path, serializedPing, Glean.configuration)
+        } catch (e: FileNotFoundException) {
+            // This shouldn't happen after we queried the directory.
+            Log.e(LOG_TAG, "Could not find ping file ${file.name}")
+            return false
+        } catch (e: IOException) {
+            // Something is not right.
+            Log.e(LOG_TAG, "IO Exception when reading file ${file.name}")
+            return false
+        }
+    }
+
+    return if (processed) {
+        val fileWasDeleted = file.delete()
+        Log.d(LOG_TAG, "${file.name} was deleted: $fileWasDeleted")
+        true
+    } else {
+        // The callback couldn't process this file.
+        false
+    }
+}
+
+/**
+ * Function to deserialize and process all serialized ping files.  This function will ignore
+ * files that don't match the UUID regex and just delete them to prevent files from polluting
+ * the ping storage directory.
+ *
+ * @return Boolean representing the success of the upload task. This may be the value bubbled up
+ *         from the callback, or if there was an error reading the files.
+ */
+fun processDirectory(lock: Any, storageDirectory: File): Boolean {
+    var success = true
+
+    Log.d(LOG_TAG, "Processing persisted pings at ${storageDirectory.absolutePath}")
+
+    synchronized(lock) {
+        storageDirectory.listFiles()?.forEach { file ->
+            if (file.name.matches(Regex(FILE_PATTERN))) {
+                Log.d(LOG_TAG, "Processing ping: ${file.name}")
+                if (!processFile(file)) {
+                    Log.e(LOG_TAG, "Error processing ping file: ${file.name}")
+                    success = false
+                }
+            } else {
+                // Delete files that don't match the UUID FILE_PATTERN regex
+                Log.d(LOG_TAG, "Pattern mismatch. Deleting ${file.name}")
+                file.delete()
+            }
+        }
+    }
+
+    return success
+}
+
 /**
  * This class is the worker class used by [WorkManager] to handle uploading the ping to the server.
  * @suppress This is internal only, don't show it in the docs.
@@ -30,9 +127,6 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
     companion object {
         internal const val PING_WORKER_TAG = "mozac_service_glean_ping_upload_worker"
 
-        // Since ping file names are UUIDs, this matches UUIDs for filtering purposes
-        private const val FILE_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-        private const val LOG_TAG = "glean/PingUploadWorker"
         // NOTE: The `PINGS_DIR` must be kept in sync with the one in the Rust implementation.
         internal const val PINGS_DIR = "pending_pings"
         // A lock to prevent simultaneous writes in the ping queue directory.
@@ -43,28 +137,6 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
         internal val pingQueueLock = Any()
 
         /**
-         * Build the constraints around which the worker can be run, such as whether network
-         * connectivity is required.
-         *
-         * @return [Constraints] object containing the required work constraints
-         */
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        fun buildConstraints(): Constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-
-        /**
-         * Build the [OneTimeWorkRequest] for enqueueing in the [WorkManager].  This also adds a tag
-         * by which enqueued requests can be identified.
-         *
-         * @return [OneTimeWorkRequest] representing the task for the [WorkManager] to enqueue and run
-         */
-        internal fun buildWorkRequest(): OneTimeWorkRequest = OneTimeWorkRequestBuilder<PingUploadWorker>()
-            .addTag(PING_WORKER_TAG)
-            .setConstraints(buildConstraints())
-            .build()
-
-        /**
          * Function to aid in properly enqueuing the worker in [WorkManager]
          *
          * @param context the application [Context] to get the [WorkManager] instance for
@@ -73,16 +145,8 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
             WorkManager.getInstance(context).enqueueUniqueWork(
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
-                buildWorkRequest())
+                buildWorkRequest(PING_WORKER_TAG))
         }
-
-        /**
-         * Function to perform the actual ping upload task.  This is created here in the
-         * companion object in order to facilitate testing.
-         *
-         * @return true if process was successful
-         */
-        internal fun uploadPings(): Boolean = process()
 
         /**
          * Function to cancel any pending ping upload workers
@@ -94,80 +158,14 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
         }
 
         /**
-         * Function to deserialize and process all serialized ping files.  This function will ignore
-         * files that don't match the UUID regex and just delete them to prevent files from polluting
-         * the ping storage directory.
+         * Function to perform the actual ping upload task.
          *
-         * @return Boolean representing the success of the upload task. This may be the value bubbled up
-         *         from the callback, or if there was an error reading the files.
+         * @return true if process was successful
          */
-        fun process(): Boolean {
-            // This function is from PingsStorageEngine in glean-ac
-
-            var success = true
-            // TODO: 1551694 Get this directory from the rust side
+        internal fun uploadPings(): Boolean {
             val storageDirectory = File(Glean.getDataDir(), PINGS_DIR)
 
-            Log.d(LOG_TAG, "Processing persisted pings at ${storageDirectory.absolutePath}")
-
-            synchronized(pingQueueLock) {
-                storageDirectory.listFiles()?.forEach { file ->
-                    if (file.name.matches(Regex(FILE_PATTERN))) {
-                        Log.d(LOG_TAG, "Processing ping: ${file.name}")
-                        if (!processFile(file)) {
-                            Log.e(LOG_TAG, "Error processing ping file: ${file.name}")
-                            success = false
-                        }
-                    } else {
-                        // Delete files that don't match the UUID FILE_PATTERN regex
-                        Log.d(LOG_TAG, "Pattern mismatch. Deleting ${file.name}")
-                        file.delete()
-                    }
-                }
-            }
-
-            return success
-        }
-
-        /**
-         * This function encapsulates processing of a single ping file.
-         *
-         * @param file The [File] to process
-         *
-         */
-        @Suppress("ReturnCount")
-        private fun processFile(
-            file: File
-        ): Boolean {
-            // This function is from PingsStorageEngine in glean-ac
-
-            var processed = false
-            BufferedReader(FileReader(file)).use {
-                try {
-                    val path = it.readLine()
-                    val serializedPing = it.readLine()
-
-                    processed = serializedPing == null ||
-                        Glean.httpClient.doUpload(path, serializedPing, Glean.configuration)
-                } catch (e: FileNotFoundException) {
-                    // This shouldn't happen after we queried the directory.
-                    Log.e(LOG_TAG, "Could not find ping file ${file.name}")
-                    return false
-                } catch (e: IOException) {
-                    // Something is not right.
-                    Log.e(LOG_TAG, "IO Exception when reading file ${file.name}")
-                    return false
-                }
-            }
-
-            return if (processed) {
-                val fileWasDeleted = file.delete()
-                Log.d(LOG_TAG, "${file.name} was deleted: $fileWasDeleted")
-                true
-            } else {
-                // The callback couldn't process this file.
-                false
-            }
+            return processDirectory(pingQueueLock, storageDirectory)
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -33,7 +33,7 @@ private const val LOG_TAG = "glean/PingUploadWorker"
  * @return [Constraints] object containing the required work constraints
  */
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-fun buildConstraints(): Constraints = Constraints.Builder()
+internal fun buildConstraints(): Constraints = Constraints.Builder()
     .setRequiredNetworkType(NetworkType.CONNECTED)
     .build()
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -43,10 +43,12 @@ fun buildConstraints(): Constraints = Constraints.Builder()
  *
  * @return [OneTimeWorkRequest] representing the task for the [WorkManager] to enqueue and run
  */
-internal fun buildWorkRequest(tag: String): OneTimeWorkRequest = OneTimeWorkRequestBuilder<PingUploadWorker>()
-    .addTag(tag)
-    .setConstraints(buildConstraints())
-    .build()
+internal inline fun <reified W : Worker> buildWorkRequest(tag: String): OneTimeWorkRequest {
+    return OneTimeWorkRequestBuilder<W>()
+        .addTag(tag)
+        .setConstraints(buildConstraints())
+        .build()
+}
 
 /**
  * This function encapsulates processing of a single ping file.
@@ -145,7 +147,7 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
             WorkManager.getInstance(context).enqueueUniqueWork(
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
-                buildWorkRequest(PING_WORKER_TAG))
+                buildWorkRequest<PingUploadWorker>(PING_WORKER_TAG))
         }
 
         /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
@@ -39,7 +39,7 @@ class PingUploadWorkerTest {
     fun testPingConfiguration() {
         // Set the constraints around which the worker can be run, in this case it
         // only requires that any network connection be available.
-        val workRequest = PingUploadWorker.buildWorkRequest()
+        val workRequest = buildWorkRequest(PingUploadWorker.PING_WORKER_TAG)
         val workSpec = workRequest.workSpec
 
         // verify constraints

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
@@ -39,7 +39,7 @@ class PingUploadWorkerTest {
     fun testPingConfiguration() {
         // Set the constraints around which the worker can be run, in this case it
         // only requires that any network connection be available.
-        val workRequest = buildWorkRequest(PingUploadWorker.PING_WORKER_TAG)
+        val workRequest = buildWorkRequest<PingUploadWorker>(PingUploadWorker.PING_WORKER_TAG)
         val workSpec = workRequest.workSpec
 
         // verify constraints

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
@@ -109,8 +109,19 @@ class DeletionRequestPingTest {
         Thread.sleep(1000) // FIXME: for some reason, without this, WorkManager won't find the job
         triggerEnqueuedUpload("mozac_service_glean_deletion_ping_upload_worker")
 
+        // We might receive previous baseline or events ping, let's ignore that
+        var retries = 3
+        var ping: JSONObject? = null
+        while (retries > 0) {
+            ping = waitForPingContent("deletion_request")
+            if (ping != null) {
+                break
+            }
+            retries -= 1
+        }
+        val deletionPing = ping!!
+
         // Validate the received data.
-        val deletionPing = waitForPingContent("deletion_request")!!
         assertEquals("deletion_request", deletionPing.getJSONObject("ping_info")["ping_type"])
 
         var clientInfo = deletionPing.getJSONObject("client_info")


### PR DESCRIPTION
I moved shared functionality into free-standing functions

We could keep it in the companion object, but it felt a bit weird to re-use functions in another class across its companion object.
Also the one in the derived class just shadows the one from the superclass, so we need to use explicit calls.