### PR TITLE
Pass missing None argument in test function

### DIFF
--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -185,7 +185,7 @@ fn test_clear_pending_pings() {
 fn test_no_pings_submitted_if_upload_disabled() {
     // Regression test, bug 1603571
 
-    let (mut glean, _) = new_glean();
+    let (mut glean, _) = new_glean(None);
     let ping_type = PingType::new("store1", true, true);
     glean.register_ping_type(&ping_type);
 


### PR DESCRIPTION
This test was added after the new_glean function landed, but that change
was not included in the branch, so it only broke once merged into
master.