### PR TITLE
Add locale metric to metrics ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v24.1.0...master)
 
+* General:
+  * Add `locale` to `client_info` section.
+  * **Deprecation Warning** Since `locale` is now in the `client_info` section, the one
+    in the baseline ping ([`glean.baseline.locale`](https://github.com/mozilla/glean/blob/c261205d6e84d2ab39c50003a8ffc3bd2b763768/glean-core/metrics.yaml#L28-L42))
+    is redundant and will be removed by the end of the quarter.
+
 # v24.1.0 (2020-01-16)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v24.0.0...v24.1.0)

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -52,6 +52,7 @@ Optional fields are marked accordingly.
 | `os_version` | String | The user-visible version of the operating system (e.g. "1.2.3") |
 | `android_sdk_version` | String | *Optional*. The Android specific SDK version of the software running on this hardware device (e.g. "23") |
 | `telemetry_sdk_build` | String | The version of the Glean SDK |
+| `locale` | String | The locale of the application (e.g. "es-ES") |
 
 All the metrics surviving application restarts (e.g. `client_id`, ...) are removed once the application using the Glean SDK is uninstalled.
 

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'jacoco'
  * created during unit testing.
  * This uses a specific version of the schema identified by a git commit hash.
  */
-String GLEAN_PING_SCHEMA_GIT_HASH = "a56043b"
+String GLEAN_PING_SCHEMA_GIT_HASH = "f2a7ce4"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/glean/glean.1.schema.json"
 
 // Set configuration for the glean_parser

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -22,6 +22,10 @@ apply plugin: 'jacoco'
  * This defines the location of the JSON schema used to validate the pings
  * created during unit testing.
  * This uses a specific version of the schema identified by a git commit hash.
+ *
+ * !IMPORTANT!
+ * Everytime this hash is changed it should also be changed in
+ * glean-core/python/tests/conftest.py
  */
 String GLEAN_PING_SCHEMA_GIT_HASH = "f2a7ce4"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/glean/glean.1.schema.json"

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -436,6 +436,7 @@ open class GleanInternalAPI internal constructor () {
         GleanInternalMetrics.deviceManufacturer.setSync(Build.MANUFACTURER)
         GleanInternalMetrics.deviceModel.setSync(Build.MODEL)
         GleanInternalMetrics.architecture.setSync(Build.SUPPORTED_ABIS[0])
+        GleanInternalMetrics.locale.setSync(getLocaleTag())
 
         configuration.channel?.let {
             GleanInternalMetrics.appChannel.setSync(it)

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -137,6 +137,7 @@ public class Glean {
         GleanInternalMetrics.deviceManufacturer.setSync(Sysctl.manufacturer)
         GleanInternalMetrics.deviceModel.setSync(Sysctl.model)
         GleanInternalMetrics.architecture.setSync(Sysctl.machine)
+        GleanInternalMetrics.locale.setSync(getLocaleTag())
 
         if let channel = self.configuration?.channel {
             GleanInternalMetrics.appChannel.setSync(channel)

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -193,6 +193,21 @@ glean.internal.metrics:
       - glean-team@mozilla.com
     expires: never
 
+  locale:
+    type: string
+    lifetime: application
+    send_in_pings:
+      - glean_client_info
+    description: |
+      The locale of the application (e.g. "es-ES").
+    bugs:
+      - https://bugzilla.mozilla.org/1601489
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1601489#c3
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+
 glean.error:
   invalid_value:
     type: labeled_counter

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -343,6 +343,7 @@ class Glean:
         metrics.glean.internal.metrics.os.set(platform.system())
         metrics.glean.internal.metrics.os_version.set(platform.release())
         metrics.glean.internal.metrics.architecture.set(platform.machine())
+        metrics.glean.internal.metrics.locale.set(util.get_locale_tag())
 
         sysinfo = hardware.get_system_information()
         metrics.glean.internal.metrics.device_manufacturer.set(sysinfo.manufacturer)

--- a/glean-core/python/tests/conftest.py
+++ b/glean-core/python/tests/conftest.py
@@ -14,6 +14,15 @@ import pytest
 from glean import testing
 from glean import __version__ as glean_version
 
+# !IMPORTANT!
+# Everytime this hash is changed it should also be changed in
+# glean-core/android/build.gradle
+GLEAN_PING_SCHEMA_GIT_HASH = "f2a7ce4"
+GLEAN_PING_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/mozilla-services/"
+    "mozilla-pipeline-schemas/{}/schemas/glean/glean/"
+    "glean.1.schema.json"
+).format(GLEAN_PING_SCHEMA_GIT_HASH)
 
 # Turn on all logging when running the unit tests
 logging.getLogger(None).setLevel(logging.INFO)
@@ -38,6 +47,11 @@ def safe_httpserver(httpserver):
 def safe_httpsserver(httpsserver):
     wait_for_server(httpsserver)
     return httpsserver
+
+
+@pytest.fixture
+def ping_schema_url():
+    return GLEAN_PING_SCHEMA_URL
 
 
 def wait_for_server(httpserver, timeout=30):

--- a/glean-core/python/tests/metrics/test_labeled.py
+++ b/glean-core/python/tests/metrics/test_labeled.py
@@ -20,7 +20,7 @@ from glean.metrics import Lifetime
 from glean.testing import ErrorType
 
 
-def test_labeled_counter_type():
+def test_labeled_counter_type(ping_schema_url):
     labeled_counter_metric = metrics.LabeledCounterMetricType(
         disabled=False,
         category="telemetry",
@@ -40,7 +40,9 @@ def test_labeled_counter_type():
 
     json_content = Glean.test_collect(_builtins.pings.metrics)
 
-    assert 0 == validate_ping.validate_ping(io.StringIO(json_content), sys.stdout)
+    assert 0 == validate_ping.validate_ping(
+        io.StringIO(json_content), sys.stdout, schema_url=ping_schema_url
+    )
 
     tree = json.loads(json_content)
 
@@ -58,7 +60,7 @@ def test_labeled_counter_type():
     )
 
 
-def test_other_label_with_predefined_labels():
+def test_other_label_with_predefined_labels(ping_schema_url):
     labeled_counter_metric = metrics.LabeledCounterMetricType(
         disabled=False,
         category="telemetry",
@@ -82,7 +84,9 @@ def test_other_label_with_predefined_labels():
 
     json_content = Glean.test_collect(_builtins.pings.metrics)
 
-    assert 0 == validate_ping.validate_ping(io.StringIO(json_content), sys.stdout)
+    assert 0 == validate_ping.validate_ping(
+        io.StringIO(json_content), sys.stdout, schema_url=ping_schema_url
+    )
 
     tree = json.loads(json_content)
 
@@ -102,7 +106,7 @@ def test_other_label_with_predefined_labels():
     )
 
 
-def test_other_label_without_predefined_labels():
+def test_other_label_without_predefined_labels(ping_schema_url):
     labeled_counter_metric = metrics.LabeledCounterMetricType(
         disabled=False,
         category="telemetry",
@@ -123,7 +127,9 @@ def test_other_label_without_predefined_labels():
 
     json_content = Glean.test_collect(_builtins.pings.metrics)
 
-    assert 0 == validate_ping.validate_ping(io.StringIO(json_content), sys.stdout)
+    assert 0 == validate_ping.validate_ping(
+        io.StringIO(json_content), sys.stdout, schema_url=ping_schema_url
+    )
 
 
 def test_other_label_without_predefined_labels_before_glean_init():

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -310,7 +310,7 @@ def test_core_metrics_should_be_cleared_with_disabling_and_enabling_uploading():
     assert _builtins.metrics.glean.internal.metrics.os.test_has_value()
 
 
-def test_collect():
+def test_collect(ping_schema_url):
     counter_metric = CounterMetricType(
         disabled=False,
         category="telemetry",
@@ -331,7 +331,9 @@ def test_collect():
 
     assert 10 == json_tree["metrics"]["counter"]["telemetry.counter_metric"]
 
-    assert 0 == validate_ping.validate_ping(io.StringIO(json_content), sys.stdout)
+    assert 0 == validate_ping.validate_ping(
+        io.StringIO(json_content), sys.stdout, schema_url=ping_schema_url
+    )
 
 
 def test_tempdir_is_cleared():


### PR DESCRIPTION
Fixes [Bug 1601489](https://bugzilla.mozilla.org/show_bug.cgi?id=1601489)

This is how this will look in the metrics ping: 

```json
   {
      "client_info": {
        "android_sdk_version": "28",
        "app_build": "0",
        "app_display_version": "glean.version.name",
        "architecture": "armeabi-v7a",
        "client_id": "41dabd38-1b93-473b-8bc1-0e4284a65c53",
        "device_manufacturer": "unknown",
        "device_model": "robolectric",
        "first_run_date": "2020-01-09+01:00",
        "os": "Android",
        "os_version": "9",
        "telemetry_sdk_build": "23.0.1"
      },
      "metrics": {
        "string": {
          "glean.baseline.locale": "en-US"
        }
      },
      "ping_info": {
        "end_time": "2020-01-09T17:24+01:00",
        "ping_type": "metrics",
        "seq": 0,
        "start_time": "2020-01-09T17:24+01:00"
      }
    }
```