### PR TITLE
Report the correct limit for String metric types [doc only]

### DIFF
--- a/docs/user/metrics/string.md
+++ b/docs/user/metrics/string.md
@@ -140,7 +140,7 @@ assert 1 == metrics.search_default.name.test_get_num_recorded_errors(
 
 ## Limits
 
-* Fixed maximum string length: 50. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
+* Fixed maximum string length: 100. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
 
 ## Examples
 


### PR DESCRIPTION
We currently report 50, but the real limit is [100](https://github.com/mozilla/glean/blob/4a64270ba246b8eb88f0b8382d0cd2423443fa1c/glean-core/src/metrics/string.rs#L12).