### PR TITLE
Fix broken link in General API docs

### DIFF
--- a/docs/user/general-api.md
+++ b/docs/user/general-api.md
@@ -21,7 +21,7 @@ The Glean SDK provides a general API that supports the following operations. See
 | `initialize` | Configure and initialize the Glean SDK. | [Initializing the Glean SDK](#initializing-the-glean-sdk) |
 | `setUploadEnabled` | Enable or disable Glean collection and upload. | [Enabling and disabling Metrics](#enabling-and-disabling-metrics) |
 | `getUploadEnabled` | Get whether or not Glean is allowed to record and upload data. | |
-| `registerPings` | Register custom pings generated from `pings.yaml`. | [Custom pings][custom pings] |
+| `registerPings` | Register custom pings generated from `pings.yaml`. | [Custom pings][custom-pings] |
 | `setExperimentActive` | Indicate that an experiment is running. | [Using the Experiments API][experiments-api] |
 | `setExperimentInactive` | Indicate that an experiment is no longer running.. | [Using the Experiments API][experiments-api] |
 


### PR DESCRIPTION
The [General API docs][docs] contain a table with a broken Markdown link to Custom pings. 📝 

![custom_pings](https://user-images.githubusercontent.com/6024445/71400328-baa1cc80-2626-11ea-85b6-844bef1b108c.png)

[docs]: https://mozilla.github.io/glean/book/user/general-api.html
