### PR TITLE
Send a `baseline` at startup if the previous session ended abruptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Android:
   * Collections performed before initialization (preinit tasks) are now dispatched off
     the main thread during initialization.
+  * The baseline ping will now include `reason` codes that indicate why it was
+    submitted. If an unclean shutdown is detected (e.g. due to force-close), this
+    ping will be sent at startup with `reason: dirty_startup`.
 * iOS:
   * Collections performed before initialization (preinit tasks) are now dispatched off
     the main thread and not awaited during initialization.

--- a/docs/user/pings/baseline.md
+++ b/docs/user/pings/baseline.md
@@ -3,13 +3,13 @@
 ## Description
 
 This ping is intended to provide metrics that are managed by the library itself, and not explicitly set by the application or included in the application's `metrics.yaml` file.
-If the application crashes no `baseline` ping is sent, no additional ping is generated with the data from before the crash.
 
 > **Note:** As the `baseline` ping was specifically designed for mobile operating systems, it is not sent when using the Glean Python bindings.
 
 ## Scheduling
 
-The `baseline` ping is automatically sent when the application is moved to the [background](index.md#defining-background-state).
+The `baseline` ping is automatically submitted with a `reason: background` when the application is moved to the [background](index.md#defining-background-state).
+The `baseline` ping will be submitted at startup with a `reason: dirty_startup`, if the previous session was not cleanly closed. This only happens from the second start.
 
 ## Contents
 
@@ -17,7 +17,7 @@ The baseline ping includes the following fields:
 
 | Field name | Type | Description |
 |---|---|---|
-| `duration` | Timespan | The duration, in seconds, of the last foreground session. [^1]  |
+| `duration` | Timespan | The duration, in seconds, of the last foreground session. Only available if `reason: background`. [^1]  |
 | `locale` | String | The locale of the application. |
 
 [^1]: A quick note about the `duration` metric: it measures specifically the time that the user spent in the last foreground session.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -70,6 +70,10 @@ internal interface LibGleanFFI : Library {
 
     fun glean_clear_application_lifetime_metrics()
 
+    fun glean_set_dirty_flag(flag: Byte)
+
+    fun glean_is_dirty_flag_set(): Byte
+
     fun glean_test_clear_all_stores()
 
     fun glean_is_first_run(): Byte

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
@@ -4,7 +4,6 @@
 
 package mozilla.telemetry.glean.scheduler
 
-import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -15,9 +14,7 @@ import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
  * Connects process lifecycle events from Android to Glean's handleEvent
  * functionality (where the actual work of sending pings is done).
  */
-internal class GleanLifecycleObserver(
-    private val applicationContext: Context
-) : LifecycleEventObserver {
+internal class GleanLifecycleObserver : LifecycleEventObserver {
     /**
      * Called when lifecycle events are triggered.
      */

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
@@ -7,8 +7,11 @@ package mozilla.telemetry.glean.scheduler
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
+import mozilla.telemetry.glean.rust.LibGleanFFI
+import mozilla.telemetry.glean.rust.toByte
 
 /**
  * Connects process lifecycle events from Android to Glean's handleEvent
@@ -25,6 +28,15 @@ internal class GleanLifecycleObserver : LifecycleEventObserver {
                 // on foreground.
                 GleanBaseline.duration.stop()
                 Glean.handleBackgroundEvent()
+
+                // Clear the "dirty flag" as the last thing when going to background.
+                // If the application is not being force-closed, we should still be
+                // alive and allowed to change this. If we're being force-closed and
+                // don't get to this point, next time Glean runs it will be detected.
+                @Suppress("EXPERIMENTAL_API_USAGE")
+                Dispatchers.API.launch {
+                    LibGleanFFI.INSTANCE.glean_set_dirty_flag(false.toByte())
+                }
             }
             Lifecycle.Event.ON_START -> {
                 // Updates the baseline.duration metric when entering the foreground.
@@ -39,6 +51,12 @@ internal class GleanLifecycleObserver : LifecycleEventObserver {
                 // because it belongs to the baseline ping and that ping is sent every
                 // time the app goes to background.
                 GleanBaseline.duration.start()
+
+                // Set the "dirty flag" to `true`.
+                @Suppress("EXPERIMENTAL_API_USAGE")
+                Dispatchers.API.launch {
+                    LibGleanFFI.INSTANCE.glean_set_dirty_flag(true.toByte())
+                }
             }
             else -> {
                 // For other lifecycle events, do nothing

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -203,7 +203,7 @@ class GleanTest {
         // Fake calling the lifecycle observer.
         val lifecycleOwner = mock(LifecycleOwner::class.java)
         val lifecycleRegistry = LifecycleRegistry(lifecycleOwner)
-        val gleanLifecycleObserver = GleanLifecycleObserver(context)
+        val gleanLifecycleObserver = GleanLifecycleObserver()
         lifecycleRegistry.addObserver(gleanLifecycleObserver)
 
         try {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -26,6 +26,7 @@ import mozilla.telemetry.glean.private.PingType
 import mozilla.telemetry.glean.private.StringMetricType
 import mozilla.telemetry.glean.rust.LibGleanFFI
 import mozilla.telemetry.glean.rust.toBoolean
+import mozilla.telemetry.glean.rust.toByte
 import mozilla.telemetry.glean.scheduler.GleanLifecycleObserver
 import mozilla.telemetry.glean.scheduler.DeletionPingUploadWorker
 import mozilla.telemetry.glean.scheduler.PingUploadWorker
@@ -244,6 +245,45 @@ class GleanTest {
         } finally {
             server.shutdown()
             lifecycleRegistry.removeObserver(gleanLifecycleObserver)
+        }
+    }
+
+    @Test
+    fun `test sending of startup baseline ping`() {
+        // Set the dirty flag.
+        LibGleanFFI.INSTANCE.glean_set_dirty_flag(true.toByte())
+
+        // Restart glean and don't clear the stores.
+        val server = getMockWebServer()
+        val context = getContextWithMockedInfo()
+        resetGlean(context, Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ), false)
+
+        try {
+            // Trigger worker task to upload the pings in the background
+            triggerWorkManager(context)
+
+            val request = server.takeRequest(20L, TimeUnit.SECONDS)
+            val docType = request.path.split("/")[3]
+            assertEquals("The received ping must be a 'baseline' ping", "baseline", docType)
+
+            val baselineJson = JSONObject(request.body.readUtf8())
+            assertEquals("dirty_startup", baselineJson.getJSONObject("ping_info")["reason"])
+            checkPingSchema(baselineJson)
+
+            val baselineMetricsObject = baselineJson.getJSONObject("metrics")
+            val baselineStringMetrics = baselineMetricsObject.getJSONObject("string")
+            assertEquals(1, baselineStringMetrics.length())
+            assertNotNull(baselineStringMetrics.get("glean.baseline.locale"))
+
+            assertFalse(
+                "The baseline ping from startup must not have a duration",
+                baselineMetricsObject.has("timespan")
+            )
+        } finally {
+            server.shutdown()
         }
     }
 

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -202,6 +202,8 @@ uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
  */
 uint8_t glean_initialize(const FfiConfiguration *cfg);
 
+uint8_t glean_is_dirty_flag_set(void);
+
 uint8_t glean_is_first_run(void);
 
 uint8_t glean_is_upload_enabled(void);
@@ -399,6 +401,8 @@ int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
 uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 void glean_register_ping_type(uint64_t ping_type_handle);
+
+void glean_set_dirty_flag(uint8_t flag);
 
 void glean_set_experiment_active(FfiStr experiment_id,
                                  FfiStr branch,

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -300,6 +300,16 @@ pub extern "C" fn glean_clear_application_lifetime_metrics() {
 }
 
 #[no_mangle]
+pub extern "C" fn glean_set_dirty_flag(flag: u8) {
+    with_glean_value_mut(|glean| glean.set_dirty_flag(flag != 0));
+}
+
+#[no_mangle]
+pub extern "C" fn glean_is_dirty_flag_set() -> u8 {
+    with_glean_value(|glean| glean.is_dirty_flag_set())
+}
+
+#[no_mangle]
 pub extern "C" fn glean_test_clear_all_stores() {
     with_glean_value(|glean| glean.test_clear_all_stores())
 }

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -202,6 +202,8 @@ uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
  */
 uint8_t glean_initialize(const FfiConfiguration *cfg);
 
+uint8_t glean_is_dirty_flag_set(void);
+
 uint8_t glean_is_first_run(void);
 
 uint8_t glean_is_upload_enabled(void);
@@ -399,6 +401,8 @@ int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
 uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 void glean_register_ping_type(uint64_t ping_type_handle);
+
+void glean_set_dirty_flag(uint8_t flag);
 
 void glean_set_experiment_active(FfiStr experiment_id,
                                  FfiStr branch,

--- a/glean-core/pings.yaml
+++ b/glean-core/pings.yaml
@@ -19,10 +19,20 @@ baseline:
   include_client_id: true
   bugs:
     - https://bugzilla.mozilla.org/1512938
+    - https://bugzilla.mozilla.org/1599877
   data_reviews:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
   notification_emails:
     - glean-team@mozilla.com
+  reasons:
+    dirty_startup: |
+      The ping was submitted at startup, because the application process was
+      killed before the Glean SDK had the chance to generate this ping, when
+      going to background, in the last session.
+
+      *Note*: this ping will not contain the `glean.baseline.duration` metric.
+    background: |
+      The ping was submitted before going to background.
 
 metrics:
   description: >

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -57,6 +57,9 @@ lazy_static! {
         Uuid::parse_str("c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0").unwrap();
 }
 
+// An internal ping name, not to be touched by anything else
+pub(crate) const INTERNAL_STORAGE: &str = "glean_internal_info";
+
 /// The global Glean instance.
 ///
 /// This is the singleton used by all wrappers to allow for a nice API.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::error_recording::{test_get_num_recorded_errors, ErrorType};
 use crate::event_database::EventDatabase;
 use crate::internal_metrics::CoreMetrics;
 use crate::internal_pings::InternalPings;
-use crate::metrics::PingType;
+use crate::metrics::{Metric, MetricType, PingType};
 use crate::ping::PingMaker;
 use crate::storage::StorageManager;
 use crate::util::{local_now_with_offset, sanitize_application_id};
@@ -577,6 +577,50 @@ impl Glean {
     /// Return whether or not this is the first run on this profile.
     pub fn is_first_run(&self) -> bool {
         self.is_first_run
+    }
+
+    fn get_dirty_bit_metric(&self) -> metrics::BooleanMetric {
+        metrics::BooleanMetric::new(CommonMetricData {
+            name: "dirtybit".into(),
+            // We don't need a category, the name is already unique
+            category: "".into(),
+            send_in_pings: vec![INTERNAL_STORAGE.into()],
+            lifetime: Lifetime::User,
+            ..Default::default()
+        })
+    }
+
+    /// ** This is not meant to be used directly.**
+    ///
+    /// Set the value of a "dirty flag" in the permanent storage.
+    /// The "dirty flag" is meant to have the following behaviour, implemented
+    /// by the consumers of the FFI layer:
+    ///
+    /// - on mobile: set to `false` when going to background or shutting down,
+    ///   set to `true` at startup and when going to foreground.
+    /// - on non-mobile platforms: set to `true` at startup and `false` at
+    ///   shutdown.
+    ///
+    /// At startup, before setting its new value, if the "dirty flag" value is
+    /// `true`, then Glean knows it did not exit cleanly and can implement
+    /// coping mechanisms (e.g. sending a `baseline` ping).
+    pub fn set_dirty_flag(&self, new_value: bool) {
+        self.get_dirty_bit_metric().set(self, new_value);
+    }
+
+    /// ** This is not meant to be used directly.**
+    ///
+    /// Check the stored value of the "dirty flag".
+    pub fn is_dirty_flag_set(&self) -> bool {
+        let dirty_bit_metric = self.get_dirty_bit_metric();
+        match StorageManager.snapshot_metric(
+            self.storage(),
+            INTERNAL_STORAGE,
+            &dirty_bit_metric.meta().identifier(self),
+        ) {
+            Some(Metric::Boolean(b)) => b,
+            _ => false,
+        }
     }
 
     /// **Test-only API (exported for FFI purposes).**

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -552,3 +552,36 @@ fn test_first_run() {
         assert!(!glean.is_first_run());
     }
 }
+
+#[test]
+fn test_dirty_bit() {
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+    {
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        // The dirty flag must not be set the first time Glean runs.
+        assert!(!glean.is_dirty_flag_set());
+
+        // Set the dirty flag and check that it gets correctly set.
+        glean.set_dirty_flag(true);
+        assert!(glean.is_dirty_flag_set());
+    }
+
+    {
+        // Check that next time Glean runs, it correctly picks up the "dirty flag".
+        // It is expected to be 'true'.
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        assert!(glean.is_dirty_flag_set());
+
+        // Set the dirty flag to false.
+        glean.set_dirty_flag(false);
+        assert!(!glean.is_dirty_flag_set());
+    }
+
+    {
+        // Check that next time Glean runs, it correctly picks up the "dirty flag".
+        // It is expected to be 'false'.
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        assert!(!glean.is_dirty_flag_set());
+    }
+}

--- a/glean-core/src/metrics/experiment.rs
+++ b/glean-core/src/metrics/experiment.rs
@@ -14,10 +14,7 @@ use crate::util::{truncate_string_at_boundary, truncate_string_at_boundary_with_
 use crate::CommonMetricData;
 use crate::Glean;
 use crate::Lifetime;
-
-// FIXME: this should be shared?
-// An internal ping name, not to be touched by anything else
-const INTERNAL_STORAGE: &str = "glean_internal_info";
+use crate::INTERNAL_STORAGE;
 
 /// The maximum length of the experiment id, the branch id, and the keys of the
 /// `extra` map. Identifiers longer than this number of characters are truncated.

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -15,10 +15,7 @@ use crate::common_metric_data::{CommonMetricData, Lifetime};
 use crate::metrics::{CounterMetric, DatetimeMetric, Metric, MetricType, PingType, TimeUnit};
 use crate::storage::StorageManager;
 use crate::util::{get_iso_time_string, local_now_with_offset};
-use crate::{Glean, Result};
-
-// An internal ping name, not to be touched by anything else
-const INTERNAL_STORAGE: &str = "glean_internal_info";
+use crate::{Glean, Result, INTERNAL_STORAGE};
 
 /// Collect a ping's data, assemble it into its full payload and store it on disk.
 pub struct PingMaker;


### PR DESCRIPTION
This attempts to address the problem of 'force-close' interfering with the `baseline` ping. It implements the following logic:

**In addition to the current behaviour:**

- when the Glean SDK is initialized, it checks for a dirty flag:
  - if the flag is set, it generates a baseline ping with reason `dirty_startup` (a new standard field being added to all pings, see #649 );
  - if the flag is not set, then set it to true;
- when going to background, clear the dirty flag after computing the foreground duration and submitting the baseline ping.

This will guarantee that whenever the product using the Glean SDK is force-closed or crashes before it has the chance to send a baseline ping with a specific reason, signaling that there was a dirty flag set.

_Important_: there will be no foreground duration reported with the baseline ping with reason “dirty-startup”.

**TODO**

- [x] Add test coverage in Kotlin
- [x] Add a changelog entry