### PR TITLE
iOS: Add missing `testGetNumRecordedErrors` methods for labeled metrics

### DIFF
--- a/docs/user/metrics/labeled_booleans.md
+++ b/docs/user/metrics/labeled_booleans.md
@@ -13,7 +13,7 @@ accessibility:
     description: >
       a11y features enabled on the device. ...
     labels:
-      - screen_reader 
+      - screen_reader
       - high_contrast
     ...
 ```
@@ -68,6 +68,8 @@ XCTAssert(Accessibility.features["high_contrast"].testHasValue())
 // Do the booleans have the expected values?
 XCTAssertEqual(true, try Accessibility.features["screen_reader"].testGetValue())
 XCTAssertEqual(false, try Accessibility.features["high_contrast"].testGetValue())
+// Were there any invalid labels?
+XCTAssertEqual(0, Accessibility.features.testGetNumRecordedErrors(.invalidLabel))
 ```
 
 </div>
@@ -119,7 +121,7 @@ assert 0 == metrics.accessibility.features.test_get_num_recorded_errors(
 
 ## Examples
 
-* Record a related set of boolean flags. 
+* Record a related set of boolean flags.
 
 ## Recorded Errors
 

--- a/docs/user/metrics/labeled_counters.md
+++ b/docs/user/metrics/labeled_counters.md
@@ -44,7 +44,7 @@ assertTrue(Stability.crashCount["native_code_crash"].testHasValue())
 // Do the counters have the expected values?
 assertEquals(1, Stability.crashCount["uncaught_exception"].testGetValue())
 assertEquals(3, Stability.crashCount["native_code_crash"].testGetValue())
-// Did we record any invalid labels?
+// Were there any invalid labels?
 assertEquals(0, Stability.crashCount.testGetNumRecordedErrors(ErrorType.InvalidLabel))
 ```
 
@@ -68,6 +68,8 @@ XCTAssert(Stability.crashCount["native_code_crash"].testHasValue())
 // Do the counters have the expected values?
 XCTAssertEqual(1, try Stability.crashCount["uncaught_exception"].testGetValue())
 XCTAssertEqual(3, try Stability.crashCount["native_code_crash"].testGetValue())
+// Were there any invalid labels?
+XCTAssertEqual(0, Stability.crashCount.testGetNumRecordedErrors(.invalidLabel))
 ```
 
 </div>
@@ -93,7 +95,7 @@ assert metrics.stability.crash_count["native_code_crash"].test_has_value()
 # Do the counters have the expected values?
 assert 1 == metrics.stability.crash_count["uncaught_exception"].test_get_value()
 assert 3 == metrics.stability.crash_count["native_code_crash"].test_get_value()
-# Did we record any invalid labels?
+# Were there any invalid labels?
 assert 0 == metrics.stability.crash_count.test_get_num_recorded_errors(
     ErrorType.INVALID_LABEL
 )

--- a/docs/user/metrics/labeled_strings.md
+++ b/docs/user/metrics/labeled_strings.md
@@ -58,6 +58,9 @@ There are test APIs available too:
 
 // Was anything recorded?
 XCTAssert(Login.errorsByStage["server_auth"].testHasValue())
+
+// Were there any invalid labels?
+XCTAssertEqual(0, Login.errorsByStage.testGetNumRecordedErrors(.invalidLabel))
 ```
 
 </div>

--- a/glean-core/ios/Glean/Metrics/LabeledMetric.swift
+++ b/glean-core/ios/Glean/Metrics/LabeledMetric.swift
@@ -123,4 +123,35 @@ public class LabeledMetricType<T> {
             assertUnreachable()
         }
     }
+
+    /// Returns the number of errors recorded for the given metric.
+    ///
+    /// - parameters:
+    ///     * errorType: The type of the error recorded.
+    ///     * pingName: represents the name of the ping to retrieve the metric for.
+    ///                 Defaults to the first value in `sendInPings`.
+    /// - returns: the number of errors recorded for the metric.
+    public func testGetNumRecordedErrors(_ errorType: ErrorType, pingName: String? = nil) -> Int32 {
+        Dispatchers.shared.assertInTestingMode()
+
+        let pingName = pingName ?? self.sendInPings[0]
+
+        switch self.subMetric {
+        case is CounterMetricType:
+            return glean_labeled_counter_test_get_num_recorded_errors(
+                self.handle, errorType.rawValue, pingName
+            )
+        case is BooleanMetricType:
+            return glean_labeled_boolean_test_get_num_recorded_errors(
+                self.handle, errorType.rawValue, pingName
+            )
+        case is StringMetricType:
+            return glean_labeled_string_test_get_num_recorded_errors(
+                self.handle, errorType.rawValue, pingName
+            )
+        default:
+            // The constructor will already throw an exception on an unhandled sub-metric type
+            assertUnreachable()
+        }
+    }
 }

--- a/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
@@ -136,6 +136,11 @@ class LabeledMetricTypeTests: XCTestCase {
         labeledCounterMetric["with/slash"].add(1)
         labeledCounterMetric["this_string_has_more_than_thirty_characters"].add(1)
 
+        XCTAssertEqual(
+            4,
+            labeledCounterMetric.testGetNumRecordedErrors(.invalidLabel)
+        )
+
         XCTAssertEqual(4, try labeledCounterMetric["__other__"].testGetValue())
     }
 


### PR DESCRIPTION
Bug 1621698

I ran all these locally and they were green:

* `make swiftlint`
* `make swiftfmt`
* `make test-swift`

Guess we can skip the iOS tests here before merge.