### PR TITLE
Automatically flush upload WorkManager jobs when using the `GleanTestLocalServer` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
     application is running. The application will no longer "wake up" at 4am
     using the Work Manager.
   * The code for migrating data from Glean SDK before version 19 was removed.
+  * When using the `GleanTestLocalServer` rule in instrumented tests, pings are
+    immediately flushed by the `WorkManager` and will reach the test endpoint as
+    soon as possible.
 * Python:
   * The Python bindings now support Python 3.5 - 3.7.
   * The Python bindings are now distributed as a wheel on Linux, macOS and

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -86,6 +86,10 @@ open class GleanInternalAPI internal constructor () {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var isMainProcess: Boolean? = null
 
+    // When sending pings to localhost, we're probably in instrumented tests. In that
+    // case pings are to be immediately submitted by the WorkManager,
+    internal var isSendingToLocalhost: Boolean = false
+
     /**
      * Initialize the Glean SDK.
      *
@@ -603,13 +607,16 @@ open class GleanInternalAPI internal constructor () {
      * TEST ONLY FUNCTION.
      * Sets the server endpoint to a local address for ingesting test pings.
      *
-     * The endpoint will be set as "http://localhost:<port>".
+     * The endpoint will be set as "http://localhost:<port>" and pings will be
+     * immediately sent by the WorkManager.
      *
      * @param port the local address to send pings to
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     internal fun testSetLocalEndpoint(port: Int) {
         Glean.enableTestingMode()
+
+        isSendingToLocalhost = true
 
         // We can't set the configuration unless we're initialized.
         assert(isInitialized())

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -88,7 +88,7 @@ open class GleanInternalAPI internal constructor () {
 
     // When sending pings to localhost, we're probably in instrumented tests. In that
     // case pings are to be immediately submitted by the WorkManager,
-    internal var isSendingToLocalhost: Boolean = false
+    internal var isSendingToTestEndpoint: Boolean = false
 
     /**
      * Initialize the Glean SDK.
@@ -616,7 +616,7 @@ open class GleanInternalAPI internal constructor () {
     internal fun testSetLocalEndpoint(port: Int) {
         Glean.enableTestingMode()
 
-        isSendingToLocalhost = true
+        isSendingToTestEndpoint = true
 
         // We can't set the configuration unless we're initialized.
         assert(isInitialized())

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -86,8 +86,8 @@ open class GleanInternalAPI internal constructor () {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var isMainProcess: Boolean? = null
 
-    // When sending pings to localhost, we're probably in instrumented tests. In that
-    // case pings are to be immediately submitted by the WorkManager,
+    // When sending pings to a test endpoint, we're probably in instrumented tests. In that
+    // case pings are to be immediately submitted by the WorkManager.
     internal var isSendingToTestEndpoint: Boolean = false
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
@@ -10,9 +10,8 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.utils.testFlushWorkManagerJob
 import java.io.File
-
-private const val LOG_TAG = "glean/DeletionPing"
 
 /**
  * This class is the worker class used by [WorkManager] to handle uploading the ping to the server.
@@ -41,6 +40,10 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
                 buildWorkRequest<DeletionPingUploadWorker>(PING_WORKER_TAG))
+
+            if (Glean.isSendingToLocalhost) {
+                testFlushWorkManagerJob(context, PING_WORKER_TAG)
+            }
         }
 
         /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/DeletionPingUploadWorker.kt
@@ -41,7 +41,7 @@ class DeletionPingUploadWorker(context: Context, params: WorkerParameters) : Wor
                 ExistingWorkPolicy.KEEP,
                 buildWorkRequest<DeletionPingUploadWorker>(PING_WORKER_TAG))
 
-            if (Glean.isSendingToLocalhost) {
+            if (Glean.isSendingToTestEndpoint) {
                 testFlushWorkManagerJob(context, PING_WORKER_TAG)
             }
         }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -151,7 +151,8 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
                 buildWorkRequest<PingUploadWorker>(PING_WORKER_TAG)
             )
 
-            // TODO: only do th9is in test mode
+            // Only flush pings immediately if sending to a test endpoint,
+            // which means we're probably in instrumented tests.
             if (Glean.isSendingToTestEndpoint) {
                 testFlushWorkManagerJob(context, PING_WORKER_TAG)
             }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -152,7 +152,7 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
             )
 
             // TODO: only do th9is in test mode
-            if (Glean.isSendingToLocalhost) {
+            if (Glean.isSendingToTestEndpoint) {
                 testFlushWorkManagerJob(context, PING_WORKER_TAG)
             }
         }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/PingUploadWorker.kt
@@ -16,6 +16,7 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.utils.testFlushWorkManagerJob
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileNotFoundException
@@ -147,7 +148,13 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
             WorkManager.getInstance(context).enqueueUniqueWork(
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
-                buildWorkRequest<PingUploadWorker>(PING_WORKER_TAG))
+                buildWorkRequest<PingUploadWorker>(PING_WORKER_TAG)
+            )
+
+            // TODO: only do th9is in test mode
+            if (Glean.isSendingToLocalhost) {
+                testFlushWorkManagerJob(context, PING_WORKER_TAG)
+            }
         }
 
         /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestLocalServer.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestLocalServer.kt
@@ -45,8 +45,9 @@ class GleanTestLocalServer(
         Glean.testSetLocalEndpoint(localPort)
 
         val config = Configuration.Builder()
-            // Use a single thread executor, we cannot make background upload
-            // tasks run on the main thread, otherwise the application will crash
+            // Use a single thread executor rather than the default test
+            // executor which runs on the main thread as we cannot make background
+            // upload tasks run on that thread. Otherwise the application will crash
             // with a "networking on the main thread" exception.
             .setExecutor(Executors.newSingleThreadExecutor())
             .build()

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/WorkManagerUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/WorkManagerUtils.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.withTimeout
  * @param workTag the tag of the WorkManager work unit
  * @param timeoutMs the maximum time to wait for the job to be enqueued in the WorkManager
  */
-fun testFlushWorkManagerJob(context: Context, workTag: String, timeoutMs: Long = 5000L) {
+internal fun testFlushWorkManagerJob(context: Context, workTag: String, timeoutMs: Long = 5000L) {
     runBlocking {
         withTimeout(timeoutMs) {
             do {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/WorkManagerUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/WorkManagerUtils.kt
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.utils
+
+import android.content.Context
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * TEST ONLY FUNCTION.
+ * Sets all the constraints for the provided workmanager work units as met.
+ *
+ * Waits until the timeout is reached if no work unit is found with the provided
+ * tag.
+ *
+ * @param context the application test context
+ * @param workTag the tag of the WorkManager work unit
+ * @param timeoutMs the maximum time to wait for the job to be enqueued in the WorkManager
+ */
+fun testFlushWorkManagerJob(context: Context, workTag: String, timeoutMs: Long = 5000L) {
+    runBlocking {
+        withTimeout(timeoutMs) {
+            do {
+                val workInfoList = WorkManager.getInstance(context).getWorkInfosByTag(workTag).get()
+                workInfoList.forEach { workInfo ->
+                    if (workInfo.state === WorkInfo.State.ENQUEUED) {
+                        // Trigger WorkManager using TestDriver
+                        val testDriver = WorkManagerTestInitHelper.getTestDriver(context)
+                        testDriver?.setAllConstraintsMet(workInfo.id)
+                        return@withTimeout
+                    }
+                }
+            } while (true)
+        }
+    }
+}

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.gleancore.pings
+
+import org.json.JSONObject
+import org.mozilla.samples.gleancore.getPingServer
+import java.util.concurrent.TimeUnit
+
+/**
+ * Waits for ping with the given name to be received
+ * in the test ping server.
+ *
+ * @param pingName the name of the ping to wait for
+ * @param maxAttempts the maximum number of attempts
+ */
+fun waitForPingContent(
+    pingName: String,
+    maxAttempts: Int = 3
+): JSONObject?
+{
+    val server = getPingServer()
+
+    var attempts = 0
+    do {
+        attempts += 1
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        val docType = request.path.split("/")[3]
+        if (pingName == docType) {
+            return JSONObject(request.body.readUtf8())
+        }
+    } while (attempts < maxAttempts)
+
+    return null
+}


### PR DESCRIPTION
This PR changes the upload work units so that, when the `GleanTestLocalServer` rule is used in integration tests, no need for external hacks is required to force the `WorkManager` to run the jobs.

The underlying problem is that, when running in test mode, the `WorkManager` does not automatically run its jobs and there's no way to tell "just behave as in production". Moreover, we're forced to set the `WorkManager` in test mode, otherwise tests crash at startup.

**How to test**
The related PR in Android Components (mozilla-mobile/android-components#5549) was used to test this, by performing a [local substitution](https://mozilla.github.io/glean/book/dev/howtos/development-with-android-components.html) of the Glean SDK with this changes in A-C.