### PR TITLE
Make Glean init in Kotlin fully async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * General:
   * `ping_type` is not included in the `ping_info` any more ([#653](https://github.com/mozilla/glean/pull/653)), the pipeline takes the value from the submission URL.
+* Android:
+  * The `Glean.initialize` method runs mostly off the main thread ([#672](https://github.com/mozilla/glean/pull/672)).
 
 # v24.2.0 (2020-02-11)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -107,7 +107,7 @@ internal object Dispatchers {
          * set to false prior to processing the queue, newly launched tasks should be executed
          * on the couroutine scope rather than added to the queue.
          */
-        internal fun flushQueuedInitialTasks() {
+        internal suspend fun flushQueuedInitialTasks() {
             val dispatcherObject = this
             // Dispatch a task to flush the pre-init tasks queue. By using `executeTask`
             // this will be executed as soon as possible, before other tasks are executed.
@@ -139,7 +139,7 @@ internal object Dispatchers {
                 if (overflowCount > 0) {
                     GleanError.preinitTasksOverflow.addSync(MAX_QUEUE_SIZE + overflowCount)
                 }
-            }
+            }?.join()
         }
 
         /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/WorkManagerUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/WorkManagerUtils.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
@@ -35,7 +36,7 @@ internal fun testFlushWorkManagerJob(context: Context, workTag: String, timeoutM
                         return@withTimeout
                     }
                 }
-            } while (true)
+            } while (isActive)
         }
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Dispatchers as KotlinDispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -107,7 +108,7 @@ class DispatchersTest {
         // Wait for the flushed tasks to be executed.
         runBlocking {
             withTimeoutOrNull(2000) {
-                while (threadCanary.get() != 3 || Dispatchers.API.taskQueue.size > 0) {
+                while (isActive && (threadCanary.get() != 3 || Dispatchers.API.taskQueue.size > 0)) {
                     delay(1)
                 }
             } ?: assertTrue("Timed out waiting for tasks to execute", false)
@@ -157,7 +158,7 @@ class DispatchersTest {
         runBlocking {
             // Ensure that all the required jobs have been added to the list.
             withTimeoutOrNull(2000) {
-                while (counter.get() < 100) {
+                while (isActive && counter.get() < 100) {
                     delay(1)
                 }
             } ?: assertEquals("Timed out waiting for tasks to execute", 100, counter.get())

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
@@ -6,7 +6,6 @@ package mozilla.telemetry.glean;
 
 import android.content.Context;
 
-import androidx.test.core.app.ApplicationProvider;
 import androidx.work.testing.WorkManagerTestInitHelper;
 
 import org.junit.Before;
@@ -25,7 +24,7 @@ public class GleanFromJavaTest {
     // callable from Java. If something goes wrong, it should complain about missing
     // methods at build-time.
 
-    private Context appContext = ApplicationProvider.getApplicationContext();
+    private Context appContext = TestUtilKt.getContextWithMockedInfo("java-test");
 
     @Before
     public void setup() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -13,6 +13,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.json.JSONObject
@@ -197,7 +198,7 @@ internal fun waitForEnqueuedWorker(
             if (getWorkerStatus(context, workTag).isEnqueued) {
                 return@withTimeout
             }
-        } while (true)
+        } while (isActive)
     }
 }
 


### PR DESCRIPTION
I tested this both using Fenix and the Glean SDK sample app: this seem to work as expected. Accumulated data is correctly accounted for and any pre-init dispatched piece of information is sent.

This PR additionally fixes some weird bugs we had in our testing code that made our tests hang forever under certain circumstances. Se the indivudual commit messages.

**TODO**

- [x] Take this for a manual QA, make sure it doesn't break
- [x] Think a bit more what changing `flushQueuedInitialTasks` implies
- [x] Test this in Fenix