### PR TITLE
1607730 - Try fixing iOS integration test interkittens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
             rustup target add aarch64-apple-ios x86_64-apple-ios
             bin/bootstrap.sh
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
-            xcrun instruments -w "iPhone 11 (13.2) [" || true
+            xcrun instruments -w "iPhone 11 (13.3) [" || true
       - run:
           name: Run XCode build, tests and generate documentation
           command: |
@@ -381,7 +381,7 @@ jobs:
             rustup target add aarch64-apple-ios x86_64-apple-ios
             bin/bootstrap.sh
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
-            xcrun instruments -w "iPhone 11 (13.2) [" || true
+            xcrun instruments -w "iPhone 11 (13.3) [" || true
       - run:
           name: Use local checkout through Carthage
           command: |

--- a/samples/ios/app/glean-sample-appUITests/BaselinePingTest.swift
+++ b/samples/ios/app/glean-sample-appUITests/BaselinePingTest.swift
@@ -60,10 +60,13 @@ class BaselinePingTest: XCTestCase {
 
         // Make sure we have a 'duration' field with a reasonable value: it should be >= 1, since
         // we slept for 1000ms.
+        XCTAssertTrue(metrics.keys.contains("timespan"), "Metrics should have timespans: \(metrics)")
         let timespans = metrics["timespan"] as! [String: Any]
+        XCTAssertTrue(timespans.keys.contains("glean.baseline.duration"),
+                      "Timespans should have baseline duration: \(timespans)")
         let duration = timespans["glean.baseline.duration"] as! [String: Any]
         let durationValue = duration["value"] as! UInt64
-        XCTAssertTrue(durationValue >= 1)
+        XCTAssertTrue(durationValue >= 1, "Duration \(durationValue) should be positive")
 
         // Make sure there's no errors.
         let errors = metrics["labeled_counter"] as? [String: Any]


### PR DESCRIPTION
It's basically: Queue ping submission behind other metric operations.

I _think_ this might actually be the cause for both problems (the "crash" and the timeout).

Please see individual commit messages for detailed explanations.