### PR TITLE
1605411 - Reset core client metrics when re-enabling upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,10 @@ commands:
           command: cargo test --all ---exclude glean-preview --verbose
       - run:
           name: Test glean-preview
-          command: cargo test -p glean-preview -- --test-threads=1
+          command:
+              # Because glean_preview is a global-singleton, we need to run the tests
+              # single-threaded to avoid different tests stomping over each other.
+              cargo test -p glean-preview -- --test-threads=1
 
   install-rustup:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,10 @@ commands:
           rust-version: <<parameters.rust-version>>
       - run:
           name: Test
-          command: cargo test --all --verbose
+          command: cargo test --all ---exclude glean-preview --verbose
+      - run:
+          name: Test glean-preview
+          command: cargo test -p glean-preview -- --test-threads=1
 
   install-rustup:
     steps:

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,13 @@ build-python: python-setup build-rust ## Build the Python bindings
 test: test-rust
 
 test-rust: ## Run all Rust tests
-	cargo test --all
+	cargo test --all --exclude glean-preview
 
 test-rust-with-logs: ## Run all Rust tests with debug logging and single-threaded
 	RUST_LOG=glean_core=debug cargo test --all -- --nocapture --test-threads=1
+
+test-preview: ## Run Rust tests for glean-preview
+	cargo test -p glean-preview -- --test-threads=1
 
 test-kotlin: ## Run all Kotlin tests
 	./gradlew test

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build-python: python-setup build-rust ## Build the Python bindings
 
 test: test-rust
 
-test-rust: ## Run all Rust tests
+test-rust: ## Run Rust tests for glean-core and glean-ffi
 	cargo test --all --exclude glean-preview
 
 test-rust-with-logs: ## Run all Rust tests with debug logging and single-threaded

--- a/glean-core/preview/src/lib.rs
+++ b/glean-core/preview/src/lib.rs
@@ -50,17 +50,24 @@ mod core_metrics;
 pub mod metrics;
 mod system;
 
-static GLEAN: OnceCell<Mutex<Glean>> = OnceCell::new();
+#[derive(Debug)]
+struct GleanWrapper {
+    instance: Glean,
+    channel: Option<String>,
+    client_info: ClientInfoMetrics,
+}
+
+static GLEAN: OnceCell<Mutex<GleanWrapper>> = OnceCell::new();
 
 /// Get a reference to the global Glean object.
 ///
 /// Panics if no global Glean object was set.
-fn global_glean() -> &'static Mutex<Glean> {
+fn global_glean() -> &'static Mutex<GleanWrapper> {
     GLEAN.get().unwrap()
 }
 
 /// Set or replace the global Glean object.
