### PR TITLE
Fix Gradle plugin to handle missing metadata files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v23.0.0...master)
 
+* Android:
+  * BUGFIX: The Glean Gradle plugin will now work if an app or library doesn't
+    have a metrics.yaml or pings.yaml file.
+
 # v23.0.0 (2020-01-07)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v22.1.0...v23.0.0)

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -126,7 +126,9 @@ subprocess.check_call([
                 // Add local registry files as input to this task. They will be turned
                 // into `arg`s later.
                 for (String item : getYamlFiles(project)) {
-                    inputs.file item
+                    if (project.file(item).exists()) {
+                        inputs.file item
+                    }
                 }
 
                 outputs.dir sourceOutputDir
@@ -201,7 +203,9 @@ subprocess.check_call([
                 // Add local registry files as input to this task. They will be turned
                 // into `arg`s later.
                 for (String item : getYamlFiles(project)) {
-                    inputs.file item
+                    if (project.file(item).exists()) {
+                        inputs.file item
+                    }
                 }
 
                 outputs.dir gleanDocsDirectory


### PR DESCRIPTION
This is a bugfix for 5ca9f66908449f374866d70ac4384b70c3ed1514 so that the plugin won't break if either the metrics.yaml or pings.yaml file is missing when adding it as a task dependency.  This was discovered in https://github.com/mozilla-mobile/android-components/pull/5490 when trying to integrate the Gradle plugin into a-c.