### PR TITLE
1602024: Improve the metrics ping scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
     migration and initialization.
   * Metrics with `lifetime: application` are now cleared when the application is started,
     after startup Glean SDK pings are generated.
+  * The metrics ping scheduler will now only send metrics pings while the
+    application is running. The application will no longer "wake up" at 4am
+    using the Work Manager.
 * All platforms:
   * The public method `PingType.send()` (in all platforms) have been deprecated
     and renamed to `PingType.submit()`.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -286,7 +286,7 @@ open class GleanInternalAPI internal constructor () {
                     // Cancel any pending workers here so that we don't accidentally upload or
                     // collect data after the upload has been disabled.
                     if (!enabled) {
-                        MetricsPingScheduler.cancel(applicationContext)
+                        metricsPingScheduler.cancel()
                         PingUploadWorker.cancel(applicationContext)
                     }
                 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -9,25 +9,16 @@ import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import android.text.format.DateUtils
 import android.util.Log
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.Worker
-import androidx.work.WorkManager
-import androidx.work.WorkerParameters
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.GleanMetrics.Pings
 import mozilla.telemetry.glean.utils.getISOTimeString
 import mozilla.telemetry.glean.utils.parseISOTimeString
 import mozilla.telemetry.glean.private.TimeUnit
-import mozilla.telemetry.glean.utils.ThreadUtils
 import java.util.Calendar
 import java.util.Date
-import java.util.concurrent.TimeUnit as AndroidTimeUnit
+import java.util.Timer
+import java.util.TimerTask
 
 /**
  * MetricsPingScheduler facilitates scheduling the periodic assembling of metrics pings,
@@ -36,53 +27,31 @@ import java.util.concurrent.TimeUnit as AndroidTimeUnit
  * - ping is overdue (due time already passed) for the current calendar day;
  * - ping is soon to be sent in the current calendar day;
  * - ping was already sent, and must be scheduled for the next calendar day.
- *
- * The scheduler also makes use of the [LifecycleObserver] in order to correctly schedule
- * the [MetricsPingWorker].
  */
 @Suppress("TooManyFunctions")
 internal class MetricsPingScheduler(
     private val applicationContext: Context,
     migratedLastSentDate: String? = null
-) : LifecycleEventObserver {
+) {
     internal val sharedPreferences: SharedPreferences by lazy {
         applicationContext.getSharedPreferences(this.javaClass.canonicalName, Context.MODE_PRIVATE)
     }
+
+    internal var timer: Timer? = null
 
     companion object {
         private const val LOG_TAG = "glean/MetricsPingSched"
         const val LAST_METRICS_PING_SENT_DATETIME = "last_metrics_ping_iso_datetime"
         const val DUE_HOUR_OF_THE_DAY = 4
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        internal var isInForeground = false
-        internal var firstForeground = true
-
-        /**
-         * Function to cancel any pending metrics ping workers
-         */
-        internal fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(MetricsPingWorker.TAG)
-        }
     }
 
     init {
-        // This should only be called from the main thread.
-        // We can't enforce this at build time here, since the @MainThread
-        // decorator can not be applied to a contructor.  However, in practice
-        // this is only called from Glean.initialize which does have that
-        // decorator.  For good measure, we also perform this run time check
-        // here.
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1581556
-        ThreadUtils.assertOnUiThread()
-
         // When performing the data migration from glean-ac, this scheduler might be
         // provided with a date the 'metrics' ping was last sent. If so, save that in
         // the new storage and use it in this scheduler.
         migratedLastSentDate?.let { acLastSentDate ->
             updateSentDate(acLastSentDate)
         }
-
-        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
 
     /**
@@ -101,25 +70,12 @@ internal class MetricsPingScheduler(
         val millisUntilNextDueTime = getMillisecondsUntilDueTime(sendTheNextCalendarDay, now)
         Log.d(LOG_TAG, "Scheduling the 'metrics' ping in ${millisUntilNextDueTime}ms")
 
-        // Build a work request: we don't use use a `PeriodicWorkRequest`, which
-        // is more suitable for this task, because of the inherent drifting. See
-        // https://developer.android.com/reference/androidx/work/PeriodicWorkRequest.html
-        // for more details.
-        val workRequest = OneTimeWorkRequestBuilder<MetricsPingWorker>()
-            .addTag(MetricsPingWorker.TAG)
-            .setInitialDelay(millisUntilNextDueTime, AndroidTimeUnit.MILLISECONDS)
-            .build()
+        // Cancel any existing scheduled work. Does not actually cancel a
+        // currently-running task.
+        timer?.cancel()
 
-        // Enqueue the work request: replace older requests if needed. This is to cover
-        // the odd case in which:
-        // - Glean is killed, but the work request is still there;
-        // - Glean restarts;
-        // - the ping is overdue and is immediately collected at startup;
-        // - a new work is scheduled for the next calendar day.
-        WorkManager.getInstance(applicationContext).enqueueUniqueWork(
-            MetricsPingWorker.TAG,
-            ExistingWorkPolicy.REPLACE,
-            workRequest)
+        timer = Timer("glean.MetricsPingScheduler")
+        timer?.schedule(MetricsPingTimerTask(this), millisUntilNextDueTime)
     }
 
     /**
@@ -301,13 +257,8 @@ internal class MetricsPingScheduler(
         // Update the collection date: we don't really care if we have data or not, let's
         // always update the sent date.
         updateSentDate(getISOTimeString(now, truncateTo = TimeUnit.Day))
-        // Reschedule the collection if we are in the foreground so that any metrics collected after
-        // this are sent in the next window.  If we are in the background, then we may stay there
-        // until the app is killed so we shouldn't reschedule unless the app is foregrounded again
-        // (see GleanLifecycleObserver).
-        if (isInForeground) {
-            schedulePingCollection(now, sendTheNextCalendarDay = true)
-        }
+        // Reschedule the collection.
+        schedulePingCollection(now, sendTheNextCalendarDay = true)
     }
 
     /**
@@ -332,6 +283,14 @@ internal class MetricsPingScheduler(
     }
 
     /**
+     * Function to cancel any pending metrics ping timers
+     */
+    fun cancel() {
+        timer?.cancel()
+        timer = null
+    }
+
+    /**
      * Update the persisted date when the metrics ping is sent.
      *
      * This is called after sending a metrics ping to timestamp when the last ping was
@@ -350,74 +309,25 @@ internal class MetricsPingScheduler(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun getCalendarInstance(): Calendar = Calendar.getInstance()
-
-    /**
-     * Called when lifecycle events are triggered.
-     */
-    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-        when (event) {
-            Lifecycle.Event.ON_STOP -> {
-                // Update flag to show we are no longer in the foreground.
-                isInForeground = false
-            }
-            Lifecycle.Event.ON_START -> {
-                // Update the flag to indicate we are moving to the foreground, and if Glean is
-                // initialized we will check to see if the metrics ping needs to be scheduled for
-                // collection.
-                isInForeground = true
-
-                // We check for the metrics ping schedule here because the app could have been in
-                // the background and resumed in which case Glean would already be initialized but
-                // we still need to perform the check to determine whether to collect and schedule
-                // the metrics ping. Since Glean.initialize() is called in the
-                // Application.onCreate() function, we will get this after glean is initialized and
-                // thus will call schedule() twice. So we prevent this by using a flag to prevent
-                // scheduling from the lifecycle observer on the first foreground event.
-                // See https://bugzilla.mozilla.org/1590329
-                if (Glean.isInitialized()) {
-                    if (!firstForeground) {
-                        schedule(overduePingAsFirst = false)
-                    } else {
-                        firstForeground = false
-                    }
-                }
-            }
-            else -> {
-                // For other lifecycle events, do nothing
-            }
-        }
-    }
 }
 
 /**
- * The class representing the work to be done by the [WorkManager]. This is used by
+ * The class representing the task to be performed by the [Timer]. This is used by
  * [MetricsPingScheduler.schedulePingCollection] for scheduling the collection of the
  * "metrics" ping at the due hour.
  */
