### PR TITLE
Remove upload feature flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,6 @@ commands:
       - run:
           name: Test
           command: cargo test --all --verbose
-      - run:
-          name: Test with upload feature
-          command: |
-              # Changing to the core crate due to: --features is not allowed in the root of a virtual workspace#
-              cd glean-core
-              cargo test --lib --verbose --features upload
 
   install-rustup:
     steps:

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -17,9 +17,6 @@ include = [
   "Cargo.toml"
 ]
 
-[features]
-upload = []
-
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "master" }
 maintenance = { status = "actively-developed" }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -36,7 +36,6 @@ mod internal_pings;
 pub mod metrics;
 pub mod ping;
 pub mod storage;
-#[cfg(feature = "upload")]
 mod upload;
 mod util;
 
@@ -50,7 +49,6 @@ use crate::internal_pings::InternalPings;
 use crate::metrics::{Metric, MetricType, PingType};
 use crate::ping::PingMaker;
 use crate::storage::StorageManager;
-#[cfg(feature = "upload")]
 use crate::upload::{PingUploadManager, PingUploadTask};
 use crate::util::{local_now_with_offset, sanitize_application_id};
 
@@ -161,7 +159,6 @@ pub struct Glean {
     start_time: DateTime<FixedOffset>,
     max_events: usize,
     is_first_run: bool,
-    #[cfg(feature = "upload")]
     upload_manager: PingUploadManager,
 }
 
@@ -186,7 +183,6 @@ impl Glean {
             event_data_store,
             core_metrics: CoreMetrics::new(),
             internal_pings: InternalPings::new(),
-            #[cfg(feature = "upload")]
             upload_manager: PingUploadManager::new(&cfg.data_path),
             data_path: PathBuf::from(cfg.data_path),
             application_id,
@@ -330,7 +326,6 @@ impl Glean {
     fn clear_metrics(&mut self) {
         // Clear the pending pings queue and acquire the lock
         // so that it can't be accessed until this function is done.
-        #[cfg(feature = "upload")]
         let _lock = self.upload_manager.clear_ping_queue();
 
         // There is only one metric that we want to survive after clearing all
@@ -421,7 +416,6 @@ impl Glean {
     /// # Return value
     ///
     /// `PingUploadTask` - an enum representing the possible tasks.
-    #[cfg(feature = "upload")]
     pub fn get_upload_task(&self) -> PingUploadTask {
         self.upload_manager.get_upload_task()
     }
@@ -432,7 +426,6 @@ impl Glean {
     ///
     /// `uuid` - The UUID of the ping in question.
     /// `status` - The HTTP status of the response.
-    #[cfg(feature = "upload")]
     pub fn process_ping_upload_response(&self, uuid: &str, status: u16) {
         self.upload_manager
             .process_ping_upload_response(uuid, status);
@@ -508,7 +501,6 @@ impl Glean {
                     return Err(e.into());
                 }
 
-                #[cfg(feature = "upload")]
                 self.upload_manager
                     .enqueue_ping(&doc_id, &url_path, content);
 


### PR DESCRIPTION
After talking to @badboy we decided that the best solution to keep the upload changes off master, now that we are going to add them to the ffi and bindings, was to make a separate branch instead of feature flagging.

This PR removes the feature flags, but it also doesn't point to master but to the new branch m16/ping-uploading. I will keep that up to date with master as much as possible and all my upcoming PRs will point to it, until we are confident enough to merge to master without the feature flag.

What do you think, @Dexterp37 ?