### PR TITLE
Disambiguate device model

### DIFF
--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -46,7 +46,7 @@ Optional fields are marked accordingly.
 | `architecture` | String | The architecture of the device (e.g. "arm", "x86") |
 | `client_id` | UUID |  *Optional* A UUID identifying a profile and allowing user-oriented correlation of data |
 | `device_manufacturer` | String | The manufacturer of the device |
-| `device_model` | String | The model name of the device |
+| `device_model` | String | The model name of the device. On Android, this is [`Build.MODEL`], the user-visible name of the device. |
 | `first_run_date` | Datetime | The date of the first run of the application, in local time and with day precision, including timezone information. |
 | `os` | String | The name of the operating system (e.g. "linux", "Android", "ios") |
 | `os_version` | String | The user-visible version of the operating system (e.g. "1.2.3") |
@@ -55,6 +55,8 @@ Optional fields are marked accordingly.
 | `locale` | String | The locale of the application (e.g. "es-ES") |
 
 All the metrics surviving application restarts (e.g. `client_id`, ...) are removed once the application using the Glean SDK is uninstalled.
+
+[`Build.MODEL`]: https://developer.android.com/reference/android/os/Build.html#MODEL
 
 ### The `experiments` object
 

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -92,8 +92,10 @@ glean.internal.metrics:
     lifetime: application
     send_in_pings:
       - glean_client_info
-    description: |
+    description: >
       The model of the device the application is running on.
+      On Android, this is Build.MODEL, the user-visible marketing name,
+      like "Pixel 2 XL".
     bugs:
       - https://bugzilla.mozilla.org/1522552
     data_reviews:


### PR DESCRIPTION
"Device model" can mean different things on Android; clarify that this is `Build.MODEL` and not e.g. `Build.DEVICE`.