### PR TITLE
Use simpler conversion between local and fixed offset

### DIFF
--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use chrono::offset::TimeZone;
 use chrono::{DateTime, FixedOffset, Local};
 
 use crate::error_recording::{record_error, ErrorType};
@@ -49,12 +48,8 @@ pub fn get_iso_time_string(datetime: DateTime<FixedOffset>, truncate_to: TimeUni
 ///
 /// This converts from the `Local` timezone into its fixed-offset equivalent.
 pub(crate) fn local_now_with_offset() -> DateTime<FixedOffset> {
-    // This looks more complicated than I imagined.
-
     let now: DateTime<Local> = Local::now();
-    let naive = now.naive_utc();
-    let fixed_tz = Local.offset_from_utc_datetime(&naive);
-    fixed_tz.from_utc_datetime(&naive)
+    now.with_timezone(now.offset())
 }
 
 /// Truncates a string, ensuring that it doesn't end in the middle of a codepoint.
@@ -119,6 +114,7 @@ pub(crate) fn truncate_string_at_boundary_with_error<S: Into<String>>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use chrono::offset::TimeZone;
 
     #[test]
     fn test_sanitize_application_id() {


### PR DESCRIPTION
For reasons chrono's API can be more cumbersome than I would like, but
converting between the system's local time and the same
system-independent fixed offset is doable in fewer lines.

Solution from
https://github.com/chronotope/chrono/issues/104#issuecomment-255655945