### PR TITLE
Python: Make public, document and test the debugging features

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
     - [Debugging products using Glean](user/debugging/index.md)
         - [Android](user/debugging/android.md)
         - [iOS](user/debugging/ios.md)
+        - [Python](user/debugging/python.md)
     - [Error reporting](user/error-reporting.md)
     - [Using the experiments API](user/experiments-api.md)
     - [Metric types](user/metrics/index.md)

--- a/docs/user/debugging/index.md
+++ b/docs/user/debugging/index.md
@@ -4,6 +4,7 @@
 
 1. [Debugging Android applications using the Glean SDK](android.md)
 2. [Debugging iOS applications using the Glean SDK](ios.md)
+3. [Debugging Python applications using the Glean SDK](python.md)
 
 ## General debugging information
 

--- a/docs/user/debugging/python.md
+++ b/docs/user/debugging/python.md
@@ -1,0 +1,21 @@
+# Debugging Python applications using the Glean SDK
+
+Glean provides a couple of configuration flags to assist with debugging Python applications.
+
+## Tagging pings
+
+The `Glean.configuration.ping_tag` property can be used to add a special flag to the HTTP header so that the ping will end up in the [Glean Debug View](https://docs.telemetry.mozilla.org/concepts/glean/debug_ping_view.html).
+
+For example:
+
+```
+Glean.configuration.ping_tag = "my-ping-tag"
+
+pings.custom_ping.submit()
+```
+
+will send the custom ping to the Glean Debug View.
+
+## Logging pings
+
+If the `Glean.configuration.log_pings` property is set to `True`, pings are logged to the console whenever they are submitted.

--- a/glean-core/python/glean/config.py
+++ b/glean-core/python/glean/config.py
@@ -93,16 +93,18 @@ class Configuration:
 
     @channel.setter
     def channel(self, value: str):
+        from ._builtins import metrics
+
         self._channel = value
+
+        metrics.glean.internal.metrics.app_channel.set(value)
 
     @property
     def max_events(self) -> int:
         """The number of events to store before force-sending."""
         return self._max_events
 
-    @max_events.setter
-    def max_events(self, value: int):
-        self._max_events = value
+    # max_events can't be changed after Glean is initialized
 
     @property
     def log_pings(self) -> bool:

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -154,6 +154,13 @@ class Glean:
             def check_pending_deletion_request():
                 DeletionPingUploadWorker.process()
 
+    @util.classproperty
+    def configuration(cls):
+        """
+        Access the configuration object to change dynamic parameters.
+        """
+        return cls._configuration
+
     @classmethod
     def reset(cls):
         """

--- a/glean-core/python/glean/util.py
+++ b/glean-core/python/glean/util.py
@@ -46,3 +46,15 @@ else:
         On Python prior to 3.7, this may have less than millisecond resolution.
         """
         return int(time.time() * 1000.0)
+
+
+class classproperty:
+    """
+    Decorator for creating a property on a class (rather than an instance).
+    """
+
+    def __init__(self, f):
+        self.f = f
+
+    def __get__(self, obj, owner):
+        return self.f(owner)


### PR DESCRIPTION
The debugging features in Python are a lot "simpler" than the other platforms because we're just providing a programmatic API at this point.  But things like sending to the Glean Debug View do work, so we should document that.