### PR TITLE
Python: Windows x86 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1052,7 +1052,11 @@ workflows:
           requires:
             - Python 3_7 tests
           filters: *release-filters
-      - pypi-windows-release:
+      - pypi-windows-i686-release:
+          requires:
+            - Python 3_7 tests
+          filters: *release-filters
+      - pypi-windows-x86_64-release:
           requires:
             - Python 3_7 tests
           filters: *release-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,14 +114,18 @@ commands:
           name: Install mingw
           command: |
             sudo apt update
+            # This package contains tools for both i686 and x86_64 targets
             sudo apt install -y gcc-mingw-w64
       - run:
           name: Add mingw target
           command: |
             rustup target add x86_64-pc-windows-gnu
+            rustup target add i686-pc-windows-gnu
             # Set the linker to use for Rust/mingw
             echo '[target.x86_64-pc-windows-gnu]' >> ~/.cargo/config
             echo 'linker = "/usr/bin/x86_64-w64-mingw32-gcc"' >> ~/.cargo/config
+            echo '[target.i686-pc-windows-gnu]' >> ~/.cargo/config
+            echo 'linker = "/usr/bin/i686-w64-mingw32-gcc"' >> ~/.cargo/config
       - run:
           name: Fix broken mingw toolchain
           command: |
@@ -130,6 +134,7 @@ commands:
             # https://github.com/rust-lang/rust/issues/49078
             # https://wiki.archlinux.org/index.php/Rust#Windows
             for lib in crt2.o dllcrt2.o libmsvcrt.a; do cp -v /usr/x86_64-w64-mingw32/lib/$lib ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-pc-windows-gnu/lib/; done
+            for lib in crt2.o dllcrt2.o libmsvcrt.a; do cp -v /usr/i686-w64-mingw32/lib/$lib ~/.rustup/toolchains/stable-i686-unknown-linux-gnu/lib/rustlib/i686-pc-windows-gnu/lib/; done
 
   install-ghr-darwin:
     steps:
@@ -804,7 +809,7 @@ jobs:
             # Upload to GitHub
             ./ghr -replace ${CIRCLE_TAG} glean-core/python/dist
 
-  pypi-windows-release:
+  pypi-windows-x86_64-release:
     docker:
       - image: circleci/python:3.7.6
     steps:
@@ -824,7 +829,38 @@ jobs:
           name: Build Windows wheel
           command: |
             cd glean-core/python
