### PR TITLE
Enhance `new_glean` test function to attend to all test cases

### DIFF
--- a/glean-core/tests/boolean.rs
+++ b/glean-core/tests/boolean.rs
@@ -9,24 +9,20 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // SKIPPED from glean-ac: string deserializer should correctly parse integers
 // This test doesn't really apply to rkv
 
 #[test]
 fn boolean_serializer_should_correctly_serialize_boolean() {
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let metric = BooleanMetric::new(CommonMetricData {
             name: "boolean_metric".into(),
@@ -51,7 +47,7 @@ fn boolean_serializer_should_correctly_serialize_boolean() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -64,7 +60,7 @@ fn boolean_serializer_should_correctly_serialize_boolean() {
 
 #[test]
 fn set_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = BooleanMetric::new(CommonMetricData {

--- a/glean-core/tests/boolean.rs
+++ b/glean-core/tests/boolean.rs
@@ -19,9 +19,9 @@ fn boolean_serializer_should_correctly_serialize_boolean() {
     let (mut tempdir, _) = tempdir();
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let metric = BooleanMetric::new(CommonMetricData {

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -45,8 +45,11 @@ pub const GLOBAL_APPLICATION_ID: &str = "org.mozilla.glean.test.app";
 
 // Create a new instance of Glean with a temporary directory.
 // We need to keep the `TempDir` alive, so that it's not deleted before we stop using it.
-pub fn new_glean() -> (Glean, tempfile::TempDir) {
-    let dir = tempfile::tempdir().unwrap();
+pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDir) {
+    let dir = match tempdir {
+        Some(tempdir) => tempdir,
+        None => tempfile::tempdir().unwrap(),
+    };
     let tmpname = dir.path().display().to_string();
 
     let cfg = glean_core::Configuration {

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
 use glean_core::{test_get_num_recorded_errors, ErrorType};
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // Tests ported from glean-ac
 
@@ -19,17 +19,13 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 
 #[test]
 fn counter_serializer_should_correctly_serialize_counters() {
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let metric = CounterMetric::new(CommonMetricData {
             name: "counter_metric".into(),
@@ -54,7 +50,7 @@ fn counter_serializer_should_correctly_serialize_counters() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg).unwrap();
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -67,7 +63,7 @@ fn counter_serializer_should_correctly_serialize_counters() {
 
 #[test]
 fn set_value_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = CounterMetric::new(CommonMetricData {
@@ -98,7 +94,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn counters_must_not_increment_when_passed_zero_or_negative() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = CounterMetric::new(CommonMetricData {
         name: "counter_metric".into(),
@@ -135,7 +131,7 @@ fn counters_must_not_increment_when_passed_zero_or_negative() {
 
 #[test]
 fn transformation_works() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let counter: CounterMetric = CounterMetric::new(CommonMetricData {
         name: "transformation".into(),
@@ -162,7 +158,7 @@ fn transformation_works() {
 
 #[test]
 fn saturates_at_boundary() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let counter: CounterMetric = CounterMetric::new(CommonMetricData {
         name: "transformation".into(),

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -22,9 +22,9 @@ fn counter_serializer_should_correctly_serialize_counters() {
     let (mut tempdir, _) = tempdir();
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let metric = CounterMetric::new(CommonMetricData {

--- a/glean-core/tests/custom_distribution.rs
+++ b/glean-core/tests/custom_distribution.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
 use glean_core::{test_get_num_recorded_errors, ErrorType};
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // Tests ported from glean-ac
 
@@ -19,18 +19,11 @@ mod linear {
 
     #[test]
     fn serializer_should_correctly_serialize_custom_distribution() {
-        let (_t, tmpname) = tempdir();
-
-        let cfg = glean_core::Configuration {
-            data_path: tmpname,
-            application_id: GLOBAL_APPLICATION_ID.into(),
-            upload_enabled: true,
-            max_events: None,
-            delay_ping_lifetime_io: false,
-        };
+        let (mut tempdir, _) = tempdir();
 
         {
-            let glean = Glean::new(cfg.clone()).unwrap();
+            let (glean, dir) = new_glean(Some(tempdir));
+            tempdir = dir;
 
             let metric = CustomDistributionMetric::new(
                 CommonMetricData {
@@ -59,7 +52,7 @@ mod linear {
         // Make a new Glean instance here, which should force reloading of the data from disk
         // so we can ensure it persisted, because it has User lifetime
         {
-            let glean = Glean::new(cfg.clone()).unwrap();
+            let (glean, _) = new_glean(Some(tempdir));
             let snapshot = StorageManager
                 .snapshot_as_json(glean.storage(), "store1", true)
                 .unwrap();
@@ -73,7 +66,7 @@ mod linear {
 
     #[test]
     fn set_value_properly_sets_the_value_in_all_stores() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
         let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
         let metric = CustomDistributionMetric::new(
@@ -114,7 +107,7 @@ mod linear {
 
     #[test]
     fn the_accumulate_samples_api_correctly_stores_memory_values() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
 
         let metric = CustomDistributionMetric::new(
             CommonMetricData {
@@ -162,7 +155,7 @@ mod linear {
 
     #[test]
     fn the_accumulate_samples_api_correctly_handles_negative_values() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
 
         let metric = CustomDistributionMetric::new(
             CommonMetricData {
@@ -211,7 +204,7 @@ mod linear {
 
     #[test]
     fn json_snapshotting_works() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
         let metric = CustomDistributionMetric::new(
             CommonMetricData {
                 name: "distribution".into(),
@@ -239,18 +232,11 @@ mod exponential {
 
     #[test]
     fn serializer_should_correctly_serialize_custom_distribution() {
-        let (_t, tmpname) = tempdir();
-
-        let cfg = glean_core::Configuration {
-            data_path: tmpname,
-            application_id: GLOBAL_APPLICATION_ID.into(),
-            upload_enabled: true,
-            max_events: None,
-            delay_ping_lifetime_io: false,
-        };
+        let (mut tempdir, _) = tempdir();
 
         {
-            let glean = Glean::new(cfg.clone()).unwrap();
+            let (glean, dir) = new_glean(Some(tempdir));
+            tempdir = dir;
 
             let metric = CustomDistributionMetric::new(
                 CommonMetricData {
@@ -279,7 +265,7 @@ mod exponential {
         // Make a new Glean instance here, which should force reloading of the data from disk
         // so we can ensure it persisted, because it has User lifetime
         {
-            let glean = Glean::new(cfg.clone()).unwrap();
+            let (glean, _) = new_glean(Some(tempdir));
             let snapshot = StorageManager
                 .snapshot_as_json(glean.storage(), "store1", true)
                 .unwrap();
@@ -293,7 +279,7 @@ mod exponential {
 
     #[test]
     fn set_value_properly_sets_the_value_in_all_stores() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
         let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
         let metric = CustomDistributionMetric::new(
@@ -334,7 +320,7 @@ mod exponential {
 
     #[test]
     fn the_accumulate_samples_api_correctly_stores_memory_values() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
 
         let metric = CustomDistributionMetric::new(
             CommonMetricData {
@@ -382,7 +368,7 @@ mod exponential {
 
     #[test]
     fn the_accumulate_samples_api_correctly_handles_negative_values() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
 
         let metric = CustomDistributionMetric::new(
             CommonMetricData {
@@ -431,7 +417,7 @@ mod exponential {
 
     #[test]
     fn json_snapshotting_works() {
-        let (glean, _t) = new_glean();
+        let (glean, _t) = new_glean(None);
         let metric = CustomDistributionMetric::new(
             CommonMetricData {
                 name: "distribution".into(),

--- a/glean-core/tests/datetime.rs
+++ b/glean-core/tests/datetime.rs
@@ -21,9 +21,9 @@ fn datetime_serializer_should_correctly_serialize_datetime() {
     let (mut tempdir, _) = tempdir();
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let metric = DatetimeMetric::new(

--- a/glean-core/tests/datetime.rs
+++ b/glean-core/tests/datetime.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // SKIPPED from glean-ac: datetime deserializer should correctly parse integers
 // This test doesn't really apply to rkv
@@ -18,17 +18,13 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 #[test]
 fn datetime_serializer_should_correctly_serialize_datetime() {
     let expected_value = "1983-04-13T12:09+00:00";
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let metric = DatetimeMetric::new(
             CommonMetricData {
@@ -60,7 +56,7 @@ fn datetime_serializer_should_correctly_serialize_datetime() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -73,7 +69,7 @@ fn datetime_serializer_should_correctly_serialize_datetime() {
 
 #[test]
 fn set_value_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = DatetimeMetric::new(
@@ -112,7 +108,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn test_that_truncation_works() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     // `1985-07-03T12:09:14.000560274+01:00`
     let high_res_datetime = FixedOffset::east(3600)

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -15,7 +15,7 @@ use glean_core::{CommonMetricData, Lifetime};
 fn record_properly_records_without_optional_arguments() {
     let store_names = vec!["store1".into(), "store2".into()];
 
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = EventMetric::new(
         CommonMetricData {
@@ -42,7 +42,7 @@ fn record_properly_records_without_optional_arguments() {
 
 #[test]
 fn record_properly_records_with_optional_arguments() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let store_names = vec!["store1".into(), "store2".into()];
 
@@ -83,7 +83,7 @@ fn record_properly_records_with_optional_arguments() {
 
 #[test]
 fn snapshot_returns_none_if_nothing_is_recorded_in_the_store() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     assert!(glean
         .event_storage()
@@ -93,7 +93,7 @@ fn snapshot_returns_none_if_nothing_is_recorded_in_the_store() {
 
 #[test]
 fn snapshot_correctly_clears_the_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let store_names = vec!["store1".into(), "store2".into()];
 
@@ -147,7 +147,7 @@ fn snapshot_correctly_clears_the_stores() {
 
 #[test]
 fn test_sending_of_event_ping_when_it_fills_up() {
-    let (mut glean, _t) = new_glean();
+    let (mut glean, _t) = new_glean(None);
 
     let store_names: Vec<String> = vec!["events".into()];
 
@@ -199,7 +199,7 @@ fn test_sending_of_event_ping_when_it_fills_up() {
 
 #[test]
 fn extra_keys_must_be_recorded_and_truncated_if_needed() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let store_names: Vec<String> = vec!["store1".into()];
 
@@ -240,7 +240,7 @@ fn extra_keys_must_be_recorded_and_truncated_if_needed() {
 
 #[test]
 fn snapshot_sorts_the_timestamps() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = EventMetric::new(
         CommonMetricData {

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -9,12 +9,11 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
-use glean_core::Glean;
 use glean_core::{CommonMetricData, Lifetime};
 
 #[test]
 fn can_create_labeled_counter_metric() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -46,7 +45,7 @@ fn can_create_labeled_counter_metric() {
 
 #[test]
 fn can_create_labeled_string_metric() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         StringMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -78,7 +77,7 @@ fn can_create_labeled_string_metric() {
 
 #[test]
 fn can_create_labeled_bool_metric() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         BooleanMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -110,7 +109,7 @@ fn can_create_labeled_bool_metric() {
 
 #[test]
 fn can_use_multiple_labels() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -148,7 +147,7 @@ fn can_use_multiple_labels() {
 
 #[test]
 fn labels_are_checked_against_static_list() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -193,7 +192,7 @@ fn labels_are_checked_against_static_list() {
 
 #[test]
 fn dynamic_labels_too_long() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -228,7 +227,7 @@ fn dynamic_labels_too_long() {
 
 #[test]
 fn dynamic_labels_regex_mimsatch() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -274,7 +273,7 @@ fn dynamic_labels_regex_mimsatch() {
 
 #[test]
 fn dynamic_labels_regex_allowed() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
             name: "labeled_metric".into(),
@@ -327,16 +326,10 @@ fn dynamic_labels_regex_allowed() {
 
 #[test]
 fn seen_labels_get_reloaded_from_disk() {
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
-    let glean = Glean::new(cfg.clone()).unwrap();
+    let (glean, dir) = new_glean(Some(tempdir));
+    tempdir = dir;
 
     let mut labeled = LabeledMetric::new(
         CounterMetric::new(CommonMetricData {
@@ -376,7 +369,7 @@ fn seen_labels_get_reloaded_from_disk() {
 
     // Force a reload
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
 
         // Try to store another label
         labeled.get("new_label").add(&glean, 40);

--- a/glean-core/tests/memory_distribution.rs
+++ b/glean-core/tests/memory_distribution.rs
@@ -70,7 +70,7 @@ fn serializer_should_correctly_serialize_memory_distribution() {
 
 #[test]
 fn set_value_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = MemoryDistributionMetric::new(
@@ -108,7 +108,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn the_accumulate_samples_api_correctly_stores_memory_values() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = MemoryDistributionMetric::new(
         CommonMetricData {
@@ -155,7 +155,7 @@ fn the_accumulate_samples_api_correctly_stores_memory_values() {
 
 #[test]
 fn the_accumulate_samples_api_correctly_handles_negative_values() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = MemoryDistributionMetric::new(
         CommonMetricData {

--- a/glean-core/tests/metrics.rs
+++ b/glean-core/tests/metrics.rs
@@ -10,7 +10,7 @@ use glean_core::CommonMetricData;
 
 #[test]
 fn stores_strings() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let metric = StringMetric::new(CommonMetricData::new("local", "string", "baseline"));
 
     assert_eq!(None, metric.test_get_value(&glean, "baseline"));
@@ -24,7 +24,7 @@ fn stores_strings() {
 
 #[test]
 fn stores_counters() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let metric = CounterMetric::new(CommonMetricData::new("local", "counter", "baseline"));
 
     assert_eq!(None, metric.test_get_value(&glean, "baseline"));

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -10,7 +10,7 @@ use glean_core::CommonMetricData;
 
 #[test]
 fn write_ping_to_disk() {
-    let (mut glean, _temp) = new_glean();
+    let (mut glean, _temp) = new_glean(None);
 
     let ping = PingType::new("metrics", true, false);
     glean.register_ping_type(&ping);
@@ -31,7 +31,7 @@ fn write_ping_to_disk() {
 
 #[test]
 fn disabling_upload_clears_pending_pings() {
-    let (mut glean, _) = new_glean();
+    let (mut glean, _) = new_glean(None);
 
     let ping = PingType::new("metrics", true, false);
     glean.register_ping_type(&ping);
@@ -66,7 +66,7 @@ fn disabling_upload_clears_pending_pings() {
 
 #[test]
 fn empty_pings_with_flag_are_sent() {
-    let (mut glean, _) = new_glean();
+    let (mut glean, _) = new_glean(None);
 
     let ping1 = PingType::new("custom-ping1", true, true);
     glean.register_ping_type(&ping1);

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -156,7 +156,7 @@ fn seq_number_must_be_sequential() {
 
 #[test]
 fn test_clear_pending_pings() {
-    let (mut glean, _) = new_glean();
+    let (mut glean, _) = new_glean(None);
     let ping_maker = PingMaker::new();
     let ping_type = PingType::new("store1", true, false);
     glean.register_ping_type(&ping_type);

--- a/glean-core/tests/quantity.rs
+++ b/glean-core/tests/quantity.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
 use glean_core::{test_get_num_recorded_errors, ErrorType};
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // Tests ported from glean-ac
 
@@ -19,17 +19,13 @@ use glean_core::{CommonMetricData, Glean, Lifetime};
 
 #[test]
 fn quantity_serializer_should_correctly_serialize_quantities() {
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let metric = QuantityMetric::new(CommonMetricData {
             name: "quantity_metric".into(),
@@ -54,7 +50,7 @@ fn quantity_serializer_should_correctly_serialize_quantities() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -67,7 +63,7 @@ fn quantity_serializer_should_correctly_serialize_quantities() {
 
 #[test]
 fn set_value_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = QuantityMetric::new(CommonMetricData {
@@ -98,7 +94,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn quantities_must_not_set_when_passed_negative() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = QuantityMetric::new(CommonMetricData {
         name: "quantity_metric".into(),

--- a/glean-core/tests/quantity.rs
+++ b/glean-core/tests/quantity.rs
@@ -22,9 +22,9 @@ fn quantity_serializer_should_correctly_serialize_quantities() {
     let (mut tempdir, _) = tempdir();
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let metric = QuantityMetric::new(CommonMetricData {

--- a/glean-core/tests/storage.rs
+++ b/glean-core/tests/storage.rs
@@ -13,7 +13,7 @@ use glean_core::{CommonMetricData, Lifetime};
 
 #[test]
 fn snapshot_returns_none_if_nothing_is_recorded_in_the_store() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     assert!(StorageManager
         .snapshot(glean.storage(), "unknown_store", true)
         .is_none())
@@ -21,7 +21,7 @@ fn snapshot_returns_none_if_nothing_is_recorded_in_the_store() {
 
 #[test]
 fn can_snapshot() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let local_metric = StringMetric::new(CommonMetricData {
         name: "can_snapshot_local_metric".into(),
@@ -39,7 +39,7 @@ fn can_snapshot() {
 
 #[test]
 fn snapshot_correctly_clears_the_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = CounterMetric::new(CommonMetricData {
@@ -71,7 +71,7 @@ fn storage_is_thread_safe() {
     use std::sync::{Arc, Barrier, Mutex};
     use std::thread;
 
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let glean = Arc::new(Mutex::new(glean));
 
     let threadsafe_metric = CounterMetric::new(CommonMetricData {

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -10,24 +10,20 @@ use serde_json::json;
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
 use glean_core::{test_get_num_recorded_errors, ErrorType};
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // SKIPPED from glean-ac: string deserializer should correctly parse integers
 // This test doesn't really apply to rkv
 
 #[test]
 fn string_serializer_should_correctly_serialize_strings() {
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let metric = StringMetric::new(CommonMetricData {
             name: "string_metric".into(),
@@ -52,7 +48,7 @@ fn string_serializer_should_correctly_serialize_strings() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -65,7 +61,7 @@ fn string_serializer_should_correctly_serialize_strings() {
 
 #[test]
 fn set_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = StringMetric::new(CommonMetricData {
@@ -97,7 +93,7 @@ fn set_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn long_string_values_are_truncated() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = StringMetric::new(CommonMetricData {
         name: "string_metric".into(),

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -20,9 +20,9 @@ fn string_serializer_should_correctly_serialize_strings() {
     let (mut tempdir, _) = tempdir();
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let metric = StringMetric::new(CommonMetricData {

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -46,9 +46,9 @@ fn stringlist_serializer_should_correctly_serialize_stringlists() {
     let (mut tempdir, _) = tempdir();
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let metric = StringListMetric::new(CommonMetricData {

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -9,11 +9,11 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
-use glean_core::{test_get_num_recorded_errors, CommonMetricData, ErrorType, Glean, Lifetime};
+use glean_core::{test_get_num_recorded_errors, CommonMetricData, ErrorType, Lifetime};
 
 #[test]
 fn list_can_store_multiple_items() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let list: StringListMetric = StringListMetric::new(CommonMetricData {
         name: "list".into(),
@@ -43,17 +43,13 @@ fn list_can_store_multiple_items() {
 
 #[test]
 fn stringlist_serializer_should_correctly_serialize_stringlists() {
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let metric = StringListMetric::new(CommonMetricData {
             name: "string_list_metric".into(),
@@ -67,7 +63,7 @@ fn stringlist_serializer_should_correctly_serialize_stringlists() {
     }
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
 
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
@@ -81,7 +77,7 @@ fn stringlist_serializer_should_correctly_serialize_stringlists() {
 
 #[test]
 fn set_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let metric = StringListMetric::new(CommonMetricData {
@@ -109,7 +105,7 @@ fn set_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn long_string_values_are_truncated() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = StringListMetric::new(CommonMetricData {
         name: "string_list_metric".into(),
@@ -152,7 +148,7 @@ fn long_string_values_are_truncated() {
 
 #[test]
 fn disabled_string_lists_dont_record() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = StringListMetric::new(CommonMetricData {
         name: "string_list_metric".into(),
@@ -181,7 +177,7 @@ fn disabled_string_lists_dont_record() {
 
 #[test]
 fn string_lists_dont_exceed_max_items() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = StringListMetric::new(CommonMetricData {
         name: "string_list_metric".into(),
@@ -230,7 +226,7 @@ fn string_lists_dont_exceed_max_items() {
 
 #[test]
 fn set_does_not_record_error_when_receiving_empty_list() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = StringListMetric::new(CommonMetricData {
         name: "string_list_metric".into(),

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -23,9 +23,9 @@ fn serializer_should_correctly_serialize_timespans() {
     let duration = 60;
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let mut metric = TimespanMetric::new(

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -12,25 +12,21 @@ use serde_json::json;
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
 use glean_core::{test_get_num_recorded_errors, ErrorType};
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // Tests ported from glean-ac
 
 #[test]
 fn serializer_should_correctly_serialize_timespans() {
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     let duration = 60;
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let mut metric = TimespanMetric::new(
             CommonMetricData {
@@ -56,7 +52,7 @@ fn serializer_should_correctly_serialize_timespans() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -70,7 +66,7 @@ fn serializer_should_correctly_serialize_timespans() {
 
 #[test]
 fn single_elapsed_time_must_be_recorded() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimespanMetric::new(
         CommonMetricData {
@@ -100,7 +96,7 @@ fn single_elapsed_time_must_be_recorded() {
 
 #[test]
 fn second_timer_run_is_skipped() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimespanMetric::new(
         CommonMetricData {
@@ -142,7 +138,7 @@ fn second_timer_run_is_skipped() {
 
 #[test]
 fn recorded_time_conforms_to_resolution() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut ns_metric = TimespanMetric::new(
         CommonMetricData {
@@ -188,7 +184,7 @@ fn recorded_time_conforms_to_resolution() {
 
 #[test]
 fn cancel_does_not_store() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimespanMetric::new(
         CommonMetricData {
@@ -210,7 +206,7 @@ fn cancel_does_not_store() {
 
 #[test]
 fn nothing_stored_before_stop() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimespanMetric::new(
         CommonMetricData {
@@ -236,7 +232,7 @@ fn nothing_stored_before_stop() {
 
 #[test]
 fn set_raw_time() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let metric = TimespanMetric::new(
         CommonMetricData {
@@ -259,7 +255,7 @@ fn set_raw_time() {
 
 #[test]
 fn set_raw_time_does_nothing_when_timer_running() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimespanMetric::new(
         CommonMetricData {
@@ -291,7 +287,7 @@ fn set_raw_time_does_nothing_when_timer_running() {
 
 #[test]
 fn timespan_is_not_tracked_across_upload_toggle() {
-    let (mut glean, _t) = new_glean();
+    let (mut glean, _t) = new_glean(None);
 
     let mut metric = TimespanMetric::new(
         CommonMetricData {

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -73,7 +73,7 @@ fn serializer_should_correctly_serialize_timing_distribution() {
 
 #[test]
 fn set_value_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
 
     let duration = 1;
@@ -111,7 +111,7 @@ fn set_value_properly_sets_the_value_in_all_stores() {
 
 #[test]
 fn timing_distributions_must_not_accumulate_negative_values() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let duration = 60;
     let time_unit = TimeUnit::Nanosecond;
@@ -149,7 +149,7 @@ fn timing_distributions_must_not_accumulate_negative_values() {
 
 #[test]
 fn the_accumulate_samples_api_correctly_stores_timing_values() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimingDistributionMetric::new(
         CommonMetricData {
@@ -196,7 +196,7 @@ fn the_accumulate_samples_api_correctly_stores_timing_values() {
 
 #[test]
 fn the_accumulate_samples_api_correctly_handles_negative_values() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimingDistributionMetric::new(
         CommonMetricData {
@@ -240,7 +240,7 @@ fn the_accumulate_samples_api_correctly_handles_negative_values() {
 
 #[test]
 fn large_nanoseconds_values() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
 
     let mut metric = TimingDistributionMetric::new(
         CommonMetricData {

--- a/glean-core/tests/uuid.rs
+++ b/glean-core/tests/uuid.rs
@@ -9,11 +9,11 @@ use serde_json::json;
 
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 #[test]
 fn uuid_is_generated_and_stored() {
-    let (mut glean, _t) = new_glean();
+    let (mut glean, _t) = new_glean(None);
 
     let uuid: UuidMetric = UuidMetric::new(CommonMetricData {
         name: "uuid".into(),
@@ -41,17 +41,13 @@ fn uuid_is_generated_and_stored() {
 fn uuid_serializer_should_correctly_serialize_uuids() {
     let value = uuid::Uuid::new_v4();
 
-    let (_t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
+    let (mut tempdir, _) = tempdir();
 
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        // We give tempdir for the `new_glean` function...
+        let (glean, dir) = new_glean(Some(tempdir));
+        // And then we get it back on that function returns.
+        tempdir = dir;
 
         let metric = UuidMetric::new(CommonMetricData {
             name: "uuid_metric".into(),
@@ -76,7 +72,7 @@ fn uuid_serializer_should_correctly_serialize_uuids() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();
@@ -89,7 +85,7 @@ fn uuid_serializer_should_correctly_serialize_uuids() {
 
 #[test]
 fn set_properly_sets_the_value_in_all_stores() {
-    let (glean, _t) = new_glean();
+    let (glean, _t) = new_glean(None);
     let store_names: Vec<String> = vec!["store1".into(), "store2".into()];
     let value = uuid::Uuid::new_v4();
 

--- a/glean-core/tests/uuid.rs
+++ b/glean-core/tests/uuid.rs
@@ -44,9 +44,9 @@ fn uuid_serializer_should_correctly_serialize_uuids() {
     let (mut tempdir, _) = tempdir();
 
     {
-        // We give tempdir for the `new_glean` function...
+        // We give tempdir to the `new_glean` function...
         let (glean, dir) = new_glean(Some(tempdir));
-        // And then we get it back on that function returns.
+        // And then we get it back once that function returns.
         tempdir = dir;
 
         let metric = UuidMetric::new(CommonMetricData {


### PR DESCRIPTION
Fixes [Bug 1601209](https://bugzilla.mozilla.org/show_bug.cgi?id=1601209)

Turns out there already was a function to "share configuration in glean-core tests" (the `tests::common::new_glean`). It just didn't work for cases when we needed to create multiple instances of glean in the same test with the same data directory.

That was fixed by adding the option to pass the tempdir as an argument to the function, which makes it possible to call it multiple times with the same data directory.