### PR TITLE
Spellcheck all the things

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 142 utf-8
+personal_ws-1.1 en 151 utf-8
 AAR
 AARs
 APIs
@@ -11,6 +11,7 @@ CMake
 CODEOWNERS
 Cartfile
 CircleCI
+Ciufo
 Datetime
 Datetimes
 Fenix
@@ -44,9 +45,11 @@ PowerShell
 ProGuard
 Protobufs
 PyPI
+Redash
 SDK
 TODO
 TWiG
+Taskcluster
 UI
 URIs
 UTF
@@ -70,10 +73,13 @@ chutten
 cmd
 codecov
 codepoints
+commandline
 conda
 coroutine
 csh
+dataset
 destructor
+dev
 dexter
 distributable
 docstrings
@@ -86,6 +92,7 @@ experimentId
 ffi
 func
 gfritzsche
+glinter
 gradle
 grcov
 hotfix
@@ -114,6 +121,7 @@ pidcat
 pipenv
 pre
 prebuilt
+preinit
 py
 pytest
 rkv
@@ -133,6 +141,7 @@ timespans
 timezones
 toolchain
 toolchains
+tooltip
 transpiler
 travis
 unhandled

--- a/bin/spellcheck.sh
+++ b/bin/spellcheck.sh
@@ -45,7 +45,7 @@ aspell --version
 shopt -s nullglob
 
 dict_filename=./.dictionary
-markdown_sources="$(find ./docs -name '*.md')"
+markdown_sources="$(git ls-files | grep -v 'DEPENDENCIES\.md' | grep '\.md$')"
 mode="check"
 aspell_args="--lang en_US --mode=markdown"
 

--- a/samples/ios/app/README.md
+++ b/samples/ios/app/README.md
@@ -3,7 +3,7 @@
 A minimal example showcasing the integration of Glean into an iOS application.
 This app does nothing, but enable Glean.
 
-Glean sends a [`baseline`][] ping when the app is backgrounded.
+Glean sends a [`baseline`][] ping when the app is sent to background.
 
 [`baseline`]: https://mozilla.github.io/glean/book/user/pings/baseline.html
 

--- a/tools/analysis/ping-patterns/README.md
+++ b/tools/analysis/ping-patterns/README.md
@@ -1,8 +1,8 @@
-This directory contains a tool to analyse the patterns of baseline and metrics pings received on a per-client basis in Fenix.  These pattern analyses are then summarized in a single plot showing various patterns and issues found in the data.
+This directory contains a tool to analyze the patterns of baseline and metrics pings received on a per-client basis in Fenix.  These pattern analyses are then summarized in a single plot showing various patterns and issues found in the data.
 
 ## Requirements
 
-A recent version of [matplotlib](https://matplotlib.org).
+A recent version of [`matplotlib`](https://matplotlib.org).
 
 ## Collecting input data
 
@@ -66,6 +66,6 @@ Baseline pings are in blue.  The thick part of the line represents the active se
 
 Metrics pings are in red.  Issues found with metrics pings are notated with a number to the right.  Hover over the number to display a tooltip with further information about the issue.
 
-Grey vertical lines are midnight local time.  Dashed grey vertical lines are 04:00 local time.
+Gray vertical lines are midnight local time.  Dashed gray vertical lines are 04:00 local time.
 
 Green vertical lines indicate the first ping coming from an interesting revision that contains a related fix.


### PR DESCRIPTION
This expands the spellchecker to run on all of the markdown files checked into git (except DEPENDENCIES.md).

This fixes a minor bug with the spellcheck script so it will always spellcheck the CHANGELOG.

The issue is that when the docs are built, `./CHANGELOG.md` is copied to `docs/appendix/changelog.md`.  The spellcheck script only looked at `.md` in the `docs` directory, so the changelog would be spellchecked only if the developer had previously built the docs.  Notably, it meant the `CHANGELOG.md` was not spellchecked on CI.  This should at least keep things consistent, and not force users to spellcheck things in the CHANGELOG that were previously missed by CI.