-internal class MetricsPingWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+internal class MetricsPingTimerTask(val scheduler: MetricsPingScheduler) : TimerTask() {
     companion object {
-        private const val LOG_TAG = "glean/MetricsPingWorker"
-        const val TAG = "mozac_service_glean_metrics_ping_tick"
+        private const val LOG_TAG = "glean/MetricsPingTimerTask"
     }
 
-    override fun doWork(): Result {
-        // This is getting the instance of the MetricsPingScheduler class instantiated by
-        // the [Glean] singleton. This is ugly. There are a few alternatives to this:
-        //
-        // 1. provide a custom WorkerFactory to the WorkManager; however this would require
-        //    us to prevent the application from initializing the WorkManager at startup in
-        //    order to manually init it ourselves and feed in our custom configuration with
-        //    the new factory.
-        // 2. make most functions of MetricsPingScheduler static and allow for calling them
-        //    from this worker; this makes testing much more complicated, due to the restrictions
-        //    related to static functions when testing.
-        val metricsScheduler = Glean.metricsPingScheduler
+    /**
+     * The callback to submit the metrics ping at the scheduled time.
+     */
+    override fun run() {
         // Perform the actual work.
-        val now = metricsScheduler.getCalendarInstance()
-        Log.d(LOG_TAG, "MetricsPingWorker doWork(), now = ${now.time}")
-        metricsScheduler.collectPingAndReschedule(now)
-        // We don't expect to fail at collection: we might fail at upload, but that's handled
-        // separately by the upload worker.
-        return Result.success()
+        val now = scheduler.getCalendarInstance()
+        Log.d(LOG_TAG, "MetricsPingTimerTask run(), now = ${now.time}")
+        scheduler.collectPingAndReschedule(now)
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -75,7 +75,7 @@ internal class MetricsPingScheduler(
         timer?.cancel()
 
         timer = Timer("glean.MetricsPingScheduler")
-        timer?.schedule(MetricsPingTimerTask(this), millisUntilNextDueTime)
+        timer?.schedule(MetricsPingTimer(this), millisUntilNextDueTime)
     }
 
     /**
@@ -316,9 +316,9 @@ internal class MetricsPingScheduler(
  * [MetricsPingScheduler.schedulePingCollection] for scheduling the collection of the
  * "metrics" ping at the due hour.
  */
-internal class MetricsPingTimerTask(val scheduler: MetricsPingScheduler) : TimerTask() {
+internal class MetricsPingTimer(val scheduler: MetricsPingScheduler) : TimerTask() {
     companion object {
-        private const val LOG_TAG = "glean/MetricsPingTimerTask"
+        private const val LOG_TAG = "glean/MetricsPingTimer"
     }
 
     /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -23,7 +23,6 @@ import mozilla.telemetry.glean.private.NoExtraKeys
 import mozilla.telemetry.glean.private.PingType
 import mozilla.telemetry.glean.private.StringMetricType
 import mozilla.telemetry.glean.scheduler.GleanLifecycleObserver
-import mozilla.telemetry.glean.scheduler.MetricsPingWorker
 import mozilla.telemetry.glean.scheduler.DeletionPingUploadWorker
 import mozilla.telemetry.glean.scheduler.PingUploadWorker
 import mozilla.telemetry.glean.testing.GleanTestRule
@@ -516,7 +515,7 @@ class GleanTest {
         assertTrue("PingUploadWorker is enqueued",
             getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
         assertTrue("MetricsPingWorker is enqueued",
-            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+            Glean.metricsPingScheduler.timer != null)
 
         Glean.setUploadEnabled(true)
 
@@ -526,7 +525,7 @@ class GleanTest {
         assertTrue("PingUploadWorker is enqueued",
             getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
         assertTrue("MetricsPingWorker is enqueued",
-            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+            Glean.metricsPingScheduler.timer != null)
 
         // Toggle upload enabled to false
         Glean.setUploadEnabled(false)
@@ -534,8 +533,8 @@ class GleanTest {
         // Verify workers have been cancelled
         assertFalse("PingUploadWorker is not enqueued",
             getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
-        assertFalse("MetricsPingWorker is not enqueued",
-            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+        assertTrue("MetricsPingWorker is not enqueued",
+            Glean.metricsPingScheduler.timer == null)
         // Verify deletion ping upload worker has been scheduled
         assertTrue("DeletionPingUploadWorker is not enqueued",
             getWorkerStatus(context, DeletionPingUploadWorker.PING_WORKER_TAG).isEnqueued)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -6,8 +6,6 @@ package mozilla.telemetry.glean.scheduler
 
 import android.content.Context
 import android.os.SystemClock
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -23,13 +21,13 @@ import mozilla.telemetry.glean.checkPingSchema
 import mozilla.telemetry.glean.triggerWorkManager
 import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.getMockWebServer
-import mozilla.telemetry.glean.getWorkerStatus
 import mozilla.telemetry.glean.utils.getISOTimeString
 import mozilla.telemetry.glean.utils.parseISOTimeString
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -38,7 +36,6 @@ import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.eq
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
@@ -302,8 +299,6 @@ class MetricsPingSchedulerTest {
         val overdueTestDate = "2015-07-05T12:36:00-06:00"
         mpsSpy.updateSentDate(overdueTestDate)
 
-        MetricsPingScheduler.isInForeground = true
-
         verify(mpsSpy, never()).collectPingAndReschedule(any(), eq(true))
 
         // Make sure to return the fake date when requested.
@@ -443,45 +438,17 @@ class MetricsPingSchedulerTest {
         // Replacing the singleton's metricsPingScheduler here since doWork() refers to it when
         // the worker runs, otherwise we can get a lateinit property is not initialized error.
         Glean.metricsPingScheduler = MetricsPingScheduler(context)
-        MetricsPingScheduler.isInForeground = true
 
         // No work should be enqueued at the beginning of the test.
-        assertFalse(getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+        assertNull(Glean.metricsPingScheduler.timer)
 
         // Manually schedule a collection task for today.
         Glean.metricsPingScheduler.schedulePingCollection(Calendar.getInstance(), sendTheNextCalendarDay = false)
 
         // We expect the worker to be scheduled.
-        assertTrue(getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+        assertNotNull(Glean.metricsPingScheduler.timer)
 
         resetGlean(clearStores = true)
-    }
-
-    @Test
-    fun `schedule() happens when returning from background when Glean is already initialized`() {
-        // Initialize Glean
-        resetGlean(clearStores = true)
-        val mpsSpy = mock(MetricsPingScheduler::class.java)
-        `when`(mpsSpy.onStateChanged(ProcessLifecycleOwner.get(), Lifecycle.Event.ON_START)).thenCallRealMethod()
-        Glean.metricsPingScheduler = mpsSpy
-
-        // Make sure schedule() has not been called.  Since we are adding the spy after resetGlean
-        // has called Glean.initialize(), we won't see the first invocation of schedule().
-        verify(mpsSpy, times(0)).schedule(overduePingAsFirst = true)
-
-        // Simulate returning to the foreground with Glean initialized.
-        Glean.metricsPingScheduler.onStateChanged(ProcessLifecycleOwner.get(), Lifecycle.Event.ON_START)
-
-        // Verify that schedule hasn't been called since we don't schedule on the first foreground
-        // since Glean.initialize() ensures schedule is called before any queued tasks are executed
-        verify(mpsSpy, times(0)).schedule(overduePingAsFirst = false)
-
-        // Simulate going to background and then foreground
-        Glean.metricsPingScheduler.onStateChanged(ProcessLifecycleOwner.get(), Lifecycle.Event.ON_STOP)
-        Glean.metricsPingScheduler.onStateChanged(ProcessLifecycleOwner.get(), Lifecycle.Event.ON_START)
-
-        // Verify that schedule has been called on subsequent foreground events
-        verify(mpsSpy, times(1)).schedule(overduePingAsFirst = false)
     }
 
     @Test
@@ -492,15 +459,15 @@ class MetricsPingSchedulerTest {
         mps.schedulePingCollection(Calendar.getInstance(), true)
 
         // Verify that the worker is enqueued
-        assertTrue("MetricsPingWorker is enqueued",
-            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+        assertNotNull("MetricsPingWorker is enqueued",
+            Glean.metricsPingScheduler.timer)
 
         // Cancel the worker
-        MetricsPingScheduler.cancel(context)
+        Glean.metricsPingScheduler.cancel()
 
         // Verify worker has been cancelled
-        assertFalse("MetricsPingWorker is not enqueued",
-            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
+        assertNull("MetricsPingWorker is not enqueued",
+            Glean.metricsPingScheduler.timer)
     }
 
     @Test


### PR DESCRIPTION
This uses a simple `Timer`, rather than the WorkManager for the MetricsPingScheduler.

As planned, we can also move the actual scheduling algorithm to Rust, but that is saved for future work.  This is just the simplest change possible to get us off of the WorkManager here.