### PR TITLE
Support deletion request pings in upload module

### DIFF
--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -63,6 +63,10 @@ lazy_static! {
 // An internal ping name, not to be touched by anything else
 pub(crate) const INTERNAL_STORAGE: &str = "glean_internal_info";
 
+// The names of the pings directories.
+pub(crate) const PENDING_PINGS_DIRECTORY: &str = "pending_pings";
+pub(crate) const DELETION_REQUEST_PINGS_DIRECTORY: &str = "deletion_request";
+
 /// The global Glean instance.
 ///
 /// This is the singleton used by all wrappers to allow for a nice API.

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -15,7 +15,9 @@ use crate::common_metric_data::{CommonMetricData, Lifetime};
 use crate::metrics::{CounterMetric, DatetimeMetric, Metric, MetricType, PingType, TimeUnit};
 use crate::storage::StorageManager;
 use crate::util::{get_iso_time_string, local_now_with_offset};
-use crate::{Glean, Result, INTERNAL_STORAGE};
+use crate::{
+    Glean, Result, DELETION_REQUEST_PINGS_DIRECTORY, INTERNAL_STORAGE, PENDING_PINGS_DIRECTORY,
+};
 
 /// Collect a ping's data, assemble it into its full payload and store it on disk.
 pub struct PingMaker;
@@ -238,9 +240,9 @@ impl PingMaker {
         // Use a special directory for deletion-request pings
         let pings_dir = match ping_type {
             Some(ping_type) if ping_type == "deletion-request" => {
-                data_path.join("deletion_request")
+                data_path.join(DELETION_REQUEST_PINGS_DIRECTORY)
             }
-            _ => data_path.join("pending_pings"),
+            _ => data_path.join(PENDING_PINGS_DIRECTORY),
         };
 
         create_dir_all(&pings_dir)?;

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -14,9 +14,7 @@ use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
 use super::PingRequest;
-
-pub const PENDING_PINGS_DIRECTORY: &str = "pending_pings";
-pub const DELETION_REQUEST_PINGS_DIRECTORY: &str = "deletion_request";
+use crate::{DELETION_REQUEST_PINGS_DIRECTORY, PENDING_PINGS_DIRECTORY};
 
 /// Get the file name from a path as a &str.
 ///

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -214,8 +214,7 @@ mod test {
 
     use super::*;
     use crate::metrics::PingType;
-    use crate::tests::new_glean;
-    use directory::PENDING_PINGS_DIRECTORY;
+    use crate::{tests::new_glean, PENDING_PINGS_DIRECTORY};
 
     const UUID: &str = "40e31919-684f-43b0-a5aa-e15c2d56a674"; // Just a random UUID.
     const URL: &str = "http://example.com";


### PR DESCRIPTION
Resolves [Bug 1614280](https://bugzilla.mozilla.org/show_bug.cgi?id=1614280)

After a good discussion in the bug I decided to take a rather simplistic approach to implementing this.

This is my understanding:
1. I don't need to worry about stale ping files when a user has disabled upload, that is taken care of elsewhere (https://github.com/mozilla/glean/blob/master/glean-core/src/lib.rs#L332).
2. Even if a client has upload enabled, if there is a deletion-request ping file we should send that.

My solution was to have the DirectoryManager always check the deletion_request directory, regardless of upload enabled or not.


