### PR TITLE
Run Kotlin tests only once in debug configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
       - skip-if-doc-only
       - run:
           name: Android tests
-          command: ./gradlew --no-daemon test
+          command: ./gradlew --no-daemon :glean:testDebugUnitTest
           environment:
             GRADLE_OPTS: -Xmx2048m
             TARGET_CFLAGS: -DNDEBUG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,21 +322,22 @@ jobs:
       - android-setup
       - skip-if-doc-only
       - run:
+          name: Restrict to Linux builds only
+          command: |
+              echo "rust.targets=linux-x86-64" > local.properties
+      - run:
           name: Android tests
           command: ./gradlew --no-daemon :glean:testDebugUnitTest
           environment:
             GRADLE_OPTS: -Xmx2048m
             TARGET_CFLAGS: -DNDEBUG
-      - store_artifacts:
-          path: glean-core/android/build/rustJniLibs/android
-          destination: libs
       - run:
           name: Save test results
           command: |
-            mkdir -p ~/test-results/junit/
-            mkdir -p ~/test-results/tests/
-            cp -a glean-core/android/build/reports/tests ~/test-results/
-            find glean-core/android/build -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+              mkdir -p ~/test-results/junit/
+              mkdir -p ~/test-results/tests/
+              cp -a glean-core/android/build/reports/tests ~/test-results/
+              find glean-core/android/build -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
           when: always
       - store_artifacts:
           path: ~/test-results/tests

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-rust-with-logs: ## Run all Rust tests with debug logging and single-threade
 	RUST_LOG=glean_core=debug cargo test --all -- --nocapture --test-threads=1
 
 test-kotlin: ## Run all Kotlin tests
-	./gradlew test
+	./gradlew :glean:testDebugUnitTest
 
 test-swift: ## Run all Swift tests
 	bin/run-ios-tests.sh


### PR DESCRIPTION
The default test target runs both testDebugUnitTest and testReleaseUnitTest, effectively running everything twice.
This seems like a waste of resources (and time) and just running it once seems fine.

Now we could decide to run testReleaseUnitTest on CI, but testDebugUnitTest for developer machines.