### PR TITLE
Switch to an auto-assign bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# This CODEOWNERS file defines individuals or teams that are responsible
-# for code in this repository.
-# See https://help.github.com/articles/about-codeowners/ for details.
-
-* @badboy @mdboom @Dexterp37 @travis79

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,10 @@
+addReviewers: true
+addAssignees: false
+reviewers:
+  - badboy
+  - mdboom
+  - Dexterp37
+  - travis79
+  - brizental
+
+numberOfReviewers: 1


### PR DESCRIPTION
Everyone from the current Glean team will now be added as an reviewer
automatically, but only one per PR.
People can still re-assign of course.

Using https://github.com/kentaro-m/auto-assign/