### PR TITLE
WIP: Handle upload enable change at startup using callbacks

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 160 utf-8
+personal_ws-1.1 en 161 utf-8
 AAR
 AARs
 APIs
@@ -79,6 +79,7 @@ codecov
 codepoints
 commandline
 conda
+config
 coroutine
 csh
 dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     * `glean_parser` now makes it easier to write external translation functions for
       different language targets.
     * BUGFIX: glean_parser now works on 32-bit Windows.
+  * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running (e.g. between the runs of a Python command using the Glean SDK), the database is correctly cleared and a deletion request ping is sent.
 * Android:
   * `gradlew clean` will no longer remove the Miniconda installation in
     `~/.gradle/glean`. Therefore `clean` can be used without reinstalling

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -6,6 +6,7 @@
 
 package mozilla.telemetry.glean.rust
 
+import com.sun.jna.Callback
 import com.sun.jna.Library
 import com.sun.jna.Native
 import com.sun.jna.Pointer
@@ -43,6 +44,14 @@ internal fun Pointer.getRustString(): String {
 
 @Suppress("TooManyFunctions")
 internal interface LibGleanFFI : Library {
+    interface OnUploadEnabledCallback: Callback {
+        fun onUploadEnabled();
+    }
+
+    interface OnUploadDisabledCallback: Callback {
+        fun onUploadDisabled();
+    }
+
     companion object {
         private val JNA_LIBRARY_NAME = "glean_ffi"
 
@@ -66,7 +75,11 @@ internal interface LibGleanFFI : Library {
 
     // Glean top-level API
 
-    fun glean_initialize(cfg: FfiConfiguration): Byte
+    fun glean_initialize(
+        cfg: FfiConfiguration,
+        on_upload_enabled: OnUploadEnabledCallback,
+        on_upload_disabled: OnUploadDisabledCallback
+    ): Byte
 
     fun glean_clear_application_lifetime_metrics()
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -114,7 +114,8 @@ internal fun resetGlean(
     context: Context = ApplicationProvider.getApplicationContext(),
     config: Configuration = Configuration(),
     clearStores: Boolean = true,
-    redirectRobolectricLogs: Boolean = true
+    redirectRobolectricLogs: Boolean = true,
+    uploadEnabled: Boolean = true
 ) {
     if (redirectRobolectricLogs) {
         ShadowLog.stream = System.out
@@ -123,7 +124,7 @@ internal fun resetGlean(
     // We're using the WorkManager in a bunch of places, and Glean will crash
     // in tests without this line. Let's simply put it here.
     WorkManagerTestInitHelper.initializeTestWorkManager(context)
-    Glean.resetGlean(context, config, clearStores)
+    Glean.resetGlean(context, config, clearStores, uploadEnabled = uploadEnabled)
 }
 
 /**


### PR DESCRIPTION
(Kotlin-only implementation for now).

This is an alternative to #786.  It avoids the weird flow control by having the Rust core be completely in charge of what to do when the upload state changes (and fixes a bug where a deletion ping is sent on first run, since the startup logic for first run can be made slightly different).

However, it is fundamentally broken since it deadlocks.  When the callback is called, it does things involving the global Glean singleton, and since the lock on that is already held, it stalls waiting for the lock.  There might be ways of rewriting the FFI wrapper to drop the glean lock and *then* call the callback, but since the callback is a member of the Glean singleton, I couldn't find a way to do it.