### PR TITLE
Fix Python publishing to github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -745,12 +745,17 @@ jobs:
             # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
             # variables are configured in CircleCI's environment variables.
             .venv/bin/python3 -m twine upload wheelhouse/*
+      - run:
+          name: Install perl
+          command: |
+            # Required for shasum
+            sudo apt install perl
       - install-ghr-linux
       - run:
           name: Publish to Github
           command: |
             # Upload to GitHub
-            ./ghr -replace ${CIRCLE_TAG} wheelhouse
+            ./ghr -replace ${CIRCLE_TAG} glean-core/python/wheelhouse
 
   pypi-macos-release:
     macos:
@@ -776,7 +781,7 @@ jobs:
           name: Publish to Github
           command: |
             # Upload to GitHub
-            ./ghr -replace ${CIRCLE_TAG} dist
+            ./ghr -replace ${CIRCLE_TAG} glean-core/python/dist
 
   pypi-windows-release:
     docker:
@@ -807,7 +812,7 @@ jobs:
           name: Publish to Github
           command: |
             # Upload to GitHub
-            ./ghr -replace ${CIRCLE_TAG} dist
+            ./ghr -replace ${CIRCLE_TAG} glean-core/python/dist
 
   ###########################################################################
   # Docs


### PR DESCRIPTION
Should fix these failures when deploying a release:

https://circleci.com/gh/mozilla/glean/38685
```
#!/bin/bash -eo pipefail
# Upload to GitHub
./ghr -replace ${CIRCLE_TAG} dist

Failed to find assets from dist: failed to get file stat: stat /home/circleci/project/dist: no such file or directory

Exited with code exit status 11
```

https://circleci.com/gh/mozilla/glean/38683
```
#!/bin/bash -eo pipefail
GHR=ghr_v0.13.0_linux_amd64
GHR_SHA256=c428627270ae26e206cb526cb8c7bdfba475dd278f6691ddaf863355adadfa13
curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/tcnksm/ghr/releases/download/v0.13.0/${GHR}.tar.gz"
echo "${GHR_SHA256} *${GHR}.tar.gz" | shasum -a 256 -c -
tar -xf "${GHR}.tar.gz"
cp ./${GHR}/ghr ghr

/bin/bash: line 3: shasum: command not found
```