-            GLEAN_PYTHON_MINGW_BUILD=1 .venv/bin/python3 setup.py bdist_wheel
+            GLEAN_PYTHON_MINGW_X86_64_BUILD=1 .venv/bin/python3 setup.py bdist_wheel
+            # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
+            # variables are configured in CircleCI's environment variables.
+            .venv/bin/python3 -m twine upload dist/*
+      - install-ghr-linux
+      - run:
+          name: Publish to Github
+          command: |
+            # Upload to GitHub
+            ./ghr -replace ${CIRCLE_TAG} glean-core/python/dist
+
+  pypi-windows-i686-release:
+    docker:
+      - image: circleci/python:3.7.6
+    steps:
+      - install-rustup
+      - setup-rust-toolchain
+      - install-mingw
+      - checkout
+      - run:
+          name: Install Python development tools for host
+          command:
+            make python-setup
+      - run:
+          name: Build Windows glean_ffi.dll
+          command:
+            cargo build --target i686-pc-windows-gnu
+      - run:
+          name: Build Windows wheel
+          command: |
+            cd glean-core/python
+            GLEAN_PYTHON_MINGW_I686_BUILD=1 .venv/bin/python3 setup.py bdist_wheel
             # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
             # variables are configured in CircleCI's environment variables.
             .venv/bin/python3 -m twine upload dist/*

--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 159 utf-8
+personal_ws-1.1 en 160 utf-8
 AAR
 AARs
 APIs
@@ -152,6 +152,7 @@ toolchains
 tooltip
 transpiler
 travis
+und
 unhandled
 uploader
 vendored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iso8601 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/docs/user/collected-metrics/metrics.md
+++ b/docs/user/collected-metrics/metrics.md
@@ -60,7 +60,7 @@ The following metrics are added to the ping:
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
 | glean.baseline.duration |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The duration of the last foreground session.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
-| glean.baseline.locale |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The locale of the application (e.g. "es-ES"). If the locale can't be determined on the system, the value is "C", which is the POSIX value for "default locale".  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
+| glean.baseline.locale |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The locale of the application (e.g. "es-ES"). If the locale can't be determined on the system, the value is "und", to indicate "undetermined".  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
 
 ## deletion-request
 

--- a/docs/user/collected-metrics/metrics.md
+++ b/docs/user/collected-metrics/metrics.md
@@ -60,7 +60,7 @@ The following metrics are added to the ping:
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
 | glean.baseline.duration |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The duration of the last foreground session.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
-| glean.baseline.locale |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The locale of the application (e.g. "es-ES").  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
+| glean.baseline.locale |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The locale of the application (e.g. "es-ES"). If the locale can't be determined on the system, the value is "C", which is the POSIX value for "default locale".  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
 
 ## deletion-request
 

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -36,6 +36,7 @@ regex = { version = "1.3.3", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 chrono = { version = "0.4.10", features = ["serde"] }
 once_cell = "1.2.0"
+libc = "0.2.0"
 
 [dev-dependencies]
 env_logger = { version = "0.7.1", default-features = false, features = ["termcolor", "atty", "humantime"] }

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -32,8 +32,8 @@ glean.baseline:
       - baseline
     description: |
       The locale of the application (e.g. "es-ES").
-      If the locale can't be determined on the system, the value is "C",
-      which is the POSIX value for "default locale".
+      If the locale can't be determined on the system, the value is "und",
+      to indicate "undetermined".
     bugs:
       - https://bugzilla.mozilla.org/1512938
       - https://bugzilla.mozilla.org/1525540

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -32,6 +32,7 @@ glean.baseline:
       - baseline
     description: |
       The locale of the application (e.g. "es-ES").
+      If the locale can't be determined on the system, the value is "C".
     bugs:
       - https://bugzilla.mozilla.org/1512938
       - https://bugzilla.mozilla.org/1525540

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -32,7 +32,8 @@ glean.baseline:
       - baseline
     description: |
       The locale of the application (e.g. "es-ES").
-      If the locale can't be determined on the system, the value is "C".
+      If the locale can't be determined on the system, the value is "C",
+      which is the POSIX value for "default locale".
     bugs:
       - https://bugzilla.mozilla.org/1512938
       - https://bugzilla.mozilla.org/1525540

--- a/glean-core/python/glean/_util.py
+++ b/glean-core/python/glean/_util.py
@@ -18,12 +18,11 @@ def get_locale_tag() -> str:
     """
     value = locale.getlocale()[0]
 
-    # In some contexts, especially on Windows, there is no locale set. Use "C"
-    # to indicate "unknown", as this is the "default locale" according to the
-    # POSIX standard:
-    # https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap07.html#tag_07_02
+    # In some contexts, especially on Windows, there is no locale set. Use "und"
+    # to indicate "undetermined", as recommended by the Unicode TR35:
+    # https://unicode.org/reports/tr35/#Unknown_or_Invalid_Identifiers
     if value is None:
-        return "C"
+        return "und"
 
     # The format of the locale string is platform depedent. At least on Linux,
     # often an understore is used between language and country, which is not

--- a/glean-core/python/glean/_util.py
+++ b/glean-core/python/glean/_util.py
@@ -18,6 +18,11 @@ def get_locale_tag() -> str:
     """
     value = locale.getlocale()[0]
 
+    # In some contexts, especially on Windows, there is no locale set. Use "C"
+    # to indicate "unknown".
+    if value is None:
+        return "C"
+
     # The format of the locale string is platform depedent. At least on Linux,
     # often an understore is used between language and country, which is not
     # RFC 1766 compliant. Correct it here.

--- a/glean-core/python/glean/_util.py
+++ b/glean-core/python/glean/_util.py
@@ -19,7 +19,9 @@ def get_locale_tag() -> str:
     value = locale.getlocale()[0]
 
     # In some contexts, especially on Windows, there is no locale set. Use "C"
-    # to indicate "unknown".
+    # to indicate "unknown", as this is the "default locale" according to the
+    # POSIX standard:
+    # https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap07.html#tag_07_02
     if value is None:
         return "C"
 

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -82,10 +82,14 @@ class PingUploadWorker:
                 try:
                     url_path = next(lines).strip()
                     serialized_ping = next(lines)
+                    valid_content = True
                 except StopIteration:
-                    path.unlink()
-                    log.error("Invalid ping content in {}".format(path.resolve()))
-                    return False
+                    valid_content = False
+            # On Windows, we must close the file before deleting it
+            if not valid_content:
+                path.unlink()
+                log.error("Invalid ping content in {}".format(path.resolve()))
+                return False
         except FileNotFoundError:
             log.error("Could not find ping file {}".format(path.resolve()))
             return False

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -14,9 +14,16 @@ import wheel.bdist_wheel
 
 
 platform = sys.platform
-if os.environ.get("GLEAN_PYTHON_MINGW_BUILD") or platform.startswith("win"):
-    platform = "windows"
 
+if os.environ.get("GLEAN_PYTHON_MINGW_I686_BUILD"):
+    mingw_arch = "i686"
+elif os.environ.get("GLEAN_PYTHON_MINGW_X86_64_BUILD"):
+    mingw_arch = "x86_64"
+else:
+    mingw_arch = None
+
+if mingw_arch is not None:
+    platform = "windows"
 
 if sys.version_info < (3, 5):
     print("glean requires at least Python 3.5", file=sys.stderr)
@@ -48,9 +55,12 @@ requirements = [
 
 setup_requirements = []
 
-shared_object_build_dir = "../../target/debug/"
-if os.environ.get("GLEAN_PYTHON_MINGW_BUILD"):
+if mingw_arch == "i686":
+    shared_object_build_dir = "../../target/i686-pc-windows-gnu/debug/"
+elif mingw_arch == "x86_64":
     shared_object_build_dir = "../../target/x86_64-pc-windows-gnu/debug/"
+else:
+    shared_object_build_dir = "../../target/debug/"
 
 
 if platform == "linux":
@@ -90,7 +100,12 @@ class bdist_wheel(wheel.bdist_wheel.bdist_wheel):
         elif platform == "darwin":
             return ("cp35", "abi3", "macosx_10_7_x86_64")
         elif platform == "windows":
-            return ("py3", "none", "win_amd64")
+            if mingw_arch == "i686":
+                return ("py3", "none", "win32")
+            elif mingw_arch == "x86_64":
+                return ("py3", "none", "win_amd64")
+            else:
+                raise ValueError("Unsupported Windows platform")
 
 
 class InstallPlatlib(install):
@@ -107,6 +122,8 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -259,7 +259,7 @@ def test_the_app_channel_must_be_correctly_set():
 
 def test_get_language_tag_reports_the_tag_for_the_default_locale():
     tag = _util.get_locale_tag()
-    assert re.match("C|([a-z][a-z]-[A-Z][A-Z])", tag)
+    assert re.match("(und)|([a-z][a-z]-[A-Z][A-Z])", tag)
 
 
 @pytest.mark.skip

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -259,7 +259,7 @@ def test_the_app_channel_must_be_correctly_set():
 
 def test_get_language_tag_reports_the_tag_for_the_default_locale():
     tag = _util.get_locale_tag()
-    assert re.match("[a-z][a-z]-[A-Z][A-Z]", tag)
+    assert re.match("C|([a-z][a-z]-[A-Z][A-Z])", tag)
 
 
 @pytest.mark.skip

--- a/glean-core/src/histogram/exponential.rs
+++ b/glean-core/src/histogram/exponential.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{Bucketing, Histogram};
 
+use crate::util::floating_point_context::FloatingPointContext;
+
 /// Create the possible ranges in an exponential distribution from `min` to `max` with
 /// `bucket_count` buckets.
 ///
@@ -19,6 +21,8 @@ use super::{Bucketing, Histogram};
 /// That means values in a bucket `i` are `bucket[i] <= value < bucket[i+1]`.
 /// It will always contain an underflow bucket (`< 1`).
 fn exponential_range(min: u64, max: u64, bucket_count: usize) -> Vec<u64> {
+    let _fpc = FloatingPointContext::new();
+
     let log_max = (max as f64).ln();
 
     let mut ranges = Vec::with_capacity(bucket_count);

--- a/glean-core/src/histogram/exponential.rs
+++ b/glean-core/src/histogram/exponential.rs
@@ -21,6 +21,7 @@ use crate::util::floating_point_context::FloatingPointContext;
 /// That means values in a bucket `i` are `bucket[i] <= value < bucket[i+1]`.
 /// It will always contain an underflow bucket (`< 1`).
 fn exponential_range(min: u64, max: u64, bucket_count: usize) -> Vec<u64> {
+    // Set the FPU control flag to the required state within this function
     let _fpc = FloatingPointContext::new();
 
     let log_max = (max as f64).ln();

--- a/glean-core/src/histogram/functional.rs
+++ b/glean-core/src/histogram/functional.rs
@@ -26,6 +26,8 @@ pub struct Functional {
 impl Functional {
     /// Instantiate a new functional bucketing.
     fn new(log_base: f64, buckets_per_magnitude: f64) -> Functional {
+        let _ = FloatingPointContext::new();
+
         let exponent = log_base.powf(1.0 / buckets_per_magnitude);
 
         Functional { exponent }
@@ -36,6 +38,7 @@ impl Functional {
     /// mathematical concept, even though the internal representation is stored and
     /// sent using the minimum value in each bucket.
     fn sample_to_bucket_index(&self, sample: u64) -> u64 {
+        let _ = FloatingPointContext::new();
         ((sample + 1) as f64).log(self.exponent) as u64
     }
 

--- a/glean-core/src/histogram/functional.rs
+++ b/glean-core/src/histogram/functional.rs
@@ -26,7 +26,7 @@ pub struct Functional {
 impl Functional {
     /// Instantiate a new functional bucketing.
     fn new(log_base: f64, buckets_per_magnitude: f64) -> Functional {
-        let _ = FloatingPointContext::new();
+        let _fpc = FloatingPointContext::new();
 
         let exponent = log_base.powf(1.0 / buckets_per_magnitude);
 
@@ -38,13 +38,13 @@ impl Functional {
     /// mathematical concept, even though the internal representation is stored and
     /// sent using the minimum value in each bucket.
     fn sample_to_bucket_index(&self, sample: u64) -> u64 {
-        let _ = FloatingPointContext::new();
+        let _fpc = FloatingPointContext::new();
         ((sample + 1) as f64).log(self.exponent) as u64
     }
 
     /// Determines the minimum value of a bucket, given a bucket index.
     fn bucket_index_to_bucket_minimum(&self, index: u64) -> u64 {
-        let _ = FloatingPointContext::new();
+        let _fpc = FloatingPointContext::new();
         self.exponent.powf(index as f64) as u64
     }
 }

--- a/glean-core/src/histogram/functional.rs
+++ b/glean-core/src/histogram/functional.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{Bucketing, Histogram};
 
+use crate::util::floating_point_context::FloatingPointContext;
+
 /// A functional bucketing algorithm.
 ///
 /// Bucketing is performed by a function, rather than pre-computed buckets.
@@ -39,6 +41,7 @@ impl Functional {
 
     /// Determines the minimum value of a bucket, given a bucket index.
     fn bucket_index_to_bucket_minimum(&self, index: u64) -> u64 {
+        let _ = FloatingPointContext::new();
         self.exponent.powf(index as f64) as u64
     }
 }

--- a/glean-core/src/histogram/functional.rs
+++ b/glean-core/src/histogram/functional.rs
@@ -26,6 +26,7 @@ pub struct Functional {
 impl Functional {
     /// Instantiate a new functional bucketing.
     fn new(log_base: f64, buckets_per_magnitude: f64) -> Functional {
+        // Set the FPU control flag to the required state within this function
         let _fpc = FloatingPointContext::new();
 
         let exponent = log_base.powf(1.0 / buckets_per_magnitude);
@@ -38,13 +39,17 @@ impl Functional {
     /// mathematical concept, even though the internal representation is stored and
     /// sent using the minimum value in each bucket.
     fn sample_to_bucket_index(&self, sample: u64) -> u64 {
+        // Set the FPU control flag to the required state within this function
         let _fpc = FloatingPointContext::new();
+
         ((sample + 1) as f64).log(self.exponent) as u64
     }
 
     /// Determines the minimum value of a bucket, given a bucket index.
     fn bucket_index_to_bucket_minimum(&self, index: u64) -> u64 {
+        // Set the FPU control flag to the required state within this function
         let _fpc = FloatingPointContext::new();
+
         self.exponent.powf(index as f64) as u64
     }
 }

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -111,16 +111,28 @@ pub(crate) fn truncate_string_at_boundary_with_error<S: Into<String>>(
     }
 }
 
+// On i686 on Windows, the CPython interpreter sets the FPU precision control
+// flag to 53 bits of precision, rather than the 64 bit default. This causes
+// different floating point results than on other architectures. This context
+// manager makes it easy to set the precision to 64-bits around floating point
+// operations.
+//
+// See https://bugzilla.mozilla.org/show_bug.cgi?id=1623335 for additional context.
 #[cfg(all(target_arch = "x86", target_os = "windows"))]
 pub mod floating_point_context {
     use libc::size_t;
 
     #[link(name = "m")]
     extern "C" {
+        // Gets and sets the floating point control word.
+        // See documentation here:
+        // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/controlfp-s
         fn _controlfp_s(current: *mut size_t, new: size_t, mask: size_t) -> size_t;
     }
 
+    // Precision control mask
     const MCW_PC: size_t = 0x00030000;
+    // Values for 64-bit precision
     const PC_64: size_t = 0x00000000;
 
     pub struct FloatingPointContext {

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -149,6 +149,12 @@ pub mod floating_point_context {
 #[cfg(not(all(target_arch = "x86", target_os = "windows")))]
 pub mod floating_point_context {
     pub struct FloatingPointContext {}
+
+    impl FloatingPointContext {
+        pub fn new() -> Self {
+            FloatingPointContext {}
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This addresses the following bugs to make 32-bit Windows builds pass the
unit tests.

1622909: Release 32-bit wheels for Windows
1623335: Functional bucketing fixes
1623587: Unable to detect locale on Windows

Also relevant (but a follow-on) is:

1623307: Add Windows tests to CI
