### PR TITLE
Remove all finalizers from metric type implementations in Kotlin

### DIFF
--- a/docs/dev/core/new-metric-type/kotlin.md
+++ b/docs/dev/core/new-metric-type/kotlin.md
@@ -42,12 +42,6 @@ class CounterMetricType(
                 disabled = disabled.toByte())
     }
 
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_counter_metric(this.handle)
-        }
-    }
-
     fun add(amount: Int = 1) {
         if (disabled) {
             return

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -49,15 +49,6 @@ class BooleanMetricType internal constructor(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_boolean_metric(this.handle)
-        }
-    }
-
-    /**
      * Set a boolean value.
      *
      * @param value This is a user defined boolean value.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -49,15 +49,6 @@ class CounterMetricType internal constructor(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_counter_metric(this.handle)
-        }
-    }
-
-    /**
      * Add to counter value.
      *
      * @param amount This is the amount to increment the counter by, defaulting to 1 if called

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -64,15 +64,6 @@ data class CustomDistributionMetricType(
         )
     }
 
-    /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_custom_distribution_metric(this.handle)
-        }
-    }
-
     override fun accumulateSamples(samples: LongArray) {
         if (disabled) {
             return

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
@@ -52,15 +52,6 @@ class DatetimeMetricType internal constructor(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_datetime_metric(this.handle)
-        }
-    }
-
-    /**
      * Set a datetime value, truncating it to the metric's resolution.
      *
      * @param value The [Date] value to set. If not provided, will record the current time.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -48,15 +48,6 @@ class MemoryDistributionMetricType internal constructor(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_memory_distribution_metric(this.handle)
-        }
-    }
-
-    /**
      * Record a single value, in the unit specified by `memoryUnit`, to the distribution.
      *
      * @param sample the value

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -62,15 +62,6 @@ class PingType<ReasonCodesEnum : Enum<ReasonCodesEnum>> (
     }
 
     /**
-     * Destroy this ping type.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_ping_type(this.handle)
-        }
-    }
-
-    /**
      * Collect and submit the ping for eventual upload.
      *
      * While the collection of metrics into pings happens synchronously, the

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -46,15 +46,6 @@ class QuantityMetricType internal constructor(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_quantity_metric(this.handle)
-        }
-    }
-
-    /**
      * Set the quantity value.
      *
      * @param value The value to set. Must be non-negative.

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -52,17 +52,6 @@ class StringListMetricType(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_string_list_metric(this.handle)
-        }
-        // Do nothing with the error, for now.
-        // It is expected to only ever error if this.handle's invalid.
-    }
-
-    /**
      * Appends a string value to one or more string list metric stores.  If the string exceeds the
      * maximum string length or if the list exceeds the maximum length it will be truncated.
      *

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -50,15 +50,6 @@ class StringMetricType internal constructor(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_string_metric(this.handle)
-        }
-    }
-
-    /**
      * Set a string value.
      *
      * @param value This is a user defined string value. If the length of the string exceeds

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -50,15 +50,6 @@ class TimespanMetricType internal constructor(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_timespan_metric(this.handle)
-        }
-    }
-
-    /**
      * Start tracking time for the provided metric.
      * This records an error if it’s already tracking time (i.e. start was already
      * called with no corresponding [stop]): in that case the original

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -49,15 +49,6 @@ class TimingDistributionMetricType internal constructor(
         )
     }
 
-    /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_timing_distribution_metric(this.handle)
-        }
-    }
-
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun getElapsedTimeNanos(): Long {
         return SystemClock.elapsedRealtimeNanos()

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
@@ -49,15 +49,6 @@ class UuidMetricType(
     }
 
     /**
-     * Destroy this metric.
-     */
-    protected fun finalize() {
-        if (this.handle != 0L) {
-            LibGleanFFI.INSTANCE.glean_destroy_uuid_metric(this.handle)
-        }
-    }
-
-    /**
      * Generate a new UUID value and set it in the metric store.
      */
     fun generateAndSet(): UUID? {


### PR DESCRIPTION
They cause us more trouble than they are worth.
This is safe.
The only thing we did do in finalizers is cleaning up the allocated
object on the native Rust side.
Without these we now potentially leak memory.
_But_ metric types were already only used for metrics, and those are
statics, so they live for the entire application runtime.
Once the application is done and exits the Glean library will also be
unloaded and thus all its data be deallocated.

The only place where we create metrics at runtime is in tests.
So we're now leaking those in tests, but that should be fine.

As a side note: Java 9 deprecates finalizers in the language, Android
itself doesn't support Java 9 (yet) and has its own implementation of it
anyway, but that's nonetheless a good hint that finalizers might not be
the best idea afterall.