### PR TITLE
Bug 1598993 - Add convenience `measure` methods to TimingDistribution and Timespan metrics

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -98,6 +98,18 @@ class TimespanMetricType internal constructor(
     }
 
     /**
+     * Convenience method to simplify measuring a function or block of code
+     */
+    inline fun <U> measure(funcToMeasure: () -> U): U {
+        start()
+        try {
+            return funcToMeasure()
+        } finally {
+            stop()
+        }
+    }
+
+    /**
      * Abort a previous [start] call. No error is recorded if no [start] was called.
      */
     fun cancel() {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -121,14 +121,14 @@ class TimingDistributionMetricType internal constructor(
     /**
      * Convenience method to simplify measuring a function or block of code
      */
-     inline fun <U> measure(funcToMeasure: () -> U): U {
+    inline fun <U> measure(funcToMeasure: () -> U): U {
         val timerId = start()
         try {
             return funcToMeasure()
         } finally {
             stopAndAccumulate(timerId)
         }
-     }
+    }
 
     /**
      * Abort a previous [start] call. No error is recorded if no [start] was called.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -119,6 +119,18 @@ class TimingDistributionMetricType internal constructor(
     }
 
     /**
+     * Convenience method to simplify measuring a function or block of code
+     */
+     inline fun <U> measure(funcToMeasure: () -> U): U {
+        val timerId = start()
+        try {
+            return funcToMeasure()
+        } finally {
+            stopAndAccumulate(timerId)
+        }
+     }
+
+    /**
      * Abort a previous [start] call. No error is recorded if no [start] was called.
      *
      * @param timerId The [GleanTimerId] associated with this timing. This allows

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
@@ -18,7 +18,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.reflect.typeOf
 
 @RunWith(AndroidJUnit4::class)
 class TimespanMetricTypeTest {
@@ -313,7 +312,7 @@ class TimespanMetricTypeTest {
             metric.measure {
                 testFunc()
             }
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             // Make sure we caught the right kind of exception: NPE
             assertTrue("Exception type must match", e is NullPointerException)
         } finally {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
@@ -7,7 +7,6 @@ package mozilla.telemetry.glean.private
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.delay
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
@@ -22,7 +21,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.spy
-import java.lang.Thread.sleep
 
 @RunWith(AndroidJUnit4::class)
 class TimingDistributionMetricTypeTest {
@@ -303,7 +301,7 @@ class TimingDistributionMetricTypeTest {
             metric.measure {
                 testFunc()
             }
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             // Ensure that the exception was a NPE
             assertTrue("Exception type must match", e is NullPointerException)
         } finally {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
@@ -7,6 +7,7 @@ package mozilla.telemetry.glean.private
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.delay
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
@@ -21,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.spy
+import java.lang.Thread.sleep
 
 @RunWith(AndroidJUnit4::class)
 class TimingDistributionMetricTypeTest {
@@ -234,5 +236,80 @@ class TimingDistributionMetricTypeTest {
 
         metric.stopAndAccumulate(GleanTimerId(-1))
         assertEquals(1, metric.testGetNumRecordedErrors(ErrorType.InvalidState))
+    }
+
+    @Test
+    fun `measure function correctly measures values`() {
+        val metric = spy(TimingDistributionMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "timing_distribution_samples",
+            sendInPings = listOf("store1"),
+            timeUnit = TimeUnit.Second
+        ))
+
+        // Create a test function to "measure". This works by mocking the getElapsedNanos return
+        // value setting it to return a known value to make it easier to validate.
+        fun testFunc(value: Long): Long {
+            `when`(metric.getElapsedTimeNanos()).thenReturn(value)
+            return value
+        }
+
+        // Accumulate a few values
+        for (i in 1L..3L) {
+            // Measure the test function, capturing the value to verify we correctly return the
+            // value of the underlying function.
+            `when`(metric.getElapsedTimeNanos()).thenReturn(0L)
+            val testValue = metric.measure {
+                testFunc(i)
+            }
+
+            assertEquals("Returned value must match", i, testValue)
+        }
+
+        // Check that data was properly recorded.
+        assertTrue(metric.testHasValue())
+        val snapshot = metric.testGetValue()
+        // Check the sum
+        assertEquals(6L, snapshot.sum)
+        // Check that the 1L fell into the first bucket (max 1)
+        assertEquals(1L, snapshot.values[1])
+        // Check that the 2L fell into the second bucket (max 2)
+        assertEquals(1L, snapshot.values[2])
+        // Check that the 3L fell into the third bucket (max 3)
+        assertEquals(1L, snapshot.values[3])
+    }
+
+    @Test
+    fun `measure function still measures and allows exceptions to bubble up`() {
+        val metric = TimingDistributionMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "timing_distribution_samples",
+            sendInPings = listOf("store1"),
+            timeUnit = TimeUnit.Second
+        )
+
+        // Create a test function that throws a NPE
+        fun testFunc() {
+            throw NullPointerException()
+        }
+
+        // Measure the test function, which should throw an exception.  We will catch the
+        // exception and verify it and that we still recorded the measurement.
+        try {
+            metric.measure {
+                testFunc()
+            }
+        } catch(e: Exception) {
+            // Ensure that the exception was a NPE
+            assertTrue("Exception type must match", e is NullPointerException)
+        } finally {
+            // Check that data was still properly recorded even though there was an exception.
+            assertTrue("Metric must have a value", metric.testHasValue())
+            assertTrue("Metric value must be greater than zero", metric.testGetValue().sum >= 0)
+        }
     }
 }

--- a/glean-core/ios/Glean/Metrics/TimespanMetric.swift
+++ b/glean-core/ios/Glean/Metrics/TimespanMetric.swift
@@ -84,7 +84,7 @@ public class TimespanMetricType {
             glean_timespan_cancel(self.handle)
         }
     }
-    
+
     /// Convenience method to simplify measuring a function or block of code
     ///
     /// - parameters:

--- a/glean-core/ios/Glean/Metrics/TimespanMetric.swift
+++ b/glean-core/ios/Glean/Metrics/TimespanMetric.swift
@@ -84,6 +84,22 @@ public class TimespanMetricType {
             glean_timespan_cancel(self.handle)
         }
     }
+    
+    /// Convenience method to simplify measuring a function or block of code
+    ///
+    /// - parameters:
+    ///     * funcToMeasure: Accepts a function or closure  to measure that can return a value
+    public func measure<U>(funcToMeasure: () -> U) -> U {
+        start()
+        // Putting `stop` in a `defer` block guarantees it will execute at the end
+        // of the scope, after the return value is pushed onto the stack.
+        // Reference: https://docs.swift.org/swift-book/LanguageGuide/ErrorHandling.html
+        // under the "Specifying Cleanup Actions" section.
+        defer {
+            stop()
+        }
+        return funcToMeasure()
+    }
 
     /// Explicitly set the timespan value, in nanoseconds.
     ///

--- a/glean-core/ios/Glean/Metrics/TimingDistributionMetric.swift
+++ b/glean-core/ios/Glean/Metrics/TimingDistributionMetric.swift
@@ -103,7 +103,7 @@ public class TimingDistributionMetricType {
             glean_timing_distribution_cancel(self.handle, timerId)
         }
     }
-    
+
     /// Convenience method to simplify measuring a function or block of code
     ///
     /// - parameters:

--- a/glean-core/ios/Glean/Metrics/TimingDistributionMetric.swift
+++ b/glean-core/ios/Glean/Metrics/TimingDistributionMetric.swift
@@ -103,6 +103,22 @@ public class TimingDistributionMetricType {
             glean_timing_distribution_cancel(self.handle, timerId)
         }
     }
+    
+    /// Convenience method to simplify measuring a function or block of code
+    ///
+    /// - parameters:
+    ///     * funcToMeasure: Accepts a function or closure  to measure that can return a value
+    public func measure<U>(funcToMeasure: () -> U) -> U {
+        let timerId = start()
+        // Putting `stopAndAccumulate` in a `defer` block guarantees it will execute at the end
+        // of the scope, after the return value is pushed onto the stack.
+        // Reference: https://docs.swift.org/swift-book/LanguageGuide/ErrorHandling.html under
+        // the "Specifying Cleanup Actions" section.
+        defer {
+            stopAndAccumulate(timerId)
+        }
+        return funcToMeasure()
+    }
 
     /// Tests whether a value is stored for the metric for testing purposes only. This function will
     /// attempt to await the last task (if any) writing to the the metric's storage engine before

--- a/glean-core/ios/GleanTests/Metrics/TimespanMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/TimespanMetricTests.swift
@@ -191,7 +191,7 @@ class TimespanMetricTypeTests: XCTestCase {
 
         XCTAssertEqual(1, metric.testGetNumRecordedErrors(.invalidState))
     }
-    
+
     func testMeasureFunctionCorrectlySavesValues() {
         let metric = TimespanMetricType(
             category: "telemetry",
@@ -203,7 +203,7 @@ class TimespanMetricTypeTests: XCTestCase {
         )
 
         XCTAssertFalse(metric.testHasValue())
-        
+
         // Create a test function that returns a value so we can measure
         // it and check that it returns the correct value from the
         // measure function.
@@ -215,7 +215,7 @@ class TimespanMetricTypeTests: XCTestCase {
         let testValue = metric.measure {
             testFunc(value: true)
         }
-        
+
         // Ensure the return value of the test function is the one
         // returned by the `measure` function
         XCTAssertTrue(testValue)

--- a/glean-core/ios/GleanTests/Metrics/TimespanMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/TimespanMetricTests.swift
@@ -191,4 +191,37 @@ class TimespanMetricTypeTests: XCTestCase {
 
         XCTAssertEqual(1, metric.testGetNumRecordedErrors(.invalidState))
     }
+    
+    func testMeasureFunctionCorrectlySavesValues() {
+        let metric = TimespanMetricType(
+            category: "telemetry",
+            name: "timespan_metric",
+            sendInPings: ["store1"],
+            lifetime: .application,
+            disabled: false,
+            timeUnit: .millisecond
+        )
+
+        XCTAssertFalse(metric.testHasValue())
+        
+        // Create a test function that returns a value so we can measure
+        // it and check that it returns the correct value from the
+        // measure function.
+        func testFunc(value: Bool) -> Bool {
+            return value
+        }
+
+        // Perform the measurement
+        let testValue = metric.measure {
+            testFunc(value: true)
+        }
+        
+        // Ensure the return value of the test function is the one
+        // returned by the `measure` function
+        XCTAssertTrue(testValue)
+
+        // Check that the count was incremented and properly recorded.
+        XCTAssert(metric.testHasValue())
+        XCTAssert(try metric.testGetValue() >= 0)
+    }
 }

--- a/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
@@ -130,4 +130,36 @@ class TimingDistributionTypeTests: XCTestCase {
 
         XCTAssertEqual(1, metric.testGetNumRecordedErrors(.invalidState))
     }
+    
+    func testMeasureFunctionCorrectlyStoresValues() {
+        let metric = TimingDistributionMetricType(
+            category: "telemetry",
+            name: "timing_distribution",
+            sendInPings: ["store1"],
+            lifetime: .ping,
+            disabled: false,
+            timeUnit: .millisecond
+        )
+        
+        func testFunc(value: Bool) -> Bool {
+            return value
+        }
+
+        // Accumulate a few values
+        for _ in 1 ... 3 {
+            let testValue = metric.measure {
+                testFunc(value: true)
+            }
+            
+            // Make sure that the `measure` function returns the value from
+            // the measured function
+            XCTAssertTrue(testValue)
+        }
+
+        // Check that data was properly recorded.
+        // We can only check the count, as we don't control the time.
+        XCTAssert(metric.testHasValue())
+        let snapshot = try! metric.testGetValue()
+        XCTAssertEqual(3, snapshot.count)
+    }
 }

--- a/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
@@ -130,7 +130,7 @@ class TimingDistributionTypeTests: XCTestCase {
 
         XCTAssertEqual(1, metric.testGetNumRecordedErrors(.invalidState))
     }
-    
+
     func testMeasureFunctionCorrectlyStoresValues() {
         let metric = TimingDistributionMetricType(
             category: "telemetry",
@@ -140,7 +140,7 @@ class TimingDistributionTypeTests: XCTestCase {
             disabled: false,
             timeUnit: .millisecond
         )
-        
+
         func testFunc(value: Bool) -> Bool {
             return value
         }
@@ -150,7 +150,7 @@ class TimingDistributionTypeTests: XCTestCase {
             let testValue = metric.measure {
                 testFunc(value: true)
             }
-            
+
             // Make sure that the `measure` function returns the value from
             // the measured function
             XCTAssertTrue(testValue)


### PR DESCRIPTION
This adds convenience methods to simplify measuring a function or block of code to both Android and iOS.  