### PR TITLE
Add "open on github" link to docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,8 +306,12 @@ jobs:
       - run:
           name: Install mdbook
           command: |
-              wget https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.0/mdbook-v0.3.0-x86_64-unknown-linux-gnu.tar.gz
-              tar -xvf mdbook-v0.3.0-x86_64-unknown-linux-gnu.tar.gz
+              MDBOOK_VERSION=v0.3.5
+              MDBOOK="mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+              MDBOOK_SHA256=e03cc253650fa0b4780fab4d75df64c48d35d48f452fcf61c5ec0ae652f9bd8e
+              curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/rust-lang-nursery/mdBook/releases/download/${MDBOOK_VERSION}/${MDBOOK}"
+              echo "${MDBOOK_SHA256} *${MDBOOK}" | shasum -a 256 -c -
+              tar -xvf "${MDBOOK}"
               mv mdbook /usr/local/cargo/bin/mdbook
       - run:
           name: Build Rust documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,16 @@ jobs:
               tar -xvf "${MDBOOK}"
               mv mdbook /usr/local/cargo/bin/mdbook
       - run:
+          name: Install mdbook-open-on-gh
+          command: |
+              OPENON_VERSION=1.0.1
+              OPENON="mdbook-open-on-gh-${OPENON_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+              OPENON_SHA256=ca5901ef58844f5a6e6b84aa31d99fc0bab1dd7f7d6913e1d8399a6a2dc80955
+              curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/badboy/mdbook-open-on-gh/releases/download/${OPENON_VERSION}/${OPENON}"
+              echo "${OPENON_SHA256} *${OPENON}" | shasum -a 256 -c -
+              tar -xvf "${OPENON}"
+              mv mdbook-open-on-gh /usr/local/cargo/bin/mdbook-open-on-gh
+      - run:
           name: Build Rust documentation
           command: bin/build-rust-docs.sh
       - persist_to_workspace:

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -11,3 +11,6 @@ create-missing = false
 additional-css = ["tabs.css"]
 additional-js = ["tabs.js"]
 git-repository-url = "https://github.com/mozilla/glean"
+
+[preprocessor.open-on-gh]
+command = "mdbook-open-on-gh"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -10,3 +10,4 @@ create-missing = false
 [output.html]
 additional-css = ["tabs.css"]
 additional-js = ["tabs.js"]
+git-repository-url = "https://github.com/mozilla/glean"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,7 +8,7 @@ build-dir = "book"
 create-missing = false
 
 [output.html]
-additional-css = ["tabs.css"]
+additional-css = ["glean.css"]
 additional-js = ["tabs.js"]
 git-repository-url = "https://github.com/mozilla/glean"
 

--- a/docs/glean.css
+++ b/docs/glean.css
@@ -40,7 +40,8 @@
     padding: 6px 12px;
 }
 
-footer {
+/* The footer with the "Open on GitHub" link */
+footer#open-on-gh {
   font-size: 0.8em;
   text-align: center;
   border-top: 1px solid black;

--- a/docs/tabs.css
+++ b/docs/tabs.css
@@ -39,3 +39,10 @@
     border-top: none;
     padding: 6px 12px;
 }
+
+footer {
+  font-size: 0.8em;
+  text-align: center;
+  border-top: 1px solid black;
+  padding: 5px 0;
+}


### PR DESCRIPTION
After a comment from @mdboom I opted for quickly writing a plugin to add a "open on github" link to each page.

It looks like this (see the bottom):

![image](https://user-images.githubusercontent.com/2129/73443323-bf108200-4356-11ea-8947-6f9064848fd9.png)
