### PR TITLE
Add interface for the upload module to Glean object

### DIFF
--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -36,6 +36,7 @@ mod internal_pings;
 pub mod metrics;
 pub mod ping;
 pub mod storage;
+#[cfg(feature = "upload")]
 pub mod upload;
 mod util;
 
@@ -49,6 +50,7 @@ use crate::internal_pings::InternalPings;
 use crate::metrics::{Metric, MetricType, PingType};
 use crate::ping::PingMaker;
 use crate::storage::StorageManager;
+#[cfg(feature = "upload")]
 use crate::upload::{PingUploadManager, PingUploadTask};
 use crate::util::{local_now_with_offset, sanitize_application_id};
 
@@ -159,6 +161,7 @@ pub struct Glean {
     start_time: DateTime<FixedOffset>,
     max_events: usize,
     is_first_run: bool,
+    #[cfg(feature = "upload")]
     upload_manager: PingUploadManager,
 }
 
@@ -183,6 +186,7 @@ impl Glean {
             event_data_store,
             core_metrics: CoreMetrics::new(),
             internal_pings: InternalPings::new(),
+            #[cfg(feature = "upload")]
             upload_manager: PingUploadManager::new(&cfg.data_path),
             data_path: PathBuf::from(cfg.data_path),
             application_id,
@@ -326,6 +330,7 @@ impl Glean {
     fn clear_metrics(&mut self) {
         // Clear the pending pings queue and acquire the lock
         // so that it can't be accessed until this function is done.
+        #[cfg(feature = "upload")]
         let _lock = self.upload_manager.clear_ping_queue();
 
         // There is only one metric that we want to survive after clearing all
@@ -416,6 +421,7 @@ impl Glean {
     /// # Return value
     ///
     /// `PingUploadTask` - an enum representing the three possible tasks.
+    #[cfg(feature = "upload")]
     pub fn get_upload_task(&self) -> PingUploadTask {
         self.upload_manager.get_upload_task()
     }
@@ -490,6 +496,7 @@ impl Glean {
                     return Err(e.into());
                 }
 
+                #[cfg(feature = "upload")]
                 self.upload_manager
                     .enqueue_ping(&doc_id, &url_path, content);
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -36,9 +36,8 @@ mod internal_pings;
 pub mod metrics;
 pub mod ping;
 pub mod storage;
+pub mod upload;
 mod util;
-
-mod upload;
 
 pub use crate::common_metric_data::{CommonMetricData, Lifetime};
 use crate::database::Database;
@@ -184,13 +183,13 @@ impl Glean {
             event_data_store,
             core_metrics: CoreMetrics::new(),
             internal_pings: InternalPings::new(),
-            data_path: PathBuf::from(&cfg.data_path),
+            upload_manager: PingUploadManager::new(&cfg.data_path),
+            data_path: PathBuf::from(cfg.data_path),
             application_id,
             ping_registry: HashMap::new(),
             start_time: local_now_with_offset(),
             max_events: cfg.max_events.unwrap_or(DEFAULT_MAX_EVENTS),
             is_first_run: false,
-            upload_manager: PingUploadManager::new(&cfg.data_path),
         };
         glean.on_change_upload_enabled(cfg.upload_enabled);
         Ok(glean)
@@ -327,7 +326,7 @@ impl Glean {
     fn clear_metrics(&mut self) {
         // Clear the pending pings queue and acquire the lock
         // so that it can't be accessed until this function is done.
-        let _queue_lock = self.upload_manager.clear_ping_queue();
+        let _lock = self.upload_manager.clear_ping_queue();
 
         // There is only one metric that we want to survive after clearing all
         // metrics: first_run_date. Here, we store its value so we can restore
@@ -412,7 +411,7 @@ impl Glean {
     ///
     /// # Return value
     ///
-    /// `PingUploadTask` - see [`PingUploadTask`](enum.PingUploadTask.html) for more information.
+    /// `PingUploadTask` - see [`PingUploadTask`](upload/enum.PingUploadTask.html) for more information.
     pub fn get_upload_task(&self) -> PingUploadTask {
         self.upload_manager.get_upload_task()
     }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -37,7 +37,7 @@ pub mod metrics;
 pub mod ping;
 pub mod storage;
 #[cfg(feature = "upload")]
-pub mod upload;
+mod upload;
 mod util;
 
 pub use crate::common_metric_data::{CommonMetricData, Lifetime};

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -407,11 +407,15 @@ impl Glean {
         self.max_events
     }
 
-    /// Gets the next `PingUploadTask`.
+    /// Gets the next task for an uploader. Which can be either:
+    ///
+    /// Wait - which means the requester should ask again later;
+    /// Upload(PingRequest) - which means there is a ping to upload. This wraps the actual request object;
+    /// Done - which means there are no more pings queued right now.
     ///
     /// # Return value
     ///
-    /// `PingUploadTask` - see [`PingUploadTask`](upload/enum.PingUploadTask.html) for more information.
+    /// `PingUploadTask` - an enum representing the three possible tasks.
     pub fn get_upload_task(&self) -> PingUploadTask {
         self.upload_manager.get_upload_task()
     }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -414,13 +414,13 @@ impl Glean {
 
     /// Gets the next task for an uploader. Which can be either:
     ///
-    /// Wait - which means the requester should ask again later;
-    /// Upload(PingRequest) - which means there is a ping to upload. This wraps the actual request object;
-    /// Done - which means there are no more pings queued right now.
+    /// * Wait - which means the requester should ask again later;
+    /// * Upload(PingRequest) - which means there is a ping to upload. This wraps the actual request object;
+    /// * Done - which means there are no more pings queued right now.
     ///
     /// # Return value
     ///
-    /// `PingUploadTask` - an enum representing the three possible tasks.
+    /// `PingUploadTask` - an enum representing the possible tasks.
     #[cfg(feature = "upload")]
     pub fn get_upload_task(&self) -> PingUploadTask {
         self.upload_manager.get_upload_task()

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -434,7 +434,8 @@ impl Glean {
     /// `status` - The HTTP status of the response.
     #[cfg(feature = "upload")]
     pub fn process_ping_upload_response(&self, uuid: &str, status: u16) {
-        self.upload_manager.process_ping_upload_response(uuid, status);
+        self.upload_manager
+            .process_ping_upload_response(uuid, status);
     }
 
     /// Take a snapshot for the given store and optionally clear it.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -426,6 +426,17 @@ impl Glean {
         self.upload_manager.get_upload_task()
     }
 
+    /// Processes the response from an attempt to upload a ping.
+    ///
+    /// # Arguments
+    ///
+    /// `uuid` - The UUID of the ping in question.
+    /// `status` - The HTTP status of the response.
+    #[cfg(feature = "upload")]
+    pub fn process_ping_upload_response(&self, uuid: &str, status: u16) {
+        self.upload_manager.process_ping_upload_response(uuid, status);
+    }
+
     /// Take a snapshot for the given store and optionally clear it.
     ///
     /// ## Arguments

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -109,12 +109,12 @@ impl PingDirectoryManager {
         log::info!("Processing ping at: {}", path.display());
 
         // The way the ping file is structured,
-        // first line should always have the url
+        // first line should always have the path
         // and second line should have the body with the ping contents in JSON format
         let mut lines = BufReader::new(file).lines();
-        if let (Some(Ok(url)), Some(Ok(body))) = (lines.next(), lines.next()) {
+        if let (Some(Ok(path)), Some(Ok(body))) = (lines.next(), lines.next()) {
             if let Ok(parsed_body) = serde_json::from_str::<JsonValue>(&body) {
-                return Some(PingRequest::new(uuid, &url, parsed_body));
+                return Some(PingRequest::new(uuid, &path, parsed_body));
             } else {
                 log::warn!(
                     "Error processing ping file: {}. Can't parse ping contents as JSON.",
@@ -257,7 +257,7 @@ mod test {
         assert_eq!(requests.len(), 1);
 
         // Verify request was returned for the "test" ping
-        let request_ping_type = requests[0].url.split('/').nth(3).unwrap();
+        let request_ping_type = requests[0].path.split('/').nth(3).unwrap();
         assert_eq!(request_ping_type, "test");
     }
 
@@ -287,7 +287,7 @@ mod test {
         assert_eq!(requests.len(), 1);
 
         // Verify request was returned for the "test" ping
-        let request_ping_type = requests[0].url.split('/').nth(3).unwrap();
+        let request_ping_type = requests[0].path.split('/').nth(3).unwrap();
         assert_eq!(request_ping_type, "test");
 
         // Verify that file was indeed deleted
@@ -320,7 +320,7 @@ mod test {
         assert_eq!(requests.len(), 1);
 
         // Verify request was returned for the "test" ping
-        let request_ping_type = requests[0].url.split('/').nth(3).unwrap();
+        let request_ping_type = requests[0].path.split('/').nth(3).unwrap();
         assert_eq!(request_ping_type, "test");
 
         // Verify that file was indeed deleted
@@ -359,7 +359,7 @@ mod test {
         assert_eq!(requests.len(), 1);
 
         // Verify request was returned for the "test" ping
-        let request_ping_type = requests[0].url.split('/').nth(3).unwrap();
+        let request_ping_type = requests[0].path.split('/').nth(3).unwrap();
         assert_eq!(request_ping_type, "test");
 
         // Verify that file was indeed deleted

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -382,11 +382,8 @@ mod test {
         // Try and process the pings folder
         let requests = directory_manager.process_dir();
 
-        // Verify there is just the one request
         assert_eq!(requests.len(), 1);
 
-        // Verify request was returned for the "test" ping
-        let request_ping_type = requests[0].url.split('/').nth(3).unwrap();
-        assert_eq!(request_ping_type, "deletion-request");
+        assert!(requests[0].is_deletion_request());
     }
 }

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -17,7 +17,7 @@
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockWriteGuard};
 use std::thread;
 
 use log;
@@ -107,13 +107,23 @@ impl PingUploadManager {
         queue.push_back(request);
     }
 
-    /// Clears the pending pings queue.
-    pub fn clear_ping_queue(&self) {
+    /// Clears the pending pings queue, leaves the deletion-request pings.
+    pub fn clear_ping_queue(&self) -> RwLockWriteGuard<'_, VecDeque<PingRequest>> {
         let mut queue = self
             .queue
             .write()
             .expect("Can't write to pending pings queue.");
+
+        let mut deletion_requests = Vec::new();
+        for ping in queue.iter() {
+            if ping.is_deletion_request() {
+                deletion_requests.push(ping.clone());
+            }
+        }
+
         queue.clear();
+        queue.extend(deletion_requests);
+        queue
     }
 
     /// Gets the next `PingUploadTask`.
@@ -217,7 +227,7 @@ mod test {
     use crate::{tests::new_glean, PENDING_PINGS_DIRECTORY};
 
     const UUID: &str = "40e31919-684f-43b0-a5aa-e15c2d56a674"; // Just a random UUID.
-    const URL: &str = "http://example.com";
+    const URL: &str = "/submit/app_id/ping_name/schema_version/doc_id";
 
     #[test]
     fn test_doesnt_error_when_there_are_no_pending_pings() {
@@ -303,10 +313,43 @@ mod test {
         }
 
         // Clear the queue
-        upload_manager.clear_ping_queue();
+        let _ = upload_manager.clear_ping_queue();
 
         // Verify there really isn't any ping in the queue
         assert_eq!(upload_manager.get_upload_task(), PingUploadTask::Done);
+    }
+
+    #[test]
+    fn test_clearing_the_queue_doesnt_clear_deletion_request_pings() {
+        let (mut glean, _) = new_glean(None);
+
+        // Register a ping for testing
+        let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
+        glean.register_ping_type(&ping_type);
+
+        // Submit the ping multiple times
+        let n = 10;
+        for _ in 0..n {
+            glean.submit_ping(&ping_type, None).unwrap();
+        }
+
+        glean
+            .internal_pings
+            .deletion_request
+            .submit(&glean, None)
+            .unwrap();
+
+        // Clear the queue
+        let _ = glean.upload_manager.clear_ping_queue();
+
+        let upload_task = glean.get_upload_task();
+        match upload_task {
+            PingUploadTask::Upload(request) => assert!(request.is_deletion_request()),
+            _ => panic!("Expected upload manager to return the next request!"),
+        }
+
+        // Verify there really isn't any other pings in the queue
+        assert_eq!(glean.get_upload_task(), PingUploadTask::Done);
     }
 
     #[test]

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -98,12 +98,12 @@ impl PingUploadManager {
     }
 
     /// Creates a `PingRequest` and adds it to the queue.
-    pub fn enqueue_ping(&self, uuid: &str, url: &str, body: JsonValue) {
+    pub fn enqueue_ping(&self, uuid: &str, path: &str, body: JsonValue) {
         let mut queue = self
             .queue
             .write()
             .expect("Can't write to pending pings queue.");
-        let request = PingRequest::new(uuid, url, body);
+        let request = PingRequest::new(uuid, path, body);
         queue.push_back(request);
     }
 
@@ -227,7 +227,7 @@ mod test {
     use crate::{tests::new_glean, PENDING_PINGS_DIRECTORY};
 
     const UUID: &str = "40e31919-684f-43b0-a5aa-e15c2d56a674"; // Just a random UUID.
-    const URL: &str = "/submit/app_id/ping_name/schema_version/doc_id";
+    const PATH: &str = "/submit/app_id/ping_name/schema_version/doc_id";
 
     #[test]
     fn test_doesnt_error_when_there_are_no_pending_pings() {
@@ -257,7 +257,7 @@ mod test {
         }
 
         // Enqueue a ping
-        upload_manager.enqueue_ping(UUID, URL, json!({}));
+        upload_manager.enqueue_ping(UUID, PATH, json!({}));
 
         // Try and get the next request.
         // Verify request was returned
@@ -281,7 +281,7 @@ mod test {
         // Enqueue a ping multiple times
         let n = 10;
         for _ in 0..n {
-            upload_manager.enqueue_ping(UUID, URL, json!({}));
+            upload_manager.enqueue_ping(UUID, PATH, json!({}));
         }
 
         // Verify a request is returned for each submitted ping
@@ -309,7 +309,7 @@ mod test {
 
         // Enqueue a ping multiple times
         for _ in 0..10 {
-            upload_manager.enqueue_ping(UUID, URL, json!({}));
+            upload_manager.enqueue_ping(UUID, PATH, json!({}));
         }
 
         // Clear the queue

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -114,15 +114,7 @@ impl PingUploadManager {
             .write()
             .expect("Can't write to pending pings queue.");
 
-        let mut deletion_requests = Vec::new();
-        for ping in queue.iter() {
-            if ping.is_deletion_request() {
-                deletion_requests.push(ping.clone());
-            }
-        }
-
-        queue.clear();
-        queue.extend(deletion_requests);
+        queue.retain(|ping| ping.is_deletion_request());
         queue
     }
 

--- a/glean-core/src/upload/request.rs
+++ b/glean-core/src/upload/request.rs
@@ -42,8 +42,8 @@ impl PingRequest {
         self.path
             .split('/')
             .nth(3)
-            .expect("URL path does not follow the expected pattern.")
-            == "deletion-request"
+            .map(|url| url == "deletion-request")
+            .unwrap_or(false)
     }
 
     /// Creates the default request headers.

--- a/glean-core/src/upload/request.rs
+++ b/glean-core/src/upload/request.rs
@@ -10,7 +10,7 @@ use chrono::prelude::{DateTime, Utc};
 use serde_json::Value as JsonValue;
 
 /// Represents a request to upload a ping.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct PingRequest {
     /// The Job ID to identify this request,
     /// this is the same as the ping UUID.
@@ -35,6 +35,15 @@ impl PingRequest {
             body,
             headers: Self::create_request_headers(),
         }
+    }
+
+    pub fn is_deletion_request(&self) -> bool {
+        // The url format should be `/submit/<app_id>/<ping_name>/<schema_version/<doc_id>`
+        self.url
+            .split('/')
+            .nth(3)
+            .expect("URL path does not follow the expected pattern.")
+            == "deletion-request"
     }
 
     /// Creates the default request headers.

--- a/glean-core/src/upload/request.rs
+++ b/glean-core/src/upload/request.rs
@@ -16,7 +16,7 @@ pub struct PingRequest {
     /// this is the same as the ping UUID.
     pub uuid: String,
     /// The path for the server to upload the ping to.
-    pub url: String,
+    pub path: String,
     /// The body of the request.
     pub body: JsonValue,
     /// A map with all the headers to be sent with the request.
@@ -28,18 +28,18 @@ impl PingRequest {
     ///
     /// Automatically creates the default request headers.
     /// Clients may add more headers such as `userAgent` to this list.
-    pub fn new(uuid: &str, url: &str, body: JsonValue) -> Self {
+    pub fn new(uuid: &str, path: &str, body: JsonValue) -> Self {
         Self {
             uuid: uuid.into(),
-            url: url.into(),
+            path: path.into(),
             body,
             headers: Self::create_request_headers(),
         }
     }
 
     pub fn is_deletion_request(&self) -> bool {
-        // The url format should be `/submit/<app_id>/<ping_name>/<schema_version/<doc_id>`
-        self.url
+        // The path format should be `/submit/<app_id>/<ping_name>/<schema_version/<doc_id>`
+        self.path
             .split('/')
             .nth(3)
             .expect("URL path does not follow the expected pattern.")


### PR DESCRIPTION
Resolves [Bug 1614284](https://bugzilla.mozilla.org/show_bug.cgi?id=1614284).

I figured glean-ffi already does the job of locking the Glean object until completion of most functions, because it usually uses [`with_glean`](https://github.com/mozilla/glean/blob/master/glean-core/ffi/src/lib.rs#L45-L57) and [`with_glean_mut`](https://github.com/mozilla/glean/blob/master/glean-core/ffi/src/lib.rs#L66-L78), which locks Glean.

Nonetheless, I decided to lock the queue until done clearing all the stores, because what if we are not interfacing with glean through the FFI?

@badboy Is there a good way to still keep this behind a feature flag?