### PR TITLE
Synchronize glean-preview tests on a global lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,7 @@ commands:
           rust-version: <<parameters.rust-version>>
       - run:
           name: Test
-          command: cargo test --all ---exclude glean-preview --verbose
-      - run:
-          name: Test glean-preview
-          command:
-            # Because glean_preview is a global-singleton, we need to run the tests
-            # single-threaded to avoid different tests stomping over each other.
-            cargo test -p glean-preview -- --test-threads=1
+          command: cargo test --all --verbose
 
   install-rustup:
     steps:

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,10 @@ build-python: python-setup build-rust ## Build the Python bindings
 test: test-rust
 
 test-rust: ## Run Rust tests for glean-core and glean-ffi
-	cargo test --all --exclude glean-preview
+	cargo test --all
 
 test-rust-with-logs: ## Run all Rust tests with debug logging and single-threaded
 	RUST_LOG=glean_core=debug cargo test --all -- --nocapture --test-threads=1
-
-test-preview: ## Run Rust tests for glean-preview
-	cargo test -p glean-preview -- --test-threads=1
 
 test-kotlin: ## Run all Kotlin tests
 	./gradlew test


### PR DESCRIPTION
Because glean_preview is a global-singleton, we need to run the tests one-by-one to avoid different tests stomping over each other.
This is only an issue because we're resetting Glean, this cannot happen in normal use of glean-preview.

We use a global lock to force synchronization of all tests, even if run multi-threaded.
This allows us to run without `--test-threads 1`.

---

Other options I tried:

* `#[ignore]` -- we use that else where and we still need to pass `--test-threads 1` to make it work reliably
* Gating on a cargo feature -- we still need to pass `--test-threads 1` to make it work reliably