### PR TITLE
Updated dependency summary and reducing dep tree

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,9 @@ jobs:
       - run:
           name: Install cargo-deny
           command: |
-            DENY_VERSION=0.4.2
+            DENY_VERSION=0.6.6
             DENY="cargo-deny-${DENY_VERSION}-x86_64-unknown-linux-musl"
-            DENY_SHA256=400edab6e6f66927c8f929dcab3e48a7f3017ceaeba7aee12c992ad33b84bdce
+            DENY_SHA256=41e2e71b7b07cd68e1275d694b1646c0c2873e40f4f809f29d88467b6a1e3c21
             curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/EmbarkStudios/cargo-deny/releases/download/${DENY_VERSION}/${DENY}.tar.gz"
             echo "${DENY_SHA256} *${DENY}.tar.gz" | shasum -a 256 -c -
             tar -xvf "${DENY}.tar.gz"
@@ -177,7 +177,7 @@ jobs:
             chmod +x /usr/local/cargo/bin/cargo-deny
       - run:
           name: Run license check
-          command: cargo deny check
+          command: cargo deny check licenses
 
   Check vendored schema:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
  "ctor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iso8601 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iso8601 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -369,10 +369,10 @@ dependencies = [
 
 [[package]]
 name = "iso8601"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -470,15 +470,6 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -886,11 +877,6 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -981,7 +967,7 @@ dependencies = [
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum iri-string 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "402e5c3bd66bbe43ac90915097caa0347fc2666ecb8a0047154f4494ed577995"
-"checksum iso8601 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43e86914a73535f3f541a765adea0a9fafcf53fa6adb73662c4988fd9233766f"
+"checksum iso8601 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cee08a007a59a8adfc96f69738ddf59e374888dfd84b49c4b916543067644d58"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum json-pointer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8be58bc6b9e76616678217b983ab122d0ec207241c487ce450361ba7b5ddafd1"
@@ -994,7 +980,6 @@ dependencies = [
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
@@ -1045,7 +1030,6 @@ dependencies = [
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1293,15 +1293,11 @@ limitations under the License.
 
 The following text applies to code linked from these dependencies:
 
-* [autocfg 1.0.0]( https://github.com/cuviper/autocfg )
-* [backtrace 0.3.40]( https://github.com/rust-lang/backtrace-rs )
 * [bitflags 1.2.1]( https://github.com/bitflags/bitflags )
-* [cc 1.0.50]( https://github.com/alexcrichton/cc-rs )
 * [cfg-if 0.1.10]( https://github.com/alexcrichton/cfg-if )
 * [env_logger 0.7.1]( https://github.com/sebasmagri/env_logger/ )
 * [failure 0.1.6]( https://github.com/rust-lang-nursery/failure )
-* [ffi-support 0.3.5]( https://github.com/mozilla/application-services )
-* [hermit-abi 0.1.6]( https://github.com/hermitcore/rusty-hermit )
+* [ffi-support 0.4.0]( https://github.com/mozilla/application-services )
 * [idna 0.2.0]( https://github.com/servo/rust-url/ )
 * [itoa 0.4.4]( https://github.com/dtolnay/itoa )
 * [lazy_static 1.4.0]( https://github.com/rust-lang-nursery/lazy-static.rs )
@@ -1311,18 +1307,15 @@ The following text applies to code linked from these dependencies:
 * [num-traits 0.2.11]( https://github.com/rust-num/num-traits )
 * [once_cell 1.2.0]( https://github.com/matklad/once_cell )
 * [percent-encoding 2.1.0]( https://github.com/servo/rust-url/ )
-* [pkg-config 0.3.17]( https://github.com/rust-lang/pkg-config-rs )
 * [proc-macro2 1.0.7]( https://github.com/alexcrichton/proc-macro2 )
 * [quote 1.0.2]( https://github.com/dtolnay/quote )
 * [regex 1.3.3]( https://github.com/rust-lang/regex )
 * [regex-syntax 0.6.13]( https://github.com/rust-lang/regex )
-* [rustc-demangle 0.1.16]( https://github.com/alexcrichton/rustc-demangle )
 * [serde 1.0.104]( https://github.com/serde-rs/serde )
 * [serde_derive 1.0.104]( https://github.com/serde-rs/serde )
 * [serde_json 1.0.44]( https://github.com/serde-rs/json )
 * [smallvec 1.1.0]( https://github.com/servo/rust-smallvec )
 * [syn 1.0.13]( https://github.com/dtolnay/syn )
-* [tempfile 3.1.0]( https://github.com/Stebalien/tempfile )
 * [time 0.1.42]( https://github.com/rust-lang/time )
 * [unicode-bidi 0.3.4]( https://github.com/servo/unicode-bidi )
 * [unicode-normalization 0.1.11]( https://github.com/unicode-rs/unicode-normalization )
@@ -1330,8 +1323,6 @@ The following text applies to code linked from these dependencies:
 * [url 2.1.1]( https://github.com/servo/rust-url )
 * [uuid 0.7.4]( https://github.com/uuid-rs/uuid )
 * [uuid 0.8.1]( https://github.com/uuid-rs/uuid )
-* [version_check 0.1.5]( https://github.com/SergioBenitez/version_check )
-* [wasi 0.9.0+wasi-snapshot-preview1]( https://github.com/bytecodealliance/wasi )
 
 
 ```
@@ -1547,7 +1538,6 @@ The following text applies to code linked from these dependencies:
 * [rand 0.7.2]( https://github.com/rust-random/rand )
 * [rand_chacha 0.2.1]( https://github.com/rust-random/rand )
 * [rand_core 0.5.1]( https://github.com/rust-random/rand )
-* [rand_hc 0.2.0]( https://github.com/rust-random/rand )
 
 
 ```
@@ -1759,213 +1749,8 @@ limitations under the License.
 
 The following text applies to code linked from these dependencies:
 
-* [remove_dir_all 0.5.2]( https://github.com/XAMPPRocky/remove_dir_all.git )
-
-
-```
-                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   "License" shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   "Licensor" shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   "Legal Entity" shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   "control" means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   "You" (or "Your") shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   "Source" form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   "Object" form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   "Work" shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   "Derivative Works" shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   "Contribution" shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, "submitted"
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as "Not a Contribution."
-
-   "Contributor" shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a "NOTICE" text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-Copyright 2017 Aaron Power
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
-```
-## Apache License 2.0
-<span id="Apache-2.0"></span>
-
-The following text applies to code linked from these dependencies:
-
-* [backtrace-sys 0.1.32]( https://github.com/alexcrichton/backtrace-rs )
-* [ctor 0.1.12]( https://github.com/mmastrac/rust-ctor )
 * [failure_derive 0.1.6]( https://github.com/withoutboats/failure_derive )
 * [lmdb-rkv-sys 0.9.6]( https://github.com/mozilla/lmdb-rs.git )
-* [winapi-i686-pc-windows-gnu 0.4.0]( https://github.com/retep998/winapi-rs )
 * [winapi-x86_64-pc-windows-gnu 0.4.0]( https://github.com/retep998/winapi-rs )
 
 
@@ -2821,68 +2606,6 @@ DEALINGS IN THE SOFTWARE.
 
 The following text applies to code linked from these dependencies:
 
-* [nom 4.2.3]( https://github.com/Geal/nom )
-
-
-```
-Copyright (c) 2014-2018 Geoffroy Couprie
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-```
-## MIT License
-<span id="MIT"></span>
-
-The following text applies to code linked from these dependencies:
-
-* [iso8601 0.3.0]( https://github.com/badboy/iso8601 )
-
-
-```
-Copyright (c) 2015 Jan-Erik Rediger, Hendrik Sollich
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-```
-## MIT License
-<span id="MIT"></span>
-
-The following text applies to code linked from these dependencies:
-
 * [ordered-float 1.0.2]( https://github.com/reem/rust-ordered-float )
 
 
@@ -2924,39 +2647,6 @@ The following text applies to code linked from these dependencies:
 
 ```
 Copyright (c) 2015-2019 Doug Tangren
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-```
-## MIT License
-<span id="MIT"></span>
-
-The following text applies to code linked from these dependencies:
-
-* [redox_syscall 0.1.56]( https://gitlab.redox-os.org/redox-os/syscall )
-
-
-```
-Copyright (c) 2017 Redox OS Developers
-
-MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -3034,7 +2724,6 @@ SOFTWARE.
 The following text applies to code linked from these dependencies:
 
 * [byteorder 1.3.2]( https://github.com/BurntSushi/byteorder )
-* [memchr 2.2.1]( https://github.com/BurntSushi/rust-memchr )
 * [termcolor 1.0.5]( https://github.com/BurntSushi/termcolor )
 * [wincolor 1.0.2]( https://github.com/BurntSushi/termcolor/tree/master/wincolor )
 
@@ -3100,9 +2789,10 @@ THE SOFTWARE.
 
 The following text applies to code linked from these dependencies:
 
-* [glean-core 23.0.1]( https://github.com/mozilla/glean )
-* [glean-ffi 23.0.1]( https://github.com/mozilla/glean )
-* [glean-preview 0.0.4]( https://github.com/mozilla/glean )
+* [benchmark 0.1.0]( https://crates.io/crates/benchmark )
+* [glean-core 25.1.0]( https://github.com/mozilla/glean )
+* [glean-ffi 25.1.0]( https://github.com/mozilla/glean )
+* [glean-preview 0.0.5]( https://github.com/mozilla/glean )
 
 
 ```

--- a/about.toml
+++ b/about.toml
@@ -7,3 +7,24 @@ accepted = [
     "BSD-3-Clause",
     "ISC",
 ]
+
+# Subset of targets we build for
+targets = [
+    # Linux/Windows/macOS
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+
+    # Android targets
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+
+    # iOS targets
+    "aarch64-apple-ios",
+    "x86_64-apple-ios"
+]
+
+ignore-build-dependencies = true
+ignore-dev-dependencies = true

--- a/deny.toml
+++ b/deny.toml
@@ -5,8 +5,5 @@ allow = [
     "MPL-2.0",
     "Apache-2.0",
     "MIT",
-    "CC0-1.0",
     "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
 ]

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -40,5 +40,5 @@ once_cell = "1.2.0"
 [dev-dependencies]
 env_logger = { version = "0.7.1", default-features = false, features = ["termcolor", "atty", "humantime"] }
 tempfile = "3.1.0"
-iso8601 = "0.3"
+iso8601 = "0.4"
 ctor = "0.1.12"

--- a/glean-core/android/dependency-licenses.xml
+++ b/glean-core/android/dependency-licenses.xml
@@ -37,20 +37,8 @@ the details of which are reproduced below.
     <url>https://github.com/cryptocorrosion/cryptocorrosion</url>
   </license>
   <license>
-    <name>Apache License 2.0: autocfg</name>
-    <url>https://github.com/cuviper/autocfg</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: backtrace</name>
-    <url>https://github.com/rust-lang/backtrace-rs</url>
-  </license>
-  <license>
     <name>Apache License 2.0: bitflags</name>
     <url>https://github.com/bitflags/bitflags</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: cc</name>
-    <url>https://github.com/alexcrichton/cc-rs</url>
   </license>
   <license>
     <name>Apache License 2.0: cfg-if</name>
@@ -67,10 +55,6 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: ffi-support</name>
     <url>https://github.com/mozilla/application-services</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: hermit-abi</name>
-    <url>https://github.com/hermitcore/rusty-hermit</url>
   </license>
   <license>
     <name>Apache License 2.0: idna</name>
@@ -109,10 +93,6 @@ the details of which are reproduced below.
     <url>https://github.com/servo/rust-url/</url>
   </license>
   <license>
-    <name>Apache License 2.0: pkg-config</name>
-    <url>https://github.com/rust-lang/pkg-config-rs</url>
-  </license>
-  <license>
     <name>Apache License 2.0: proc-macro2</name>
     <url>https://github.com/alexcrichton/proc-macro2</url>
   </license>
@@ -127,10 +107,6 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: regex-syntax</name>
     <url>https://github.com/rust-lang/regex</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: rustc-demangle</name>
-    <url>https://github.com/alexcrichton/rustc-demangle</url>
   </license>
   <license>
     <name>Apache License 2.0: serde</name>
@@ -151,10 +127,6 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: syn</name>
     <url>https://github.com/dtolnay/syn</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: tempfile</name>
-    <url>https://github.com/Stebalien/tempfile</url>
   </license>
   <license>
     <name>Apache License 2.0: time</name>
@@ -185,14 +157,6 @@ the details of which are reproduced below.
     <url>https://github.com/uuid-rs/uuid</url>
   </license>
   <license>
-    <name>Apache License 2.0: version_check</name>
-    <url>https://github.com/SergioBenitez/version_check</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: wasi</name>
-    <url>https://github.com/bytecodealliance/wasi</url>
-  </license>
-  <license>
     <name>Apache License 2.0: getrandom</name>
     <url>https://github.com/rust-random/getrandom</url>
   </license>
@@ -209,32 +173,12 @@ the details of which are reproduced below.
     <url>https://github.com/rust-random/rand</url>
   </license>
   <license>
-    <name>Apache License 2.0: rand_hc</name>
-    <url>https://github.com/rust-random/rand</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: remove_dir_all</name>
-    <url>https://github.com/XAMPPRocky/remove_dir_all.git</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: backtrace-sys</name>
-    <url>https://github.com/alexcrichton/backtrace-rs</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: ctor</name>
-    <url>https://github.com/mmastrac/rust-ctor</url>
-  </license>
-  <license>
     <name>Apache License 2.0: failure_derive</name>
     <url>https://github.com/withoutboats/failure_derive</url>
   </license>
   <license>
     <name>Apache License 2.0: lmdb-rkv-sys</name>
     <url>https://github.com/mozilla/lmdb-rs.git</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: winapi-i686-pc-windows-gnu</name>
-    <url>https://github.com/retep998/winapi-rs</url>
   </license>
   <license>
     <name>Apache License 2.0: winapi-x86_64-pc-windows-gnu</name>
@@ -261,24 +205,12 @@ the details of which are reproduced below.
     <url>https://github.com/SimonSapin/rust-std-candidates</url>
   </license>
   <license>
-    <name>MIT License: nom</name>
-    <url>https://github.com/Geal/nom</url>
-  </license>
-  <license>
-    <name>MIT License: iso8601</name>
-    <url>https://github.com/badboy/iso8601</url>
-  </license>
-  <license>
     <name>MIT License: ordered-float</name>
     <url>https://github.com/reem/rust-ordered-float</url>
   </license>
   <license>
     <name>MIT License: atty</name>
     <url>https://github.com/softprops/atty</url>
-  </license>
-  <license>
-    <name>MIT License: redox_syscall</name>
-    <url>https://gitlab.redox-os.org/redox-os/syscall</url>
   </license>
   <license>
     <name>MIT License: synstructure</name>
@@ -293,10 +225,6 @@ the details of which are reproduced below.
     <url>https://github.com/BurntSushi/byteorder</url>
   </license>
   <license>
-    <name>MIT License: memchr</name>
-    <url>https://github.com/BurntSushi/rust-memchr</url>
-  </license>
-  <license>
     <name>MIT License: termcolor</name>
     <url>https://github.com/BurntSushi/termcolor</url>
   </license>
@@ -307,6 +235,10 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: winapi-util</name>
     <url>https://github.com/BurntSushi/winapi-util</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: benchmark</name>
+    <url>https://crates.io/crates/benchmark</url>
   </license>
   <license>
     <name>Mozilla Public License 2.0: glean-core</name>


### PR DESCRIPTION
An accumulation of multiple changes, none of which are super critical.
I marked them all as `[doc only]` because either they are or it's Rust tests only and I ran those locally (the dep upgrade)