### PR TITLE
1612940: Don't include null extras in experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     in the baseline ping ([`glean.baseline.locale`](https://github.com/mozilla/glean/blob/c261205d6e84d2ab39c50003a8ffc3bd2b763768/glean-core/metrics.yaml#L28-L42))
     is redundant and will be removed by the end of the quarter.
   * Drop the Glean handle and move state into glean-core ([#664](https://github.com/mozilla/glean/pull/664))
+  * If an experiment includes no `extra` fields, it will no longer include `{"extra": null}` in the JSON paylod.
 * Android:
   * Collections performed before initialization (preinit tasks) are now dispatched off
     the main thread during initialization.

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -150,7 +150,7 @@ impl Metric {
             }
             Metric::CustomDistributionLinear(hist) => json!(custom_distribution::snapshot(hist)),
             Metric::Datetime(d, time_unit) => json!(get_iso_time_string(*d, *time_unit)),
-            Metric::Experiment(e) => json!(e),
+            Metric::Experiment(e) => e.as_json(),
             Metric::Quantity(q) => json!(q),
             Metric::String(s) => json!(s),
             Metric::StringList(v) => json!(v),

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -232,8 +232,6 @@ mod test {
         assert!(empty_snapshot.is_none());
     }
 
-    // Experiment's API tests: the next test comes from glean-ac's
-    // ExperimentsStorageEngineTest.kt.
     #[test]
     fn test_experiments_json_serialization_empty() {
         let t = tempfile::tempdir().unwrap();
@@ -246,7 +244,6 @@ mod test {
         let snapshot = StorageManager
             .snapshot_experiments_as_json(glean.storage(), "glean_internal_info")
             .unwrap();
-        print!("{:?}", snapshot);
         assert_eq!(
             json!({"some-experiment": {"branch": "test-branch"}}),
             snapshot

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -231,4 +231,31 @@ mod test {
             StorageManager.snapshot_experiments_as_json(glean.storage(), "glean_internal_info");
         assert!(empty_snapshot.is_none());
     }
+
+    // Experiment's API tests: the next test comes from glean-ac's
+    // ExperimentsStorageEngineTest.kt.
+    #[test]
+    fn test_experiments_json_serialization_empty() {
+        let t = tempfile::tempdir().unwrap();
+        let name = t.path().display().to_string();
+        let glean = Glean::with_options(&name, "org.mozilla.glean", true).unwrap();
+
+        let metric = ExperimentMetric::new(&glean, "some-experiment".to_string());
+
+        metric.set_active(&glean, "test-branch".to_string(), None);
+        let snapshot = StorageManager
+            .snapshot_experiments_as_json(glean.storage(), "glean_internal_info")
+            .unwrap();
+        print!("{:?}", snapshot);
+        assert_eq!(
+            json!({"some-experiment": {"branch": "test-branch"}}),
+            snapshot
+        );
+
+        metric.set_inactive(&glean);
+
+        let empty_snapshot =
+            StorageManager.snapshot_experiments_as_json(glean.storage(), "glean_internal_info");
+        assert!(empty_snapshot.is_none());
+    }
 }


### PR DESCRIPTION
I couldn't find a magic serde incantation to have a different behavior on JSON vs. bincode, so I came up with this.  But maybe there's something I missed...