### PR TITLE
Cache cargo builds on CI for iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -526,9 +526,23 @@ jobs:
             bin/bootstrap.sh
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
             xcrun instruments -w "iPhone 11 (13.3) [" || true
+            # Store build type for use in cache key
+            if [ -z "${CIRCLE_TAG}" ]; then
+              echo "release" > buildtype.txt
+            else
+              echo "debug" > buildtype.txt
+            fi
+      - restore_cache:
+          keys:
+            - v1-cargo-cache-{{arch}}-{{checksum "buildtype.txt"}}-{{checksum "Cargo.lock"}}
       - run:
           name: Run iOS build
           command: bash bin/run-ios-build.sh
+      - save_cache:
+          paths:
+            - /Users/distiller/.cargo/registry
+            - target
+          key: v1-cargo-cache-{{arch}}-{{checksum "buildtype.txt"}}-{{checksum "Cargo.lock"}}
       - run:
           name: Run iOS tests
           command: |

--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -6,7 +6,7 @@ if [ "$#" -ne 4 ]
 then
     echo "Usage (note: only call inside xcode!):"
     echo "Args: $*"
-    echo "path/to/build-scripts/xc-universal-binary.sh <STATIC_LIB_NAME> <FFI_TARGET> <APPSVC_ROOT_PATH> <buildvariant>"
+    echo "path/to/build-scripts/xc-universal-binary.sh <STATIC_LIB_NAME> <FFI_TARGET> <GLEAN_ROOT_PATH> <buildvariant>"
     exit 1
 fi
 # e.g. libglean_ffi.a
@@ -14,7 +14,7 @@ STATIC_LIB_NAME=$1
 # what to pass to cargo build -p, e.g. glean_ffi
 FFI_TARGET=$2
 # path to app services root
-APPSVC_ROOT=$3
+GLEAN_ROOT=$3
 # buildvariant from our xcconfigs
 BUILDVARIANT=$4
 
@@ -25,7 +25,7 @@ if [[ "$BUILDVARIANT" != "debug" ]]; then
     RELDIR=release
 fi
 
-TARGETDIR=$APPSVC_ROOT/target
+TARGETDIR=$GLEAN_ROOT/target
 
 # We can't use cargo lipo because we can't link to universal libraries :(
 # https://github.com/rust-lang/rust/issues/55235

--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -29,10 +29,8 @@ TARGETDIR=$GLEAN_ROOT/target
 
 # We can't use cargo lipo because we can't link to universal libraries :(
 # https://github.com/rust-lang/rust/issues/55235
-LIBS_ARCHS=("x86_64" "arm64")
 IOS_TRIPLES=("x86_64-apple-ios" "aarch64-apple-ios")
-for i in "${!LIBS_ARCHS[@]}"; do
-    LIB_ARCH=${LIBS_ARCHS[$i]}
+for i in "${!IOS_TRIPLES[@]}"; do
     env -i PATH="$PATH" \
     $HOME/.cargo/bin/cargo build -p $FFI_TARGET --lib $RELFLAG --target ${IOS_TRIPLES[$i]}
 done

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -887,7 +887,7 @@
 				BF3DE3A42243A2F20018E23F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		BF3DE3A52243A2F20018E23F /* Build configuration list for PBXNativeTarget "Glean" */ = {
 			isa = XCConfigurationList;
@@ -896,7 +896,7 @@
 				BF3DE3A72243A2F20018E23F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		BF3DE3A82243A2F20018E23F /* Build configuration list for PBXNativeTarget "GleanTests" */ = {
 			isa = XCConfigurationList;
@@ -905,7 +905,7 @@
 				BF3DE3AA2243A2F20018E23F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
Turns out: most of the time during the iOS builds is spent on building Glean twice (for 2 iOS targets). It accounted for about 80% of the runtime for the build.

We can cache that. It improves subsequent builds on a fresh cache significantly.
The downside: the cache is big (300-400mb) which takes time to restore (about a minute on CircleCI).
Still, in total we save a bit.
This also means it is slower on dependency changes (or version updates of Glean itself), because the cache is invalidated.

Additionally for some reason our Xcode project was set to choose "Use Release for command-line builds". I changed that to "Debug", but haven't really seen it make a difference. I might be misunderstanding that setting or we already do force Debug whenever we don't force Release, I don't know. That commit I can easily drop from this PR.