### PR TITLE
1615256: Don't clean the miniconda installation on `gradlew clean`

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 155 utf-8
+personal_ws-1.1 en 156 utf-8
 AAR
 AARs
 APIs
@@ -37,6 +37,7 @@ Lockwise
 MPL
 Makefile
 Mingw
+Miniconda
 Mockito
 Mutex
 NDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v25.1.0...master)
 
+* Android:
+  * `gradlew clean` will no longer remove the Miniconda installation in
+    `~/.gradle/glean`. Therefore `clean` can be used without reinstalling
+    Miniconda afterward every time.
+
 # v25.1.0 (2020-02-26)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v25.0.0...v25.1.0)

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -330,10 +330,6 @@ subprocess.check_call([
         project.preBuild.dependsOn(createBuildDir)
         project.preBuild.finalizedBy("build_envs")
 
-        project.clean {
-            delete condaBootstrapDir
-        }
-
         return condaDir
     }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/fenix/issues/8039