### PR TITLE
Change the behaviour of `lifetime: application`

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -75,6 +75,8 @@ internal interface LibGleanFFI : Library {
         seq_num_len: Int
     ): Long
 
+    fun glean_clear_application_lifetime_metrics(handle: Long)
+
     fun glean_test_clear_all_stores(handle: Long)
 
     fun glean_destroy_glean(handle: Long)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -79,6 +79,8 @@ internal interface LibGleanFFI : Library {
 
     fun glean_test_clear_all_stores(handle: Long)
 
+    fun glean_is_first_run(handle: Long): Byte
+
     fun glean_destroy_glean(handle: Long)
 
     fun glean_on_ready_to_submit_pings(handle: Long): Byte

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -98,6 +98,8 @@ uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
                                      uint64_t metric_id,
                                      FfiStr storage_name);
 
+void glean_clear_application_lifetime_metrics(uint64_t glean_handle);
+
 void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
 
 int32_t glean_counter_test_get_num_recorded_errors(uint64_t glean_handle,
@@ -223,6 +225,8 @@ uint8_t glean_experiment_test_is_active(uint64_t glean_handle, FfiStr experiment
  * A valid and non-null configuration object is required for this function.
  */
 uint64_t glean_initialize(const FfiConfiguration *cfg);
+
+uint8_t glean_is_first_run(uint64_t glean_handle);
 
 uint8_t glean_is_upload_enabled(uint64_t glean_handle);
 

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -270,7 +270,9 @@ pub extern "C" fn glean_experiment_test_get_data(
 
 #[no_mangle]
 pub extern "C" fn glean_clear_application_lifetime_metrics(glean_handle: u64) {
-    GLEAN.call_infallible(glean_handle, |glean| glean.clear_application_lifetime_metrics());
+    GLEAN.call_infallible(glean_handle, |glean| {
+        glean.clear_application_lifetime_metrics()
+    });
 }
 
 #[no_mangle]

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -269,6 +269,11 @@ pub extern "C" fn glean_experiment_test_get_data(
 }
 
 #[no_mangle]
+pub extern "C" fn glean_clear_application_lifetime_metrics(glean_handle: u64) {
+    GLEAN.call_infallible(glean_handle, |glean| glean.clear_application_lifetime_metrics());
+}
+
+#[no_mangle]
 pub extern "C" fn glean_test_clear_all_stores(glean_handle: u64) {
     GLEAN.call_infallible(glean_handle, |glean| glean.test_clear_all_stores());
 }

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -278,5 +278,10 @@ pub extern "C" fn glean_test_clear_all_stores(glean_handle: u64) {
     GLEAN.call_infallible(glean_handle, |glean| glean.test_clear_all_stores());
 }
 
+#[no_mangle]
+pub extern "C" fn glean_is_first_run(glean_handle: u64) -> u8 {
+    GLEAN.call_infallible(glean_handle, |glean| glean.is_first_run())
+}
+
 define_infallible_handle_map_deleter!(GLEAN, glean_destroy_glean);
 define_string_destructor!(glean_str_free);

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -98,6 +98,8 @@ uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
                                      uint64_t metric_id,
                                      FfiStr storage_name);
 
+void glean_clear_application_lifetime_metrics(uint64_t glean_handle);
+
 void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
 
 int32_t glean_counter_test_get_num_recorded_errors(uint64_t glean_handle,
@@ -223,6 +225,8 @@ uint8_t glean_experiment_test_is_active(uint64_t glean_handle, FfiStr experiment
  * A valid and non-null configuration object is required for this function.
  */
 uint64_t glean_initialize(const FfiConfiguration *cfg);
+
+uint8_t glean_is_first_run(uint64_t glean_handle);
 
 uint8_t glean_is_upload_enabled(uint64_t glean_handle);
 

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -19,10 +19,6 @@ use crate::Result;
 #[derive(Debug)]
 pub struct Database {
     rkv: Rkv,
-    // Metrics with 'application' lifetime only live as long
-    // as the application lives: they don't need to be persisted
-    // to disk using rkv. Store them in a map.
-    app_lifetime_data: RwLock<BTreeMap<String, Metric>>,
     // If the `delay_ping_lifetime_io` Glean config option is `true`,
     // we will save metrics with 'ping' lifetime data in a map temporarily
     // so as to persist them to disk using rkv in bulk on demand.
@@ -40,7 +36,6 @@ impl Database {
     pub fn new(data_path: &str, delay_ping_lifetime_io: bool) -> Result<Self> {
         let db = Self {
             rkv: Self::open_rkv(data_path)?,
-            app_lifetime_data: RwLock::new(BTreeMap::new()),
             ping_lifetime_data: if delay_ping_lifetime_io {
                 Some(RwLock::new(BTreeMap::new()))
             } else {
@@ -152,22 +147,6 @@ impl Database {
         let iter_start = Self::get_storage_key(storage_name, metric_key);
         let len = iter_start.len();
 
-        // Lifetime::Application data is not persisted to disk
-        if lifetime == Lifetime::Application {
-            let data = self
-                .app_lifetime_data
-                .read()
-                .expect("Can't read app lifetime data");
-            for (key, value) in data.iter() {
-                if key.starts_with(&iter_start) {
-                    let key = &key[len..];
-                    transaction_fn(key.as_bytes(), value);
-                }
-            }
-
-            return;
-        }
-
         // Lifetime::Ping data is not immediately persisted to disk if
         // Glean has `delay_ping_lifetime_io` set to true
         if lifetime == Lifetime::Ping {
@@ -229,15 +208,6 @@ impl Database {
     ) -> bool {
         let key = Self::get_storage_key(storage_name, Some(metric_identifier));
 
-        // Lifetime::Application data is not persisted to disk
-        if lifetime == Lifetime::Application {
-            return self
-                .app_lifetime_data
-                .read()
-                .map(|data| data.contains_key(&key))
-                .unwrap_or(false);
-        }
-
         // Lifetime::Ping data is not persisted to disk if
         // Glean has `delay_ping_lifetime_io` set to true
         if lifetime == Lifetime::Ping {
@@ -264,16 +234,11 @@ impl Database {
     ///
     /// ## Panics
     ///
-    /// * This function will panic for `Lifetime::Application`.
     /// * This function will **not** panic on database errors.
     pub fn write_with_store<F>(&self, store_name: Lifetime, mut transaction_fn: F) -> Result<()>
     where
         F: FnMut(rkv::Writer, SingleStore) -> Result<()>,
     {
-        if store_name == Lifetime::Application {
-            panic!("Can't write with store for application-lifetime data");
-        }
-
         let store: SingleStore = self
             .rkv
             .open_single(store_name.as_str(), StoreOptions::create())?;
@@ -312,15 +277,6 @@ impl Database {
         metric: &Metric,
     ) -> Result<()> {
         let final_key = Self::get_storage_key(storage_name, Some(key));
-
-        if lifetime == Lifetime::Application {
-            let mut data = self
-                .app_lifetime_data
-                .write()
-                .expect("Can't read app lifetime data");
-            data.insert(final_key, metric.clone());
-            return Ok(());
-        }
 
         // Lifetime::Ping data is not immediately persisted to disk if
         // Glean has `delay_ping_lifetime_io` set to true
@@ -386,25 +342,7 @@ impl Database {
     {
         let final_key = Self::get_storage_key(storage_name, Some(key));
 
-        if lifetime == Lifetime::Application {
-            let mut data = self
-                .app_lifetime_data
-                .write()
-                .expect("Can't access app lifetime data as writable");
-            let entry = data.entry(final_key);
-            match entry {
-                Entry::Vacant(entry) => {
-                    entry.insert(transform(None));
-                }
-                Entry::Occupied(mut entry) => {
-                    let old_value = entry.get().clone();
-                    entry.insert(transform(Some(old_value)));
-                }
-            }
-            return Ok(());
-        }
-
-        // Lifetime::Ping data is not immediately persisted to disk if
+        // Lifetime::Ping data is not persisted to disk if
         // Glean has `delay_ping_lifetime_io` set to true
         if lifetime == Lifetime::Ping {
             if let Some(ping_lifetime_data) = &self.ping_lifetime_data {
@@ -525,17 +463,8 @@ impl Database {
     ) -> Result<()> {
         let final_key = Self::get_storage_key(storage_name, Some(metric_name));
 
-        if lifetime == Lifetime::Application {
-            let mut data = self
-                .app_lifetime_data
-                .write()
-                .expect("Can't access app lifetime data as writable");
-            data.remove(&final_key);
-            return Ok(());
-        }
-
-        // Lifetime::Ping data will be saved to `ping_lifetime_data`
-        // in case `delay_ping_lifetime_io` is set to true
+        // Lifetime::Ping data is not persisted to disk if
+        // Glean has `delay_ping_lifetime_io` set to true
         if lifetime == Lifetime::Ping {
             if let Some(ping_lifetime_data) = &self.ping_lifetime_data {
                 let mut data = ping_lifetime_data
@@ -567,8 +496,6 @@ impl Database {
     ///
     /// * This function will **not** panic on database errors.
     pub fn clear_all(&self) {
-        // Lifetime::Ping might also have data saved to `ping_lifetime_data`
-        // in case `delay_ping_lifetime_io` is set to true
         if let Some(ping_lifetime_data) = &self.ping_lifetime_data {
             ping_lifetime_data
                 .write()
@@ -576,21 +503,9 @@ impl Database {
                 .clear();
         }
 
-        for lifetime in [Lifetime::User, Lifetime::Ping].iter() {
-            let res = self.write_with_store(*lifetime, |mut writer, store| {
-                store.clear(&mut writer)?;
-                writer.commit()?;
-                Ok(())
-            });
-            if let Err(e) = res {
-                log::error!("Could not clear store for lifetime {:?}: {:?}", lifetime, e);
-            }
+        for lifetime in [Lifetime::User, Lifetime::Ping, Lifetime::Application].iter() {
+            self.clear_lifetime(*lifetime);
         }
-
-        self.app_lifetime_data
-            .write()
-            .expect("Can't access app lifetime data as writable")
-            .clear();
     }
 
     /// Persist ping_lifetime_data to disk.
@@ -1012,13 +927,13 @@ mod test {
             let db = Database::new(&str_dir, true).unwrap();
 
             // Attempt to record a known value.
-            db.record_per_lifetime(
-                Lifetime::Ping,
-                test_storage,
-                test_metric_id,
-                &Metric::String(test_value.to_string()),
-            )
-            .unwrap();
+        db.record_per_lifetime(
+            Lifetime::Ping,
+            test_storage,
+            test_metric_id,
+            &Metric::String(test_value.to_string()),
+        )
+        .unwrap();
 
             // Verify that test_value is in memory.
             let data = match &db.ping_lifetime_data {
@@ -1043,7 +958,7 @@ mod test {
                 .get(&reader, format!("{}#{}", test_storage, test_metric_id))
                 .unwrap_or(None)
                 .is_some());
-        }
+            }
 
         // Now create a new instace of the db and check if data was
         // correctly loaded from rkv to memory.
@@ -1054,7 +969,7 @@ mod test {
             let data = match &db.ping_lifetime_data {
                 Some(ping_lifetime_data) => ping_lifetime_data,
                 None => panic!("Expected `ping_lifetime_data` to exist here!"),
-            };
+        };
             let data = data.read().unwrap();
             assert!(data
                 .get(&format!("{}#{}", test_storage, test_metric_id))
@@ -1066,9 +981,9 @@ mod test {
                 .open_single(Lifetime::Ping.as_str(), StoreOptions::create())
                 .unwrap();
             let reader = db.rkv.read().unwrap();
-            assert!(store
+        assert!(store
                 .get(&reader, format!("{}#{}", test_storage, test_metric_id))
-                .unwrap_or(None)
+            .unwrap_or(None)
                 .is_some());
         }
     }

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -488,6 +488,24 @@ impl Database {
         })
     }
 
+    /// Clears all the metrics in the database, for the provided lifetime.
+    ///
+    /// Errors are logged.
+    ///
+    /// ## Panics
+    ///
+    /// * This function will **not** panic on database errors.
+    pub fn clear_lifetime(&self, lifetime: Lifetime) {
+        let res = self.write_with_store(lifetime, |mut writer, store| {
+            store.clear(&mut writer)?;
+            writer.commit()?;
+            Ok(())
+        });
+        if let Err(e) = res {
+            log::error!("Could not clear store for lifetime {:?}: {:?}", lifetime, e);
+        }
+    }
+
     /// Clears all metrics in the database.
     ///
     /// Errors are logged.

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -945,13 +945,13 @@ mod test {
             let db = Database::new(&str_dir, true).unwrap();
 
             // Attempt to record a known value.
-        db.record_per_lifetime(
-            Lifetime::Ping,
-            test_storage,
-            test_metric_id,
-            &Metric::String(test_value.to_string()),
-        )
-        .unwrap();
+            db.record_per_lifetime(
+                Lifetime::Ping,
+                test_storage,
+                test_metric_id,
+                &Metric::String(test_value.to_string()),
+            )
+            .unwrap();
 
             // Verify that test_value is in memory.
             let data = match &db.ping_lifetime_data {
@@ -976,7 +976,7 @@ mod test {
                 .get(&reader, format!("{}#{}", test_storage, test_metric_id))
                 .unwrap_or(None)
                 .is_some());
-            }
+        }
 
         // Now create a new instace of the db and check if data was
         // correctly loaded from rkv to memory.
@@ -987,7 +987,7 @@ mod test {
             let data = match &db.ping_lifetime_data {
                 Some(ping_lifetime_data) => ping_lifetime_data,
                 None => panic!("Expected `ping_lifetime_data` to exist here!"),
-        };
+            };
             let data = data.read().unwrap();
             assert!(data
                 .get(&format!("{}#{}", test_storage, test_metric_id))
@@ -999,9 +999,9 @@ mod test {
                 .open_single(Lifetime::Ping.as_str(), StoreOptions::create())
                 .unwrap();
             let reader = db.rkv.read().unwrap();
-        assert!(store
+            assert!(store
                 .get(&reader, format!("{}#{}", test_storage, test_metric_id))
-            .unwrap_or(None)
+                .unwrap_or(None)
                 .is_some());
         }
     }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -567,7 +567,7 @@ impl Glean {
     }
 
     /// ** This is not meant to be used directly.**
-    /// 
+    ///
     /// Clear all the metrics that have `Lifetime::Application`.
     pub fn clear_application_lifetime_metrics(&self) {
         log::debug!("Clearing Lifetime::Application metrics");

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -576,7 +576,7 @@ impl Glean {
 
     /// Return whether or not this is the first run on this profile.
     pub fn is_first_run(&self) -> bool {
-        return self.is_first_run;
+        self.is_first_run
     }
 
     /// **Test-only API (exported for FFI purposes).**

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -122,6 +122,7 @@ pub struct Glean {
     ping_registry: HashMap<String, PingType>,
     start_time: DateTime<FixedOffset>,
     max_events: usize,
+    is_first_run: bool,
 }
 
 impl Glean {
@@ -150,6 +151,7 @@ impl Glean {
             ping_registry: HashMap::new(),
             start_time: local_now_with_offset(),
             max_events: cfg.max_events.unwrap_or(DEFAULT_MAX_EVENTS),
+            is_first_run: false,
         };
         glean.on_change_upload_enabled(cfg.upload_enabled);
         Ok(glean)
@@ -227,6 +229,10 @@ impl Glean {
             .is_none()
         {
             self.core_metrics.first_run_date.set(self, None);
+            // The `first_run_date` field is generated on the very first run
+            // and persisted across upload toggling. We can assume that, the only
+            // time it is set, that's indeed our "first run".
+            self.is_first_run = true;
         }
     }
 
@@ -566,6 +572,11 @@ impl Glean {
     pub fn clear_application_lifetime_metrics(&self) {
         log::debug!("Clearing Lifetime::Application metrics");
         self.data_store.clear_lifetime(Lifetime::Application);
+    }
+
+    /// Return whether or not this is the first run on this profile.
+    pub fn is_first_run(&self) -> bool {
+        return self.is_first_run;
     }
 
     /// **Test-only API (exported for FFI purposes).**

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -560,6 +560,14 @@ impl Glean {
         self.data_store.persist_ping_lifetime_data()
     }
 
+    /// ** This is not meant to be used directly.**
+    /// 
+    /// Clear all the metrics that have `Lifetime::Application`.
+    pub fn clear_application_lifetime_metrics(&self) {
+        log::debug!("Clearing Lifetime::Application metrics");
+        self.data_store.clear_lifetime(Lifetime::Application);
+    }
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Check if an experiment is currently active.

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -414,3 +414,20 @@ fn correct_order() {
         }
     }
 }
+
+#[test]
+fn test_first_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+    {
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        // Check that this is indeed the first run.
+        assert!(glean.is_first_run());
+    }
+
+    {
+        // Other runs must be not marked as "first run".
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        assert!(!glean.is_first_run());
+    }
+}


### PR DESCRIPTION
This PR changes the behaviour of `lifetime: application` metrics ([docs](https://mozilla.github.io/glean/book/user/metric-parameters.html#optional-metric-parameters)).

*Current behaviour*
The `lifetime: application` are only stored in volatile memory so, when a product using Glean is closed, they are lost. Product should regenerate them at startup. If glean generates any startup ping, they will be missing from the generated pings.

*New behaviour*
The `lifetime: application` are stored in the metrics database and _not_ cleared on shutdown. They are instead cleared at startup, after all the Glean SDK-owned pings are generated. Any previously stored `lifetime: application` metric will make it into these pings.

Any product-set startup metric will be recorded _after_ Glean inits, so no data is lost.

**TODO**

- [x] make sure no metric set before Glean inits gets dispatched before Glean's startup pings.
- [x] init core metrics after glean owned pings are set, after the first startup (on the first startup they need to init before pings are collected)
- [x] after the first startup, clear the application lifetime metrics after startup pings are collected (on first startup, do nothing... there should not be anything stored :) )
- [x] add test coverage in the Kotlin side
- [ ]  file bugs for supporting other platforms

This depends on #594 