### PR TITLE
Extend timeout in UI tests

### DIFF
--- a/samples/ios/app/glean-sample-appUITests/ViewControllerTest.swift
+++ b/samples/ios/app/glean-sample-appUITests/ViewControllerTest.swift
@@ -54,7 +54,7 @@ class ViewControllerTest: XCTestCase {
         expectation = expectation(description: "Completed upload")
         sendButton.tap()
 
-        waitForExpectations(timeout: 5.0) { error in
+        waitForExpectations(timeout: 10.0) { error in
             XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
         }
 
@@ -69,7 +69,7 @@ class ViewControllerTest: XCTestCase {
         expectation = expectation(description: "Completed upload")
         sendButton.tap()
 
-        waitForExpectations(timeout: 5.0) { error in
+        waitForExpectations(timeout: 10.0) { error in
             XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
         }
 


### PR DESCRIPTION
For some reason we see frequent timeout errors in these tests when run
on CI.
It's unclear if that is due to a too-short timeout or actual issues.

Let's increase it for now and see if it is still hit.