### PR TITLE
Build macOS wheels for Python bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -744,6 +744,31 @@ jobs:
             # variables are configured in CircleCI's environment variables.
             .venv/bin/python3 -m twine upload wheelhouse/*
 
+  pypi-macos-release:
+    macos:
+      xcode: "11.3.0"
+    steps:
+      - run:
+          name: Set Ruby Version
+          command: echo 'chruby ruby-2.6.5' >> ~/.bash_profile
+      - run:
+          name: Show Ruby environment
+          command: |
+            ruby --version
+            gem env
+      - install-rustup
+      - setup-rust-toolchain
+      - checkout
+      - run:
+          name: Build Python extension
+          command: |
+            make build-python
+      - run:
+          name: Build macOS wheel
+          command: |
+            cd glean-core/python
+            .venv/bin/python3 setup.py bdist_wheel
+
 workflows:
   version: 2
   check-formating:
@@ -792,6 +817,7 @@ workflows:
           filters:
             branches:
               only: master
+      - pypi-macos-release
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,6 +817,7 @@ workflows:
           filters:
             branches:
               only: master
+      - pypi-linux-release
       - pypi-macos-release
 
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -748,14 +748,6 @@ jobs:
     macos:
       xcode: "11.3.0"
     steps:
-      - run:
-          name: Set Ruby Version
-          command: echo 'chruby ruby-2.6.5' >> ~/.bash_profile
-      - run:
-          name: Show Ruby environment
-          command: |
-            ruby --version
-            gem env
       - install-rustup
       - setup-rust-toolchain
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -752,14 +752,17 @@ jobs:
       - setup-rust-toolchain
       - checkout
       - run:
-          name: Build Python extension
+          name: Build and Test Python extension
           command: |
-            make build-python
+            make test-python
       - run:
           name: Build macOS wheel
           command: |
             cd glean-core/python
             .venv/bin/python3 setup.py bdist_wheel
+            # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
+            # variables are configured in CircleCI's environment variables.
+            .venv/bin/python3 -m twine upload dist/*
 
 workflows:
   version: 2
@@ -809,8 +812,6 @@ workflows:
           filters:
             branches:
               only: master
-      - pypi-linux-release
-      - pypi-macos-release
 
   release:
     jobs:
@@ -850,6 +851,14 @@ workflows:
             tags:
               only: /^v.*/
       - pypi-linux-release:
+          requires:
+            - Python 3_7 tests
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - pypi-macos-release:
           requires:
             - Python 3_7 tests
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * The code for migrating data from Glean SDK before version 19 was removed.
 * Python:
   * The Python bindings now support Python 3.5 - 3.7.
+  * The Python bindings are now distributed as a wheel on both Linux and macOS.
 
 # v23.0.1 (2020-01-08)
 


### PR DESCRIPTION
This needs to support all platforms that Firefox can be built *on* (not necessarily built *for*).

From the [Firefox macOS build prerequisites](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mac_OS_X_Prerequisites), that appears to be MacOSX 10.9 or later.

From the [Rust documentation](https://forge.rust-lang.org/release/platform-support.html), it appears that the rustc `x86_64-apple-darwin` target produces code that is compatible on 10.7 or later, so I think it has us covered.

This the produces a wheel that runs on macOS 10.7 or later, with Python 3.5 or later, for x86_64.

It's not clear whether we need `x86` wheels, but that can be a follow-on PR if necessary.  That would require adding another Rust target and build etc...