### PR TITLE
Drop the Glean handle and move state into glean-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * **Deprecation Warning** Since `locale` is now in the `client_info` section, the one
     in the baseline ping ([`glean.baseline.locale`](https://github.com/mozilla/glean/blob/c261205d6e84d2ab39c50003a8ffc3bd2b763768/glean-core/metrics.yaml#L28-L42))
     is redundant and will be removed by the end of the quarter.
+  * Drop the Glean handle and move state into glean-core ([#664](https://github.com/mozilla/glean/pull/664))
 * Android:
   * Collections performed before initialization (preinit tasks) are now dispatched off
     the main thread during initialization.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -632,6 +632,7 @@ open class GleanInternalAPI internal constructor () {
             return
         }
 
+        LibGleanFFI.INSTANCE.glean_destroy_glean()
         handle = 0L
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -6,7 +6,6 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toByte
 
@@ -70,7 +69,7 @@ class BooleanMetricType internal constructor(
 
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
-            LibGleanFFI.INSTANCE.glean_boolean_set(Glean.handle, this@BooleanMetricType.handle, value.toByte())
+            LibGleanFFI.INSTANCE.glean_boolean_set(this@BooleanMetricType.handle, value.toByte())
         }
     }
 
@@ -87,7 +86,6 @@ class BooleanMetricType internal constructor(
         }
 
         LibGleanFFI.INSTANCE.glean_boolean_set(
-            Glean.handle,
             this@BooleanMetricType.handle,
             value.toByte()
         )
@@ -108,7 +106,7 @@ class BooleanMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
-        val res = LibGleanFFI.INSTANCE.glean_boolean_test_has_value(Glean.handle, this.handle, pingName)
+        val res = LibGleanFFI.INSTANCE.glean_boolean_test_has_value(this.handle, pingName)
         return res.toBoolean()
     }
 
@@ -130,6 +128,6 @@ class BooleanMetricType internal constructor(
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        return LibGleanFFI.INSTANCE.glean_boolean_test_get_value(Glean.handle, this.handle, pingName).toBoolean()
+        return LibGleanFFI.INSTANCE.glean_boolean_test_get_value(this.handle, pingName).toBoolean()
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toBoolean
 import mozilla.telemetry.glean.rust.toByte
@@ -73,7 +72,6 @@ class CounterMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_counter_add(
-                Glean.handle,
                 this@CounterMetricType.handle,
                 amount)
         }
@@ -92,7 +90,6 @@ class CounterMetricType internal constructor(
         }
 
         LibGleanFFI.INSTANCE.glean_counter_add(
-            Glean.handle,
             this@CounterMetricType.handle,
             amount
         )
@@ -113,7 +110,7 @@ class CounterMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
-        val res = LibGleanFFI.INSTANCE.glean_counter_test_has_value(Glean.handle, this.handle, pingName)
+        val res = LibGleanFFI.INSTANCE.glean_counter_test_has_value(this.handle, pingName)
         return res.toBoolean()
     }
 
@@ -135,7 +132,7 @@ class CounterMetricType internal constructor(
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        return LibGleanFFI.INSTANCE.glean_counter_test_get_value(Glean.handle, this.handle, pingName)
+        return LibGleanFFI.INSTANCE.glean_counter_test_get_value(this.handle, pingName)
     }
 
     /**
@@ -153,7 +150,7 @@ class CounterMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_counter_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
@@ -90,7 +89,6 @@ data class CustomDistributionMetricType(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_custom_distribution_accumulate_samples(
-                Glean.handle,
                 this@CustomDistributionMetricType.handle,
                 samples,
                 samples.size
@@ -112,7 +110,7 @@ data class CustomDistributionMetricType(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI
-            .INSTANCE.glean_custom_distribution_test_has_value(Glean.handle, this.handle, pingName)
+            .INSTANCE.glean_custom_distribution_test_has_value(this.handle, pingName)
             .toBoolean()
     }
 
@@ -135,7 +133,6 @@ data class CustomDistributionMetricType(
         }
 
         val ptr = LibGleanFFI.INSTANCE.glean_custom_distribution_test_get_value_as_json_string(
-                Glean.handle,
                 this.handle,
                 pingName)!!
 
@@ -157,7 +154,7 @@ data class CustomDistributionMetricType(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_custom_distribution_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
@@ -10,7 +10,6 @@ import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
@@ -86,7 +85,6 @@ class DatetimeMetricType internal constructor(
         }
 
         LibGleanFFI.INSTANCE.glean_datetime_set(
-            Glean.handle,
             this@DatetimeMetricType.handle,
             year = cal.get(Calendar.YEAR),
             month = cal.get(Calendar.MONTH) + 1,
@@ -118,7 +116,6 @@ class DatetimeMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_datetime_set(
-                Glean.handle,
                 this@DatetimeMetricType.handle,
                 year = value.get(Calendar.YEAR),
                 month = value.get(Calendar.MONTH) + 1,
@@ -150,7 +147,7 @@ class DatetimeMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI
-            .INSTANCE.glean_datetime_test_has_value(Glean.handle, this.handle, pingName)
+            .INSTANCE.glean_datetime_test_has_value(this.handle, pingName)
             .toBoolean()
     }
 
@@ -175,7 +172,7 @@ class DatetimeMetricType internal constructor(
         }
         val ptr = LibGleanFFI
             .INSTANCE
-            .glean_datetime_test_get_value_as_string(Glean.handle, this.handle, pingName)!!
+            .glean_datetime_test_get_value_as_string(this.handle, pingName)!!
         return ptr.getAndConsumeRustString()
     }
 
@@ -213,7 +210,7 @@ class DatetimeMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_datetime_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
@@ -8,7 +8,6 @@ import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
@@ -133,7 +132,6 @@ class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>> internal constructor(
             }
 
             LibGleanFFI.INSTANCE.glean_event_record(
-                Glean.handle,
                 this@EventMetricType.handle,
                 timestamp,
                 keys,
@@ -157,7 +155,6 @@ class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>> internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_event_test_has_value(
-            Glean.handle,
             this.handle,
             pingName
         ).toBoolean()
@@ -209,7 +206,6 @@ class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>> internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         val ptr = LibGleanFFI.INSTANCE.glean_event_test_get_value_as_json_string(
-            Glean.handle,
             this.handle,
             pingName
         )!!
@@ -245,7 +241,7 @@ class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>> internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_event_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toByte
 import mozilla.telemetry.glean.testing.ErrorType
@@ -135,17 +134,17 @@ class LabeledMetricType<T>(
         return when (subMetric) {
             is CounterMetricType -> {
                 LibGleanFFI.INSTANCE.glean_labeled_counter_test_get_num_recorded_errors(
-                    Glean.handle, this.handle, errorType.ordinal, pingName
+                    this.handle, errorType.ordinal, pingName
                 )
             }
             is BooleanMetricType -> {
                 LibGleanFFI.INSTANCE.glean_labeled_boolean_test_get_num_recorded_errors(
-                    Glean.handle, this.handle, errorType.ordinal, pingName
+                    this.handle, errorType.ordinal, pingName
                 )
             }
             is StringMetricType -> {
                 LibGleanFFI.INSTANCE.glean_labeled_string_test_get_num_recorded_errors(
-                    Glean.handle, this.handle, errorType.ordinal, pingName
+                    this.handle, errorType.ordinal, pingName
                 )
             }
             else -> throw IllegalStateException(

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
@@ -70,7 +69,6 @@ class MemoryDistributionMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_memory_distribution_accumulate(
-                Glean.handle,
                 this@MemoryDistributionMetricType.handle,
                 sample
             )
@@ -93,7 +91,6 @@ class MemoryDistributionMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_memory_distribution_accumulate_samples(
-                Glean.handle,
                 this@MemoryDistributionMetricType.handle,
                 samples,
                 samples.size
@@ -117,7 +114,7 @@ class MemoryDistributionMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI
-            .INSTANCE.glean_memory_distribution_test_has_value(Glean.handle, this.handle, pingName)
+            .INSTANCE.glean_memory_distribution_test_has_value(this.handle, pingName)
             .toBoolean()
     }
 
@@ -141,7 +138,6 @@ class MemoryDistributionMetricType internal constructor(
         }
 
         val ptr = LibGleanFFI.INSTANCE.glean_memory_distribution_test_get_value_as_json_string(
-                Glean.handle,
                 this.handle,
                 pingName)!!
 
@@ -163,7 +159,7 @@ class MemoryDistributionMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_memory_distribution_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toBoolean
 import mozilla.telemetry.glean.rust.toByte
@@ -68,7 +67,6 @@ class QuantityMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_quantity_set(
-                Glean.handle,
                 this@QuantityMetricType.handle,
                 value)
         }
@@ -89,7 +87,7 @@ class QuantityMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
-        val res = LibGleanFFI.INSTANCE.glean_quantity_test_has_value(Glean.handle, this.handle, pingName)
+        val res = LibGleanFFI.INSTANCE.glean_quantity_test_has_value(this.handle, pingName)
         return res.toBoolean()
     }
 
@@ -111,7 +109,7 @@ class QuantityMetricType internal constructor(
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        return LibGleanFFI.INSTANCE.glean_quantity_test_get_value(Glean.handle, this.handle, pingName)
+        return LibGleanFFI.INSTANCE.glean_quantity_test_get_value(this.handle, pingName)
     }
 
     /**
@@ -129,7 +127,7 @@ class QuantityMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_quantity_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
@@ -78,7 +77,6 @@ class StringListMetricType(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_string_list_add(
-                Glean.handle,
                 this@StringListMetricType.handle,
                 value)
         }
@@ -99,7 +97,6 @@ class StringListMetricType(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_string_list_set(
-                Glean.handle,
                 this@StringListMetricType.handle,
                 ffiValueList,
                 value.size)
@@ -121,7 +118,6 @@ class StringListMetricType(
         val ffiValueList = StringArray(value.toTypedArray(), "utf-8")
 
         LibGleanFFI.INSTANCE.glean_string_list_set(
-            Glean.handle,
             this@StringListMetricType.handle,
             ffiValueList,
             value.size
@@ -143,7 +139,7 @@ class StringListMetricType(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
-        val res = LibGleanFFI.INSTANCE.glean_string_list_test_has_value(Glean.handle, this.handle, pingName)
+        val res = LibGleanFFI.INSTANCE.glean_string_list_test_has_value(this.handle, pingName)
         return res.toBoolean()
     }
 
@@ -168,7 +164,6 @@ class StringListMetricType(
 
         val jsonRes: JSONArray
         val ptr = LibGleanFFI.INSTANCE.glean_string_list_test_get_value_as_json_string(
-            Glean.handle,
             this.handle,
             pingName)!!
         try {
@@ -194,7 +189,7 @@ class StringListMetricType(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_string_list_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.toBoolean
@@ -80,7 +79,7 @@ class StringMetricType internal constructor(
      * Internal only, synchronous API for setting a string value.
      */
     internal fun setSync(value: String) {
-        LibGleanFFI.INSTANCE.glean_string_set(Glean.handle, this.handle, value)
+        LibGleanFFI.INSTANCE.glean_string_set(this.handle, value)
     }
 
     /**
@@ -98,7 +97,7 @@ class StringMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
-        val res = LibGleanFFI.INSTANCE.glean_string_test_has_value(Glean.handle, this.handle, pingName)
+        val res = LibGleanFFI.INSTANCE.glean_string_test_has_value(this.handle, pingName)
         return res.toBoolean()
     }
 
@@ -120,7 +119,7 @@ class StringMetricType internal constructor(
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        val ptr = LibGleanFFI.INSTANCE.glean_string_test_get_value(Glean.handle, this.handle, pingName)!!
+        val ptr = LibGleanFFI.INSTANCE.glean_string_test_get_value(this.handle, pingName)!!
         return ptr.getAndConsumeRustString()
     }
 
@@ -139,7 +138,7 @@ class StringMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_string_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -8,7 +8,6 @@ import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toBoolean
 import mozilla.telemetry.glean.rust.toByte
@@ -74,7 +73,7 @@ class TimespanMetricType internal constructor(
 
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
-            LibGleanFFI.INSTANCE.glean_timespan_set_start(Glean.handle, this@TimespanMetricType.handle, startTime)
+            LibGleanFFI.INSTANCE.glean_timespan_set_start(this@TimespanMetricType.handle, startTime)
         }
     }
 
@@ -94,7 +93,7 @@ class TimespanMetricType internal constructor(
 
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
-            LibGleanFFI.INSTANCE.glean_timespan_set_stop(Glean.handle, this@TimespanMetricType.handle, stopTime)
+            LibGleanFFI.INSTANCE.glean_timespan_set_stop(this@TimespanMetricType.handle, stopTime)
         }
     }
 
@@ -130,7 +129,6 @@ class TimespanMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_timespan_set_raw_nanos(
-                Glean.handle,
                 this@TimespanMetricType.handle,
                 elapsedNanos)
         }
@@ -150,7 +148,7 @@ class TimespanMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI
-            .INSTANCE.glean_timespan_test_has_value(Glean.handle, this.handle, pingName)
+            .INSTANCE.glean_timespan_test_has_value(this.handle, pingName)
             .toBoolean()
     }
 
@@ -171,7 +169,7 @@ class TimespanMetricType internal constructor(
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        return LibGleanFFI.INSTANCE.glean_timespan_test_get_value(Glean.handle, this.handle, pingName)
+        return LibGleanFFI.INSTANCE.glean_timespan_test_get_value(this.handle, pingName)
     }
 
     /**
@@ -189,7 +187,7 @@ class TimespanMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_timespan_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -8,7 +8,6 @@ import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.GleanTimerId
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
@@ -111,7 +110,6 @@ class TimingDistributionMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_timing_distribution_set_stop_and_accumulate(
-                    Glean.handle,
                     this@TimingDistributionMetricType.handle,
                     timerId.id,
                     stopTime)
@@ -152,7 +150,6 @@ class TimingDistributionMetricType internal constructor(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_timing_distribution_accumulate_samples(
-                Glean.handle,
                 this@TimingDistributionMetricType.handle,
                 samples,
                 samples.size
@@ -176,7 +173,7 @@ class TimingDistributionMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI
-            .INSTANCE.glean_timing_distribution_test_has_value(Glean.handle, this.handle, pingName)
+            .INSTANCE.glean_timing_distribution_test_has_value(this.handle, pingName)
             .toBoolean()
     }
 
@@ -200,7 +197,6 @@ class TimingDistributionMetricType internal constructor(
         }
 
         val ptr = LibGleanFFI.INSTANCE.glean_timing_distribution_test_get_value_as_json_string(
-                Glean.handle,
                 this.handle,
                 pingName)!!
 
@@ -222,7 +218,7 @@ class TimingDistributionMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         return LibGleanFFI.INSTANCE.glean_timing_distribution_test_get_num_recorded_errors(
-            Glean.handle, this.handle, errorType.ordinal, pingName
+            this.handle, errorType.ordinal, pingName
         )
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import androidx.annotation.VisibleForTesting
 import com.sun.jna.StringArray
 import mozilla.telemetry.glean.Dispatchers
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.getAndConsumeRustString
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toBoolean
@@ -87,7 +86,6 @@ class UuidMetricType(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             LibGleanFFI.INSTANCE.glean_uuid_set(
-                Glean.handle,
                 this@UuidMetricType.handle,
                 value.toString())
         }
@@ -104,7 +102,6 @@ class UuidMetricType(
         }
 
         LibGleanFFI.INSTANCE.glean_uuid_set(
-            Glean.handle,
             this@UuidMetricType.handle,
             value.toString())
     }
@@ -124,7 +121,7 @@ class UuidMetricType(
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
-        val res = LibGleanFFI.INSTANCE.glean_uuid_test_has_value(Glean.handle, this.handle, pingName)
+        val res = LibGleanFFI.INSTANCE.glean_uuid_test_has_value(this.handle, pingName)
         return res.toBoolean()
     }
 
@@ -146,7 +143,7 @@ class UuidMetricType(
         if (!testHasValue(pingName)) {
             throw NullPointerException()
         }
-        val ptr = LibGleanFFI.INSTANCE.glean_uuid_test_get_value(Glean.handle, this.handle, pingName)!!
+        val ptr = LibGleanFFI.INSTANCE.glean_uuid_test_get_value(this.handle, pingName)!!
         return UUID.fromString(ptr.getAndConsumeRustString())
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -74,7 +74,7 @@ internal interface LibGleanFFI : Library {
 
     fun glean_is_first_run(): Byte
 
-    fun glean_destroy_glean(handle: Long)
+    fun glean_destroy_glean()
 
     fun glean_on_ready_to_submit_pings(): Byte
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -70,30 +70,28 @@ internal interface LibGleanFFI : Library {
 
     fun glean_clear_application_lifetime_metrics(handle: Long)
 
-    fun glean_test_clear_all_stores(handle: Long)
+    fun glean_test_clear_all_stores()
 
-    fun glean_is_first_run(handle: Long): Byte
+    fun glean_is_first_run(): Byte
 
     fun glean_destroy_glean(handle: Long)
 
-    fun glean_on_ready_to_submit_pings(handle: Long): Byte
+    fun glean_on_ready_to_submit_pings(): Byte
 
     fun glean_enable_logging()
 
-    fun glean_set_upload_enabled(glean_handle: Long, flag: Byte)
+    fun glean_set_upload_enabled(flag: Byte)
 
-    fun glean_is_upload_enabled(glean_handle: Long): Byte
+    fun glean_is_upload_enabled(): Byte
 
-    fun glean_ping_collect(glean_handle: Long, ping_type_handle: Long): Pointer?
+    fun glean_ping_collect(ping_type_handle: Long): Pointer?
 
     fun glean_submit_pings_by_name(
-        glean_handle: Long,
         ping_names: StringArray,
         ping_names_len: Int
     ): Byte
 
     fun glean_set_experiment_active(
-        glean_handle: Long,
         experiment_id: String,
         branch: String,
         extra_keys: StringArray?,
@@ -101,11 +99,11 @@ internal interface LibGleanFFI : Library {
         extra_len: Int
     )
 
-    fun glean_set_experiment_inactive(glean_handle: Long, experiment_id: String)
+    fun glean_set_experiment_inactive(experiment_id: String)
 
-    fun glean_experiment_test_is_active(glean_handle: Long, experiment_id: String): Byte
+    fun glean_experiment_test_is_active(experiment_id: String): Byte
 
-    fun glean_experiment_test_get_data(glean_handle: Long, experiment_id: String): Pointer?
+    fun glean_experiment_test_get_data(experiment_id: String): Pointer?
 
     // Ping type
 
@@ -113,9 +111,9 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_ping_type(handle: Long)
 
-    fun glean_register_ping_type(glean_handle: Long, ping_type_id: Long)
+    fun glean_register_ping_type(ping_type_id: Long)
 
-    fun glean_test_has_ping_type(glean_handle: Long, name: String): Byte
+    fun glean_test_has_ping_type(name: String): Byte
 
     // Boolean
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -66,9 +66,9 @@ internal interface LibGleanFFI : Library {
 
     // Glean top-level API
 
-    fun glean_initialize(cfg: FfiConfiguration): Long
+    fun glean_initialize(cfg: FfiConfiguration): Byte
 
-    fun glean_clear_application_lifetime_metrics(handle: Long)
+    fun glean_clear_application_lifetime_metrics()
 
     fun glean_test_clear_all_stores()
 
@@ -128,11 +128,11 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_boolean_metric(handle: Long)
 
-    fun glean_boolean_set(glean_handle: Long, metric_id: Long, value: Byte)
+    fun glean_boolean_set(metric_id: Long, value: Byte)
 
-    fun glean_boolean_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_boolean_test_get_value(metric_id: Long, storage_name: String): Byte
 
-    fun glean_boolean_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_boolean_test_has_value(metric_id: Long, storage_name: String): Byte
 
     // Counter
 
@@ -147,14 +147,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_counter_metric(handle: Long)
 
-    fun glean_counter_add(glean_handle: Long, metric_id: Long, amount: Int)
+    fun glean_counter_add(metric_id: Long, amount: Int)
 
-    fun glean_counter_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Int
+    fun glean_counter_test_get_value(metric_id: Long, storage_name: String): Int
 
-    fun glean_counter_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_counter_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_counter_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -173,14 +172,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_quantity_metric(handle: Long)
 
-    fun glean_quantity_set(glean_handle: Long, metric_id: Long, value: Long)
+    fun glean_quantity_set(metric_id: Long, value: Long)
 
-    fun glean_quantity_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Long
+    fun glean_quantity_test_get_value(metric_id: Long, storage_name: String): Long
 
-    fun glean_quantity_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_quantity_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_quantity_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -199,14 +197,13 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_string_metric(handle: Long)
 
-    fun glean_string_set(glean_handle: Long, metric_id: Long, value: String)
+    fun glean_string_set(metric_id: Long, value: String)
 
-    fun glean_string_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Pointer?
+    fun glean_string_test_get_value(metric_id: Long, storage_name: String): Pointer?
 
-    fun glean_string_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_string_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_string_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -227,7 +224,6 @@ internal interface LibGleanFFI : Library {
     fun glean_destroy_datetime_metric(handle: Long)
 
     fun glean_datetime_set(
-        glean_handle: Long,
         metric_id: Long,
         year: Int,
         month: Int,
@@ -239,12 +235,11 @@ internal interface LibGleanFFI : Library {
         offset_seconds: Int
     )
 
-    fun glean_datetime_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_datetime_test_has_value(metric_id: Long, storage_name: String): Byte
 
-    fun glean_datetime_test_get_value_as_string(glean_handle: Long, metric_id: Long, storage_name: String): Pointer?
+    fun glean_datetime_test_get_value_as_string(metric_id: Long, storage_name: String): Pointer?
 
     fun glean_datetime_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -263,20 +258,18 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_string_list_metric(handle: Long)
 
-    fun glean_string_list_add(glean_handle: Long, metric_id: Long, value: String)
+    fun glean_string_list_add(metric_id: Long, value: String)
 
-    fun glean_string_list_set(glean_handle: Long, metric_id: Long, values: StringArray, values_len: Int)
+    fun glean_string_list_set(metric_id: Long, values: StringArray, values_len: Int)
 
-    fun glean_string_list_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_string_list_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_string_list_test_get_value_as_json_string(
-        glean_handle: Long,
         metric_id: Long,
         storage_name: String
     ): Pointer?
 
     fun glean_string_list_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -295,11 +288,11 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_uuid_metric(handle: Long)
 
-    fun glean_uuid_set(glean_handle: Long, metric_id: Long, value: String)
+    fun glean_uuid_set(metric_id: Long, value: String)
 
-    fun glean_uuid_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_uuid_test_has_value(metric_id: Long, storage_name: String): Byte
 
-    fun glean_uuid_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Pointer?
+    fun glean_uuid_test_get_value(metric_id: Long, storage_name: String): Pointer?
 
     // Timespan
 
@@ -315,20 +308,19 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_timespan_metric(handle: Long)
 
-    fun glean_timespan_set_start(glean_handle: Long, metric_id: Long, start_time: Long)
+    fun glean_timespan_set_start(metric_id: Long, start_time: Long)
 
-    fun glean_timespan_set_stop(glean_handle: Long, metric_id: Long, stop_time: Long)
+    fun glean_timespan_set_stop(metric_id: Long, stop_time: Long)
 
     fun glean_timespan_cancel(metric_id: Long)
 
-    fun glean_timespan_set_raw_nanos(glean_handle: Long, metric_id: Long, elapsed_nanos: Long)
+    fun glean_timespan_set_raw_nanos(metric_id: Long, elapsed_nanos: Long)
 
-    fun glean_timespan_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_timespan_test_has_value(metric_id: Long, storage_name: String): Byte
 
-    fun glean_timespan_test_get_value(glean_handle: Long, metric_id: Long, storage_name: String): Long
+    fun glean_timespan_test_get_value(metric_id: Long, storage_name: String): Long
 
     fun glean_timespan_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -351,7 +343,6 @@ internal interface LibGleanFFI : Library {
     fun glean_timing_distribution_set_start(metric_id: Long, start_time: Long): Long
 
     fun glean_timing_distribution_set_stop_and_accumulate(
-        glean_handle: Long,
         metric_id: Long,
         timer_id: Long,
         stop_time: Long
@@ -359,18 +350,16 @@ internal interface LibGleanFFI : Library {
 
     fun glean_timing_distribution_cancel(metric_id: Long, timer_id: Long)
 
-    fun glean_timing_distribution_accumulate_samples(glean_handle: Long, metric_id: Long, samples: LongArray?, len: Int)
+    fun glean_timing_distribution_accumulate_samples(metric_id: Long, samples: LongArray?, len: Int)
 
-    fun glean_timing_distribution_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_timing_distribution_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_timing_distribution_test_get_value_as_json_string(
-        glean_handle: Long,
         metric_id: Long,
         storage_name: String
     ): Pointer?
 
     fun glean_timing_distribution_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -390,20 +379,18 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_memory_distribution_metric(handle: Long)
 
-    fun glean_memory_distribution_accumulate(glean_handle: Long, metric_id: Long, sample: Long)
+    fun glean_memory_distribution_accumulate(metric_id: Long, sample: Long)
 
-    fun glean_memory_distribution_accumulate_samples(glean_handle: Long, metric_id: Long, samples: LongArray?, len: Int)
+    fun glean_memory_distribution_accumulate_samples(metric_id: Long, samples: LongArray?, len: Int)
 
-    fun glean_memory_distribution_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_memory_distribution_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_memory_distribution_test_get_value_as_json_string(
-        glean_handle: Long,
         metric_id: Long,
         storage_name: String
     ): Pointer?
 
     fun glean_memory_distribution_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -426,18 +413,16 @@ internal interface LibGleanFFI : Library {
 
     fun glean_destroy_custom_distribution_metric(handle: Long)
 
-    fun glean_custom_distribution_accumulate_samples(glean_handle: Long, metric_id: Long, samples: LongArray?, len: Int)
+    fun glean_custom_distribution_accumulate_samples(metric_id: Long, samples: LongArray?, len: Int)
 
-    fun glean_custom_distribution_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_custom_distribution_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_custom_distribution_test_get_value_as_json_string(
-        glean_handle: Long,
         metric_id: Long,
         storage_name: String
     ): Pointer?
 
     fun glean_custom_distribution_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -457,7 +442,6 @@ internal interface LibGleanFFI : Library {
     ): Long
 
     fun glean_event_record(
-        glean_handle: Long,
         handle: Long,
         timestamp: Long,
         extra_keys: IntArray?,
@@ -465,16 +449,14 @@ internal interface LibGleanFFI : Library {
         extra_len: Int
     )
 
-    fun glean_event_test_has_value(glean_handle: Long, metric_id: Long, storage_name: String): Byte
+    fun glean_event_test_has_value(metric_id: Long, storage_name: String): Byte
 
     fun glean_event_test_get_value_as_json_string(
-        glean_handle: Long,
         handle: Long,
         storage_Name: String
     ): Pointer?
 
     fun glean_event_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -496,7 +478,6 @@ internal interface LibGleanFFI : Library {
     fun glean_labeled_counter_metric_get(handle: Long, label: String): Long
 
     fun glean_labeled_counter_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -518,7 +499,6 @@ internal interface LibGleanFFI : Library {
     fun glean_labeled_boolean_metric_get(handle: Long, label: String): Long
 
     fun glean_labeled_boolean_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -540,7 +520,6 @@ internal interface LibGleanFFI : Library {
     fun glean_labeled_string_metric_get(handle: Long, label: String): Long
 
     fun glean_labeled_string_test_get_num_recorded_errors(
-        glean_handle: Long,
         metric_id: Long,
         error_type: Int,
         storage_name: String
@@ -550,5 +529,3 @@ internal interface LibGleanFFI : Library {
 
     fun glean_str_free(ptr: Pointer)
 }
-
-internal typealias MetricHandle = Long

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -574,7 +574,7 @@ class GleanTest {
             100, Dispatchers.API.taskQueue.size)
         assertEquals("overflowCount is correct", 10, Dispatchers.API.overflowCount)
 
-        Glean.handle = 0
+        Glean.testDestroyGleanHandle()
         // Now trigger execution to ensure the tasks fired
         Glean.initialize(context, true, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,

--- a/glean-core/ffi/examples/glean_app.c
+++ b/glean-core/ffi/examples/glean_app.c
@@ -14,14 +14,14 @@ int main(void)
     true,
     NULL
   };
-  uint64_t glean = glean_initialize(&cfg);
+  glean_initialize(&cfg);
   uint64_t store1 = glean_new_ping_type("store1", true, false);
-  glean_register_ping_type(glean, store1);
+  glean_register_ping_type(store1);
 
-  printf("Glean upload enabled? %d\n", glean_is_upload_enabled(glean));
-  glean_set_upload_enabled(glean, 0);
-  printf("Glean upload enabled? %d\n", glean_is_upload_enabled(glean));
-  glean_set_upload_enabled(glean, 1);
+  printf("Glean upload enabled? %d\n", glean_is_upload_enabled());
+  glean_set_upload_enabled(0);
+  printf("Glean upload enabled? %d\n", glean_is_upload_enabled());
+  glean_set_upload_enabled(1);
 
   const char *pings[2];
   pings[0] = "store1";
@@ -29,15 +29,15 @@ int main(void)
   uint64_t metric = glean_new_counter_metric("local", "counter", pings, 1, 0, 0);
   printf("Created counter: %llu\n", metric);
 
-  glean_counter_add(glean, metric, 2);
+  glean_counter_add(metric, 2);
 
-  char *payload = glean_ping_collect(glean, store1);
+  char *payload = glean_ping_collect(store1);
   printf("Payload:\n%s\n", payload);
   glean_str_free(payload);
 
   glean_destroy_counter_metric(metric);
 
-  glean_destroy_glean(glean);
+  glean_destroy_glean();
 
   return 0;
 }

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -88,53 +88,38 @@ typedef struct {
  */
 typedef uint64_t TimerId;
 
-void glean_boolean_set(uint64_t glean_handle, uint64_t metric_id, uint8_t value);
+void glean_boolean_set(uint64_t metric_id, uint8_t value);
 
-uint8_t glean_boolean_test_get_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+uint8_t glean_boolean_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+uint8_t glean_boolean_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_clear_application_lifetime_metrics(uint64_t glean_handle);
+void glean_clear_application_lifetime_metrics(void);
 
-void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
+void glean_counter_add(uint64_t metric_id, int32_t amount);
 
-int32_t glean_counter_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                   uint64_t metric_id,
+int32_t glean_counter_test_get_num_recorded_errors(uint64_t metric_id,
                                                    int32_t error_type,
                                                    FfiStr storage_name);
 
-int32_t glean_counter_test_get_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+int32_t glean_counter_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_counter_test_has_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+uint8_t glean_counter_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_custom_distribution_accumulate_samples(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+void glean_custom_distribution_accumulate_samples(uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
 
-int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                               uint64_t metric_id,
+int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t metric_id,
                                                                int32_t error_type,
                                                                FfiStr storage_name);
 
-char *glean_custom_distribution_test_get_value_as_json_string(uint64_t glean_handle,
-                                                              uint64_t metric_id,
+char *glean_custom_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_custom_distribution_test_has_value(uint64_t glean_handle,
-                                                 uint64_t metric_id,
-                                                 FfiStr storage_name);
+uint8_t glean_custom_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_datetime_set(uint64_t glean_handle,
-                        uint64_t metric_id,
+void glean_datetime_set(uint64_t metric_id,
                         int32_t year,
                         uint32_t month,
                         uint32_t day,
@@ -144,18 +129,13 @@ void glean_datetime_set(uint64_t glean_handle,
                         int64_t nano,
                         int32_t offset_seconds);
 
-int32_t glean_datetime_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                    uint64_t metric_id,
+int32_t glean_datetime_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-char *glean_datetime_test_get_value_as_string(uint64_t glean_handle,
-                                              uint64_t metric_id,
-                                              FfiStr storage_name);
+char *glean_datetime_test_get_value_as_string(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_datetime_test_has_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+uint8_t glean_datetime_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 void glean_destroy_boolean_metric(uint64_t v);
 
@@ -167,7 +147,7 @@ void glean_destroy_datetime_metric(uint64_t v);
 
 void glean_destroy_event_metric(uint64_t v);
 
-void glean_destroy_glean(uint64_t v);
+void glean_destroy_glean(void);
 
 void glean_destroy_labeled_boolean_metric(uint64_t v);
 
@@ -197,46 +177,41 @@ void glean_destroy_uuid_metric(uint64_t v);
  */
 void glean_enable_logging(void);
 
-void glean_event_record(uint64_t glean_handle,
-                        uint64_t metric_id,
+void glean_event_record(uint64_t metric_id,
                         uint64_t timestamp,
                         RawIntArray extra_keys,
                         RawStringArray extra_values,
                         int32_t extra_len);
 
-int32_t glean_event_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                 uint64_t metric_id,
+int32_t glean_event_test_get_num_recorded_errors(uint64_t metric_id,
                                                  int32_t error_type,
                                                  FfiStr storage_name);
 
-char *glean_event_test_get_value_as_json_string(uint64_t glean_handle,
-                                                uint64_t metric_id,
-                                                FfiStr storage_name);
+char *glean_event_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_event_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_event_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-char *glean_experiment_test_get_data(uint64_t glean_handle, FfiStr experiment_id);
+char *glean_experiment_test_get_data(FfiStr experiment_id);
 
-uint8_t glean_experiment_test_is_active(uint64_t glean_handle, FfiStr experiment_id);
+uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
 
 /**
  * # Safety
  *
  * A valid and non-null configuration object is required for this function.
  */
-uint64_t glean_initialize(const FfiConfiguration *cfg);
+uint8_t glean_initialize(const FfiConfiguration *cfg);
 
-uint8_t glean_is_first_run(uint64_t glean_handle);
+uint8_t glean_is_first_run(void);
 
-uint8_t glean_is_upload_enabled(uint64_t glean_handle);
+uint8_t glean_is_upload_enabled(void);
 
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
 uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
 
-int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                           uint64_t metric_id,
+int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t metric_id,
                                                            int32_t error_type,
                                                            FfiStr storage_name);
 
@@ -245,8 +220,7 @@ int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t glean_handle
  */
 uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
 
-int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                           uint64_t metric_id,
+int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t metric_id,
                                                            int32_t error_type,
                                                            FfiStr storage_name);
 
@@ -255,32 +229,24 @@ int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t glean_handle
  */
 uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
 
-int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                          uint64_t metric_id,
+int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                           int32_t error_type,
                                                           FfiStr storage_name);
 
-void glean_memory_distribution_accumulate(uint64_t glean_handle,
-                                          uint64_t metric_id,
-                                          uint64_t sample);
+void glean_memory_distribution_accumulate(uint64_t metric_id, uint64_t sample);
 
-void glean_memory_distribution_accumulate_samples(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+void glean_memory_distribution_accumulate_samples(uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
 
-int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                               uint64_t metric_id,
+int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t metric_id,
                                                                int32_t error_type,
                                                                FfiStr storage_name);
 
-char *glean_memory_distribution_test_get_value_as_json_string(uint64_t glean_handle,
-                                                              uint64_t metric_id,
+char *glean_memory_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_memory_distribution_test_has_value(uint64_t glean_handle,
-                                                 uint64_t metric_id,
-                                                 FfiStr storage_name);
+uint8_t glean_memory_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 uint64_t glean_new_boolean_metric(FfiStr category,
                                   FfiStr name,
@@ -414,37 +380,31 @@ uint64_t glean_new_uuid_metric(FfiStr category,
                                int32_t lifetime,
                                uint8_t disabled);
 
-uint8_t glean_on_ready_to_submit_pings(uint64_t glean_handle);
+uint8_t glean_on_ready_to_submit_pings(void);
 
-char *glean_ping_collect(uint64_t glean_handle, uint64_t ping_type_handle);
+char *glean_ping_collect(uint64_t ping_type_handle);
 
-void glean_quantity_set(uint64_t glean_handle, uint64_t metric_id, int64_t value);
+void glean_quantity_set(uint64_t metric_id, int64_t value);
 
-int32_t glean_quantity_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                    uint64_t metric_id,
+int32_t glean_quantity_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-int64_t glean_quantity_test_get_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_quantity_test_has_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_register_ping_type(uint64_t glean_handle, uint64_t ping_type_handle);
+void glean_register_ping_type(uint64_t ping_type_handle);
 
-void glean_set_experiment_active(uint64_t glean_handle,
-                                 FfiStr experiment_id,
+void glean_set_experiment_active(FfiStr experiment_id,
                                  FfiStr branch,
                                  RawStringArray extra_keys,
                                  RawStringArray extra_values,
                                  int32_t extra_len);
 
-void glean_set_experiment_inactive(uint64_t glean_handle, FfiStr experiment_id);
+void glean_set_experiment_inactive(FfiStr experiment_id);
 
-void glean_set_upload_enabled(uint64_t glean_handle, uint8_t flag);
+void glean_set_upload_enabled(uint8_t flag);
 
 /**
  * Public destructor for strings managed by the other side of the FFI.
@@ -459,70 +419,51 @@ void glean_set_upload_enabled(uint64_t glean_handle, uint8_t flag);
  */
 void glean_str_free(char *s);
 
-void glean_string_list_add(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+void glean_string_list_add(uint64_t metric_id, FfiStr value);
 
-void glean_string_list_set(uint64_t glean_handle,
-                           uint64_t metric_id,
-                           RawStringArray values,
-                           int32_t values_len);
+void glean_string_list_set(uint64_t metric_id, RawStringArray values, int32_t values_len);
 
-int32_t glean_string_list_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                       uint64_t metric_id,
+int32_t glean_string_list_test_get_num_recorded_errors(uint64_t metric_id,
                                                        int32_t error_type,
                                                        FfiStr storage_name);
 
-char *glean_string_list_test_get_value_as_json_string(uint64_t glean_handle,
-                                                      uint64_t metric_id,
-                                                      FfiStr storage_name);
+char *glean_string_list_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_string_list_test_has_value(uint64_t glean_handle,
-                                         uint64_t metric_id,
-                                         FfiStr storage_name);
+uint8_t glean_string_list_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_string_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+void glean_string_set(uint64_t metric_id, FfiStr value);
 
-int32_t glean_string_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+int32_t glean_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                   int32_t error_type,
                                                   FfiStr storage_name);
 
-char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+char *glean_string_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_string_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_string_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_submit_pings_by_name(uint64_t glean_handle,
-                                   RawStringArray ping_names,
-                                   int32_t ping_names_len);
+uint8_t glean_submit_pings_by_name(RawStringArray ping_names, int32_t ping_names_len);
 
-void glean_test_clear_all_stores(uint64_t glean_handle);
+void glean_test_clear_all_stores(void);
 
-uint8_t glean_test_has_ping_type(uint64_t glean_handle, FfiStr ping_name);
+uint8_t glean_test_has_ping_type(FfiStr ping_name);
 
 void glean_timespan_cancel(uint64_t metric_id);
 
-void glean_timespan_set_raw_nanos(uint64_t glean_handle,
-                                  uint64_t metric_id,
-                                  uint64_t elapsed_nanos);
+void glean_timespan_set_raw_nanos(uint64_t metric_id, uint64_t elapsed_nanos);
 
-void glean_timespan_set_start(uint64_t glean_handle, uint64_t metric_id, uint64_t start_time);
+void glean_timespan_set_start(uint64_t metric_id, uint64_t start_time);
 
-void glean_timespan_set_stop(uint64_t glean_handle, uint64_t metric_id, uint64_t stop_time);
+void glean_timespan_set_stop(uint64_t metric_id, uint64_t stop_time);
 
-int32_t glean_timespan_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                    uint64_t metric_id,
+int32_t glean_timespan_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-uint64_t glean_timespan_test_get_value(uint64_t glean_handle,
-                                       uint64_t metric_id,
-                                       FfiStr storage_name);
+uint64_t glean_timespan_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_timespan_test_has_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+uint8_t glean_timespan_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_timing_distribution_accumulate_samples(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+void glean_timing_distribution_accumulate_samples(uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
 
@@ -530,26 +471,21 @@ void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
 
 TimerId glean_timing_distribution_set_start(uint64_t metric_id, uint64_t start_time);
 
-void glean_timing_distribution_set_stop_and_accumulate(uint64_t glean_handle,
-                                                       uint64_t metric_id,
+void glean_timing_distribution_set_stop_and_accumulate(uint64_t metric_id,
                                                        TimerId timer_id,
                                                        uint64_t stop_time);
 
-int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                               uint64_t metric_id,
+int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t metric_id,
                                                                int32_t error_type,
                                                                FfiStr storage_name);
 
-char *glean_timing_distribution_test_get_value_as_json_string(uint64_t glean_handle,
-                                                              uint64_t metric_id,
+char *glean_timing_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_timing_distribution_test_has_value(uint64_t glean_handle,
-                                                 uint64_t metric_id,
-                                                 FfiStr storage_name);
+uint8_t glean_timing_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_uuid_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+void glean_uuid_set(uint64_t metric_id, FfiStr value);
 
-char *glean_uuid_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+char *glean_uuid_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_uuid_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_uuid_test_has_value(uint64_t metric_id, FfiStr storage_name);

--- a/glean-core/ffi/src/boolean.rs
+++ b/glean-core/ffi/src/boolean.rs
@@ -4,7 +4,7 @@
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
 
 define_metric!(BooleanMetric => BOOLEAN_METRICS {
     new           -> glean_new_boolean_metric(),
@@ -12,8 +12,8 @@ define_metric!(BooleanMetric => BOOLEAN_METRICS {
 });
 
 #[no_mangle]
-pub extern "C" fn glean_boolean_set(glean_handle: u64, metric_id: u64, value: u8) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_boolean_set(metric_id: u64, value: u8) {
+    with_glean_value(|glean| {
         BOOLEAN_METRICS.call_infallible(metric_id, |metric| {
             metric.set(glean, value != 0);
         })
@@ -21,12 +21,8 @@ pub extern "C" fn glean_boolean_set(glean_handle: u64, metric_id: u64, value: u8
 }
 
 #[no_mangle]
-pub extern "C" fn glean_boolean_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_boolean_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         BOOLEAN_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -36,12 +32,8 @@ pub extern "C" fn glean_boolean_test_has_value(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_boolean_test_get_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_boolean_test_get_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         BOOLEAN_METRICS.call_infallible(metric_id, |metric| {
             metric.test_get_value(glean, storage_name.as_str()).unwrap()
         })

--- a/glean-core/ffi/src/counter.rs
+++ b/glean-core/ffi/src/counter.rs
@@ -4,7 +4,7 @@
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
+use crate::{define_metric, handlemap_ext::HandleMapExtension};
 
 define_metric!(CounterMetric => COUNTER_METRICS {
     new           -> glean_new_counter_metric(),
@@ -15,29 +15,21 @@ define_metric!(CounterMetric => COUNTER_METRICS {
 });
 
 #[no_mangle]
-pub extern "C" fn glean_counter_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        COUNTER_METRICS.call_infallible(metric_id, |metric| {
-            metric
-                .test_get_value(glean, storage_name.as_str())
-                .is_some()
-        })
+pub extern "C" fn glean_counter_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    let glean = glean_core::global_glean().lock().unwrap();
+    COUNTER_METRICS.call_infallible(metric_id, |metric| {
+        metric
+            .test_get_value(&glean, storage_name.as_str())
+            .is_some()
     })
 }
 
 #[no_mangle]
-pub extern "C" fn glean_counter_test_get_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> i32 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        COUNTER_METRICS.call_infallible(metric_id, |metric| {
-            metric.test_get_value(glean, storage_name.as_str()).unwrap()
-        })
+pub extern "C" fn glean_counter_test_get_value(metric_id: u64, storage_name: FfiStr) -> i32 {
+    let glean = glean_core::global_glean().lock().unwrap();
+    COUNTER_METRICS.call_infallible(metric_id, |metric| {
+        metric
+            .test_get_value(&glean, storage_name.as_str())
+            .unwrap()
     })
 }

--- a/glean-core/ffi/src/counter.rs
+++ b/glean-core/ffi/src/counter.rs
@@ -4,7 +4,7 @@
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
 
 define_metric!(CounterMetric => COUNTER_METRICS {
     new           -> glean_new_counter_metric(),
@@ -16,20 +16,22 @@ define_metric!(CounterMetric => COUNTER_METRICS {
 
 #[no_mangle]
 pub extern "C" fn glean_counter_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
-    let glean = glean_core::global_glean().lock().unwrap();
-    COUNTER_METRICS.call_infallible(metric_id, |metric| {
-        metric
-            .test_get_value(&glean, storage_name.as_str())
-            .is_some()
+    with_glean_value(|glean| {
+        COUNTER_METRICS.call_infallible(metric_id, |metric| {
+            metric
+                .test_get_value(&glean, storage_name.as_str())
+                .is_some()
+        })
     })
 }
 
 #[no_mangle]
 pub extern "C" fn glean_counter_test_get_value(metric_id: u64, storage_name: FfiStr) -> i32 {
-    let glean = glean_core::global_glean().lock().unwrap();
-    COUNTER_METRICS.call_infallible(metric_id, |metric| {
-        metric
-            .test_get_value(&glean, storage_name.as_str())
-            .unwrap()
+    with_glean_value(|glean| {
+        COUNTER_METRICS.call_infallible(metric_id, |metric| {
+            metric
+                .test_get_value(&glean, storage_name.as_str())
+                .unwrap()
+        })
     })
 }

--- a/glean-core/ffi/src/custom_distribution.rs
+++ b/glean-core/ffi/src/custom_distribution.rs
@@ -7,7 +7,8 @@ use std::os::raw::c_char;
 use ffi_support::FfiStr;
 
 use crate::{
-    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, RawInt64Array, GLEAN,
+    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, with_glean_value,
+    RawInt64Array,
 };
 
 define_metric!(CustomDistributionMetric => CUSTOM_DISTRIBUTION_METRICS {
@@ -18,12 +19,11 @@ define_metric!(CustomDistributionMetric => CUSTOM_DISTRIBUTION_METRICS {
 
 #[no_mangle]
 pub extern "C" fn glean_custom_distribution_accumulate_samples(
-    glean_handle: u64,
     metric_id: u64,
     raw_samples: RawInt64Array,
     num_samples: i32,
 ) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         CUSTOM_DISTRIBUTION_METRICS.call_infallible_mut(metric_id, |metric| {
             // The Kotlin code is sending Long(s), which are 64 bits, as there's
             // currently no stable UInt type. The positive part of [Int] would not
@@ -38,11 +38,10 @@ pub extern "C" fn glean_custom_distribution_accumulate_samples(
 
 #[no_mangle]
 pub extern "C" fn glean_custom_distribution_test_has_value(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         CUSTOM_DISTRIBUTION_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -53,11 +52,10 @@ pub extern "C" fn glean_custom_distribution_test_has_value(
 
 #[no_mangle]
 pub extern "C" fn glean_custom_distribution_test_get_value_as_json_string(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         CUSTOM_DISTRIBUTION_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value_as_json_string(glean, storage_name.as_str())

--- a/glean-core/ffi/src/datetime.rs
+++ b/glean-core/ffi/src/datetime.rs
@@ -6,7 +6,7 @@ use std::os::raw::c_char;
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
 
 define_metric!(DatetimeMetric => DATETIME_METRICS {
     new           -> glean_new_datetime_metric(time_unit: i32),
@@ -16,7 +16,6 @@ define_metric!(DatetimeMetric => DATETIME_METRICS {
 
 #[no_mangle]
 pub extern "C" fn glean_datetime_set(
-    glean_handle: u64,
     metric_id: u64,
     year: i32,
     month: u32,
@@ -37,7 +36,7 @@ pub extern "C" fn glean_datetime_set(
 
     // We are within the u32 boundaries for nano, we should be ok converting.
     let converted_nanos = nano as u32;
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         DATETIME_METRICS.call_infallible(metric_id, |metric| {
             metric.set_with_details(
                 glean,
@@ -55,12 +54,8 @@ pub extern "C" fn glean_datetime_set(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_datetime_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_datetime_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         DATETIME_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value_as_string(glean, storage_name.as_str())
@@ -71,11 +66,10 @@ pub extern "C" fn glean_datetime_test_has_value(
 
 #[no_mangle]
 pub extern "C" fn glean_datetime_test_get_value_as_string(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         DATETIME_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value_as_string(glean, storage_name.as_str())

--- a/glean-core/ffi/src/event.rs
+++ b/glean-core/ffi/src/event.rs
@@ -13,8 +13,8 @@ use glean_core::{CommonMetricData, Lifetime};
 use crate::ffi_string_ext::FallibleToString;
 use crate::handlemap_ext::HandleMapExtension;
 use crate::{
-    define_metric, from_raw_int_array_and_string_array, from_raw_string_array, RawIntArray,
-    RawStringArray, GLEAN,
+    define_metric, from_raw_int_array_and_string_array, from_raw_string_array, with_glean_value,
+    RawIntArray, RawStringArray,
 };
 
 define_metric!(EventMetric => EVENT_METRICS {
@@ -56,14 +56,13 @@ pub extern "C" fn glean_new_event_metric(
 
 #[no_mangle]
 pub extern "C" fn glean_event_record(
-    glean_handle: u64,
     metric_id: u64,
     timestamp: u64,
     extra_keys: RawIntArray,
     extra_values: RawStringArray,
     extra_len: i32,
 ) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         EVENT_METRICS.call_with_log(metric_id, |metric| {
             let extra = from_raw_int_array_and_string_array(extra_keys, extra_values, extra_len)?;
             metric.record(glean, timestamp, extra);
@@ -73,12 +72,8 @@ pub extern "C" fn glean_event_record(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_event_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_event_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         EVENT_METRICS.call_infallible(metric_id, |metric| {
             metric.test_has_value(glean, storage_name.as_str())
         })
@@ -87,11 +82,10 @@ pub extern "C" fn glean_event_test_has_value(
 
 #[no_mangle]
 pub extern "C" fn glean_event_test_get_value_as_json_string(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         EVENT_METRICS.call_infallible(metric_id, |metric| {
             metric.test_get_value_as_json_string(glean, storage_name.as_str())
         })

--- a/glean-core/ffi/src/handlemap_ext.rs
+++ b/glean-core/ffi/src/handlemap_ext.rs
@@ -19,6 +19,17 @@ use std::panic::UnwindSafe;
 
 use ffi_support::{ConcurrentHandleMap, ExternError, IntoFfi};
 
+pub fn handle_result<R, F>(callback: F) -> R::Value
+where
+    F: UnwindSafe + FnOnce() -> Result<R, glean_core::Error>,
+    R: IntoFfi,
+{
+    let mut error = ffi_support::ExternError::success();
+    let res = ffi_support::abort_on_panic::call_with_result(&mut error, callback);
+    log_if_error(error);
+    res
+}
+
 /// Helper for the case where we aren't exposing this back over the FFI and
 /// we just want to warn if an error occurred and then release the allocated
 /// memory.

--- a/glean-core/ffi/src/labeled.rs
+++ b/glean-core/ffi/src/labeled.rs
@@ -85,12 +85,11 @@ macro_rules! impl_labeled_metric {
 
         #[no_mangle]
         pub extern "C" fn $test_get_num_recorded_errors(
-            glean_handle: u64,
             metric_id: u64,
             error_type: i32,
             storage_name: FfiStr,
         ) -> i32 {
-            crate::HandleMapExtension::call_infallible(&*crate::GLEAN, glean_handle, |glean| {
+            crate::with_glean_value(|glean| {
                 crate::HandleMapExtension::call_infallible(&*$global, metric_id, |metric| {
                     let error_type = std::convert::TryFrom::try_from(error_type).unwrap();
                     let storage_name =

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -283,8 +283,7 @@ pub extern "C" fn glean_test_clear_all_stores() {
 
 #[no_mangle]
 pub extern "C" fn glean_destroy_glean() {
-    // intentionally left empty
-    // currently used by the FFI in test mode
+    with_glean_value_mut(|glean| glean.destroy_db())
 }
 
 #[no_mangle]

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -4,9 +4,9 @@
 
 use std::convert::TryFrom;
 use std::os::raw::c_char;
+use std::panic::UnwindSafe;
 
-use ffi_support::{define_string_destructor, ConcurrentHandleMap, FfiStr};
-use lazy_static::lazy_static;
+use ffi_support::{define_string_destructor, ConcurrentHandleMap, FfiStr, IntoFfi};
 
 use glean_core::Glean;
 
@@ -35,8 +35,48 @@ use from_raw::*;
 use handlemap_ext::HandleMapExtension;
 use ping_type::PING_TYPES;
 
-lazy_static! {
-    static ref GLEAN: ConcurrentHandleMap<Glean> = ConcurrentHandleMap::new();
+pub(crate) fn with_glean<R, F>(callback: F) -> R::Value
+where
+    F: UnwindSafe + FnOnce(&Glean) -> Result<R, glean_core::Error>,
+    R: IntoFfi,
+{
+    let mut error = ffi_support::ExternError::success();
+    let res = ffi_support::abort_on_panic::call_with_result(&mut error, || {
+        let glean = glean_core::global_glean().lock().unwrap();
+        callback(&glean)
+    });
+    handlemap_ext::log_if_error(error);
+    res
+}
+
+pub(crate) fn with_glean_mut<R, F>(callback: F) -> R::Value
+where
+    F: UnwindSafe + FnOnce(&mut Glean) -> Result<R, glean_core::Error>,
+    R: IntoFfi,
+{
+    let mut error = ffi_support::ExternError::success();
+    let res = ffi_support::abort_on_panic::call_with_result(&mut error, || {
+        let mut glean = glean_core::global_glean().lock().unwrap();
+        callback(&mut glean)
+    });
+    handlemap_ext::log_if_error(error);
+    res
+}
+
+pub(crate) fn with_glean_value<R, F>(callback: F) -> R::Value
+where
+    F: UnwindSafe + FnOnce(&Glean) -> R,
+    R: IntoFfi,
+{
+    with_glean(|glean| Ok(callback(glean)))
+}
+
+pub(crate) fn with_glean_value_mut<R, F>(callback: F) -> R::Value
+where
+    F: UnwindSafe + FnOnce(&mut Glean) -> R,
+    R: IntoFfi,
+{
+    with_glean_mut(|glean| Ok(callback(glean)))
 }
 
 /// Initialize the logging system based on the target platform. This ensures
@@ -129,45 +169,45 @@ impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
 ///
 /// A valid and non-null configuration object is required for this function.
 #[no_mangle]
-pub unsafe extern "C" fn glean_initialize(cfg: *const FfiConfiguration) -> u64 {
+pub unsafe extern "C" fn glean_initialize(cfg: *const FfiConfiguration) -> u8 {
     assert!(!cfg.is_null());
 
-    GLEAN.insert_with_log(|| {
+    handlemap_ext::handle_result(|| {
         // We can create a reference to the FfiConfiguration struct:
         // 1. We did a null check
         // 2. We're not holding on to it beyond this function
         //    and we copy out all data when needed.
         let glean_cfg = glean_core::Configuration::try_from(&*cfg)?;
         let glean = Glean::new(glean_cfg)?;
+        glean_core::setup_glean(glean)?;
         log::info!("Glean initialized");
-        Ok(glean)
+        Ok(true)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn glean_on_ready_to_submit_pings(glean_handle: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| glean.on_ready_to_submit_pings())
+pub extern "C" fn glean_on_ready_to_submit_pings() -> u8 {
+    with_glean_value(|glean| glean.on_ready_to_submit_pings())
 }
 
 #[no_mangle]
-pub extern "C" fn glean_is_upload_enabled(glean_handle: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| glean.is_upload_enabled())
+pub extern "C" fn glean_is_upload_enabled() -> u8 {
+    with_glean_value(|glean| glean.is_upload_enabled())
 }
 
 #[no_mangle]
-pub extern "C" fn glean_set_upload_enabled(glean_handle: u64, flag: u8) {
-    GLEAN.call_infallible_mut(glean_handle, |glean| glean.set_upload_enabled(flag != 0));
+pub extern "C" fn glean_set_upload_enabled(flag: u8) {
+    with_glean_value_mut(|glean| glean.set_upload_enabled(flag != 0));
     // The return value of set_upload_enabled is an implementation detail
     // that isn't exposed over FFI.
 }
 
 #[no_mangle]
 pub extern "C" fn glean_submit_pings_by_name(
-    glean_handle: u64,
     ping_names: RawStringArray,
     ping_names_len: i32,
 ) -> u8 {
-    GLEAN.call_with_log(glean_handle, |glean| {
+    with_glean(|glean| {
         let pings = from_raw_string_array(ping_names, ping_names_len)?;
 
         Ok(glean.submit_pings_by_name(&pings))
@@ -175,12 +215,12 @@ pub extern "C" fn glean_submit_pings_by_name(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_ping_collect(glean_handle: u64, ping_type_handle: u64) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_ping_collect(ping_type_handle: u64) -> *mut c_char {
+    with_glean_value(|glean| {
         PING_TYPES.call_infallible(ping_type_handle, |ping_type| {
             let ping_maker = glean_core::ping::PingMaker::new();
             let data = ping_maker
-                .collect_string(glean, ping_type)
+                .collect_string(&glean, ping_type)
                 .unwrap_or_else(|| String::from(""));
             log::info!("Ping({}): {}", ping_type.name.as_str(), data);
             data
@@ -190,14 +230,13 @@ pub extern "C" fn glean_ping_collect(glean_handle: u64, ping_type_handle: u64) -
 
 #[no_mangle]
 pub extern "C" fn glean_set_experiment_active(
-    glean_handle: u64,
     experiment_id: FfiStr,
     branch: FfiStr,
     extra_keys: RawStringArray,
     extra_values: RawStringArray,
     extra_len: i32,
 ) {
-    GLEAN.call_with_log(glean_handle, |glean| {
+    with_glean(|glean| {
         let experiment_id = experiment_id.to_string_fallible()?;
         let branch = branch.to_string_fallible()?;
         let extra = from_raw_string_array_and_string_array(extra_keys, extra_values, extra_len)?;
@@ -208,8 +247,8 @@ pub extern "C" fn glean_set_experiment_active(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_set_experiment_inactive(glean_handle: u64, experiment_id: FfiStr) {
-    GLEAN.call_with_log(glean_handle, |glean| {
+pub extern "C" fn glean_set_experiment_inactive(experiment_id: FfiStr) {
+    with_glean(|glean| {
         let experiment_id = experiment_id.to_string_fallible()?;
         glean.set_experiment_inactive(experiment_id);
         Ok(())
@@ -217,40 +256,40 @@ pub extern "C" fn glean_set_experiment_inactive(glean_handle: u64, experiment_id
 }
 
 #[no_mangle]
-pub extern "C" fn glean_experiment_test_is_active(glean_handle: u64, experiment_id: FfiStr) -> u8 {
-    GLEAN.call_with_log(glean_handle, |glean| {
+pub extern "C" fn glean_experiment_test_is_active(experiment_id: FfiStr) -> u8 {
+    with_glean(|glean| {
         let experiment_id = experiment_id.to_string_fallible()?;
         Ok(glean.test_is_experiment_active(experiment_id))
     })
 }
 
 #[no_mangle]
-pub extern "C" fn glean_experiment_test_get_data(
-    glean_handle: u64,
-    experiment_id: FfiStr,
-) -> *mut c_char {
-    GLEAN.call_with_log(glean_handle, |glean| {
+pub extern "C" fn glean_experiment_test_get_data(experiment_id: FfiStr) -> *mut c_char {
+    with_glean(|glean| {
         let experiment_id = experiment_id.to_string_fallible()?;
         Ok(glean.test_get_experiment_data_as_json(experiment_id))
     })
 }
 
 #[no_mangle]
-pub extern "C" fn glean_clear_application_lifetime_metrics(glean_handle: u64) {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        glean.clear_application_lifetime_metrics()
-    });
+pub extern "C" fn glean_clear_application_lifetime_metrics() {
+    with_glean_value(|glean| glean.clear_application_lifetime_metrics());
 }
 
 #[no_mangle]
-pub extern "C" fn glean_test_clear_all_stores(glean_handle: u64) {
-    GLEAN.call_infallible(glean_handle, |glean| glean.test_clear_all_stores());
+pub extern "C" fn glean_test_clear_all_stores() {
+    with_glean_value(|glean| glean.test_clear_all_stores())
 }
 
 #[no_mangle]
-pub extern "C" fn glean_is_first_run(glean_handle: u64) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| glean.is_first_run())
+pub extern "C" fn glean_destroy_glean() {
+    // intentionally left empty
+    // currently used by the FFI in test mode
 }
 
-define_infallible_handle_map_deleter!(GLEAN, glean_destroy_glean);
+#[no_mangle]
+pub extern "C" fn glean_is_first_run() -> u8 {
+    with_glean_value(|glean| glean.is_first_run())
+}
+
 define_string_destructor!(glean_str_free);

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -35,6 +35,13 @@ use from_raw::*;
 use handlemap_ext::HandleMapExtension;
 use ping_type::PING_TYPES;
 
+/// Execute the callback with a reference to the Glean singleton, returning a `Result`.
+///
+/// The callback returns a `Result<T, E>` while:
+///
+/// - Catching panics, and logging them.
+/// - Converting `T` to a C-compatible type using [`IntoFfi`].
+/// - Logging `E` and returning a default value.
 pub(crate) fn with_glean<R, F>(callback: F) -> R::Value
 where
     F: UnwindSafe + FnOnce(&Glean) -> Result<R, glean_core::Error>,
@@ -49,6 +56,13 @@ where
     res
 }
 
+/// Execute the callback with a mutable reference to the Glean singleton, returning a `Result`.
+///
+/// The callback returns a `Result<T, E>` while:
+///
+/// - Catching panics, and logging them.
+/// - Converting `T` to a C-compatible type using [`IntoFfi`].
+/// - Logging `E` and returning a default value.
 pub(crate) fn with_glean_mut<R, F>(callback: F) -> R::Value
 where
     F: UnwindSafe + FnOnce(&mut Glean) -> Result<R, glean_core::Error>,
@@ -63,6 +77,12 @@ where
     res
 }
 
+/// Execute the callback with a reference to the Glean singleton, returning a value.
+///
+/// The callback returns a value while:
+///
+/// - Catching panics, and logging them.
+/// - Converting the returned value to a C-compatible type using [`IntoFfi`].
 pub(crate) fn with_glean_value<R, F>(callback: F) -> R::Value
 where
     F: UnwindSafe + FnOnce(&Glean) -> R,
@@ -71,6 +91,12 @@ where
     with_glean(|glean| Ok(callback(glean)))
 }
 
+/// Execute the callback with a mutable reference to the Glean singleton, returning a value.
+///
+/// The callback returns a value while:
+///
+/// - Catching panics, and logging them.
+/// - Converting the returned value to a C-compatible type using [`IntoFfi`].
 pub(crate) fn with_glean_value_mut<R, F>(callback: F) -> R::Value
 where
     F: UnwindSafe + FnOnce(&mut Glean) -> R,

--- a/glean-core/ffi/src/macros.rs
+++ b/glean-core/ffi/src/macros.rs
@@ -90,15 +90,16 @@ macro_rules! define_metric {
             storage_name: FfiStr
         ) -> i32 {
                 crate::HandleMapExtension::call_infallible(&*$metric_map, metric_id, |metric| {
-                    let glean = glean_core::global_glean().lock().unwrap();
-                    let error_type = std::convert::TryFrom::try_from(error_type).unwrap();
-                    let storage_name = crate::FallibleToString::to_string_fallible(&storage_name).unwrap();
-                    glean_core::test_get_num_recorded_errors(
-                        &glean,
-                        glean_core::metrics::MetricType::meta(metric),
-                        error_type,
-                        Some(&storage_name)
-                    ).unwrap_or(0)
+                    crate::with_glean_value(|glean| {
+                        let error_type = std::convert::TryFrom::try_from(error_type).unwrap();
+                        let storage_name = crate::FallibleToString::to_string_fallible(&storage_name).unwrap();
+                        glean_core::test_get_num_recorded_errors(
+                            &glean,
+                            glean_core::metrics::MetricType::meta(metric),
+                            error_type,
+                            Some(&storage_name)
+                        ).unwrap_or(0)
+                    })
                 })
         }
         )?

--- a/glean-core/ffi/src/memory_distribution.rs
+++ b/glean-core/ffi/src/memory_distribution.rs
@@ -7,7 +7,8 @@ use std::os::raw::c_char;
 use ffi_support::FfiStr;
 
 use crate::{
-    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, RawInt64Array, GLEAN,
+    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, with_glean_value,
+    RawInt64Array,
 };
 
 define_metric!(MemoryDistributionMetric => MEMORY_DISTRIBUTION_METRICS {
@@ -19,12 +20,11 @@ define_metric!(MemoryDistributionMetric => MEMORY_DISTRIBUTION_METRICS {
 
 #[no_mangle]
 pub extern "C" fn glean_memory_distribution_accumulate_samples(
-    glean_handle: u64,
     metric_id: u64,
     raw_samples: RawInt64Array,
     num_samples: i32,
 ) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         MEMORY_DISTRIBUTION_METRICS.call_infallible_mut(metric_id, |metric| {
             // The Kotlin code is sending Long(s), which are 64 bits, as there's
             // currently no stable UInt type. The positive part of [Int] would not
@@ -39,11 +39,10 @@ pub extern "C" fn glean_memory_distribution_accumulate_samples(
 
 #[no_mangle]
 pub extern "C" fn glean_memory_distribution_test_has_value(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         MEMORY_DISTRIBUTION_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -54,11 +53,10 @@ pub extern "C" fn glean_memory_distribution_test_has_value(
 
 #[no_mangle]
 pub extern "C" fn glean_memory_distribution_test_get_value_as_json_string(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         MEMORY_DISTRIBUTION_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value_as_json_string(glean, storage_name.as_str())

--- a/glean-core/ffi/src/ping_type.rs
+++ b/glean-core/ffi/src/ping_type.rs
@@ -9,6 +9,7 @@ use glean_core::metrics::PingType;
 
 use crate::ffi_string_ext::FallibleToString;
 use crate::handlemap_ext::HandleMapExtension;
+use crate::{with_glean_value, with_glean_value_mut};
 
 lazy_static! {
     pub(crate) static ref PING_TYPES: ConcurrentHandleMap<PingType> = ConcurrentHandleMap::new();
@@ -33,17 +34,12 @@ pub extern "C" fn glean_new_ping_type(
 
 #[no_mangle]
 pub extern "C" fn glean_test_has_ping_type(ping_name: FfiStr) -> u8 {
-    glean_core::global_glean()
-        .lock()
-        .unwrap()
-        .get_ping_by_name(ping_name.as_str())
-        .is_some() as u8
+    with_glean_value(|glean| glean.get_ping_by_name(ping_name.as_str()).is_some() as u8)
 }
 
 #[no_mangle]
 pub extern "C" fn glean_register_ping_type(ping_type_handle: u64) {
     PING_TYPES.call_infallible(ping_type_handle, |ping_type| {
-        let mut glean = glean_core::global_glean().lock().unwrap();
-        glean.register_ping_type(ping_type)
+        with_glean_value_mut(|glean| glean.register_ping_type(ping_type))
     })
 }

--- a/glean-core/ffi/src/quantity.rs
+++ b/glean-core/ffi/src/quantity.rs
@@ -4,7 +4,7 @@
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
 
 define_metric!(QuantityMetric => QUANTITY_METRICS {
     new           -> glean_new_quantity_metric(),
@@ -15,12 +15,8 @@ define_metric!(QuantityMetric => QUANTITY_METRICS {
 });
 
 #[no_mangle]
-pub extern "C" fn glean_quantity_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_quantity_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         QUANTITY_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -30,12 +26,8 @@ pub extern "C" fn glean_quantity_test_has_value(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_quantity_test_get_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> i64 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_quantity_test_get_value(metric_id: u64, storage_name: FfiStr) -> i64 {
+    with_glean_value(|glean| {
         QUANTITY_METRICS.call_infallible(metric_id, |metric| {
             metric.test_get_value(glean, storage_name.as_str()).unwrap()
         })

--- a/glean-core/ffi/src/string.rs
+++ b/glean-core/ffi/src/string.rs
@@ -6,9 +6,7 @@ use std::os::raw::c_char;
 
 use ffi_support::FfiStr;
 
-use crate::{
-    define_metric, ffi_string_ext::FallibleToString, handlemap_ext::HandleMapExtension, GLEAN,
-};
+use crate::{define_metric, ffi_string_ext::FallibleToString, handlemap_ext::HandleMapExtension};
 
 define_metric!(StringMetric => STRING_METRICS {
     new           -> glean_new_string_metric(),
@@ -17,40 +15,31 @@ define_metric!(StringMetric => STRING_METRICS {
 });
 
 #[no_mangle]
-pub extern "C" fn glean_string_set(glean_handle: u64, metric_id: u64, value: FfiStr) {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        STRING_METRICS.call_with_log(metric_id, |metric| {
-            let value = value.to_string_fallible()?;
-            metric.set(glean, value);
-            Ok(())
-        })
+pub extern "C" fn glean_string_set(metric_id: u64, value: FfiStr) {
+    let glean = glean_core::global_glean().lock().unwrap();
+    STRING_METRICS.call_with_log(metric_id, |metric| {
+        let value = value.to_string_fallible()?;
+        metric.set(&glean, value);
+        Ok(())
     })
 }
 
 #[no_mangle]
-pub extern "C" fn glean_string_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        STRING_METRICS.call_infallible(metric_id, |metric| {
-            metric
-                .test_get_value(glean, storage_name.as_str())
-                .is_some()
-        })
+pub extern "C" fn glean_string_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    let glean = glean_core::global_glean().lock().unwrap();
+    STRING_METRICS.call_infallible(metric_id, |metric| {
+        metric
+            .test_get_value(&glean, storage_name.as_str())
+            .is_some()
     })
 }
 
 #[no_mangle]
-pub extern "C" fn glean_string_test_get_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
-        STRING_METRICS.call_infallible(metric_id, |metric| {
-            metric.test_get_value(glean, storage_name.as_str()).unwrap()
-        })
+pub extern "C" fn glean_string_test_get_value(metric_id: u64, storage_name: FfiStr) -> *mut c_char {
+    let glean = glean_core::global_glean().lock().unwrap();
+    STRING_METRICS.call_infallible(metric_id, |metric| {
+        metric
+            .test_get_value(&glean, storage_name.as_str())
+            .unwrap()
     })
 }

--- a/glean-core/ffi/src/string_list.rs
+++ b/glean-core/ffi/src/string_list.rs
@@ -8,7 +8,7 @@ use ffi_support::FfiStr;
 
 use crate::{
     define_metric, ffi_string_ext::FallibleToString, from_raw_string_array,
-    handlemap_ext::HandleMapExtension, RawStringArray, GLEAN,
+    handlemap_ext::HandleMapExtension, with_glean_value, RawStringArray,
 };
 
 define_metric!(StringListMetric => STRING_LIST_METRICS {
@@ -18,8 +18,8 @@ define_metric!(StringListMetric => STRING_LIST_METRICS {
 });
 
 #[no_mangle]
-pub extern "C" fn glean_string_list_add(glean_handle: u64, metric_id: u64, value: FfiStr) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_string_list_add(metric_id: u64, value: FfiStr) {
+    with_glean_value(|glean| {
         STRING_LIST_METRICS.call_with_log(metric_id, |metric| {
             let value = value.to_string_fallible()?;
             metric.add(glean, value);
@@ -29,13 +29,8 @@ pub extern "C" fn glean_string_list_add(glean_handle: u64, metric_id: u64, value
 }
 
 #[no_mangle]
-pub extern "C" fn glean_string_list_set(
-    glean_handle: u64,
-    metric_id: u64,
-    values: RawStringArray,
-    values_len: i32,
-) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_string_list_set(metric_id: u64, values: RawStringArray, values_len: i32) {
+    with_glean_value(|glean| {
         STRING_LIST_METRICS.call_with_log(metric_id, |metric| {
             let values = from_raw_string_array(values, values_len)?;
             metric.set(glean, values);
@@ -45,12 +40,8 @@ pub extern "C" fn glean_string_list_set(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_string_list_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_string_list_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         STRING_LIST_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -61,11 +52,10 @@ pub extern "C" fn glean_string_list_test_has_value(
 
 #[no_mangle]
 pub extern "C" fn glean_string_list_test_get_value_as_json_string(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         STRING_LIST_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value_as_json_string(glean, storage_name.as_str())

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, GLEAN};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
 
 define_metric!(TimespanMetric => TIMESPAN_METRICS {
     new           -> glean_new_timespan_metric(time_unit: i32),
@@ -15,8 +15,8 @@ define_metric!(TimespanMetric => TIMESPAN_METRICS {
 });
 
 #[no_mangle]
-pub extern "C" fn glean_timespan_set_start(glean_handle: u64, metric_id: u64, start_time: u64) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_timespan_set_start(metric_id: u64, start_time: u64) {
+    with_glean_value(|glean| {
         TIMESPAN_METRICS.call_infallible_mut(metric_id, |metric| {
             metric.set_start(glean, start_time);
         })
@@ -24,8 +24,8 @@ pub extern "C" fn glean_timespan_set_start(glean_handle: u64, metric_id: u64, st
 }
 
 #[no_mangle]
-pub extern "C" fn glean_timespan_set_stop(glean_handle: u64, metric_id: u64, stop_time: u64) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_timespan_set_stop(metric_id: u64, stop_time: u64) {
+    with_glean_value(|glean| {
         TIMESPAN_METRICS.call_infallible_mut(metric_id, |metric| {
             metric.set_stop(glean, stop_time);
         })
@@ -40,13 +40,9 @@ pub extern "C" fn glean_timespan_cancel(metric_id: u64) {
 }
 
 #[no_mangle]
-pub extern "C" fn glean_timespan_set_raw_nanos(
-    glean_handle: u64,
-    metric_id: u64,
-    elapsed_nanos: u64,
-) {
+pub extern "C" fn glean_timespan_set_raw_nanos(metric_id: u64, elapsed_nanos: u64) {
     let elapsed = Duration::from_nanos(elapsed_nanos);
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
             metric.set_raw(glean, elapsed, false);
         })
@@ -54,12 +50,8 @@ pub extern "C" fn glean_timespan_set_raw_nanos(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_timespan_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_timespan_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -69,12 +61,8 @@ pub extern "C" fn glean_timespan_test_has_value(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_timespan_test_get_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u64 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_timespan_test_get_value(metric_id: u64, storage_name: FfiStr) -> u64 {
+    with_glean_value(|glean| {
         TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
             metric.test_get_value(glean, storage_name.as_str()).unwrap()
         })

--- a/glean-core/ffi/src/timing_distribution.rs
+++ b/glean-core/ffi/src/timing_distribution.rs
@@ -7,7 +7,8 @@ use std::os::raw::c_char;
 use ffi_support::FfiStr;
 
 use crate::{
-    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, RawInt64Array, GLEAN,
+    define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, with_glean_value,
+    RawInt64Array,
 };
 use glean_core::metrics::TimerId;
 
@@ -25,12 +26,11 @@ pub extern "C" fn glean_timing_distribution_set_start(metric_id: u64, start_time
 
 #[no_mangle]
 pub extern "C" fn glean_timing_distribution_set_stop_and_accumulate(
-    glean_handle: u64,
     metric_id: u64,
     timer_id: TimerId,
     stop_time: u64,
 ) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         TIMING_DISTRIBUTION_METRICS.call_infallible_mut(metric_id, |metric| {
             metric.set_stop_and_accumulate(glean, timer_id, stop_time);
         })
@@ -46,12 +46,11 @@ pub extern "C" fn glean_timing_distribution_cancel(metric_id: u64, timer_id: Tim
 
 #[no_mangle]
 pub extern "C" fn glean_timing_distribution_accumulate_samples(
-    glean_handle: u64,
     metric_id: u64,
     raw_samples: RawInt64Array,
     num_samples: i32,
 ) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         TIMING_DISTRIBUTION_METRICS.call_infallible_mut(metric_id, |metric| {
             // The Kotlin code is sending Long(s), which are 64 bits, as there's
             // currently no stable UInt type. The positive part of [Int] would not
@@ -66,11 +65,10 @@ pub extern "C" fn glean_timing_distribution_accumulate_samples(
 
 #[no_mangle]
 pub extern "C" fn glean_timing_distribution_test_has_value(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         TIMING_DISTRIBUTION_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -81,11 +79,10 @@ pub extern "C" fn glean_timing_distribution_test_has_value(
 
 #[no_mangle]
 pub extern "C" fn glean_timing_distribution_test_get_value_as_json_string(
-    glean_handle: u64,
     metric_id: u64,
     storage_name: FfiStr,
 ) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+    with_glean_value(|glean| {
         TIMING_DISTRIBUTION_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value_as_json_string(glean, storage_name.as_str())

--- a/glean-core/ffi/src/uuid.rs
+++ b/glean-core/ffi/src/uuid.rs
@@ -7,7 +7,8 @@ use std::os::raw::c_char;
 use ffi_support::FfiStr;
 
 use crate::{
-    define_metric, ffi_string_ext::FallibleToString, handlemap_ext::HandleMapExtension, GLEAN,
+    define_metric, ffi_string_ext::FallibleToString, handlemap_ext::HandleMapExtension,
+    with_glean_value,
 };
 
 define_metric!(UuidMetric => UUID_METRICS {
@@ -16,8 +17,8 @@ define_metric!(UuidMetric => UUID_METRICS {
 });
 
 #[no_mangle]
-pub extern "C" fn glean_uuid_set(glean_handle: u64, metric_id: u64, value: FfiStr) {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_uuid_set(metric_id: u64, value: FfiStr) {
+    with_glean_value(|glean| {
         UUID_METRICS.call_with_log(metric_id, |metric| {
             let value = value.to_string_fallible()?;
             let uuid = uuid::Uuid::parse_str(&value);
@@ -28,12 +29,8 @@ pub extern "C" fn glean_uuid_set(glean_handle: u64, metric_id: u64, value: FfiSt
 }
 
 #[no_mangle]
-pub extern "C" fn glean_uuid_test_has_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> u8 {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_uuid_test_has_value(metric_id: u64, storage_name: FfiStr) -> u8 {
+    with_glean_value(|glean| {
         UUID_METRICS.call_infallible(metric_id, |metric| {
             metric
                 .test_get_value(glean, storage_name.as_str())
@@ -43,12 +40,8 @@ pub extern "C" fn glean_uuid_test_has_value(
 }
 
 #[no_mangle]
-pub extern "C" fn glean_uuid_test_get_value(
-    glean_handle: u64,
-    metric_id: u64,
-    storage_name: FfiStr,
-) -> *mut c_char {
-    GLEAN.call_infallible(glean_handle, |glean| {
+pub extern "C" fn glean_uuid_test_get_value(metric_id: u64, storage_name: FfiStr) -> *mut c_char {
+    with_glean_value(|glean| {
         UUID_METRICS.call_infallible(metric_id, |metric| {
             metric.test_get_value(glean, storage_name.as_str()).unwrap()
         })

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -88,53 +88,38 @@ typedef struct {
  */
 typedef uint64_t TimerId;
 
-void glean_boolean_set(uint64_t glean_handle, uint64_t metric_id, uint8_t value);
+void glean_boolean_set(uint64_t metric_id, uint8_t value);
 
-uint8_t glean_boolean_test_get_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+uint8_t glean_boolean_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_boolean_test_has_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+uint8_t glean_boolean_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_clear_application_lifetime_metrics(uint64_t glean_handle);
+void glean_clear_application_lifetime_metrics(void);
 
-void glean_counter_add(uint64_t glean_handle, uint64_t metric_id, int32_t amount);
+void glean_counter_add(uint64_t metric_id, int32_t amount);
 
-int32_t glean_counter_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                   uint64_t metric_id,
+int32_t glean_counter_test_get_num_recorded_errors(uint64_t metric_id,
                                                    int32_t error_type,
                                                    FfiStr storage_name);
 
-int32_t glean_counter_test_get_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+int32_t glean_counter_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_counter_test_has_value(uint64_t glean_handle,
-                                     uint64_t metric_id,
-                                     FfiStr storage_name);
+uint8_t glean_counter_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_custom_distribution_accumulate_samples(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+void glean_custom_distribution_accumulate_samples(uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
 
-int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                               uint64_t metric_id,
+int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t metric_id,
                                                                int32_t error_type,
                                                                FfiStr storage_name);
 
-char *glean_custom_distribution_test_get_value_as_json_string(uint64_t glean_handle,
-                                                              uint64_t metric_id,
+char *glean_custom_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_custom_distribution_test_has_value(uint64_t glean_handle,
-                                                 uint64_t metric_id,
-                                                 FfiStr storage_name);
+uint8_t glean_custom_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_datetime_set(uint64_t glean_handle,
-                        uint64_t metric_id,
+void glean_datetime_set(uint64_t metric_id,
                         int32_t year,
                         uint32_t month,
                         uint32_t day,
@@ -144,18 +129,13 @@ void glean_datetime_set(uint64_t glean_handle,
                         int64_t nano,
                         int32_t offset_seconds);
 
-int32_t glean_datetime_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                    uint64_t metric_id,
+int32_t glean_datetime_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-char *glean_datetime_test_get_value_as_string(uint64_t glean_handle,
-                                              uint64_t metric_id,
-                                              FfiStr storage_name);
+char *glean_datetime_test_get_value_as_string(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_datetime_test_has_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+uint8_t glean_datetime_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 void glean_destroy_boolean_metric(uint64_t v);
 
@@ -167,7 +147,7 @@ void glean_destroy_datetime_metric(uint64_t v);
 
 void glean_destroy_event_metric(uint64_t v);
 
-void glean_destroy_glean(uint64_t v);
+void glean_destroy_glean(void);
 
 void glean_destroy_labeled_boolean_metric(uint64_t v);
 
@@ -197,46 +177,41 @@ void glean_destroy_uuid_metric(uint64_t v);
  */
 void glean_enable_logging(void);
 
-void glean_event_record(uint64_t glean_handle,
-                        uint64_t metric_id,
+void glean_event_record(uint64_t metric_id,
                         uint64_t timestamp,
                         RawIntArray extra_keys,
                         RawStringArray extra_values,
                         int32_t extra_len);
 
-int32_t glean_event_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                 uint64_t metric_id,
+int32_t glean_event_test_get_num_recorded_errors(uint64_t metric_id,
                                                  int32_t error_type,
                                                  FfiStr storage_name);
 
-char *glean_event_test_get_value_as_json_string(uint64_t glean_handle,
-                                                uint64_t metric_id,
-                                                FfiStr storage_name);
+char *glean_event_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_event_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_event_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-char *glean_experiment_test_get_data(uint64_t glean_handle, FfiStr experiment_id);
+char *glean_experiment_test_get_data(FfiStr experiment_id);
 
-uint8_t glean_experiment_test_is_active(uint64_t glean_handle, FfiStr experiment_id);
+uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
 
 /**
  * # Safety
  *
  * A valid and non-null configuration object is required for this function.
  */
-uint64_t glean_initialize(const FfiConfiguration *cfg);
+uint8_t glean_initialize(const FfiConfiguration *cfg);
 
-uint8_t glean_is_first_run(uint64_t glean_handle);
+uint8_t glean_is_first_run(void);
 
-uint8_t glean_is_upload_enabled(uint64_t glean_handle);
+uint8_t glean_is_upload_enabled(void);
 
 /**
  * Create a new instance of the sub-metric of this labeled metric.
  */
 uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
 
-int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                           uint64_t metric_id,
+int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t metric_id,
                                                            int32_t error_type,
                                                            FfiStr storage_name);
 
@@ -245,8 +220,7 @@ int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t glean_handle
  */
 uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
 
-int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                           uint64_t metric_id,
+int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t metric_id,
                                                            int32_t error_type,
                                                            FfiStr storage_name);
 
@@ -255,32 +229,24 @@ int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t glean_handle
  */
 uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
 
-int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                          uint64_t metric_id,
+int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                           int32_t error_type,
                                                           FfiStr storage_name);
 
-void glean_memory_distribution_accumulate(uint64_t glean_handle,
-                                          uint64_t metric_id,
-                                          uint64_t sample);
+void glean_memory_distribution_accumulate(uint64_t metric_id, uint64_t sample);
 
-void glean_memory_distribution_accumulate_samples(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+void glean_memory_distribution_accumulate_samples(uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
 
-int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                               uint64_t metric_id,
+int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t metric_id,
                                                                int32_t error_type,
                                                                FfiStr storage_name);
 
-char *glean_memory_distribution_test_get_value_as_json_string(uint64_t glean_handle,
-                                                              uint64_t metric_id,
+char *glean_memory_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_memory_distribution_test_has_value(uint64_t glean_handle,
-                                                 uint64_t metric_id,
-                                                 FfiStr storage_name);
+uint8_t glean_memory_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 uint64_t glean_new_boolean_metric(FfiStr category,
                                   FfiStr name,
@@ -414,37 +380,31 @@ uint64_t glean_new_uuid_metric(FfiStr category,
                                int32_t lifetime,
                                uint8_t disabled);
 
-uint8_t glean_on_ready_to_submit_pings(uint64_t glean_handle);
+uint8_t glean_on_ready_to_submit_pings(void);
 
-char *glean_ping_collect(uint64_t glean_handle, uint64_t ping_type_handle);
+char *glean_ping_collect(uint64_t ping_type_handle);
 
-void glean_quantity_set(uint64_t glean_handle, uint64_t metric_id, int64_t value);
+void glean_quantity_set(uint64_t metric_id, int64_t value);
 
-int32_t glean_quantity_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                    uint64_t metric_id,
+int32_t glean_quantity_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-int64_t glean_quantity_test_get_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_quantity_test_has_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_register_ping_type(uint64_t glean_handle, uint64_t ping_type_handle);
+void glean_register_ping_type(uint64_t ping_type_handle);
 
-void glean_set_experiment_active(uint64_t glean_handle,
-                                 FfiStr experiment_id,
+void glean_set_experiment_active(FfiStr experiment_id,
                                  FfiStr branch,
                                  RawStringArray extra_keys,
                                  RawStringArray extra_values,
                                  int32_t extra_len);
 
-void glean_set_experiment_inactive(uint64_t glean_handle, FfiStr experiment_id);
+void glean_set_experiment_inactive(FfiStr experiment_id);
 
-void glean_set_upload_enabled(uint64_t glean_handle, uint8_t flag);
+void glean_set_upload_enabled(uint8_t flag);
 
 /**
  * Public destructor for strings managed by the other side of the FFI.
@@ -459,70 +419,51 @@ void glean_set_upload_enabled(uint64_t glean_handle, uint8_t flag);
  */
 void glean_str_free(char *s);
 
-void glean_string_list_add(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+void glean_string_list_add(uint64_t metric_id, FfiStr value);
 
-void glean_string_list_set(uint64_t glean_handle,
-                           uint64_t metric_id,
-                           RawStringArray values,
-                           int32_t values_len);
+void glean_string_list_set(uint64_t metric_id, RawStringArray values, int32_t values_len);
 
-int32_t glean_string_list_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                       uint64_t metric_id,
+int32_t glean_string_list_test_get_num_recorded_errors(uint64_t metric_id,
                                                        int32_t error_type,
                                                        FfiStr storage_name);
 
-char *glean_string_list_test_get_value_as_json_string(uint64_t glean_handle,
-                                                      uint64_t metric_id,
-                                                      FfiStr storage_name);
+char *glean_string_list_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_string_list_test_has_value(uint64_t glean_handle,
-                                         uint64_t metric_id,
-                                         FfiStr storage_name);
+uint8_t glean_string_list_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_string_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+void glean_string_set(uint64_t metric_id, FfiStr value);
 
-int32_t glean_string_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+int32_t glean_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                   int32_t error_type,
                                                   FfiStr storage_name);
 
-char *glean_string_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+char *glean_string_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_string_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_string_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_submit_pings_by_name(uint64_t glean_handle,
-                                   RawStringArray ping_names,
-                                   int32_t ping_names_len);
+uint8_t glean_submit_pings_by_name(RawStringArray ping_names, int32_t ping_names_len);
 
-void glean_test_clear_all_stores(uint64_t glean_handle);
+void glean_test_clear_all_stores(void);
 
-uint8_t glean_test_has_ping_type(uint64_t glean_handle, FfiStr ping_name);
+uint8_t glean_test_has_ping_type(FfiStr ping_name);
 
 void glean_timespan_cancel(uint64_t metric_id);
 
-void glean_timespan_set_raw_nanos(uint64_t glean_handle,
-                                  uint64_t metric_id,
-                                  uint64_t elapsed_nanos);
+void glean_timespan_set_raw_nanos(uint64_t metric_id, uint64_t elapsed_nanos);
 
-void glean_timespan_set_start(uint64_t glean_handle, uint64_t metric_id, uint64_t start_time);
+void glean_timespan_set_start(uint64_t metric_id, uint64_t start_time);
 
-void glean_timespan_set_stop(uint64_t glean_handle, uint64_t metric_id, uint64_t stop_time);
+void glean_timespan_set_stop(uint64_t metric_id, uint64_t stop_time);
 
-int32_t glean_timespan_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                    uint64_t metric_id,
+int32_t glean_timespan_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-uint64_t glean_timespan_test_get_value(uint64_t glean_handle,
-                                       uint64_t metric_id,
-                                       FfiStr storage_name);
+uint64_t glean_timespan_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_timespan_test_has_value(uint64_t glean_handle,
-                                      uint64_t metric_id,
-                                      FfiStr storage_name);
+uint8_t glean_timespan_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_timing_distribution_accumulate_samples(uint64_t glean_handle,
-                                                  uint64_t metric_id,
+void glean_timing_distribution_accumulate_samples(uint64_t metric_id,
                                                   RawInt64Array raw_samples,
                                                   int32_t num_samples);
 
@@ -530,26 +471,21 @@ void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
 
 TimerId glean_timing_distribution_set_start(uint64_t metric_id, uint64_t start_time);
 
-void glean_timing_distribution_set_stop_and_accumulate(uint64_t glean_handle,
-                                                       uint64_t metric_id,
+void glean_timing_distribution_set_stop_and_accumulate(uint64_t metric_id,
                                                        TimerId timer_id,
                                                        uint64_t stop_time);
 
-int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t glean_handle,
-                                                               uint64_t metric_id,
+int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t metric_id,
                                                                int32_t error_type,
                                                                FfiStr storage_name);
 
-char *glean_timing_distribution_test_get_value_as_json_string(uint64_t glean_handle,
-                                                              uint64_t metric_id,
+char *glean_timing_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_timing_distribution_test_has_value(uint64_t glean_handle,
-                                                 uint64_t metric_id,
-                                                 FfiStr storage_name);
+uint8_t glean_timing_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_uuid_set(uint64_t glean_handle, uint64_t metric_id, FfiStr value);
+void glean_uuid_set(uint64_t metric_id, FfiStr value);
 
-char *glean_uuid_test_get_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+char *glean_uuid_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_uuid_test_has_value(uint64_t glean_handle, uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_uuid_test_has_value(uint64_t metric_id, FfiStr storage_name);

--- a/glean-core/ios/Glean/Metrics/BooleanMetric.swift
+++ b/glean-core/ios/Glean/Metrics/BooleanMetric.swift
@@ -54,7 +54,7 @@ public class BooleanMetricType {
         guard !self.disabled else { return }
 
         Dispatchers.shared.launchAPI {
-            glean_boolean_set(Glean.shared.handle, self.handle, value.toByte())
+            glean_boolean_set(self.handle, value.toByte())
         }
     }
 
@@ -70,7 +70,7 @@ public class BooleanMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_boolean_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_boolean_test_has_value(self.handle, pingName) != 0
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -92,6 +92,6 @@ public class BooleanMetricType {
             throw "Missing value"
         }
 
-        return glean_boolean_test_get_value(Glean.shared.handle, self.handle, pingName).toBool()
+        return glean_boolean_test_get_value(self.handle, pingName).toBool()
     }
 }

--- a/glean-core/ios/Glean/Metrics/CounterMetric.swift
+++ b/glean-core/ios/Glean/Metrics/CounterMetric.swift
@@ -54,7 +54,7 @@ public class CounterMetricType {
         guard !self.disabled else { return }
 
         Dispatchers.shared.launchAPI {
-            glean_counter_add(Glean.shared.handle, self.handle, amount)
+            glean_counter_add(self.handle, amount)
         }
     }
 
@@ -70,7 +70,7 @@ public class CounterMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_counter_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_counter_test_has_value(self.handle, pingName) != 0
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -92,7 +92,7 @@ public class CounterMetricType {
             throw "Missing value"
         }
 
-        return glean_counter_test_get_value(Glean.shared.handle, self.handle, pingName)
+        return glean_counter_test_get_value(self.handle, pingName)
     }
 
     /// Returns the number of errors recorded for the given metric.
@@ -109,7 +109,6 @@ public class CounterMetricType {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_counter_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/DatetimeMetric.swift
+++ b/glean-core/ios/Glean/Metrics/DatetimeMetric.swift
@@ -72,7 +72,6 @@ public class DatetimeMetricType {
 
         Dispatchers.shared.launchAPI {
             glean_datetime_set(
-                Glean.shared.handle,
                 self.handle,
                 Int32(components.year ?? 0),
                 UInt32(components.month ?? 0),
@@ -98,7 +97,7 @@ public class DatetimeMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_datetime_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_datetime_test_has_value(self.handle, pingName) != 0
     }
 
     /// Returns the string representation of the stored value for testing purposes only. This function
@@ -123,7 +122,6 @@ public class DatetimeMetricType {
 
         return String(
             freeingRustString: glean_datetime_test_get_value_as_string(
-                Glean.shared.handle,
                 self.handle,
                 pingName
             )
@@ -161,7 +159,6 @@ public class DatetimeMetricType {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_datetime_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/EventMetric.swift
+++ b/glean-core/ios/Glean/Metrics/EventMetric.swift
@@ -128,7 +128,6 @@ public class EventMetricType<ExtraKeysEnum: ExtraKeys> {
 
             withArrayOfCStrings(values) { values in
                 glean_event_record(
-                    Glean.shared.handle,
                     self.handle,
                     timestamp,
                     keys,
@@ -151,7 +150,7 @@ public class EventMetricType<ExtraKeysEnum: ExtraKeys> {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_event_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_event_test_has_value(self.handle, pingName) != 0
     }
 
     /// Deserializes an event in JSON into a RecordedEventData object.
@@ -198,7 +197,7 @@ public class EventMetricType<ExtraKeysEnum: ExtraKeys> {
         }
 
         let res = String(
-            freeingRustString: glean_event_test_get_value_as_json_string(Glean.shared.handle, self.handle, pingName)
+            freeingRustString: glean_event_test_get_value_as_json_string(self.handle, pingName)
         )
 
         do {
@@ -240,7 +239,6 @@ public class EventMetricType<ExtraKeysEnum: ExtraKeys> {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_event_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/MemoryDistributionMetric.swift
+++ b/glean-core/ios/Glean/Metrics/MemoryDistributionMetric.swift
@@ -52,7 +52,7 @@ public class MemoryDistributionMetricType {
         guard !self.disabled else { return }
 
         Dispatchers.shared.launchAPI {
-            return glean_memory_distribution_accumulate(self.handle, sample)
+            glean_memory_distribution_accumulate(self.handle, sample)
         }
     }
 

--- a/glean-core/ios/Glean/Metrics/MemoryDistributionMetric.swift
+++ b/glean-core/ios/Glean/Metrics/MemoryDistributionMetric.swift
@@ -52,7 +52,7 @@ public class MemoryDistributionMetricType {
         guard !self.disabled else { return }
 
         Dispatchers.shared.launchAPI {
-            return glean_memory_distribution_accumulate(Glean.shared.handle, self.handle, sample)
+            return glean_memory_distribution_accumulate(self.handle, sample)
         }
     }
 
@@ -68,7 +68,7 @@ public class MemoryDistributionMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_memory_distribution_test_has_value(Glean.shared.handle, self.handle, pingName).toBool()
+        return glean_memory_distribution_test_has_value(self.handle, pingName).toBool()
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -92,7 +92,6 @@ public class MemoryDistributionMetricType {
 
         let json = String(
             freeingRustString: glean_memory_distribution_test_get_value_as_json_string(
-                Glean.shared.handle,
                 self.handle,
                 pingName
             )
@@ -115,7 +114,6 @@ public class MemoryDistributionMetricType {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_memory_distribution_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/StringListMetric.swift
+++ b/glean-core/ios/Glean/Metrics/StringListMetric.swift
@@ -57,7 +57,7 @@ public class StringListMetricType {
         guard !self.disabled else { return }
 
         Dispatchers.shared.launchAPI {
-            glean_string_list_add(Glean.shared.handle, self.handle, value)
+            glean_string_list_add(self.handle, value)
         }
     }
 
@@ -72,7 +72,7 @@ public class StringListMetricType {
         Dispatchers.shared.launchAPI {
             let len = value.count
             withArrayOfCStrings(value) { value in
-                glean_string_list_set(Glean.shared.handle, self.handle, value, Int32(len))
+                glean_string_list_set(self.handle, value, Int32(len))
             }
         }
     }
@@ -89,7 +89,7 @@ public class StringListMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_string_list_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_string_list_test_has_value(self.handle, pingName) != 0
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -111,7 +111,7 @@ public class StringListMetricType {
             throw "Missing value"
         }
 
-        let cstr = glean_string_list_test_get_value_as_json_string(Glean.shared.handle, self.handle, pingName)!
+        let cstr = glean_string_list_test_get_value_as_json_string(self.handle, pingName)!
         let json = String(freeingRustString: cstr)
         let data = json.data(using: .utf8)!
         if let content = try JSONSerialization.jsonObject(with: data, options: []) as? [String] {
@@ -135,7 +135,6 @@ public class StringListMetricType {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_string_list_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/StringMetric.swift
+++ b/glean-core/ios/Glean/Metrics/StringMetric.swift
@@ -61,7 +61,7 @@ public class StringMetricType {
 
     /// Internal only, synchronous API for setting a string value.
     func setSync(_ value: String) {
-        glean_string_set(Glean.shared.handle, self.handle, value)
+        glean_string_set(self.handle, value)
     }
 
     /// Tests whether a value is stored for the metric for testing purposes only. This function will
@@ -76,7 +76,7 @@ public class StringMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_string_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_string_test_has_value(self.handle, pingName) != 0
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -98,7 +98,7 @@ public class StringMetricType {
             throw "Missing value"
         }
 
-        return String(freeingRustString: glean_string_test_get_value(Glean.shared.handle, self.handle, pingName))
+        return String(freeingRustString: glean_string_test_get_value(self.handle, pingName))
     }
 
     /// Returns the number of errors recorded for the given metric.
@@ -115,7 +115,6 @@ public class StringMetricType {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_string_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/TimespanMetric.swift
+++ b/glean-core/ios/Glean/Metrics/TimespanMetric.swift
@@ -57,7 +57,7 @@ public class TimespanMetricType {
         let startTime = timestampNanos()
 
         Dispatchers.shared.launchAPI {
-            glean_timespan_set_start(Glean.shared.handle, self.handle, startTime)
+            glean_timespan_set_start(self.handle, startTime)
         }
     }
 
@@ -72,7 +72,7 @@ public class TimespanMetricType {
         let stopTime = timestampNanos()
 
         Dispatchers.shared.launchAPI {
-            glean_timespan_set_stop(Glean.shared.handle, self.handle, stopTime)
+            glean_timespan_set_stop(self.handle, stopTime)
         }
     }
 
@@ -98,7 +98,7 @@ public class TimespanMetricType {
         guard !self.disabled else { return }
 
         Dispatchers.shared.launchAPI {
-            glean_timespan_set_raw_nanos(Glean.shared.handle, self.handle, elapsedNanos)
+            glean_timespan_set_raw_nanos(self.handle, elapsedNanos)
         }
     }
 
@@ -114,7 +114,7 @@ public class TimespanMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_timespan_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_timespan_test_has_value(self.handle, pingName) != 0
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -136,7 +136,7 @@ public class TimespanMetricType {
             throw "Missing value"
         }
 
-        return glean_timespan_test_get_value(Glean.shared.handle, self.handle, pingName)
+        return glean_timespan_test_get_value(self.handle, pingName)
     }
 
     /// Returns the number of errors recorded for the given metric.
@@ -153,7 +153,6 @@ public class TimespanMetricType {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_timespan_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/TimingDistributionMetric.swift
+++ b/glean-core/ios/Glean/Metrics/TimingDistributionMetric.swift
@@ -82,7 +82,6 @@ public class TimingDistributionMetricType {
 
         Dispatchers.shared.launchAPI {
             glean_timing_distribution_set_stop_and_accumulate(
-                Glean.shared.handle,
                 self.handle,
                 timerId,
                 stopTime
@@ -117,7 +116,7 @@ public class TimingDistributionMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_timing_distribution_test_has_value(Glean.shared.handle, self.handle, pingName).toBool()
+        return glean_timing_distribution_test_has_value(self.handle, pingName).toBool()
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -141,7 +140,6 @@ public class TimingDistributionMetricType {
 
         let json = String(
             freeingRustString: glean_timing_distribution_test_get_value_as_json_string(
-                Glean.shared.handle,
                 self.handle,
                 pingName
             )
@@ -164,7 +162,6 @@ public class TimingDistributionMetricType {
         let pingName = pingName ?? self.sendInPings[0]
 
         return glean_timing_distribution_test_get_num_recorded_errors(
-            Glean.shared.handle,
             self.handle,
             errorType.rawValue,
             pingName

--- a/glean-core/ios/Glean/Metrics/UuidMetric.swift
+++ b/glean-core/ios/Glean/Metrics/UuidMetric.swift
@@ -59,7 +59,7 @@ public class UuidMetricType {
         guard !self.disabled else { return }
 
         Dispatchers.shared.launchAPI {
-            glean_uuid_set(Glean.shared.handle, self.handle, value.uuidString.lowercased())
+            glean_uuid_set(self.handle, value.uuidString.lowercased())
         }
     }
 
@@ -75,7 +75,7 @@ public class UuidMetricType {
         Dispatchers.shared.assertInTestingMode()
 
         let pingName = pingName ?? self.sendInPings[0]
-        return glean_uuid_test_has_value(Glean.shared.handle, self.handle, pingName) != 0
+        return glean_uuid_test_has_value(self.handle, pingName) != 0
     }
 
     /// Returns the stored value for testing purposes only. This function will attempt to await the
@@ -97,7 +97,7 @@ public class UuidMetricType {
             throw "Missing value"
         }
 
-        let uuid = String(freeingRustString: glean_uuid_test_get_value(Glean.shared.handle, self.handle, pingName))
+        let uuid = String(freeingRustString: glean_uuid_test_get_value(self.handle, pingName))
 
         return UUID(uuidString: uuid)!
     }

--- a/glean-core/ios/GleanTests/Metrics/PingTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/PingTests.swift
@@ -118,7 +118,7 @@ class PingTests: XCTestCase {
 
         Glean.shared.submitPingsByName(pingNames: ["unknown"])
 
-        /// We wait for a timeout to happen, as we don't expect any data to be sent.
+        // We wait for a timeout to happen, as we don't expect any data to be sent.
         waitForExpectations(timeout: 5.0) { _ in
             XCTAssert(true, "Test didn't time out when it should")
         }

--- a/glean-core/python/glean/metrics/counter.py
+++ b/glean-core/python/glean/metrics/counter.py
@@ -6,7 +6,6 @@
 from typing import List, Optional
 
 
-from ..glean import Glean
 from .. import _ffi
 from .._dispatcher import Dispatcher
 from ..testing import ErrorType
@@ -65,7 +64,7 @@ class CounterMetricType:
 
         @Dispatcher.launch
         def add():
-            _ffi.lib.glean_counter_add(Glean._handle, self._handle, amount)
+            _ffi.lib.glean_counter_add(self._handle, amount)
 
     def test_has_value(self, ping_name: Optional[str] = None) -> bool:
         """
@@ -84,7 +83,7 @@ class CounterMetricType:
 
         return bool(
             _ffi.lib.glean_counter_test_has_value(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+                self._handle, _ffi.ffi_encode_string(ping_name)
             )
         )
 
@@ -106,7 +105,7 @@ class CounterMetricType:
             raise ValueError("metric has no value")
 
         return _ffi.lib.glean_counter_test_get_value(
-            Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+            self._handle, _ffi.ffi_encode_string(ping_name)
         )
 
     def test_get_num_recorded_errors(
@@ -128,10 +127,7 @@ class CounterMetricType:
             ping_name = self._send_in_pings[0]
 
         return _ffi.lib.glean_counter_test_get_num_recorded_errors(
-            Glean._handle,
-            self._handle,
-            error_type.value,
-            _ffi.ffi_encode_string(ping_name),
+            self._handle, error_type.value, _ffi.ffi_encode_string(ping_name),
         )
 
 

--- a/glean-core/python/glean/metrics/event.py
+++ b/glean-core/python/glean/metrics/event.py
@@ -7,7 +7,6 @@ import json
 from typing import Dict, List, Optional
 
 
-from ..glean import Glean
 from .. import _ffi
 from .._dispatcher import Dispatcher
 from ..testing import ErrorType
@@ -140,7 +139,6 @@ class EventMetricType:
                 nextra = len(extra)
 
             _ffi.lib.glean_event_record(
-                Glean._handle,
                 self._handle,
                 timestamp,
                 _ffi.ffi_encode_vec_int32(keys),
@@ -165,7 +163,7 @@ class EventMetricType:
 
         return bool(
             _ffi.lib.glean_event_test_has_value(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+                self._handle, _ffi.ffi_encode_string(ping_name)
             )
         )
 
@@ -190,7 +188,7 @@ class EventMetricType:
 
         json_string = _ffi.ffi_decode_string(
             _ffi.lib.glean_event_test_get_value_as_json_string(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+                self._handle, _ffi.ffi_encode_string(ping_name)
             )
         )
 
@@ -217,10 +215,7 @@ class EventMetricType:
             ping_name = self._send_in_pings[0]
 
         return _ffi.lib.glean_event_test_get_num_recorded_errors(
-            Glean._handle,
-            self._handle,
-            error_type.value,
-            _ffi.ffi_encode_string(ping_name),
+            self._handle, error_type.value, _ffi.ffi_encode_string(ping_name),
         )
 
 

--- a/glean-core/python/glean/metrics/labeled.py
+++ b/glean-core/python/glean/metrics/labeled.py
@@ -7,7 +7,6 @@ import abc
 from typing import Callable, List, Optional, Set, Type
 
 
-from ..glean import Glean
 from .. import _ffi
 from .counter import CounterMetricType
 from .lifetime import Lifetime
@@ -119,10 +118,7 @@ class LabeledMetricBase(abc.ABC):
             ping_name = self._send_in_pings[0]
 
         return self._test_get_num_recorded_errors_ffi(
-            Glean._handle,
-            self._handle,
-            error_type.value,
-            _ffi.ffi_encode_string(ping_name),
+            self._handle, error_type.value, _ffi.ffi_encode_string(ping_name),
         )
 
 

--- a/glean-core/python/glean/metrics/string.py
+++ b/glean-core/python/glean/metrics/string.py
@@ -6,7 +6,6 @@
 from typing import List, Optional
 
 
-from ..glean import Glean
 from .. import _ffi
 from .._dispatcher import Dispatcher
 from ..testing import ErrorType
@@ -65,9 +64,7 @@ class StringMetricType:
 
         @Dispatcher.launch
         def set():
-            _ffi.lib.glean_string_set(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(value)
-            )
+            _ffi.lib.glean_string_set(self._handle, _ffi.ffi_encode_string(value))
 
     def test_has_value(self, ping_name: Optional[str] = None) -> bool:
         """
@@ -86,7 +83,7 @@ class StringMetricType:
 
         return bool(
             _ffi.lib.glean_string_test_has_value(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+                self._handle, _ffi.ffi_encode_string(ping_name)
             )
         )
 
@@ -109,7 +106,7 @@ class StringMetricType:
 
         return _ffi.ffi_decode_string(
             _ffi.lib.glean_string_test_get_value(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+                self._handle, _ffi.ffi_encode_string(ping_name)
             )
         )
 
@@ -132,10 +129,7 @@ class StringMetricType:
             ping_name = self._send_in_pings[0]
 
         return _ffi.lib.glean_string_test_get_num_recorded_errors(
-            Glean._handle,
-            self._handle,
-            error_type.value,
-            _ffi.ffi_encode_string(ping_name),
+            self._handle, error_type.value, _ffi.ffi_encode_string(ping_name),
         )
 
 

--- a/glean-core/python/glean/metrics/uuid.py
+++ b/glean-core/python/glean/metrics/uuid.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 import uuid
 
 
-from ..glean import Glean
 from .. import _ffi
 from .._dispatcher import Dispatcher
 from ..testing import ErrorType
@@ -75,9 +74,7 @@ class UuidMetricType:
 
         @Dispatcher.launch
         def set():
-            _ffi.lib.glean_uuid_set(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(str(value))
-            )
+            _ffi.lib.glean_uuid_set(self._handle, _ffi.ffi_encode_string(str(value)))
 
     def test_has_value(self, ping_name: Optional[str] = None) -> bool:
         """
@@ -96,7 +93,7 @@ class UuidMetricType:
 
         return bool(
             _ffi.lib.glean_uuid_test_has_value(
-                Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+                self._handle, _ffi.ffi_encode_string(ping_name)
             )
         )
 
@@ -121,7 +118,7 @@ class UuidMetricType:
             "urn:uuid:"
             + _ffi.ffi_decode_string(
                 _ffi.lib.glean_uuid_test_get_value(
-                    Glean._handle, self._handle, _ffi.ffi_encode_string(ping_name)
+                    self._handle, _ffi.ffi_encode_string(ping_name)
                 )
             )
         )
@@ -145,10 +142,7 @@ class UuidMetricType:
             ping_name = self._send_in_pings[0]
 
         return _ffi.lib.glean_uuid_test_get_num_recorded_errors(
-            Glean._handle,
-            self._handle,
-            error_type.value,
-            _ffi.ffi_encode_string(ping_name),
+            self._handle, error_type.value, _ffi.ffi_encode_string(ping_name),
         )
 
 

--- a/glean-core/src/histogram/exponential.rs
+++ b/glean-core/src/histogram/exponential.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use once_cell::unsync::OnceCell;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
 use super::{Bucketing, Histogram};

--- a/glean-core/src/histogram/linear.rs
+++ b/glean-core/src/histogram/linear.rs
@@ -5,7 +5,7 @@
 use std::cmp;
 use std::collections::HashMap;
 
-use once_cell::unsync::OnceCell;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
 use super::{Bucketing, Histogram};

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -169,7 +169,7 @@ fn client_id_and_first_run_date_must_be_regenerated() {
     {
         let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
 
-        glean.data_store.clear_all();
+        glean.data_store.as_ref().unwrap().clear_all();
 
         assert!(glean
             .core_metrics


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1602751

This is finally addressing the changes to move Glean's state into the glean-core crate, dropping all use of a "glean handle" through the FFI.

This will ultimatively allow others to use Glean through FFI without relying on our direct platform wrappers (think application-service's use across dynamic library boundaries).

This is a huge change and touches all parts of the code base, so I'd like review from a bigger set of eyes.
I tried structuring the commits to make sense on their own.
The "Remove the glean handle from *" parts are mostly automatic simple code changes, the other commits contain the actual logic changes.

This leaves the user-facing API untouched (Android/iOS consumers will keep working).