### PR TITLE
WIP: 1624695: Act on changes in upload enable state outside of application

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 160 utf-8
+personal_ws-1.1 en 161 utf-8
 AAR
 AARs
 APIs
@@ -79,6 +79,7 @@ codecov
 codepoints
 commandline
 conda
+config
 coroutine
 csh
 dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
     * `glean_parser` now makes it easier to write external translation functions for
       different language targets.
     * BUGFIX: glean_parser now works on 32-bit Windows.
-  * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running, the database is correctly cleared and a deletion request ping is sent.
+  * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running (e.g. between the runs of a Python command using the Glean SDK), the database is correctly cleared and a deletion request ping is sent.
 * Android:
   * `gradlew clean` will no longer remove the Miniconda installation in
     `~/.gradle/glean`. Therefore `clean` can be used without reinstalling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     * `glean_parser` now makes it easier to write external translation functions for
       different language targets.
     * BUGFIX: glean_parser now works on 32-bit Windows.
+  * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running, the database is correctly cleared and a deletion request ping is sent.
 * Android:
   * `gradlew clean` will no longer remove the Miniconda installation in
     `~/.gradle/glean`. Therefore `clean` can be used without reinstalling

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -17,11 +17,10 @@ import mozilla.telemetry.glean.net.PingUploader
  * **CAUTION**: This must match _exactly_ the definition on the Rust side.
  *  If this side is changed, the Rust side need to be changed, too.
  */
