### PR TITLE
Release version 22.0.0

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 21.3.0
+libraryVersion: 22.0.0
 groupId: org.mozilla.telemetry
 projects:
   glean:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v21.3.0...master)
+[Full changelog](https://github.com/mozilla/glean/compare/v22.0.0...master)
+
+# v22.0.0 (2019-12-05)
+
+[Full changelog](https://github.com/mozilla/glean/compare/v21.3.0...22.0.0)
+
+* Add option to defer ping lifetime metric persistence ([#530](https://github.com/mozilla/glean/pull/530))
+* Add a crate for the nice control API ([#542](https://github.com/mozilla/glean/pull/542))
+* Pending `deletion_request` pings are resent on start ([#545](https://github.com/mozilla/glean/pull/545))
 
 # v21.3.0 (2019-12-03)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "21.3.0"
+version = "22.0.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -320,12 +320,12 @@ dependencies = [
 
 [[package]]
 name = "glean-ffi"
-version = "21.3.0"
+version = "22.0.0"
 dependencies = [
  "android_logger 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 21.3.0",
+ "glean-core 22.0.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -337,8 +337,8 @@ version = "0.0.1"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 21.3.0",
- "glean-ffi 21.3.0",
+ "glean-core 22.0.0",
+ "glean-ffi 22.0.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "21.3.0"
+version = "22.0.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-ffi"
-version = "21.3.0"
+version = "22.0.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "FFI layer for Glean, a modern Telemetry library"
 repository = "https://github.com/mozilla/glean"
@@ -34,7 +34,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 
 [dependencies.glean-core]
 path = ".."
-version = "21.3.0"
+version = "22.0.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = { version = "0.8.5", default-features = false }

--- a/glean-core/preview/Cargo.toml
+++ b/glean-core/preview/Cargo.toml
@@ -22,11 +22,11 @@ maintenance = { status = "actively-developed" }
 
 [dependencies.glean-ffi]
 path = "../ffi"
-version = "21.3.0"
+version = "22.0.0"
 
 [dependencies.glean-core]
 path = ".."
-version = "21.3.0"
+version = "22.0.0"
 
 [dependencies]
 ffi-support = "0.3.5"

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -367,7 +367,7 @@ subprocess.check_call([
     }
 
     void apply(Project project) {
-        project.ext.glean_version = "21.3.0"
+        project.ext.glean_version = "22.0.0"
 
         File condaDir = setupPythonEnvironmentTasks(project)
         project.ext.set("gleanCondaDir", condaDir)


### PR DESCRIPTION
In order for me to publish the API preview crate, I actually need minimal changes on the FFI layer.
Which means I need to release that.
Which means we need to do a full release.

(And this is where I think having all with the same version number falls down a bit, maybe we need to revisit that in the new year)