### PR TITLE
1609735: Python: Add instrumentation when overflowing preinit queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
     clearing of application lifetime metrics now occurs after the metrics ping is
     sent in order to preserve values meant to be included in the startup metrics
     ping.
+* Python:
+  * When the pre-init task queue overruns, this is now recorded in the metric
+    `glean.error.preinit_tasks_overflow`.
 
 # v24.2.0 (2020-02-11)
 


### PR DESCRIPTION
This is a Python port of https://github.com/mozilla/glean/pull/657