### PR TITLE
Metrics recorded during init must not get into overdue `metrics` pings

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -519,7 +519,8 @@ open class GleanInternalAPI internal constructor () {
      * policies.
      *
      * If the ping currently contains no content, it will not be assembled and
-     * queued for sending.
+     * queued for sending, unless explicitly specified otherwise in the registry
+     * file.
      *
      * @param pingNames List of ping names to submit.
      * @return The async [Job] performing the work of assembling the ping
@@ -540,7 +541,8 @@ open class GleanInternalAPI internal constructor () {
      * policies.
      *
      * If the ping currently contains no content, it will not be assembled and
-     * queued for sending.
+     * queued for sending, unless explicitly specified otherwise in the registry
+     * file.
      *
      * @param pingNames List of ping names to submit.
      */

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -199,7 +199,7 @@ open class GleanInternalAPI internal constructor () {
             applicationContext,
             acMetadata.metricsPingLastSentDate
         )
-        metricsPingScheduler.schedule()
+        metricsPingScheduler.schedule(overduePingAsFirst = true)
 
         // Signal Dispatcher that init is complete
         @Suppress("EXPERIMENTAL_API_USAGE")
@@ -526,14 +526,33 @@ open class GleanInternalAPI internal constructor () {
      */
     @Suppress("EXPERIMENTAL_API_USAGE")
     internal fun submitPingsByName(pingNames: List<String>) = Dispatchers.API.launch {
+        submitPingsByNameSync(pingNames)
+    }
+
+    /**
+     * Collect and submit a list of pings for eventual upload by name, synchronously.
+     *
+     * Each ping will be looked up in the known instances of [PingType]. If the
+     * ping isn't known, an error is logged and the ping isn't queued for uploading.
+     *
+     * The ping content is assembled as soon as possible, but upload is not
+     * guaranteed to happen immediately, as that depends on the upload
+     * policies.
+     *
+     * If the ping currently contains no content, it will not be assembled and
+     * queued for sending.
+     *
+     * @param pingNames List of ping names to submit.
+     */
+    internal fun submitPingsByNameSync(pingNames: List<String>) {
         if (!isInitialized()) {
             Log.e(LOG_TAG, "Glean must be initialized before submitting pings.")
-            return@launch
+            return
         }
 
         if (!getUploadEnabled()) {
             Log.e(LOG_TAG, "Glean must be enabled before submitting pings.")
-            return@launch
+            return
         }
 
         val pingArray = StringArray(pingNames.toTypedArray(), "utf-8")

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -241,8 +241,11 @@ internal class MetricsPingScheduler(
                 // before any other recording API call.
                 //
                 // * Do not change `Dispatchers.API.executeTask` to `Dispatchers.API.launch` as
-                // this would break startup overdue ping collection. For more context, see bug
-                // 1604861 and the implementation of `collectPingAndReschedule`.
+                // this would break startup overdue ping collection. *
+                // `executeTask` schedules the task for immediate execution on the
+                // `Dispatchers.API` thread pool, before any other enqueued task. For more
+                // context, see bug 1604861 and the implementation of
+                // `collectPingAndReschedule`.
                 if (overduePingAsFirst) {
                     @Suppress("EXPERIMENTAL_API_USAGE")
                     Dispatchers.API.executeTask {
@@ -281,7 +284,7 @@ internal class MetricsPingScheduler(
             //
             // During the Glean initialization, we require any metric recording to be
             // batched up and replayed after any startup metrics ping is sent. To guarantee
-            // that, we dispatch this function from `Dispatchers.API.executaTask`. However,
+            // that, we dispatch this function from `Dispatchers.API.executeTask`. However,
             // Pings.metrics.submit() ends up calling `Dispatchers.API.launch` again which
             // will delay the ping collection task after any pending metric recording is
             // executed, breaking the 'metrics' ping promise of sending a startup 'metrics'

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -12,6 +12,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.components.support.test.any
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.getContextWithMockedInfo
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.private.Lifetime
@@ -36,6 +37,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
@@ -302,7 +304,7 @@ class MetricsPingSchedulerTest {
 
         MetricsPingScheduler.isInForeground = true
 
-        verify(mpsSpy, never()).collectPingAndReschedule(any())
+        verify(mpsSpy, never()).collectPingAndReschedule(any(), eq(true))
 
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
@@ -310,14 +312,14 @@ class MetricsPingSchedulerTest {
         // Trigger the startup check. We need to wrap this in `blockDispatchersAPI` since
         // the immediate startup collection happens in the Dispatchers.API context. If we
         // don't, test will fail due to async weirdness.
-        mpsSpy.schedule()
+        mpsSpy.schedule(overduePingAsFirst = true)
 
         // And that we're storing the current date (this only reports the date, not the time).
         fakeNow.set(Calendar.HOUR_OF_DAY, 0)
         assertEquals(fakeNow.time, mpsSpy.getLastCollectedDate())
 
         // Verify that we're immediately collecting.
-        verify(mpsSpy, times(1)).collectPingAndReschedule(fakeNow)
+        verify(mpsSpy, times(1)).collectPingAndReschedule(fakeNow, true)
     }
 
     @Test
@@ -339,12 +341,12 @@ class MetricsPingSchedulerTest {
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
 
         // Trigger the startup check.
-        mpsSpy.schedule()
+        mpsSpy.schedule(overduePingAsFirst = true)
 
         // Verify that we're scheduling for the next day and not collecting immediately.
         verify(mpsSpy, times(1)).schedulePingCollection(fakeNow, sendTheNextCalendarDay = true)
         verify(mpsSpy, never()).schedulePingCollection(fakeNow, sendTheNextCalendarDay = false)
-        verify(mpsSpy, never()).collectPingAndReschedule(any())
+        verify(mpsSpy, never()).collectPingAndReschedule(any(), eq(true))
     }
 
     @Test
@@ -370,12 +372,12 @@ class MetricsPingSchedulerTest {
         verify(mpsSpy, never()).schedulePingCollection(any(), anyBoolean())
 
         // Trigger the startup check.
-        mpsSpy.schedule()
+        mpsSpy.schedule(overduePingAsFirst = true)
 
         // Verify that we're scheduling for today, but not collecting immediately.
         verify(mpsSpy, times(1)).schedulePingCollection(fakeNow, sendTheNextCalendarDay = false)
         verify(mpsSpy, never()).schedulePingCollection(fakeNow, sendTheNextCalendarDay = true)
-        verify(mpsSpy, never()).collectPingAndReschedule(any())
+        verify(mpsSpy, never()).collectPingAndReschedule(any(), eq(true))
     }
 
     @Test
@@ -390,16 +392,16 @@ class MetricsPingSchedulerTest {
             spy(MetricsPingScheduler(context))
         mpsSpy.sharedPreferences.edit().clear().apply()
 
-        verify(mpsSpy, never()).collectPingAndReschedule(any())
+        verify(mpsSpy, never()).collectPingAndReschedule(any(), anyBoolean())
 
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
 
         // Trigger the startup check.
-        mpsSpy.schedule()
+        mpsSpy.schedule(overduePingAsFirst = true)
 
         // Verify that we're immediately collecting.
-        verify(mpsSpy, never()).collectPingAndReschedule(fakeNow)
+        verify(mpsSpy, never()).collectPingAndReschedule(fakeNow, true)
         verify(mpsSpy, times(1)).schedulePingCollection(fakeNow, sendTheNextCalendarDay = false)
     }
 
@@ -415,13 +417,13 @@ class MetricsPingSchedulerTest {
             spy(MetricsPingScheduler(context))
         mpsSpy.sharedPreferences.edit().clear().apply()
 
-        verify(mpsSpy, never()).collectPingAndReschedule(any())
+        verify(mpsSpy, never()).collectPingAndReschedule(any(), anyBoolean())
 
         // Make sure to return the fake date when requested.
         doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
 
         // Trigger the startup check.
-        mpsSpy.schedule()
+        mpsSpy.schedule(overduePingAsFirst = true)
 
         // And that we're storing the current date (this only reports the date, not the time).
         fakeNow.set(Calendar.HOUR_OF_DAY, 0)
@@ -432,7 +434,7 @@ class MetricsPingSchedulerTest {
         )
 
         // Verify that we're immediately collecting.
-        verify(mpsSpy, times(1)).collectPingAndReschedule(fakeNow)
+        verify(mpsSpy, times(1)).collectPingAndReschedule(fakeNow, true)
         verify(mpsSpy, never()).schedulePingCollection(fakeNow, sendTheNextCalendarDay = false)
     }
 
@@ -465,21 +467,21 @@ class MetricsPingSchedulerTest {
 
         // Make sure schedule() has not been called.  Since we are adding the spy after resetGlean
         // has called Glean.initialize(), we won't see the first invocation of schedule().
-        verify(mpsSpy, times(0)).schedule()
+        verify(mpsSpy, times(0)).schedule(overduePingAsFirst = true)
 
         // Simulate returning to the foreground with Glean initialized.
         Glean.metricsPingScheduler.onStateChanged(ProcessLifecycleOwner.get(), Lifecycle.Event.ON_START)
 
         // Verify that schedule hasn't been called since we don't schedule on the first foreground
         // since Glean.initialize() ensures schedule is called before any queued tasks are executed
-        verify(mpsSpy, times(0)).schedule()
+        verify(mpsSpy, times(0)).schedule(overduePingAsFirst = false)
 
         // Simulate going to background and then foreground
         Glean.metricsPingScheduler.onStateChanged(ProcessLifecycleOwner.get(), Lifecycle.Event.ON_STOP)
         Glean.metricsPingScheduler.onStateChanged(ProcessLifecycleOwner.get(), Lifecycle.Event.ON_START)
 
         // Verify that schedule has been called on subsequent foreground events
-        verify(mpsSpy, times(1)).schedule()
+        verify(mpsSpy, times(1)).schedule(overduePingAsFirst = false)
     }
 
     @Test
@@ -499,6 +501,98 @@ class MetricsPingSchedulerTest {
         // Verify worker has been cancelled
         assertFalse("MetricsPingWorker is not enqueued",
             getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+    }
+
+    @Test
+    fun `Data recorded before Glean inits must not get into overdue pings`() {
+        val context = getContextWithMockedInfo()
+
+        // Reset Glean and do not start it right away.
+        Glean.testDestroyGleanHandle()
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.setTaskQueueing(true)
+
+        // Let's create a fake time the metrics ping was sent: this is required for
+        // us to not send a 'metrics' ping the first time we init glean.
+        val fakeNowDoNotSend = Calendar.getInstance()
+        fakeNowDoNotSend.clear()
+        fakeNowDoNotSend.set(2015, 6, 11, 4, 0, 0)
+        SystemClock.setCurrentTimeMillis(fakeNowDoNotSend.timeInMillis)
+
+        // Create a fake instance of the metrics ping scheduler just to set the last
+        // collection time.
+        val fakeMpsSetter = spy(MetricsPingScheduler(context))
+        fakeMpsSetter.updateSentDate(getISOTimeString(fakeNowDoNotSend, truncateTo = TimeUnit.Day))
+
+        // Create a metric and set its value. We expect this to be sent in the ping that gets
+        // generated the SECOND time we start glean.
+        val expectedStringMetric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "expected_metric",
+            sendInPings = listOf("metrics")
+        )
+        val expectedValue = "must-exist-in-the-first-ping"
+
+        // Reset Glean and start it for the FIRST time, then record a value.
+        resetGlean(context)
+        expectedStringMetric.set(expectedValue)
+
+        // Destroy glean: it will retain the previously stored metric.
+        Glean.testDestroyGleanHandle()
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.setTaskQueueing(true)
+
+        // Create a metric and attempt to record data before Glean is initialized. This
+        // will be queued in the dispatcher.
+        val stringMetric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "canary_metric",
+            sendInPings = listOf("metrics")
+        )
+        val canaryValue = "must-not-be-in-the-first-ping"
+        stringMetric.set(canaryValue)
+
+        // Set the current system time to a known datetime: this should make the metrics ping
+        // overdue and trigger it at startup.
+        val fakeNowTriggerPing = Calendar.getInstance()
+        fakeNowTriggerPing.clear()
+        fakeNowTriggerPing.set(2015, 6, 12, 7, 0, 0)
+        SystemClock.setCurrentTimeMillis(fakeNowTriggerPing.timeInMillis)
+
+        // Start the web-server that will receive the metrics ping.
+        val server = getMockWebServer()
+
+        try {
+            // Initialize Glean the SECOND time: it will send the expected string metric (stored
+            // from the previous run) but must not send the canary string, which would be sent
+            // next time the 'metrics' ping is collected after this one.
+            Glean.initialize(context, Configuration(
+                    serverEndpoint = "http://" + server.hostName + ":" + server.port, logPings = true
+                )
+            )
+
+            // Trigger worker task to upload the pings in the background.
+            triggerWorkManager(context)
+
+            // Wait for the metrics ping to be received.
+            val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)
+
+            val metricsJsonData = request.body.readUtf8()
+            val pingJson = JSONObject(metricsJsonData)
+
+            assertEquals("The received ping must be a 'metrics' ping",
+                "metrics", pingJson.getJSONObject("ping_info")["ping_type"])
+            assertFalse("The canary metric must not be present in this ping",
+                metricsJsonData.contains("must-not-be-in-the-first-ping"))
+            assertTrue("The expected metric must be in this ping",
+                metricsJsonData.contains(expectedValue))
+        } finally {
+            server.shutdown()
+        }
     }
 
     // @Test


### PR DESCRIPTION
This attempts to fix the problem of components/products recording metrics while or before Glean is still initializing and then flowing into overdue startup `metrics` pings that get generated.

Note that the current behaviour, without this fix, is flaky:

- We're always collecting & sending a `metrics` ping at startup if *any* component or product records a metric and a ping is overdue (not already sent on the current calendar day and we're after 4AM);
- Metrics collected during early startup will get into the generated overdue `metrics` ping, violating the principle of "measurement windows", letting data from a future measurement window fall into the ping related to a previous measurement window.