### PR TITLE
1609169: Fix deploying Python wheels to Github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ commands:
             GHR=ghr_v0.13.0_linux_amd64
             GHR_SHA256=c428627270ae26e206cb526cb8c7bdfba475dd278f6691ddaf863355adadfa13
             curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/tcnksm/ghr/releases/download/v0.13.0/${GHR}.tar.gz"
-            echo "${GHR_SHA256} *${GHR}.tar.gz" | shasum -a 256 -c -
+            echo "${GHR_SHA256} *${GHR}.tar.gz" | sha256sum -c -
             tar -xf "${GHR}.tar.gz"
             cp ./${GHR}/ghr ghr
 


### PR DESCRIPTION
The Docker image used for Linux wheels has an ancient version of Perl that ships `sha256sum` but not the generic `shasum`.