### PR TITLE
Document potential data loss when changing metric types

### DIFF
--- a/docs/user/metric-parameters.md
+++ b/docs/user/metric-parameters.md
@@ -4,6 +4,8 @@
 
 - `type`: **Required.**  Specifies the type of a metric, like "counter" or "event". This defines which operations are valid for the metric, how it is stored and how data analysis tooling displays it. See the list of [supported metric types](metrics/index.md).
 
+> **Important**: Once a metric is released in a product, its `type` should not be changed. If any data was collected locally with the older `type`, and hasn't yet been sent in a ping, recording data with the new `type` may cause any old persisted data to be lost for that metric. See [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1621757#c1) for an extended explanation of the different scenarios.
+
 - `description`: **Required.** A textual description of the metric for humans. It should describe what the metric does, what it means for analysts, and its edge cases or any other helpful information.
 
   The description field may contain [markdown syntax](https://www.markdownguide.org/basic-syntax/).


### PR DESCRIPTION
This additionally adds test coverage as requested by @badboy 