### PR TITLE
1609442 - Test that a startup ping contains the old version after an upgrade 

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -126,15 +126,16 @@ internal fun resetGlean(
 }
 
 /**
- * Get a context that contains [PackageInfo.versionName] mocked to
- * "glean.version.name".
+ * Get a context that contains [PackageInfo.versionName] mocked to the passed value
+ * or "glean.version.name" by default.
  *
+ * @param versionName a [String] used as the display version (default: "glean.version.name").
  * @return an application [Context] that can be used to init Glean
  */
-internal fun getContextWithMockedInfo(): Context {
+internal fun getContextWithMockedInfo(versionName: String = "glean.version.name"): Context {
     val context = Mockito.spy<Context>(ApplicationProvider.getApplicationContext<Context>())
     val packageInfo = Mockito.mock(PackageInfo::class.java)
-    packageInfo.versionName = "glean.version.name"
+    packageInfo.versionName = versionName
     val packageManager = Mockito.mock(PackageManager::class.java)
     Mockito.`when`(
         packageManager.getPackageInfo(

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -30,6 +30,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.anyBoolean
@@ -54,6 +55,19 @@ class MetricsPingSchedulerTest {
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
         Glean.enableTestingMode()
+    }
+
+    @After
+    fun cleanup() {
+        // Always reset Glean to clear all data.
+        // It might not have been initialized, but the reset functions handle that.
+        resetGlean(clearStores = true)
+
+        // Once all data is cleared, destroy the handle.
+        // Individual tests will start Glean if necessary.
+        Glean.testDestroyGleanHandle()
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.setTaskQueueing(true)
     }
 
     @Test
@@ -476,8 +490,6 @@ class MetricsPingSchedulerTest {
 
         // We expect the worker to be scheduled.
         assertNotNull(Glean.metricsPingScheduler.timer)
-
-        resetGlean(clearStores = true)
     }
 
     @Test


### PR DESCRIPTION
also fixes that the MPS tests hang when run in isolation.