### PR TITLE
Add a table of all different implementations and projects of the Glean SDK

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 158 utf-8
+personal_ws-1.1 en 159 utf-8
 AAR
 AARs
 APIs
@@ -63,6 +63,7 @@ alphanumerics
 analytics
 aspell
 async
+autodetected
 backend
 barcode
 boolean

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -68,6 +68,7 @@
         - [Payload format](dev/core/internal/payload.md).
         - [Directory structure](dev/core/internal/directory-structure.md)
         - [Debug Pings](dev/core/internal/debug-pings.md)
+        - [Implementations](dev/core/internal/implementations.md)
     - [Howtos](dev/howtos/index.md)
         - [Development with android-components](dev/howtos/development-with-android-components.md)
         - [Locally-published components in Fenix](dev/howtos/locally-published-components-in-fenix.md)

--- a/docs/dev/core/internal/implementations.md
+++ b/docs/dev/core/internal/implementations.md
@@ -1,0 +1,17 @@
+# Implementations
+
+| Project Name      | Language Bindings   | Operating System  | App lifecycle type  | Environment Data source |
+| ----------------- | ------------------- | ----------------  | ------------------- | ----------------------- |
+| glean-core        | Rust                | all               | all                 | none                    |
+| glean-ffi         | C                   | all               | all                 | none                    |
+| glean-preview[^1] | Rust                | Windows/Mac/Linux | Desktop application | OS info build-time autodetected, app info passed in |
+| Glean Android     | Kotlin, Java        | Android           | Mobile app          | Autodetected from the Android environment |
+| Glean iOS         | Swift               | iOS               | Mobile app          | Autodetected from the iOS environment
+| Glean.py          | Python              | Windows/Mac/Linux | all                 | Autodetected at runtime |
+| FOG[^2]           | Rust/C++/JavaScript | as Firefox supports | Desktop application | OS info build-time autodetected, app info passed in |
+
+---
+
+[^1]: [glean-preview](https://crates.io/crates/glean-preview) is an experimental crate for prototyping integration into Firefox. It it not recommended for general use. See Project FOG.
+
+[^2]: [Firefox on Glean (FOG)](https://firefox-source-docs.mozilla.org/toolkit/components/glean/index.html) is the name of the layer that integrates the Glean SDK into Firefox Desktop. It is currently being designed and implemented.

--- a/docs/dev/core/internal/implementations.md
+++ b/docs/dev/core/internal/implementations.md
@@ -1,6 +1,6 @@
 # Implementations
 
-| Project Name      | Language Bindings   | Operating System  | App lifecycle type  | Environment Data source |
+| Project Name      | Language Bindings   | Operating System  | App Lifecycle Type  | Environment Data source |
 | ----------------- | ------------------- | ----------------  | ------------------- | ----------------------- |
 | glean-core        | Rust                | all               | all                 | none                    |
 | glean-ffi         | C                   | all               | all                 | none                    |


### PR DESCRIPTION
As discused in the [Naming proposal](https://docs.google.com/document/d/1M8xc_LmOxqnalyM6FJyIYtp1KnumSsQe99-XcWYYSJw/edit#) I'm bringing the table over into our offical SDK docs..

I also call them "implementations" side-stepping all the platform/architecture/project discussion (aaaand that's a new bikeshedding...)

Rendered:

![screenshot of the rendered book chapter](https://tmp.fnordig.de/scr/ce43cdf84b.png)

(I'm considering making our main content _slightly _wider to better accomodate tables.)