### PR TITLE
Add glean registry files as `inputs` to the generation tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 * Python bindings:
 
   * Support for events was added.
-  
-* The Glean Gradle Plugin correctly triggers docs and API updates when registry files
-  change, without requiring them to be deleted.
+
+* All platforms
+
+  * The Glean Gradle Plugin correctly triggers docs and API updates when registry files
+    change, without requiring them to be deleted.
 
 # v22.0.0 (2019-12-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Python bindings:
 
   * Support for events was added.
+  
+* The Glean Gradle Plugin correctly triggers docs and API updates when registry files
+  change, without requiring them to be deleted.
 
 # v22.0.0 (2019-12-05)
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -123,6 +123,12 @@ subprocess.check_call([
                     }.files
                 }
 
+                // Add local registry files as input to this task. They will be turned
+                // into `arg`s later.
+                for (String item : getYamlFiles(project)) {
+                    inputs.file item
+                }
+
                 outputs.dir sourceOutputDir
 
                 workingDir project.rootDir
@@ -146,9 +152,6 @@ subprocess.check_call([
                 args "namespace=$fullNamespace"
                 args "-s"
                 args "glean_namespace=$gleanNamespace"
-                for (String item : getYamlFiles(project)) {
-                    args item
-                }
 
                 // If we're building the Glean library itself (rather than an
                 // application using Glean) pass the --allow-reserved flag so we can
@@ -160,11 +163,9 @@ subprocess.check_call([
                 doFirst {
                     // Add the potential 'metrics.yaml' files at evaluation-time, rather than
                     // configuration-time. Otherwise the Gradle build will fail.
-                    if (project.ext.has("allowMetricsFromAAR")) {
-                        inputs.files.forEach { file ->
-                            project.logger.lifecycle("Glean SDK - generating API from ${file.path}")
-                            args file.path
-                        }
+                    inputs.files.forEach { file ->
+                        project.logger.lifecycle("Glean SDK - generating API from ${file.path}")
+                        args file.path
                     }
                 }
 
@@ -197,6 +198,12 @@ subprocess.check_call([
                     }.files
                 }
 
+                // Add local registry files as input to this task. They will be turned
+                // into `arg`s later.
+                for (String item : getYamlFiles(project)) {
+                    inputs.file item
+                }
+
                 outputs.dir gleanDocsDirectory
                 workingDir project.rootDir
                 commandLine getPythonCommand(condaDir)
@@ -210,9 +217,6 @@ subprocess.check_call([
                 args "markdown"
                 args "-o"
                 args gleanDocsDirectory
-                for (String item : getYamlFiles(project)) {
-                    args item
-                }
 
                 // If we're building the Glean library itself (rather than an
                 // application using Glean) pass the --allow-reserved flag so we can
@@ -224,11 +228,9 @@ subprocess.check_call([
                 doFirst {
                     // Add the potential 'metrics.yaml' files at evaluation-time, rather than
                     // configuration-time. Otherwise the Gradle build will fail.
-                    if (project.ext.has("allowMetricsFromAAR")) {
-                        inputs.files.forEach{ file ->
-                            project.logger.lifecycle("Glean SDK - generating docs for ${file.path} in $gleanDocsDirectory")
-                            args file.path
-                        }
+                    inputs.files.forEach{ file ->
+                        project.logger.lifecycle("Glean SDK - generating docs for ${file.path} in $gleanDocsDirectory")
+                        args file.path
                     }
                 }
 


### PR DESCRIPTION
This ensures that, whenever a change is made to a registry file, docs and specific metrics APIs are regenerated accordingly.

This was tested by adding metrics to both the sample app and glean-core's registry files, then just building using the "Android Studio" hammer button. Doc changes were picked up and the APIs were correctly regenerated.

Without this change, sometimes, the code wouldn't be regenerated.