### PR TITLE
Release 23.0.0

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 22.1.0
+libraryVersion: 23.0.0
 groupId: org.mozilla.telemetry
 projects:
   glean:

--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 22.0.0
+libraryVersion: 22.1.0
 groupId: org.mozilla.telemetry
 projects:
   glean:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     and renamed to `PingType.submit()`.
   * Rename `deletion_request` ping to `deletion-request` ping after glean_parser update
 
+* Add `InvalidOverflow` error to `TimingDistribution`s ([#583](https://github.com/mozilla/glean/pull/583))
 
 # v22.0.0 (2019-12-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v22.1.0...master)
+[Full changelog](https://github.com/mozilla/glean/compare/v23.0.0...master)
+
+# v23.0.0 (2020-01-07)
+
+[Full changelog](https://github.com/mozilla/glean/compare/v22.1.0...v23.0.0)
 
 * Python bindings:
   * Support for events and UUID metrics was added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 # v22.1.0 (2019-12-17)
 
-[Full changelog](https://github.com/mozilla/glean/compare/v22.0.0...22.1.0)
+[Full changelog](https://github.com/mozilla/glean/compare/v22.0.0...v22.1.0)
 
 * Add `InvalidOverflow` error to `TimingDistribution`s ([#583](https://github.com/mozilla/glean/pull/583))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v22.0.0...master)
+[Full changelog](https://github.com/mozilla/glean/compare/v22.1.0...master)
 
 * Python bindings:
   * Support for events and UUID metrics was added.
@@ -15,6 +15,10 @@
   * The public method `PingType.send()` (in all platforms) have been deprecated
     and renamed to `PingType.submit()`.
   * Rename `deletion_request` ping to `deletion-request` ping after glean_parser update
+
+# v22.1.0 (2019-12-17)
+
+[Full changelog](https://github.com/mozilla/glean/compare/v22.0.0...22.1.0)
 
 * Add `InvalidOverflow` error to `TimingDistribution`s ([#583](https://github.com/mozilla/glean/pull/583))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "22.1.0"
+version = "23.0.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -320,12 +320,12 @@ dependencies = [
 
 [[package]]
 name = "glean-ffi"
-version = "22.1.0"
+version = "23.0.0"
 dependencies = [
  "android_logger 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 22.1.0",
+ "glean-core 23.0.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -336,7 +336,7 @@ name = "glean-preview"
 version = "0.0.4"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 22.1.0",
+ "glean-core 23.0.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "22.0.0"
+version = "22.1.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -320,12 +320,12 @@ dependencies = [
 
 [[package]]
 name = "glean-ffi"
-version = "22.0.0"
+version = "22.1.0"
 dependencies = [
  "android_logger 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 22.0.0",
+ "glean-core 22.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -336,7 +336,7 @@ name = "glean-preview"
 version = "0.0.4"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glean-core 22.0.0",
+ "glean-core 22.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -90,6 +90,14 @@ run $SED -i.bak -E \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
+### GLEAN-PREVIEW ###
+
+FILE=glean-core/preview/Cargo.toml
+run $SED -i.bak -E \
+    -e "/glean-core/!b;n;n;s/version = \"[0-9a-z.-]+\"/version = \"${NEW_VERSION}\"/" \
+    "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
 ### Update Cargo.lock
 
 cargo update -p glean-core -p glean-ffi

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -75,6 +75,8 @@ fi
 
 ### GLEAN-CORE ###
 
+# Update the glean-core version
+
 FILE=glean-core/Cargo.toml
 run $SED -i.bak -E \
     -e "s/^version = \"[0-9a-z.-]+\"/version = \"${NEW_VERSION}\"/" \
@@ -82,6 +84,8 @@ run $SED -i.bak -E \
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
 ### GLEAN-FFI ###
+
+# Update the glean-ffi version, and its glean-core dependency
 
 FILE=glean-core/ffi/Cargo.toml
 run $SED -i.bak -E \
@@ -91,6 +95,8 @@ run $SED -i.bak -E \
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
 ### GLEAN-PREVIEW ###
+
+# Update the version of the glean-core dependency
 
 FILE=glean-core/preview/Cargo.toml
 run $SED -i.bak -E \

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "22.1.0"
+version = "23.0.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "22.0.0"
+version = "22.1.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-ffi"
-version = "22.1.0"
+version = "23.0.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "FFI layer for Glean, a modern Telemetry library"
 repository = "https://github.com/mozilla/glean"
@@ -34,7 +34,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 
 [dependencies.glean-core]
 path = ".."
-version = "22.1.0"
+version = "23.0.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = { version = "0.8.5", default-features = false }

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-ffi"
-version = "22.0.0"
+version = "22.1.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "FFI layer for Glean, a modern Telemetry library"
 repository = "https://github.com/mozilla/glean"
@@ -34,7 +34,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 
 [dependencies.glean-core]
 path = ".."
-version = "22.0.0"
+version = "22.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = { version = "0.8.5", default-features = false }

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -274,3 +274,5 @@ glean.error:
     notification_emails:
       - glean-team@mozilla.com
     expires: never
+    no_lint:
+      - COMMON_PREFIX

--- a/glean-core/preview/Cargo.toml
+++ b/glean-core/preview/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies.glean-core]
 path = ".."
-version = "22.0.0"
+version = "23.0.0"
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -369,7 +369,7 @@ subprocess.check_call([
     }
 
     void apply(Project project) {
-        project.ext.glean_version = "22.1.0"
+        project.ext.glean_version = "23.0.0"
 
         File condaDir = setupPythonEnvironmentTasks(project)
         project.ext.set("gleanCondaDir", condaDir)

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -369,7 +369,7 @@ subprocess.check_call([
     }
 
     void apply(Project project) {
-        project.ext.glean_version = "22.0.0"
+        project.ext.glean_version = "22.1.0"
 
         File condaDir = setupPythonEnvironmentTasks(project)
         project.ext.set("gleanCondaDir", condaDir)


### PR DESCRIPTION
A couple of complications beyond the usual here:

I merged the `v22.1.0` tag into master -- I don't think this was done earlier, and it fixes the changelog which previously didn't have an entry for that version.

Updated the `prepare_release.sh` script to update the version in `glean-preview`.