### PR TITLE
Bug 1614785 - Add clearing of app lifetime metrics after sending metrics ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   * The baseline ping will now include `reason` codes that indicate why it was
     submitted. If an unclean shutdown is detected (e.g. due to force-close), this
     ping will be sent at startup with `reason: dirty_startup`.
+  * Per [Bug 1614785](https://bugzilla.mozilla.org/show_bug.cgi?id=1614785), the
+    clearing of application lifetime metrics now occurs after the metrics ping is
+    sent in order to preserve values meant to be included in the startup metrics
+    ping.
 
 # v24.2.0 (2020-02-11)
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -65,6 +65,7 @@ public class Glean {
     ///       If disabled, all persisted metrics, events and queued pings (except
     ///       first_run_date) are cleared.
     ///     * configuration: A Glean `Configuration` object with global settings.
+    // swiftlint:disable function_body_length
     public func initialize(uploadEnabled: Bool,
                            configuration: Configuration = Configuration()) {
         if self.isInitialized() {
@@ -102,7 +103,13 @@ public class Glean {
             self.pingTypeQueue.removeAll()
         }
 
-        initializeCoreMetrics()
+        // If this is the first time ever the Glean SDK runs, make sure to set
+        // some initial core metrics in case we need to generate early pings.
+        // The next times we start, we would have them around already.
+        let isFirstRun = glean_is_first_run().toBool()
+        if isFirstRun {
+            initializeCoreMetrics()
+        }
 
         // Deal with any pending events so we can start recording new ones
         Dispatchers.shared.serialOperationQueue.addOperation {
@@ -116,13 +123,26 @@ public class Glean {
         // Check for overdue metrics pings
         metricsPingScheduler.schedule()
 
+        // From the second time we run, after all startup pings are generated,
+        // make sure to clear `lifetime: application` metrics and set them again.
+        // Any new value will be sent in newly generted pings after startup.
+        // NOTE: we are adding this directly to the serialOperationQueue which
+        // bypasses the queue for initial tasks, otherwise this could get lost
+        // if the initial tasks queue overflows.
+        if !isFirstRun {
+            Dispatchers.shared.serialOperationQueue.addOperation {
+                glean_clear_application_lifetime_metrics()
+                self.initializeCoreMetrics()
+            }
+        }
+
         // Signal Dispatcher that init is complete
         Dispatchers.shared.flushQueuedInitialTasks()
 
         // Check if the "dirty flag" is set. That means the product was probably
         // force-closed. If that's the case, submit a 'baseline' ping with the
         // reason "dirty_startup". We only do that from the second run.
-        if !glean_is_first_run().toBool() {
+        if !isFirstRun {
             Dispatchers.shared.launchAPI {
                 if glean_is_dirty_flag_set().toBool() {
                     self.submitPingByNameSync(


### PR DESCRIPTION
This is the iOS equivalent to [Bug 1604862](https://bugzilla.mozilla.org/show_bug.cgi?id=1604862)