-fn setup_glean(glean: Glean) -> Result<()> {
+fn setup_glean(glean: GleanWrapper) -> Result<()> {
     if GLEAN.get().is_none() {
         GLEAN.set(Mutex::new(glean)).unwrap();
     } else {
@@ -75,7 +82,15 @@ where
     F: Fn(&Glean) -> R,
 {
     let lock = global_glean().lock().unwrap();
-    f(&lock)
+    f(&lock.instance)
+}
+
+fn with_glean_wrapper_mut<F, R>(f: F) -> R
+where
+    F: Fn(&mut GleanWrapper) -> R,
+{
+    let mut lock = global_glean().lock().unwrap();
+    f(&mut lock)
 }
 
 fn with_glean_mut<F, R>(f: F) -> R
@@ -83,38 +98,49 @@ where
     F: Fn(&mut Glean) -> R,
 {
     let mut lock = global_glean().lock().unwrap();
-    f(&mut lock)
+    f(&mut lock.instance)
 }
 
 /// Create and initialize a new Glean object.
 ///
 /// See `glean_core::Glean::new`.
 pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) -> Result<()> {
-    let channel = cfg.channel;
-    let cfg = glean_core::Configuration {
+    let core_cfg = glean_core::Configuration {
         upload_enabled: cfg.upload_enabled,
-        data_path: cfg.data_path,
-        application_id: cfg.application_id,
+        data_path: cfg.data_path.clone(),
+        application_id: cfg.application_id.clone(),
         max_events: cfg.max_events,
         delay_ping_lifetime_io: cfg.delay_ping_lifetime_io,
     };
-    let glean = Glean::new(cfg)?;
+    let glean = Glean::new(core_cfg)?;
 
     // First initialize core metrics
-    initialize_core_metrics(&glean, client_info, channel);
+    initialize_core_metrics(&glean, &client_info, &cfg.channel);
+
     // Now make this the global object available to others.
-    setup_glean(glean)?;
+    let wrapper = GleanWrapper {
+        instance: glean,
+        channel: cfg.channel,
+        client_info,
+    };
+    setup_glean(wrapper)?;
 
     Ok(())
 }
 
-fn initialize_core_metrics(glean: &Glean, client_info: ClientInfoMetrics, channel: Option<String>) {
+fn initialize_core_metrics(
+    glean: &Glean,
+    client_info: &ClientInfoMetrics,
+    channel: &Option<String>,
+) {
     let core_metrics = core_metrics::InternalMetrics::new();
 
-    core_metrics.app_build.set(glean, client_info.app_build);
+    core_metrics
+        .app_build
+        .set(glean, &client_info.app_build[..]);
     core_metrics
         .app_display_version
-        .set(glean, client_info.app_display_version);
+        .set(glean, &client_info.app_display_version[..]);
     if let Some(app_channel) = channel {
         core_metrics.app_channel.set(glean, app_channel);
     }
@@ -132,10 +158,18 @@ fn initialize_core_metrics(glean: &Glean, client_info: ClientInfoMetrics, channe
 /// Set whether upload is enabled or not.
 ///
 /// See `glean_core::Glean.set_upload_enabled`.
-pub fn set_upload_enabled(flag: bool) -> bool {
-    with_glean_mut(|glean| {
-        glean.set_upload_enabled(flag);
-        glean.is_upload_enabled()
+pub fn set_upload_enabled(enabled: bool) -> bool {
+    with_glean_wrapper_mut(|glean| {
+        let old_enabled = glean.instance.is_upload_enabled();
+        glean.instance.set_upload_enabled(enabled);
+
+        if !old_enabled && enabled {
+            // If uploading is being re-enabled, we have to restore the
+            // application-lifetime metrics.
+            initialize_core_metrics(&glean.instance, &glean.client_info, &glean.channel);
+        }
+
+        enabled
     })
 }
 
@@ -183,3 +217,6 @@ pub fn submit_ping_by_name(ping: &str) -> bool {
 pub fn submit_pings_by_name(pings: &[String]) -> bool {
     with_glean(|glean| glean.submit_pings_by_name(pings))
 }
+
+#[cfg(test)]
+mod test;

--- a/glean-core/preview/src/lib.rs
+++ b/glean-core/preview/src/lib.rs
@@ -115,7 +115,7 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) -> Result<
     let glean = Glean::new(core_cfg)?;
 
     // First initialize core metrics
-    initialize_core_metrics(&glean, &client_info, &cfg.channel);
+    initialize_core_metrics(&glean, &client_info, cfg.channel.clone());
 
     // Now make this the global object available to others.
     let wrapper = GleanWrapper {
@@ -131,7 +131,7 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) -> Result<
 fn initialize_core_metrics(
     glean: &Glean,
     client_info: &ClientInfoMetrics,
-    channel: &Option<String>,
+    channel: Option<String>,
 ) {
     let core_metrics = core_metrics::InternalMetrics::new();
 
@@ -166,7 +166,7 @@ pub fn set_upload_enabled(enabled: bool) -> bool {
         if !old_enabled && enabled {
             // If uploading is being re-enabled, we have to restore the
             // application-lifetime metrics.
-            initialize_core_metrics(&glean.instance, &glean.client_info, &glean.channel);
+            initialize_core_metrics(&glean.instance, &glean.client_info, glean.channel.clone());
         }
 
         enabled

--- a/glean-core/preview/src/test.rs
+++ b/glean-core/preview/src/test.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+const GLOBAL_APPLICATION_ID: &str = "org.mozilla.fogotype.test";
+
+// Create a new instance of Glean with a temporary directory.
+// We need to keep the `TempDir` alive, so that it's not deleted before we stop using it.
+fn new_glean() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+
+    let cfg = Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        channel: Some("testing".into()),
+    };
+
+    initialize(cfg, ClientInfoMetrics::unknown()).unwrap();
+    dir
+}
+
+#[test]
+fn it_initializes() {
+    env_logger::try_init().ok();
+    let _ = new_glean();
+}
+
+#[test]
+fn it_toggles_upload() {
+    env_logger::try_init().ok();
+
+    let _t = new_glean();
+
+    assert!(crate::is_upload_enabled());
+    crate::set_upload_enabled(false);
+    assert!(!crate::is_upload_enabled());
+}
+
+#[test]
+fn client_info_reset_after_toggle() {
+    env_logger::try_init().ok();
+
+    let _t = new_glean();
+
+    assert!(crate::is_upload_enabled());
+
+    // Metrics are identified by category.name, so it's safe to recreate the objects here.
+    let core_metrics = core_metrics::InternalMetrics::new();
+
+    // At start we should have a value.
+    with_glean(|glean| {
+        assert!(core_metrics
+            .os
+            .test_get_value(glean, "glean_client_info")
+            .is_some());
+    });
+
+    // Disabling upload clears everything.
+    crate::set_upload_enabled(false);
+    with_glean(|glean| {
+        assert!(!core_metrics
+            .os
+            .test_get_value(glean, "glean_client_info")
+            .is_some());
+    });
+
+    // Re-enabling upload should reset the values.
+    crate::set_upload_enabled(true);
+    with_glean(|glean| {
+        assert!(core_metrics
+            .os
+            .test_get_value(glean, "glean_client_info")
+            .is_some());
+    });
+}


### PR DESCRIPTION
We clear all metrics when upload is disabled (glean-core takes care of that),
so we need to reset the initial values only known to the platform when
re-enabling upload.

Now the client info and the channel are passed into the initialize
function of glean_preview.
Before this commit we didn't keep that data around, which means we also
couldn't restore it.
By introducing a small wrapper around the Glean instance we are able to
carry around that data and reuse it when necessary.

This now also adds tests for glean-preview with one big caveat:
Because glean_preview is a global-singleton, we need to run the tests
single-threaded to avoid different tests stomping over each other.
There's no explicit check in the tests, developers will notice problems
by tests just hard crashing on them.

Pass `--test-threads 1` to `cargo test --` or set an environment
variable: `RUST_TEST_THREADS=1`.