### PR TITLE
Add the `invalid_overflow` error to Timing Distributions

### DIFF
--- a/docs/user/collected-metrics/metrics.md
+++ b/docs/user/collected-metrics/metrics.md
@@ -20,6 +20,7 @@ The following metrics are added to the ping:
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
 | glean.error.invalid_label |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set with an invalid label. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |
+| glean.error.invalid_overflow |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set a value that overflew. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1591912#c3)||never |
 | glean.error.invalid_state |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a timing metric was used incorrectly. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |
 | glean.error.invalid_value |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set to an invalid value. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |
 

--- a/docs/user/error-reporting.md
+++ b/docs/user/error-reporting.md
@@ -7,8 +7,10 @@ Additionally, error metrics are always sent in the [`metrics` ping](pings/metric
 
 The following categories of errors are recorded:
 
-- `invalid_value`: The metric value was invalid or out-of-range.
+- `invalid_value`: The metric value was invalid.
 - `invalid_label`: The label on a labeled metric was invalid.
+- `invalid_state`: The metric caught an invalid state while recording.
+- `invalid_overflow`: The metric value to be recorded overflows the metric-specific upper range.
 
 For example, if you had a string metric and passed it a string that was too long:
 

--- a/docs/user/metrics/timing_distribution.md
+++ b/docs/user/metrics/timing_distribution.md
@@ -183,7 +183,7 @@ XCTAssertEqual(1, pages.pageLoad.testGetNumRecordedErrors(.invalidValue))
 
 * `invalid_value`: If recording a negative timespan.
 * `invalid_value`: If a non-existing/stopped timer is stopped again.
-* `invalid_value`: If recording a time longer than 10 minutes.
+* `invalid_overflow`: If recording a time longer than 10 minutes.
 
 ## Reference
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/ErrorType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/ErrorType.kt
@@ -18,5 +18,10 @@ enum class ErrorType {
     /**
      * For when timings are recorded incorrectly
      */
-    InvalidState
+    InvalidState,
+
+    /**
+     * For when the value to be recorded overflows the metric-specific upper range
+     */
+    InvalidOverflow
 }

--- a/glean-core/ios/Glean/Testing/ErrorType.swift
+++ b/glean-core/ios/Glean/Testing/ErrorType.swift
@@ -14,4 +14,7 @@ public enum ErrorType: Int32 {
 
     // For when timings are recorded incorrectly
     case invalidState = 2
+
+    // For when the value to be recorded overflows the metric-specific upper range
+    case invalidOverflow = 3
 }

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -244,3 +244,20 @@ glean.error:
       - all_pings
     no_lint:
       - COMMON_PREFIX
+
+  invalid_overflow:
+    type: labeled_counter
+    description:
+      Counts the number of times a metric was set a value that overflew.
+      The labels are the `category.name` identifier of the metric.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1591912
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1591912#c3
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+    send_in_pings:
+      - all_pings
+    no_lint:
+      - COMMON_PREFIX

--- a/glean-core/python/glean/testing/error_type.py
+++ b/glean-core/python/glean/testing/error_type.py
@@ -19,3 +19,9 @@ class ErrorType(Enum):
 
     # For when timings are recorded incorrectly
     INVALID_STATE = 2
+
+    INVALID_OVERFLOW = 3
+    """
+    For when the value to be recorded overflows the metric-specific upper range
+    """
+

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -23,6 +23,9 @@ use crate::Glean;
 use crate::Lifetime;
 
 /// The possible error types for metric recording.
+/// Note: the cases in this enum must be kept in sync with the ones
+/// in the platform-specific code (e.g. ErrorType.kt) and with the
+/// metrics in the registry files.
 #[derive(Debug)]
 pub enum ErrorType {
     /// For when the value to be recorded does not match the metric-specific restrictions

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -31,6 +31,8 @@ pub enum ErrorType {
     InvalidLabel,
     /// For when the metric caught an invalid state while recording
     InvalidState,
+    /// For when the value to be recorded overflows the metric-specific upper range
+    InvalidOverflow,
 }
 
 impl ErrorType {
@@ -40,6 +42,7 @@ impl ErrorType {
             ErrorType::InvalidValue => "invalid_value",
             ErrorType::InvalidLabel => "invalid_label",
             ErrorType::InvalidState => "invalid_state",
+            ErrorType::InvalidOverflow => "invalid_overflow",
         }
     }
 }
@@ -52,6 +55,7 @@ impl TryFrom<i32> for ErrorType {
             0 => Ok(ErrorType::InvalidValue),
             1 => Ok(ErrorType::InvalidLabel),
             2 => Ok(ErrorType::InvalidState),
+            4 => Ok(ErrorType::InvalidOverflow),
             e => Err(ErrorKind::Lifetime(e).into()),
         }
     }


### PR DESCRIPTION
This backports the changes from master to this branch, since we don't want to do a major version bump in A-C just before holidays.