### PR TITLE
Validate a simple generated custom ping against the ping schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
     resource_class: "medium+"
     steps:
       - test-rust:
-          rust-version: "1.36.0"
+          rust-version: "1.41.0"
 
   Rust FFI header check:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,9 +324,11 @@ version = "0.0.5"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glean-core 25.1.0",
+ "jsonschema-valid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -357,6 +359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iri-string"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "iso8601"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +387,30 @@ dependencies = [
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "json-pointer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonschema-valid"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iri-string 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json-pointer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -444,6 +479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -846,6 +890,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,9 +980,12 @@ dependencies = [
 "checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+"checksum iri-string 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "402e5c3bd66bbe43ac90915097caa0347fc2666ecb8a0047154f4494ed577995"
 "checksum iso8601 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43e86914a73535f3f541a765adea0a9fafcf53fa6adb73662c4988fd9233766f"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum json-pointer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8be58bc6b9e76616678217b983ab122d0ec207241c487ce450361ba7b5ddafd1"
+"checksum jsonschema-valid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6362170d8507a225c45f03991531bee7b87c54ce2c06c48fb2d3b11036667d8"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum lmdb-rkv 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "605061e5465304475be2041f19967a900175ea1b6d8f47fbab84a84fb8c48452"
@@ -943,6 +995,7 @@ dependencies = [
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
@@ -993,6 +1046,7 @@ dependencies = [
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The code in this repository is organized as follows:
 * [./glean-core/ios](glean-core/ios) contains the Swift bindings for use by iOS applications.
 * [./glean-core/python](glean-core/python) contains Python bindings (currently under development).
 
-**Note: The Glean SDK requires at least [Rust 1.36.0](https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html). Older versions are untested.**
+**Note: The Glean SDK requires at least [Rust 1.41.0](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html). Older versions are untested.**
 
 ## Contact
 

--- a/glean-core/preview/Cargo.toml
+++ b/glean-core/preview/Cargo.toml
@@ -33,3 +33,5 @@ once_cell = "1.2.0"
 env_logger = { version = "0.7.1", default-features = false, features = ["termcolor", "atty", "humantime"] }
 tempfile = "3.1.0"
 log = "0.4.8"
+jsonschema-valid = "0.3.0"
+serde_json = "1.0.44"

--- a/glean-core/preview/tests/glean.1.schema.json
+++ b/glean-core/preview/tests/glean.1.schema.json
@@ -1,0 +1,806 @@
+{
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$originUrl": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/f2a7ce4/schemas/glean/glean/glean.1.schema.json",
+  "additionalProperties": false,
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "properties": {
+    "$schema": {
+      "enum": [
+        "moz://mozilla.org/schemas/glean/ping/1"
+      ],
+      "type": "string"
+    },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
+        "app_build": {
+          "type": "string"
+        },
+        "app_channel": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
+    "events": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "extra": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "timestamp": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "category",
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "metrics": {
+      "additionalProperties": false,
+      "properties": {
+        "boolean": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "counter": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "custom_distribution": {
+          "additionalProperties": {
+            "properties": {
+              "sum": {
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "pattern": "[0-9]+"
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "sum",
+              "values"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "datetime": {
+          "additionalProperties": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "enumeration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_boolean": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_datetime": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "format": "datetime",
+              "type": "string"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_enumeration": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_number": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_rate": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string_list": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_timing_distribution": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "bucket_count": {
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "enum": [
+                    "linear",
+                    "exponential"
+                  ],
+                  "type": "string"
+                },
+                "overflow": {
+                  "type": "integer"
+                },
+                "range": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "sum": {
+                  "type": "integer"
+                },
+                "time_unit": {
+                  "enum": [
+                    "nanosecond",
+                    "microsecond",
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day"
+                  ],
+                  "type": "string"
+                },
+                "underflow": {
+                  "type": "integer"
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "pattern": "[0-9]+"
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "values"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_usage": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_use_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "denominator": {
+                  "properties": {
+                    "name": {
+                      "maxLength": 30,
+                      "pattern": "^[a-z_][a-z0-9_]*$",
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_uuid": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+              "type": "string"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 61,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "memory_distribution": {
+          "additionalProperties": {
+            "properties": {
+              "sum": {
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "pattern": "[0-9]+"
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "values"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "number": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "quantity": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "rate": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string_list": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timespan": {
+          "additionalProperties": {
+            "properties": {
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "value",
+              "time_unit"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timing_distribution": {
+          "additionalProperties": {
+            "properties": {
+              "bucket_count": {
+                "type": "integer"
+              },
+              "histogram_type": {
+                "enum": [
+                  "linear",
+                  "exponential"
+                ],
+                "type": "string"
+              },
+              "overflow": {
+                "type": "integer"
+              },
+              "range": {
+                "items": {
+                  "type": "number"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "sum": {
+                "type": "integer"
+              },
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ],
+                "type": "string"
+              },
+              "underflow": {
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "pattern": "[0-9]+"
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "values"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "usage": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "use_counter": {
+          "additionalProperties": {
+            "properties": {
+              "denominator": {
+                "properties": {
+                  "name": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "maxLength": 30,
+                  "pattern": "^[a-z_][a-z0-9_]*$",
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "uuid": {
+          "additionalProperties": {
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ping_info": {
+      "additionalProperties": false,
+      "properties": {
+        "end_time": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "branch": {
+                "maxLength": 100,
+                "type": "string"
+              },
+              "extra": {
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "branch"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "ping_type": {
+          "maxLength": 30,
+          "pattern": "^[a-z-_][a-z0-9-_]*$",
+          "type": "string"
+        },
+        "reason": {
+          "maxLength": 30,
+          "type": "string"
+        },
+        "seq": {
+          "type": "integer"
+        },
+        "start_time": {
+          "format": "datetime",
+          "type": "string"
+        }
+      },
+      "required": [
+        "seq",
+        "start_time",
+        "end_time"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "ping_info",
+    "client_info"
+  ],
+  "title": "Ping transport",
+  "type": "object"
+}

--- a/glean-core/preview/tests/schema.rs
+++ b/glean-core/preview/tests/schema.rs
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use jsonschema_valid::{self, schemas::Draft6};
+use serde_json::Value;
+
+use glean::{metrics::PingType, ClientInfoMetrics, Configuration};
+use glean_preview as glean;
+
+const SCHEMA_JSON: &str = include_str!("glean.1.schema.json");
+
+fn load_schema() -> Value {
+    serde_json::from_str(SCHEMA_JSON).unwrap()
+}
+
+const GLOBAL_APPLICATION_ID: &str = "org.mozilla.glean.test.app";
+
+// Create a new instance of Glean with a temporary directory.
+// We need to keep the `TempDir` alive, so that it's not deleted before we stop using it.
+fn new_glean() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+
+    let cfg = Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        channel: None,
+    };
+
+    let client_info = ClientInfoMetrics {
+        app_build: env!("CARGO_PKG_VERSION").to_string(),
+        app_display_version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+
+    glean::initialize(cfg, client_info).unwrap();
+
+    dir
+}
+
+#[test]
+fn validate_against_schema() {
+    let schema = load_schema();
+
+    let dir = new_glean();
+
+    // Register and submit a ping for testing
+    let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
+    glean::register_ping_type(&ping_type);
+    ping_type.submit(None);
+
+    // Read the ping from disk.
+    // We know where it should be placed.
+    let pings_dir = dir.path().join("pending_pings");
+    let pending_pings: Vec<PathBuf> = pings_dir
+        .read_dir()
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| match entry.file_type() {
+            Ok(f) if f.is_file() => Some(entry.path()),
+            _ => None,
+        })
+        .collect();
+
+    // There should only be one: our custom ping.
+    assert_eq!(1, pending_pings.len());
+
+    // 1. line: the URL
+    // 2. line: the JSON body
+    let file = File::open(&pending_pings[0]).unwrap();
+    let mut lines = BufReader::new(file).lines();
+    let _url = lines.next().unwrap().unwrap();
+    let body = lines.next().unwrap().unwrap();
+
+    // Now validate against the vendored schema
+    let data = serde_json::from_str(&body).unwrap();
+    let cfg = jsonschema_valid::Config::from_schema(&schema, Some(&Draft6)).unwrap();
+    let validation = cfg.validate(&data);
+    match validation {
+        Ok(()) => {}
+        Err(e) => {
+            let errors = e.map(|e| format!("{}", e)).collect::<Vec<_>>();
+            assert!(false, "Data: {:#?}\nErrors: {:#?}", data, errors);
+        }
+    }
+}


### PR DESCRIPTION
Ping schema is taken from https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/f2a7ce4/schemas/glean/glean/glean.1.schema.json
and vendored.
It was changed to include an "$originUrl" as a way to track which one we imported.

---

Through #717 we noticed we only validate pings against the schema in Kotlin and Python test suites.

This is for several reasons:

* Validation is done by `glean_parser`, a Python project. A Python environment is only around for Kotlin and Python test suites
* Pings generated by _only_ `glean_core` are not trivially valid, due to `client_info` data misssing. We can set it, but it's not done by default.

But we only require _jsonschema validation_, and that's independent of other work from `glean_parser`, so one thing we can do is use a Rust project for the Rust part.
Additionally we do have a project that acts as kind of a "platform layer": `glean_preview`. That allows us to set `client_info` data as part of the normal flow.

Notes:
* I vendored the schema from above URL (and also added the exact URL as `$sourceURL` in the schema itself. I wanted to avoid requiring an internet connection and also a way to download stuff
* This uses [valico](https://github.com/rustless/valico), the first crate that supports jsonschema validation and was stable. I have not looked at their code yet (I did check the license)
  * for example they say they support jsonschema draf-4, but we use draft-6 (?!), however the test works.
* Currently contains `doc only` in the commit to avoid runnning the tests. This should be a discussion if we want to do it like this, if so I can remove that and run CI tests.

This is what it would look like if it fails to validate:

(long output hidden behind a detail view)
<details>

```
[Running cargo test -p glean-preview --test schema]
   Compiling glean-preview v0.0.5 (/Users/jrediger/mozilla/src/glean.rs/glean-core/preview)
    Finished test [unoptimized + debuginfo] target(s) in 2.25s
     Running target/debug/deps/schema-486af64b29843148

running 1 test
test validate_against_schema ... FAILED

failures:

---- validate_against_schema stdout ----
thread 'validate_against_schema' panicked at 'Data: Object(
    {
        "client_info": Object(
            {
                "telemetry_sdk_build": String(
                    "25.0.0",
                ),
            },
        ),
        "ping_info": Object(
            {
                "end_time": String(
                    "2020-02-19T15:59+01:00",
                ),
                "seq": Number(
                    0,
                ),
                "start_time": String(
                    "2020-02-19T15:59+01:00",
                ),
            },
        ),
    },
), Validation: ValidationState {
    errors: [
        Required {
            path: "/client_info/app_build",
        },
        Required {
            path: "/client_info/app_display_version",
        },
        Required {
            path: "/client_info/architecture",
        },
        Required {
            path: "/client_info/device_manufacturer",
        },
        Required {
            path: "/client_info/device_model",
        },
        Required {
            path: "/client_info/first_run_date",
        },
        Required {
            path: "/client_info/os",
        },
        Required {
            path: "/client_info/os_version",
        },
    ],
    missing: [],
}', glean-core/preview/tests/schema.rs:81:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

</details>