### PR TITLE
Test that exceptions in dispatched actions are correctly handled

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
@@ -200,7 +200,7 @@ class DispatchersTest {
             throw Exception("Test exception for DispatchersTest")
         }
 
-        // Add 3 tasks to queue each one setting threadCanary to true
+        // Add 3 tasks to queue each one increments threadCanary
         // to indicate if any task has ran.
         repeat(3) {
             Dispatchers.API.launch {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/DispatchersTest.kt
@@ -178,4 +178,50 @@ class DispatchersTest {
             assertEquals("This list is out of order $orderedList", num, orderedList[num])
         }
     }
+
+    @Test
+    fun `dispatched tasks throwing exceptions are correctly handled`() {
+        val mainThread = Thread.currentThread()
+        val threadCanary = AtomicInteger()
+
+        // By setting testing mode to false, we make sure that things
+        // are executed asynchronously.
+        Dispatchers.API.setTestingMode(false)
+        Dispatchers.API.setTaskQueueing(false)
+
+        // Dispatch an initial tasks that throws an exception.
+        Dispatchers.API.launch {
+            assertNotSame(
+                "Tasks must be executed off the main thread",
+                mainThread,
+                Thread.currentThread()
+            )
+            @Suppress("TooGenericExceptionThrown")
+            throw Exception("Test exception for DispatchersTest")
+        }
+
+        // Add 3 tasks to queue each one setting threadCanary to true
+        // to indicate if any task has ran.
+        repeat(3) {
+            Dispatchers.API.launch {
+                assertNotSame(
+                    "Tasks must be executed off the main thread",
+                    mainThread,
+                    Thread.currentThread()
+                )
+                threadCanary.incrementAndGet()
+            }
+        }
+
+        // Wait for the flushed tasks to be executed.
+        runBlocking {
+            withTimeoutOrNull(2000) {
+                while (isActive && (threadCanary.get() != 3)) {
+                    delay(1)
+                }
+            } ?: assertTrue("Timed out waiting for tasks to execute", false)
+        }
+
+        assertEquals("All the dispatched actions should execute", 3, threadCanary.get())
+    }
 }


### PR DESCRIPTION
I had a weird feeling while dealing with the intermittent from #672 . And I was (sadly) right: whenever something throws an exception in our dispatcher queue, everything goes kaput.

Luckily, our APIs are not really expected to throw exceptions ([except at startup](https://github.com/mozilla/glean/blob/f9d320db8763524fbdd5c03d2ec3be61667e5d68/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt#L464) and in the test APIs).

Still, this is something we need to do a bit better. I'll work on our resiliency as part of this.