### PR TITLE
Add script to update schema and run checks on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,25 @@ jobs:
           name: Run license check
           command: cargo deny check
 
+  Check vendored schema:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run:
+          name: Check vendored schema for upstream updates
+          command: |
+            bin/update-schema.sh latest
+            if ! git diff --exit-code HEAD -- glean-core/preview/tests/glean.1.schema.json; then
+              echo "===================================="
+              echo "Latest schema from upstream changed."
+              echo "Please regenerate the file using:"
+              echo "    bin/update-schema.sh latest"
+              echo "Commit the modified files and push."
+              echo "===================================="
+              exit 1
+            fi
+
   Lint YAML with yamllint:
     docker:
       - image: circleci/python:3.7.5
@@ -896,6 +915,7 @@ workflows:
       - Rust FFI header check
       - Lint Android with ktlint and detekt
       - Lint Python
+      - Check vendored schema
 
   ci:
     jobs:

--- a/bin/update-schema.sh
+++ b/bin/update-schema.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Update the bundled schema version tests run against.
+#
+# The schema is pulled from mozilla-pipeline-schemas at the following URL:
+#
+#     https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$HASH/schemas/glean/glean/glean.1.schema.json
+#
+# References in the code base are updated.
+#
+# Usage: update-schema.sh <commit hash>
+#
+# Environment:
+#
+# DRY_RUN - Do not modify files or run destructive commands when set.
+# VERB    - Log commands that are run when set.
+
+set -eo pipefail
+
+run() {
+  [ "${VERB:-0}" != 0 ] && echo "+ $*"
+  if [ "$DOIT" = y ]; then
+      "$@"
+  else
+      true
+  fi
+}
+
+update() {
+  COMMIT_HASH="$1"
+  FULL_URL="$(printf "$SCHEMA_URL" "$COMMIT_HASH")"
+  SCHEMA_PATH="${WORKSPACE_ROOT}/glean-core/preview/tests/glean.1.schema.json"
+
+  echo "Vendoring schema from ${FULL_URL}"
+  run curl --silent --fail --show-error --location --retry 5 --retry-delay 10 "$FULL_URL" --output "$SCHEMA_PATH"
+
+  # Update the android/build.gradle version
+
+  FILE=glean-core/android/build.gradle
+  run $SED -i.bak -E \
+      -e "s/^String GLEAN_PING_SCHEMA_GIT_HASH = \"[0-9a-z.-]+\"/String GLEAN_PING_SCHEMA_GIT_HASH = \"${COMMIT_HASH}\"/" \
+      "${WORKSPACE_ROOT}/${FILE}"
+  run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
+  # Update the Python testso
+
+  FILE=glean-core/python/tests/conftest.py
+  run $SED -i.bak -E \
+      -e "s/^GLEAN_PING_SCHEMA_GIT_HASH = \"[0-9a-z.-]+\"/GLEAN_PING_SCHEMA_GIT_HASH = \"${COMMIT_HASH}\"/" \
+      "${WORKSPACE_ROOT}/${FILE}"
+  run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+}
+
+get_latest() {
+  API_URL="https://api.github.com/repos/mozilla-services/mozilla-pipeline-schemas/commits?path=schemas%2Fglean%2Fglean%2Fglean.1.schema.json&page=1&per_page=1"
+  SHA="$(curl --silent --fail --show-error --location --retry 5 --retry-delay 10 "$API_URL" | grep --max-count=1 sha)"
+
+  echo "$SHA" | $SED -E -e 's/.+: "([^"]+)".*/\1/'
+}
+
+SED=sed
+if command -v gsed >/dev/null; then
+    SED=gsed
+fi
+
+DOIT=y
+if [[ -n "$DRY_RUN" ]]; then
+    echo "Dry-run. Not modifying files."
+    DOIT=n
+fi
+
+WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
+SCHEMA_URL="https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/%s/schemas/glean/glean/glean.1.schema.json"
+
+if [ -z "$1" ]; then
+    echo "Usage: $(basename $0) <commit hash>"
+    echo
+    echo "Update schema version to test"
+    exit 1
+fi
+
+COMMIT_HASH="$1"
+
+if [ "$COMMIT_HASH" = "latest" ]; then
+  COMMIT_HASH="$(get_latest)"
+fi
+
+update "$COMMIT_HASH"

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'jacoco'
  * Everytime this hash is changed it should also be changed in
  * glean-core/python/tests/conftest.py
  */
-String GLEAN_PING_SCHEMA_GIT_HASH = "ee08e7c"
+String GLEAN_PING_SCHEMA_GIT_HASH = "63dcb4285b73c0c625cbee46cf1fe506b7f4c5f6"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/glean/glean.1.schema.json"
 
 // Set configuration for the glean_parser

--- a/glean-core/preview/tests/glean.1.schema.json
+++ b/glean-core/preview/tests/glean.1.schema.json
@@ -752,12 +752,19 @@
                 "type": "string"
               },
               "extra": {
-                "properties": {
-                  "type": {
-                    "type": "string"
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
                   }
-                },
-                "type": "object"
+                ]
               }
             },
             "required": [

--- a/glean-core/preview/tests/glean.1.schema.json
+++ b/glean-core/preview/tests/glean.1.schema.json
@@ -1,7 +1,6 @@
 {
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "$originUrl": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/f2a7ce4/schemas/glean/glean/glean.1.schema.json",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {

--- a/glean-core/python/tests/conftest.py
+++ b/glean-core/python/tests/conftest.py
@@ -17,7 +17,7 @@ from glean import __version__ as glean_version
 # !IMPORTANT!
 # Everytime this hash is changed it should also be changed in
 # glean-core/android/build.gradle
-GLEAN_PING_SCHEMA_GIT_HASH = "f2a7ce4"
+GLEAN_PING_SCHEMA_GIT_HASH = "ee08e7c"
 GLEAN_PING_SCHEMA_URL = (
     "https://raw.githubusercontent.com/mozilla-services/"
     "mozilla-pipeline-schemas/{}/schemas/glean/glean/"

--- a/glean-core/python/tests/conftest.py
+++ b/glean-core/python/tests/conftest.py
@@ -17,7 +17,7 @@ from glean import __version__ as glean_version
 # !IMPORTANT!
 # Everytime this hash is changed it should also be changed in
 # glean-core/android/build.gradle
-GLEAN_PING_SCHEMA_GIT_HASH = "ee08e7c"
+GLEAN_PING_SCHEMA_GIT_HASH = "63dcb4285b73c0c625cbee46cf1fe506b7f4c5f6"
 GLEAN_PING_SCHEMA_URL = (
     "https://raw.githubusercontent.com/mozilla-services/"
     "mozilla-pipeline-schemas/{}/schemas/glean/glean/"


### PR DESCRIPTION
Previously we ran schema checks in Python (`test_glean.py`) and Kotlin (several).
These relied on fetching the schema from the mozilla-pipeline-schemas repository.
For reproducability it uses a fixed git hash across both tests.

Now we also bundle a schema into the repository and run a single test
against it from glean-preview.

This is a small imrprovement, but it still means we can miss updating it
(or miss updating all places in the repository to the same version).
The previous commit already introduced a script to automate that.

This CI task now runs an explicit check, failing if the upstream version
changed.

This does mean that unrelated PRs can now fail due to schema changes,
that may not affect them.

In a future world we could have a nightly task that runs this check and
opens a PR with the changed files.
