### PR TITLE
Remove failure as a direct dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,6 @@ dependencies = [
  "color-backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "iso8601 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -28,7 +28,6 @@ rkv = "0.10.2"
 bincode = "1.1.3"
 log = "0.4.6"
 uuid = { version = "0.8.1", features = ["v4"] }
-failure = "0.1.5"
 ffi-support = "0.3.5"
 regex = { version = "1.3.0", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"


### PR DESCRIPTION
We can just implement the error trait ourselves and add some quick
Display formatting. It's not that much more code for us either.