### PR TITLE
Properly escape Glean schema path on Windows

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -40,7 +40,9 @@ android {
         // TODO: 1551691 Get the version from git tag...? Also, we need to select a
         // version that won't conflict with legacy glean-ac versions.
         buildConfigField("String", "LIBRARY_VERSION", "\"0.1\"")
-        buildConfigField("String", "GLEAN_PING_SCHEMA_PATH", "\"" + GLEAN_PING_SCHEMA_PATH + "\"")
+        // Carefully escape the string here so it will support `\` in
+        // Windows paths correctly.
+        buildConfigField("String", "GLEAN_PING_SCHEMA_PATH", JsonOutput.toJson(GLEAN_PING_SCHEMA_PATH.path))
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
This was broken by #747. This PR properly scapes the paths on Windows.