### PR TITLE
Let clippy fix our code

### DIFF
--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -849,7 +849,7 @@ mod test {
                     *lifetime,
                     test_storage,
                     &format!("{}_{}", metric_id_pattern, value),
-                    &Metric::String(value.to_string()),
+                    &Metric::String((*value).to_string()),
                 )
                 .unwrap();
             }

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -43,9 +43,9 @@ fn experiment_id_and_branch_get_truncated_if_too_long() {
     glean.set_experiment_active(very_long_id.clone(), very_long_branch_id.clone(), None);
 
     // Generate the expected id and branch strings.
-    let mut expected_id = very_long_id.clone();
+    let mut expected_id = very_long_id;
     expected_id.truncate(100);
-    let mut expected_branch_id = very_long_branch_id.clone();
+    let mut expected_branch_id = very_long_branch_id;
     expected_branch_id.truncate(100);
 
     assert!(
@@ -54,7 +54,7 @@ fn experiment_id_and_branch_get_truncated_if_too_long() {
     );
 
     // Make sure the branch id was truncated as well.
-    let experiment_data = glean.test_get_experiment_data_as_json(expected_id.clone());
+    let experiment_data = glean.test_get_experiment_data_as_json(expected_id);
     assert!(
         !experiment_data.is_none(),
         "Experiment data must be available"
@@ -84,7 +84,7 @@ fn limits_on_experiments_extras_are_applied_correctly() {
     }
 
     // Mark the experiment as active.
-    glean.set_experiment_active(experiment_id.clone(), branch_id.clone(), Some(extras));
+    glean.set_experiment_active(experiment_id.clone(), branch_id, Some(extras));
 
     // Make sure it is active
     assert!(
@@ -93,7 +93,7 @@ fn limits_on_experiments_extras_are_applied_correctly() {
     );
 
     // Get the data
-    let experiment_data = glean.test_get_experiment_data_as_json(experiment_id.clone());
+    let experiment_data = glean.test_get_experiment_data_as_json(experiment_id);
     assert!(
         !experiment_data.is_none(),
         "Experiment data must be available"
@@ -135,11 +135,7 @@ fn experiments_status_is_correctly_toggled() {
         .collect();
 
     // Activate an experiment.
-    glean.set_experiment_active(
-        experiment_id.clone(),
-        branch_id.clone(),
-        Some(extra.clone()),
-    );
+    glean.set_experiment_active(experiment_id.clone(), branch_id, Some(extra.clone()));
 
     // Check that the experiment is marekd as active.
     assert!(
@@ -156,12 +152,12 @@ fn experiments_status_is_correctly_toggled() {
 
     let parsed_data: RecordedExperimentData =
         ::serde_json::from_str(&experiment_data.unwrap()).unwrap();
-    assert_eq!(parsed_data.extra.unwrap(), extra.clone());
+    assert_eq!(parsed_data.extra.unwrap(), extra);
 
     // Disable the experiment and check that is no longer available.
     glean.set_experiment_inactive(experiment_id.clone());
     assert!(
-        !glean.test_is_experiment_active(experiment_id.clone()),
+        !glean.test_is_experiment_active(experiment_id),
         "The experiment must not be available any more."
     );
 }

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -101,7 +101,7 @@ fn snapshot_correctly_clears_the_stores() {
         CommonMetricData {
             name: "test_event_clear".into(),
             category: "telemetry".into(),
-            send_in_pings: store_names.clone(),
+            send_in_pings: store_names,
             disabled: false,
             lifetime: Lifetime::Ping,
             ..Default::default()
@@ -159,7 +159,7 @@ fn test_sending_of_event_ping_when_it_fills_up() {
         CommonMetricData {
             name: "click".into(),
             category: "ui".into(),
-            send_in_pings: store_names.clone(),
+            send_in_pings: store_names,
             disabled: false,
             lifetime: Lifetime::Ping,
             ..Default::default()
@@ -207,7 +207,7 @@ fn extra_keys_must_be_recorded_and_truncated_if_needed() {
         CommonMetricData {
             name: "testEvent".into(),
             category: "ui".into(),
-            send_in_pings: store_names.clone(),
+            send_in_pings: store_names,
             disabled: false,
             lifetime: Lifetime::Ping,
             ..Default::default()

--- a/glean-core/tests/memory_distribution.rs
+++ b/glean-core/tests/memory_distribution.rs
@@ -56,7 +56,7 @@ fn serializer_should_correctly_serialize_memory_distribution() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let glean = Glean::new(cfg).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/storage.rs
+++ b/glean-core/tests/storage.rs
@@ -45,7 +45,7 @@ fn snapshot_correctly_clears_the_stores() {
     let metric = CounterMetric::new(CommonMetricData {
         name: "metric".into(),
         category: "telemetry".into(),
-        send_in_pings: store_names.clone(),
+        send_in_pings: store_names,
         disabled: false,
         lifetime: Lifetime::Ping,
         ..Default::default()

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -59,7 +59,7 @@ fn serializer_should_correctly_serialize_timing_distribution() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let glean = Glean::new(cfg).unwrap();
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();


### PR DESCRIPTION
With the release of Rust 1.40.0 a few new clippy lints were introduced.
For us they only apply to test code.
The following code automatically applied all of then:

  cargo +nightly fix -Z unstable-options --clippy

(This autofix feature requires Rust nightly, which is 2 versions ahead
of stable as always, but the code is still valid for our minimum supported Rust version)