### PR TITLE
Report `invalid_state` when stopping non started TimingDistribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v24.0.0...v24.1.0)
 
+* General:
+  * Stopping a non started measurement in a timing distribution will now be reported
+    as an `invalid_state` error.
 * Android:
   * A new metric `glean.error.preinit_tasks_overflow` was added to report when
     the preinit task queue overruns, leading to data loss. See [bug

--- a/docs/user/metrics/timing_distribution.md
+++ b/docs/user/metrics/timing_distribution.md
@@ -182,7 +182,7 @@ XCTAssertEqual(1, pages.pageLoad.testGetNumRecordedErrors(.invalidValue))
 ## Recorded errors
 
 * `invalid_value`: If recording a negative timespan.
-* `invalid_value`: If a non-existing/stopped timer is stopped again.
+* `invalid_state`: If a non-existing/stopped timer is stopped again.
 * `invalid_overflow`: If recording a time longer than 10 minutes.
 
 ## Reference

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
@@ -233,6 +233,6 @@ class TimingDistributionMetricTypeTest {
         )
 
         metric.stopAndAccumulate(GleanTimerId(-1))
-        assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidValue))
+        assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidState))
     }
 }

--- a/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
@@ -128,6 +128,6 @@ class TimingDistributionTypeTests: XCTestCase {
 
         metric.stopAndAccumulate(0)
 
-        XCTAssertEqual(1, metric.testGetNumRecordedErrors(.invalidValue))
+        XCTAssertEqual(1, metric.testGetNumRecordedErrors(.invalidState))
     }
 }

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -314,3 +314,33 @@ fn large_nanoseconds_values() {
     // Check that we got the right sum and number of samples.
     assert_eq!(val.sum() as u64, time);
 }
+
+#[test]
+fn stopping_non_existing_id_records_an_error() {
+    let (glean, _t) = new_glean(None);
+
+    let mut metric = TimingDistributionMetric::new(
+        CommonMetricData {
+            name: "non_existing_id".into(),
+            category: "test".into(),
+            send_in_pings: vec!["store1".into()],
+            disabled: false,
+            lifetime: Lifetime::Ping,
+            ..Default::default()
+        },
+        TimeUnit::Nanosecond,
+    );
+
+    metric.set_stop_and_accumulate(&glean, 3785, 60);
+
+    // 1 error should be reported.
+    assert_eq!(
+        Ok(1),
+        test_get_num_recorded_errors(
+            &glean,
+            metric.meta(),
+            ErrorType::InvalidState,
+            Some("store1")
+        )
+    );
+}


### PR DESCRIPTION
This will be reported when stop_and_accumulate() is called without a prior call to start()