### PR TITLE
Update Python SDK documentation for logging pings 

### DIFF
--- a/docs/user/debugging/python.md
+++ b/docs/user/debugging/python.md
@@ -25,6 +25,15 @@ After doing so, something like `pings.custom_ping.submit()` will send the custom
 
 ## Logging pings
 
-If the `Glean.configuration.log_pings` property is set to `True`, pings are logged to the console whenever they are submitted.
+If the `Glean.configuration.log_pings` property is set to `True`, pings are
+logged to the console on `DEBUG` level whenever they are submitted. You can set
+this property in a similar way as the `ping_tag` property above.
 
-You can set this property in a similar way as the `ping_tag` property above.
+Make sure that when you configure logging in your application, you set the
+level for the `glean` logger to `DEBUG` or higher. Otherwise pings won't be
+logged even if `log_pings` is set to `True`.
+
+See the [Python logging documentation][python-logging] for more information.
+
+[python-logging]: https://docs.python.org/3.8/library/logging.html
+

--- a/docs/user/debugging/python.md
+++ b/docs/user/debugging/python.md
@@ -33,6 +33,14 @@ Make sure that when you configure logging in your application, you set the
 level for the `glean` logger to `DEBUG` or higher. Otherwise pings won't be
 logged even if `log_pings` is set to `True`.
 
+You can set the logging level for Glean to `DEBUG` as follows:
+
+```python
+import logging
+
+logging.getLogger("glean").setLevel(logging.DEBUG)
+```
+
 See the [Python logging documentation][python-logging] for more information.
 
 [python-logging]: https://docs.python.org/3.8/library/logging.html


### PR DESCRIPTION
My application used `logging.basicConfig(level=logging.INFO)` to configure logging and I realized that pings weren't logged even though I set the according configuration option `log_pings` to `True` (see [documentation](https://mozilla.github.io/glean/book/user/debugging/python.html#logging-pings)). 📝  

This PR updates the Python SDK documentation to point out that the `glean` logger uses level `DEBUG` and consumers need to configure logging accordingly, if they want pings to be logged.