### PR TITLE
Update payload schema tested against

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'jacoco'
  * created during unit testing.
  * This uses a specific version of the schema identified by a git commit hash.
  */
-String GLEAN_PING_SCHEMA_GIT_HASH = "9c9903c"
+String GLEAN_PING_SCHEMA_GIT_HASH = "a56043b"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/glean/glean.1.schema.json"
 
 // Set configuration for the glean_parser

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -23,8 +23,8 @@ apply plugin: 'jacoco'
  * created during unit testing.
  * This uses a specific version of the schema identified by a git commit hash.
  */
-String GLEAN_PING_SCHEMA_GIT_HASH = "f13ae39"
-String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/baseline/baseline.1.schema.json"
+String GLEAN_PING_SCHEMA_GIT_HASH = "9c9903c"
+String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/glean/glean.1.schema.json"
 
 // Set configuration for the glean_parser
 ext.allowGleanInternal = true


### PR DESCRIPTION
This PR updates to pipeline schema that the unit tests run against to the latest master.

It adds a test for `snake_case` and `kebab-case` ping names (both of which must work indefinitely), and we can see the `kebab-case` one failing because of https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/470 not being merged.