### PR TITLE
Avoid race-condition and thus tackle intermittent

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
@@ -72,7 +72,7 @@ class DispatchersTest {
     @Test
     fun `queued tasks are flushed off the main thread`() {
         val mainThread = Thread.currentThread()
-        var threadCanary = 0
+        val threadCanary = AtomicInteger()
 
         // By setting testing mode to false, we make sure that things
         // are executed asynchronously.
@@ -88,13 +88,13 @@ class DispatchersTest {
                     mainThread,
                     Thread.currentThread()
                 )
-                threadCanary += 1
+                threadCanary.incrementAndGet()
             }
         }
 
         assertEquals("Task queue contains the correct number of tasks",
             3, Dispatchers.API.taskQueue.size)
-        assertEquals("Tasks have not run while in queue", 0, threadCanary)
+        assertEquals("Tasks have not run while in queue", 0, threadCanary.get())
 
         // Now trigger execution to ensure the tasks fired
         Dispatchers.API.flushQueuedInitialTasks()
@@ -102,7 +102,7 @@ class DispatchersTest {
         // Wait for the flushed tasks to be executed.
         runBlocking {
             withTimeoutOrNull(2000) {
-                while (threadCanary == 2) {
+                while (threadCanary.get() == 2) {
                     delay(1)
                 }
             } ?: assertTrue("Timed out waiting for tasks to execute", false)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
@@ -102,12 +102,13 @@ class DispatchersTest {
         // Wait for the flushed tasks to be executed.
         runBlocking {
             withTimeoutOrNull(2000) {
-                while (threadCanary.get() == 2) {
+                while (threadCanary.get() != 3) {
                     delay(1)
                 }
             } ?: assertTrue("Timed out waiting for tasks to execute", false)
         }
 
+        assertEquals("All tasks ran to completion", 3, threadCanary.get())
         assertEquals("Task queue is cleared", 0, Dispatchers.API.taskQueue.size)
     }
 


### PR DESCRIPTION
Across multiple async tasks it's better to use an atomic integer.
We also need to wait for all of them to complete.