### PR TITLE
Don't block on dispatching tasks enqueued before init

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
@@ -15,7 +15,6 @@ import mozilla.telemetry.glean.config.Configuration
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -70,17 +69,5 @@ class AccumulationsBeforeGleanInitTest {
 
         assertEquals(1, labeledCounterMetric["label1"].testGetValue())
         assertFalse(GleanError.preinitTasksTimeout.testHasValue())
-    }
-
-    @Test
-    fun `queued tasks that time out record an error`() {
-        @Suppress("EXPERIMENTAL_API_USAGE")
-        Dispatchers.API.launch {
-            Thread.sleep(6000)
-        }
-
-        forceInitGlean()
-
-        assertTrue(GleanError.preinitTasksTimeout.testGetValue())
     }
 }


### PR DESCRIPTION
This does not block the main thread when flushing enqueued tasks at initialization. This works and retains the current implemented behaviour, at least in Kotlin, since [this](https://github.com/mozilla/glean/blob/fa6aaac11d8d8eb1b883a085fdcc508dba275a6a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt#L257) already dispatches `setUploadEnabled` in the APIs threadpool.