-@Structure.FieldOrder("dataDir", "packageName", "uploadEnabled", "maxEvents", "delayPingLifetimeIO")
+@Structure.FieldOrder("dataDir", "packageName", "maxEvents", "delayPingLifetimeIO")
 internal class FfiConfiguration(
     dataDir: String,
     packageName: String,
-    uploadEnabled: Boolean,
     maxEvents: Int? = null,
     delayPingLifetimeIO: Boolean
 ) : Structure() {
@@ -34,8 +33,6 @@ internal class FfiConfiguration(
     public var dataDir: String = dataDir
     @JvmField
     public var packageName: String = packageName
-    @JvmField
-    public var uploadEnabled: Byte = uploadEnabled.toByte()
     @JvmField
     public var maxEvents: IntByReference = if (maxEvents == null) IntByReference() else IntByReference(maxEvents)
     @JvmField

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -689,6 +689,11 @@ class GleanTest {
             uploadEnabled = false
         )
 
+        // Now trigger it to upload
+        triggerWorkManager(context, DeletionPingUploadWorker.PING_WORKER_TAG)
+
+        assertEquals(1, server.requestCount)
+
         resetGlean(
             context,
             Glean.configuration.copy(
@@ -702,6 +707,6 @@ class GleanTest {
         // Now trigger it to upload
         triggerWorkManager(context, DeletionPingUploadWorker.PING_WORKER_TAG)
 
-        assertEquals(0, server.requestCount)
+        assertEquals(1, server.requestCount)
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -646,4 +646,62 @@ class GleanTest {
 
         Dispatchers.API.overflowCount = 0
     }
+
+    @Test
+    fun `sending deletion ping if disabled outside of run`() {
+        val server = getMockWebServer()
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = true
+        )
+
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = false,
+            clearStores = false
+        )
+
+        // Now trigger it to upload
+        triggerWorkManager(context, DeletionPingUploadWorker.PING_WORKER_TAG)
+
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        val docType = request.path.split("/")[3]
+        assertEquals("deletion-request", docType)
+    }
+
+    @Test
+    fun `no sending of deletion ping if unchanged outside of run`() {
+        val server = getMockWebServer()
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = false
+        )
+
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = false,
+            clearStores = false
+        )
+
+        // Now trigger it to upload
+        triggerWorkManager(context, DeletionPingUploadWorker.PING_WORKER_TAG)
+
+        assertEquals(0, server.requestCount)
+    }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -114,7 +114,8 @@ internal fun resetGlean(
     context: Context = ApplicationProvider.getApplicationContext(),
     config: Configuration = Configuration(),
     clearStores: Boolean = true,
-    redirectRobolectricLogs: Boolean = true
+    redirectRobolectricLogs: Boolean = true,
+    uploadEnabled: Boolean = true
 ) {
     if (redirectRobolectricLogs) {
         ShadowLog.stream = System.out
@@ -123,7 +124,7 @@ internal fun resetGlean(
     // We're using the WorkManager in a bunch of places, and Glean will crash
     // in tests without this line. Let's simply put it here.
     WorkManagerTestInitHelper.initializeTestWorkManager(context)
-    Glean.resetGlean(context, config, clearStores)
+    Glean.resetGlean(context, config, clearStores, uploadEnabled = uploadEnabled)
 }
 
 /**

--- a/glean-core/benchmark/benches/bench_basic.rs
+++ b/glean-core/benchmark/benches/bench_basic.rs
@@ -9,7 +9,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let data_dir = tempfile::tempdir().unwrap();
     let tmpname = data_dir.path().display().to_string();
     let cfg = Configuration {
-        upload_enabled: true,
         data_path: tmpname,
         application_id: "glean.bench".into(),
         max_events: None,

--- a/glean-core/examples/sample.rs
+++ b/glean-core/examples/sample.rs
@@ -20,7 +20,6 @@ fn main() {
     let cfg = glean_core::Configuration {
         data_path,
         application_id: "org.mozilla.glean_core.example".into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
     };

--- a/glean-core/ffi/examples/glean_app.c
+++ b/glean-core/ffi/examples/glean_app.c
@@ -11,7 +11,6 @@ int main(void)
   FfiConfiguration cfg = {
     "/tmp/glean_data",
     "c-app",
-    true,
     NULL
   };
   glean_initialize(&cfg);

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -78,7 +78,6 @@ typedef const char *const *RawStringArray;
 typedef struct {
   FfiStr data_dir;
   FfiStr package_name;
-  uint8_t upload_enabled;
   const int32_t *max_events;
   uint8_t delay_ping_lifetime_io;
 } FfiConfiguration;

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -165,7 +165,6 @@ pub extern "C" fn glean_enable_logging() {
 pub struct FfiConfiguration<'a> {
     pub data_dir: FfiStr<'a>,
     pub package_name: FfiStr<'a>,
-    pub upload_enabled: u8,
     pub max_events: Option<&'a i32>,
     pub delay_ping_lifetime_io: u8,
 }
@@ -177,12 +176,10 @@ impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
     fn try_from(cfg: &FfiConfiguration) -> Result<Self, Self::Error> {
         let data_path = cfg.data_dir.to_string_fallible()?;
         let application_id = cfg.package_name.to_string_fallible()?;
-        let upload_enabled = cfg.upload_enabled != 0;
         let max_events = cfg.max_events.filter(|&&i| i >= 0).map(|m| *m as usize);
         let delay_ping_lifetime_io = cfg.delay_ping_lifetime_io != 0;
 
         Ok(Self {
-            upload_enabled,
             data_path,
             application_id,
             max_events,

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -86,7 +86,6 @@ public class Glean {
                 // `relativePath` for a file URL gives us the absolute filesystem path.
                 dataDir: getDocumentsDirectory().relativePath,
                 packageName: AppInfo.name,
-                uploadEnabled: uploadEnabled,
                 configuration: configuration
             ) { cfg in
                 var cfg = cfg
@@ -97,6 +96,8 @@ public class Glean {
             if !self.initialized {
                 return
             }
+
+            self.setUploadEnabled(uploadEnabled)
 
             // If any pings were registered before initializing, do so now
             for ping in self.pingTypeQueue {
@@ -199,7 +200,7 @@ public class Glean {
         if isInitialized() {
             let originalEnabled = getUploadEnabled()
 
-            Dispatchers.shared.launchAPI {
+            Dispatchers.shared.launchConcurrent {
                 // glean_set_upload_enabled might delete all of the queued pings.
                 // Currently a ping uploader could be scheduled ahead of this,
                 // at which point it will pick up scheduled pings before the setting was toggled.

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -78,7 +78,6 @@ typedef const char *const *RawStringArray;
 typedef struct {
   FfiStr data_dir;
   FfiStr package_name;
-  uint8_t upload_enabled;
   const int32_t *max_events;
   uint8_t delay_ping_lifetime_io;
 } FfiConfiguration;

--- a/glean-core/preview/examples/prototype.rs
+++ b/glean-core/preview/examples/prototype.rs
@@ -29,7 +29,6 @@ fn main() -> Result<(), Error> {
     let cfg = Configuration {
         data_path,
         application_id: "org.mozilla.glean_core.example".into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
         channel: None,

--- a/glean-core/preview/src/configuration.rs
+++ b/glean-core/preview/src/configuration.rs
@@ -7,8 +7,6 @@
 /// Optional values will be filled in with default values.
 #[derive(Debug, Clone)]
 pub struct Configuration {
-    /// Whether upload should be enabled.
-    pub upload_enabled: bool,
     /// Path to a directory to store all data in.
     pub data_path: String,
     /// The application ID (will be sanitized during initialization).

--- a/glean-core/preview/src/lib.rs
+++ b/glean-core/preview/src/lib.rs
@@ -22,12 +22,12 @@
 //! let cfg = Configuration {
 //!     data_path: "/tmp/data".into(),
 //!     application_id: "org.mozilla.glean_core.example".into(),
-//!     upload_enabled: true,
 //!     max_events: None,
 //!     delay_ping_lifetime_io: false,
 //!     channel: None,
 //! };
 //! glean_preview::initialize(cfg, ClientInfoMetrics::unknown())?;
+//! glean_preview::set_upload_enabled(true);
 //!
 //! let prototype_ping = PingType::new("prototype", true, true, vec!());
 //!
@@ -103,7 +103,6 @@ where
 /// See `glean_core::Glean::new`.
 pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) -> Result<()> {
     let core_cfg = glean_core::Configuration {
-        upload_enabled: cfg.upload_enabled,
         data_path: cfg.data_path.clone(),
         application_id: cfg.application_id.clone(),
         max_events: cfg.max_events,

--- a/glean-core/preview/src/test.rs
+++ b/glean-core/preview/src/test.rs
@@ -21,7 +21,6 @@ fn new_glean() -> tempfile::TempDir {
     let cfg = Configuration {
         data_path: tmpname,
         application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
         channel: Some("testing".into()),

--- a/glean-core/preview/tests/schema.rs
+++ b/glean-core/preview/tests/schema.rs
@@ -29,7 +29,6 @@ fn new_glean() -> tempfile::TempDir {
     let cfg = Configuration {
         data_path: tmpname,
         application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
         channel: None,

--- a/glean-core/python/glean/_ffi.py
+++ b/glean-core/python/glean/_ffi.py
@@ -46,9 +46,7 @@ lib = ffi.dlopen(str(Path(__file__).parent / get_shared_object_filename()))
 lib.glean_enable_logging()
 
 
-def make_config(
-    data_dir: Path, package_name: str, upload_enabled: bool, max_events: int,
-) -> Any:
+def make_config(data_dir: Path, package_name: str, max_events: int,) -> Any:
     """
     Make an `FfiConfiguration` object.
 
@@ -64,7 +62,6 @@ def make_config(
 
     cfg.data_dir = data_dir
     cfg.package_name = package_name
-    cfg.upload_enabled = upload_enabled
     cfg.max_events = max_events
     cfg.delay_ping_lifetime_io = False
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -122,12 +122,7 @@ class Glean:
 
         cls._upload_enabled = upload_enabled
 
-        cfg = _ffi.make_config(
-            cls._data_dir,
-            application_id,
-            cls._upload_enabled,
-            configuration.max_events,
-        )
+        cfg = _ffi.make_config(cls._data_dir, application_id, configuration.max_events,)
 
         cls._initialized = _ffi.lib.glean_initialize(cfg) != 0
 
@@ -135,6 +130,8 @@ class Glean:
         # further
         if not cls._initialized:
             return
+
+        cls.set_upload_enabled(cls._upload_enabled)
 
         for ping in cls._ping_type_queue:
             cls.register_ping_type(ping)
@@ -232,7 +229,7 @@ class Glean:
         if cls.is_initialized():
             original_enabled = cls.get_upload_enabled()
 
-            @Dispatcher.launch
+            @Dispatcher.launch_at_front
             def set_upload_enabled():
                 _ffi.lib.glean_set_upload_enabled(enabled)
 

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -159,7 +159,7 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
         let tmpname = dir.path().display().to_string();
 
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true).unwrap();
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID).unwrap();
 
         (glean, dir)
     }

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -207,7 +207,7 @@ mod test {
     fn test_experiments_json_serialization() {
         let t = tempfile::tempdir().unwrap();
         let name = t.path().display().to_string();
-        let glean = Glean::with_options(&name, "org.mozilla.glean", true).unwrap();
+        let glean = Glean::with_options(&name, "org.mozilla.glean").unwrap();
 
         let extra: HashMap<String, String> = [("test-key".into(), "test-value".into())]
             .iter()
@@ -236,7 +236,7 @@ mod test {
     fn test_experiments_json_serialization_empty() {
         let t = tempfile::tempdir().unwrap();
         let name = t.path().display().to_string();
-        let glean = Glean::with_options(&name, "org.mozilla.glean", true).unwrap();
+        let glean = Glean::with_options(&name, "org.mozilla.glean").unwrap();
 
         let metric = ExperimentMetric::new(&glean, "some-experiment".to_string());
 

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -55,7 +55,6 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
     let cfg = glean_core::Configuration {
         data_path: tmpname,
         application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
     };

--- a/glean-core/tests/memory_distribution.rs
+++ b/glean-core/tests/memory_distribution.rs
@@ -24,7 +24,6 @@ fn serializer_should_correctly_serialize_memory_distribution() {
     let cfg = glean_core::Configuration {
         data_path: tmpname,
         application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
     };

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -16,7 +16,6 @@ fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
     let cfg = glean_core::Configuration {
         data_path: tmpname,
         application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
     };

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -26,7 +26,6 @@ fn serializer_should_correctly_serialize_timing_distribution() {
     let cfg = glean_core::Configuration {
         data_path: tmpname,
         application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
     };


### PR DESCRIPTION
This is trickier than it needs to be because the handling of actions
based on the change in upload state is handled both on the Rust and
language wrapper side.

The solution I arrived at is to no longer pass in an initial value
for upload enabled when initializing the Rust side, but to instead let
Glean determine the upload enable state from the database -- it is
disabled if either there is no client_id or client_id == c0ffee.

Then the language bindings immediately change the upload state based
on the what the user has passed in, allowing the usual state flipping
operations to run as usual.

Even though the FfiConfiguration object loses an uploadEnabled field as
part of this change, that is purely internal API and the public API doesn't
change at all here.

Before merging:

- [ ] Port new tests to Swift
