### PR TITLE
Ensure we only generate a deletion-request ping when toggling from on to off

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -63,7 +63,7 @@ open class GleanInternalAPI internal constructor () {
     // This is the wrapped http uploading mechanism: provides base functionalities
     // for logging and delegates the actual upload to the implementation in
     // the `Configuration`.
-    internal val httpClient by lazy { BaseUploader(configuration.httpClient) }
+    internal lateinit var httpClient: BaseUploader
 
     private lateinit var applicationContext: Context
 
@@ -140,6 +140,7 @@ open class GleanInternalAPI internal constructor () {
         this.applicationContext = applicationContext
 
         this.configuration = configuration
+        this.httpClient = BaseUploader(configuration.httpClient)
         this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR)
 
         setUploadEnabled(uploadEnabled)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -208,11 +208,12 @@ internal fun waitForEnqueuedWorker(
  * is fixed, the contents of this can be amended to trigger WorkManager directly.
  *
  * @param context the application [Context] to get the [WorkManager] instance for
+ * @param workerTag the tag for the expected worker (default: `PingUploadWorker.PING_WORKER_TAG`)
  */
-internal fun triggerWorkManager(context: Context) {
+internal fun triggerWorkManager(context: Context, workerTag: String = PingUploadWorker.PING_WORKER_TAG) {
     // Check that the work is scheduled
-    val status = getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG)
-    Assert.assertTrue("A scheduled PingUploadWorker must exist",
+    val status = getWorkerStatus(context, workerTag)
+    Assert.assertTrue("A scheduled $workerTag must exist",
         status.isEnqueued)
 
     // Trigger WorkManager using TestDriver

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -276,14 +276,14 @@ impl Glean {
     pub fn set_upload_enabled(&mut self, flag: bool) -> bool {
         log::info!("Upload enabled: {:?}", flag);
 
-        // When upload is disabled, submit a deletion-request ping
-        if !flag {
-            if let Err(err) = self.internal_pings.deletion_request.submit(self, None) {
-                log::error!("Failed to send deletion-request ping on optout: {}", err);
-            }
-        }
-
         if self.upload_enabled != flag {
+            // When upload is disabled, submit a deletion-request ping
+            if !flag {
+                if let Err(err) = self.internal_pings.deletion_request.submit(self, None) {
+                    log::error!("Failed to submit deletion-request ping on optout: {}", err);
+                }
+            }
+
             self.upload_enabled = flag;
             self.on_change_upload_enabled(flag);
             true

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -65,6 +65,24 @@ fn disabling_upload_clears_pending_pings() {
 }
 
 #[test]
+fn deletion_request_only_when_toggled_from_on_to_off() {
+    let (mut glean, _) = new_glean(None);
+
+    // Disabling upload generates a deletion ping
+    glean.set_upload_enabled(false);
+    assert_eq!(1, get_deletion_pings(glean.get_data_path()).unwrap().len());
+
+    // Re-setting it to `false` should not generate an additional ping.
+    // As we didn't clear the pending ping, that's the only one that sticks around.
+    glean.set_upload_enabled(false);
+    assert_eq!(1, get_deletion_pings(glean.get_data_path()).unwrap().len());
+
+    // Toggling back to true won't generate a ping either.
+    glean.set_upload_enabled(true);
+    assert_eq!(1, get_deletion_pings(glean.get_data_path()).unwrap().len());
+}
+
+#[test]
 fn empty_pings_with_flag_are_sent() {
     let (mut glean, _) = new_glean(None);
 


### PR DESCRIPTION
The old code already did what we wanted, because when `upload_enabled` is false the ping submission will exit early.
This just makes it more explicit, easier to read and understand without that context and we avoid a useless log line.