### PR TITLE
Specify the exact file name for storing the log artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,10 +262,10 @@ jobs:
             bash bin/build-swift-docs.sh
       - store_artifacts:
           path: raw_xcodebuild.log
-          destination: log
+          destination: raw_xcodebuild.log
       - store_artifacts:
           path: raw_xcodetest.log
-          destination: log
+          destination: raw_xcodetest.log
       - persist_to_workspace:
           root: build/
           paths: docs/swift
@@ -367,14 +367,14 @@ jobs:
             bash bin/run-ios-sample-app-build.sh
       - store_artifacts:
           path: raw_sample_xcodebuild.log
-          destination: log
+          destination: raw_sample_xcodebuild.log
       - run:
           name: Run sample app tests
           command: |
             bash bin/run-ios-sample-app-test.sh
       - store_artifacts:
           path: raw_sample_xcodetest.log
-          destination: log
+          destination: raw_sample_xcodetest.log
 
   Lint Android with ktlint and detekt:
     docker:


### PR DESCRIPTION
Turns out it takes the destination as a file path, not a directory path,
if the source is just a file