### PR TITLE
Don't try to install perl on the PyPi image anymore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -744,11 +744,6 @@ jobs:
             # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
             # variables are configured in CircleCI's environment variables.
             .venv/bin/python3 -m twine upload wheelhouse/*
-      - run:
-          name: Install perl
-          command: |
-            # Required for shasum
-            sudo apt install perl
       - install-ghr-linux
       - run:
           name: Publish to Github


### PR DESCRIPTION
The image doesn't have `sudo` and thus this fails.
We already switched away from shasum in #704