### PR TITLE
Merge pull request #676 from mozilla/shellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ swiftlint: ## Run swiftlint to lint Swift code
 yamllint: ## Run yamllint to lint YAML files
 	yamllint glean-core .circleci
 
+shellcheck: ## Run shellcheck against important shell scripts
+	shellcheck glean-core/ios/sdk_generator.sh
+
 pythonlint: python-setup ## Run flake8 and black to lint Python code
 	$(GLEAN_PYENV)/bin/python3 -m flake8 glean-core/python/glean glean-core/python/tests
 	$(GLEAN_PYENV)/bin/python3 -m black --check glean-core/python

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -27,7 +27,9 @@ set -e
 
 GLEAN_PARSER_VERSION=1.15.5
 
-CMDNAME=$(basename $0)
+# CMDNAME is used in the usage text below.
+# shellcheck disable=SC2034
+CMDNAME=$(basename "$0")
 USAGE=$(cat <<'HEREDOC'
 $(CMDNAME)
 Glean Team <glean-team@mozilla.com>
@@ -63,11 +65,11 @@ helptext() {
     echo "$USAGE"
 }
 
-PARAMS=""
+declare -a PARAMS=()
 ALLOW_RESERVED=""
 GLEAN_NAMESPACE=Glean
 DOCS_DIRECTORY=""
-YAML_FILES=""
+declare -a YAML_FILES=()
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 
 while (( "$#" )); do
@@ -96,29 +98,29 @@ while (( "$#" )); do
             shift
             break
             ;;
-        -*|--*=) # unsupported flags
+        --*=|-*) # unsupported flags
             echo "Error: Unsupported flag $1" >&2
             exit 1
             ;;
         *) # preserve positional arguments
-            PARAMS="$PARAMS $1"
+            PARAMS+=("$1")
             shift
             ;;
     esac
 done
 
-if [ -n "$PARAMS" ]; then
-    YAML_FILES="$PARAMS"
+if [ "${#PARAMS[@]}" -gt 0 ]; then
+    YAML_FILES=("${PARAMS[@]}")
 else
     if [ -z "$SCRIPT_INPUT_FILE_COUNT" ] || [ "$SCRIPT_INPUT_FILE_COUNT" -eq 0 ]; then
         echo "warning: No input files specified."
         exit 0
     fi
 
-    for i in $(seq 0 $(expr $SCRIPT_INPUT_FILE_COUNT - 1)); do
+    for i in $(seq 0 $((SCRIPT_INPUT_FILE_COUNT - 1))); do
         infilevar="SCRIPT_INPUT_FILE_${i}"
         infile="${!infilevar}"
-        YAML_FILES="${YAML_FILES} ${infile}"
+        YAML_FILES+=("${infile}")
     done
 fi
 
@@ -137,32 +139,32 @@ fi
 VENVDIR="${SOURCE_ROOT}/.venv"
 
 [ -x "${VENVDIR}/bin/python" ] || python3 -m venv "${VENVDIR}"
-${VENVDIR}/bin/pip install --upgrade glean_parser==$GLEAN_PARSER_VERSION
+"${VENVDIR}"/bin/pip install --upgrade glean_parser==$GLEAN_PARSER_VERSION
 
 # Run the glinter
 # Turn its warnings into warnings visible in Xcode (but don't do for the success message)
-${VENVDIR}/bin/python -m glean_parser \
+"${VENVDIR}"/bin/python -m glean_parser \
     glinter \
     $ALLOW_RESERVED \
-    $YAML_FILES 2>&1 \
+    "${YAML_FILES[@]}" 2>&1 \
     | sed 's/^\(.\)/warning: \1/'  \
     | sed '/Your metrics are Glean/s/^warning: //'
 
-PARSER_OUTPUT=$(${VENVDIR}/bin/python -m glean_parser \
+PARSER_OUTPUT=$("${VENVDIR}"/bin/python -m glean_parser \
     translate \
     -f "swift" \
     -o "${OUTPUT_DIR}" \
     -s "glean_namespace=${GLEAN_NAMESPACE}" \
     $ALLOW_RESERVED \
-    $YAML_FILES 2>&1) || { echo "$PARSER_OUTPUT"; echo "error: glean_parser failed. See errors above."; exit 1; }
+    "${YAML_FILES[@]}" 2>&1) || { echo "$PARSER_OUTPUT"; echo "error: glean_parser failed. See errors above."; exit 1; }
 
 if [ -n "$DOCS_DIRECTORY" ]; then
-    ${VENVDIR}/bin/python -m glean_parser \
+    "${VENVDIR}"/bin/python -m glean_parser \
         translate \
         -f "markdown" \
         -o "${DOCS_DIRECTORY}" \
         $ALLOW_RESERVED \
-        $YAML_FILES
+        "${YAML_FILES[@]}"
 fi
 
 exit 0


### PR DESCRIPTION
The now-popular shellcheck tool is a static analysis tool for shell scripts.
It can detect common mistakes or potential bugs in shell scripts.

As the sdk_generator.sh is intended to be used by Glean users, we should
ensure it works across all systems and configurations.
This commit ran shellcheck against it and fixed all warnings and errors:

* Use shell arrays instead of appending to strings
* Properly quote paths to not fail when they contain spaces (not too uncommon on macOS after all)
* Rely on bash for expansion and math