### PR TITLE
Re-use already-built Glean in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,15 +527,19 @@ jobs:
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
             xcrun instruments -w "iPhone 11 (13.3) [" || true
       - run:
-          name: Run XCode build, tests and generate documentation
+          name: Run iOS build
+          command: bash bin/run-ios-build.sh
+      - run:
+          name: Run iOS tests
           command: |
-            bash bin/run-ios-build.sh
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[doc only\]'; then
-                true
+                echo "Skipping this step. Last commit was tagged to not require tests."
             else
                 bash bin/run-ios-tests.sh
             fi
-            bash bin/build-swift-docs.sh
+      - run:
+          name: Generate Swift documentation
+          command: bash bin/build-swift-docs.sh
       - store_artifacts:
           path: raw_xcodebuild.log
           destination: raw_xcodebuild.log
@@ -546,13 +550,6 @@ jobs:
           root: build/
           paths: docs/swift
       - skip-if-doc-only
-      - run:
-          name: Check skip condition before running more steps
-          command: |
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[doc only\]'; then
-                echo "Skipping this step. Last commit was tagged to not require tests."
-                circleci-agent step halt
-            fi
       - run:
           name: Build Carthage archive
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,7 +612,6 @@ jobs:
           name: Setup build environment
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
-            bin/bootstrap.sh
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
             xcrun instruments -w "iPhone 11 (13.3) [" || true
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,12 +570,18 @@ jobs:
           command: |
             ZIP_URL=https://circleci.com/api/v1.1/project/github/mozilla/glean/$CIRCLE_BUILD_NUM/artifacts/0/dist/Glean.framework.zip
             echo "{\"0.0.1\":\"$ZIP_URL\"}" > mozilla.glean.json
+            # Store the build number for retrieval in a later step.
+            echo "$CIRCLE_BUILD_NUM" > ios-build-num.txt
       - store_artifacts:
           path: Glean.framework.zip
           destination: dist/Glean.framework.zip
       - store_artifacts:
           path: mozilla.glean.json
           destination: dist/mozilla.glean.json
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ios-build-num.txt
       - run:
           name: "Carthage binary snapshot URL"
           command: |
@@ -609,24 +615,30 @@ jobs:
             bin/bootstrap.sh
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
             xcrun instruments -w "iPhone 11 (13.3) [" || true
+      - attach_workspace:
+          at: .
       - run:
-          name: Use local checkout through Carthage
+          name: Use binary build of Glean
           command: |
+            # Retrieve the previous build number
+            IOS_BUILD_NUM=$(< ios-build-num.txt)
             GLEAN_PATH="$(pwd)"
-            GLEAN_COMMIT="${CIRCLE_SHA1}"
             CARTFILE_PATH="${GLEAN_PATH}/samples/ios/app/Cartfile"
+            # The previous step generated a binary file and the corresponding JSON manifest
+            JSON_URL="https://circleci.com/api/v1.1/project/github/mozilla/glean/${IOS_BUILD_NUM}/artifacts/0/dist/mozilla.glean.json"
+
             echo "Current Cartfile:"
             cat "${CARTFILE_PATH}"
             echo "================="
             echo "New Cartfile:"
-            sed -i.bak "s#github \"mozilla/glean\" \"master\"#git \"file://${GLEAN_PATH}\" \"${GLEAN_COMMIT}\"#" "$CARTFILE_PATH"
+            sed -i.bak "/mozilla\/glean/s#.*#binary \"$JSON_URL\" ~> 0.0.1-SNAPSHOT#" "$CARTFILE_PATH"
             cat "${CARTFILE_PATH}"
       - run:
           name: Build sample app
           command: |
             # Build in Debug mode to speed it all up
             pushd samples/ios/app
-            carthage bootstrap --platform iOS --no-use-binaries --cache-builds --configuration Debug --verbose
+            carthage bootstrap --platform iOS --cache-builds --configuration Debug --verbose
             popd
             bash bin/run-ios-sample-app-build.sh
       - store_artifacts:
@@ -900,7 +912,9 @@ workflows:
       - C tests
       - Android tests
       - iOS build and test
-      - iOS integration test
+      - iOS integration test:
+          requires:
+            - iOS build and test
       - Python 3_5 tests
       - Python 3_6 tests
       - Python 3_7 tests


### PR DESCRIPTION
This will re-use the binary build of Glean in the integration tests.

Old timing:
* build+test: 9min
* integraion test: 10min

New timing:
* build+test: unchanged
* integration test: 4-5min

Caution: This does not necessarily reduce the _total_ runtime of CI, as previously build+test and integration tests could run in parallel.
They now need to run sequentially.

https://bugzilla.mozilla.org/show_bug.cgi?id=1594334