### PR TITLE
1624695: Act on changes in upload enable state outside of application

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 160 utf-8
+personal_ws-1.1 en 161 utf-8
 AAR
 AARs
 APIs
@@ -79,6 +79,7 @@ codecov
 codepoints
 commandline
 conda
+config
 coroutine
 csh
 dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * General:
   * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running (e.g. between the runs of a Python command using the Glean SDK), the database is correctly cleared and a deletion request ping is sent. See [#791](https://github.com/mozilla/glean/pull/791).
+* iOS:
+  * BUGFIX: A bug where the metrics ping is sent immediately at startup on the last day of the month has been fixed.
+
 # v26.0.0 (2020-03-27)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v25.1.0...v26.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v26.0.0...master)
 
+* General:
+  * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running (e.g. between the runs of a Python command using the Glean SDK), the database is correctly cleared and a deletion request ping is sent. See [#791](https://github.com/mozilla/glean/pull/791).
 # v26.0.0 (2020-03-27)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v25.1.0...v26.0.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -593,7 +593,8 @@ open class GleanInternalAPI internal constructor () {
     internal fun resetGlean(
         context: Context,
         config: Configuration,
-        clearStores: Boolean
+        clearStores: Boolean,
+        uploadEnabled: Boolean = true
     ) {
         Glean.enableTestingMode()
 
@@ -606,7 +607,7 @@ open class GleanInternalAPI internal constructor () {
 
         // Init Glean.
         Glean.testDestroyGleanHandle()
-        Glean.initialize(context, true, config)
+        Glean.initialize(context, uploadEnabled, config)
     }
 
     /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -646,4 +646,59 @@ class GleanTest {
 
         Dispatchers.API.overflowCount = 0
     }
+
+    @Test
+    fun `sending deletion ping if disabled outside of run`() {
+        val server = getMockWebServer()
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = true
+        )
+
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = false,
+            clearStores = false
+        )
+
+        // Now trigger it to upload
+        triggerWorkManager(context, DeletionPingUploadWorker.PING_WORKER_TAG)
+
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        val docType = request.path.split("/")[3]
+        assertEquals("deletion-request", docType)
+    }
+
+    @Test
+    fun `no sending of deletion ping if unchanged outside of run`() {
+        val server = getMockWebServer()
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = false
+        )
+
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            uploadEnabled = false,
+            clearStores = false
+        )
+
+        assertEquals(0, server.requestCount)
+    }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -114,7 +114,8 @@ internal fun resetGlean(
     context: Context = ApplicationProvider.getApplicationContext(),
     config: Configuration = Configuration(),
     clearStores: Boolean = true,
-    redirectRobolectricLogs: Boolean = true
+    redirectRobolectricLogs: Boolean = true,
+    uploadEnabled: Boolean = true
 ) {
     if (redirectRobolectricLogs) {
         ShadowLog.stream = System.out
@@ -123,7 +124,7 @@ internal fun resetGlean(
     // We're using the WorkManager in a bunch of places, and Glean will crash
     // in tests without this line. Let's simply put it here.
     WorkManagerTestInitHelper.initializeTestWorkManager(context)
-    Glean.resetGlean(context, config, clearStores)
+    Glean.resetGlean(context, config, clearStores, uploadEnabled = uploadEnabled)
 }
 
 /**

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -481,7 +481,9 @@ public class Glean {
     /// - parameters:
     ///     * configuration: the `Configuration` to init Glean with
     ///     * clearStores: if true, clear the contents of all stores
-    public func resetGlean(configuration: Configuration = Configuration(), clearStores: Bool) {
+    public func resetGlean(configuration: Configuration = Configuration(),
+                           clearStores: Bool,
+                           uploadEnabled: Bool = true) {
         enableTestingMode()
 
         if isInitialized() && clearStores {
@@ -491,6 +493,6 @@ public class Glean {
 
         // Init Glean.
         testDestroyGleanHandle()
-        initialize(uploadEnabled: true, configuration: configuration)
+        initialize(uploadEnabled: uploadEnabled, configuration: configuration)
     }
 }

--- a/glean-core/ios/Glean/Scheduler/MetricsPingScheduler.swift
+++ b/glean-core/ios/Glean/Scheduler/MetricsPingScheduler.swift
@@ -59,7 +59,7 @@ class MetricsPingScheduler {
                 byAdding: .day,
                 value: 1,
                 to: fireDate,
-                wrappingComponents: true
+                wrappingComponents: false
             )!
             fireDate = tomorrow
         }

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -147,4 +147,79 @@ class GleanTests: XCTestCase {
             XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
         }
     }
+
+    func testSendingDeletionPingIfDisabledOutsideOfRun() {
+        // Set up the test stub based on the default telemetry endpoint
+        let host = URL(string: Configuration.Constants.defaultTelemetryEndpoint)!.host!
+        stub(condition: isHost(host)) { data in
+            let path = (data as NSURLRequest).url!
+
+            let parts = path.absoluteString.split(separator: "/")
+
+            XCTAssertEqual("deletion-request", parts[4])
+
+            DispatchQueue.main.async {
+                // let the response get processed before we mark the expectation fulfilled
+                self.expectation?.fulfill()
+            }
+
+            return OHHTTPStubsResponse(
+                jsonObject: [],
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        // Set up the expectation that will be fulfilled by the stub above
+        expectation = expectation(description: "Deletion Request Received")
+
+        // Reset Glean with uploadEnabled
+        Glean.shared.resetGlean(clearStores: true, uploadEnabled: true)
+
+        // Now reset Glean with uploadEnabled = false and not clearing the stores to
+        // trigger the deletion request ping.
+        Glean.shared.resetGlean(clearStores: false, uploadEnabled: false)
+        waitForExpectations(timeout: 5.0) { error in
+            XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
+        }
+    }
+
+    func testNotSendingDeletionRequestIfUnchangedOutsideOfRun() {
+        // Set up the test stub based on the default telemetry endpoint
+        let host = URL(string: Configuration.Constants.defaultTelemetryEndpoint)!.host!
+        stub(condition: isHost(host)) { _ in
+            XCTFail("Should not have recieved any ping")
+
+            DispatchQueue.main.async {
+                // let the response get processed before we mark the expectation fulfilled
+                self.expectation?.fulfill()
+            }
+
+            return OHHTTPStubsResponse(
+                jsonObject: [],
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        // Set up the expectation that will NOT be fulfilled by the stub above.  If it is
+        // then it will trigger an assertion due to the `assertForOverFulfill` property.
+        expectation = expectation(description: "Deletion Request Received")
+
+        // So we can wait for expectations below, we will go ahead and fulfill the
+        // expectation.  We want to assert if the ping is triggered and over fulfills it
+        // from the stub above.
+        expectation?.fulfill()
+
+        // Reset Glean with uploadEnabled = false
+        Glean.shared.resetGlean(clearStores: true, uploadEnabled: false)
+
+        // Now reset Glean with uploadEnabled = false again without clearing the stores to
+        // make sure we don't trigger the deletion request ping.  If it does, then we will
+        // have overfulfilled the expectation which will trigger a test assertion.
+        Glean.shared.resetGlean(clearStores: false, uploadEnabled: false)
+        waitForExpectations(timeout: 5.0) { error in
+            XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
+        }
+    }
 }

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -141,6 +141,11 @@ class GleanTests: XCTestCase {
         // Set up the expectation that will be fulfilled by the stub above
         expectation = expectation(description: "Baseline Ping Received")
 
+        // Set the last time the "metrics" ping was sent to now. This is required for us to not
+        // send a metrics pings the first time we initialize Glean and to keep it from interfering
+        // with these tests.
+        let now = Date()
+        Glean.shared.metricsPingScheduler.updateSentDate(now)
         // Restart Glean and don't clear the stores and then await the expectation
         Glean.shared.resetGlean(clearStores: false)
         waitForExpectations(timeout: 5.0) { error in

--- a/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
+++ b/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
@@ -125,7 +125,7 @@ class MetricsPingSchedulerTests: XCTestCase {
                 byAdding: .day,
                 value: 1,
                 to: now,
-                wrappingComponents: true
+                wrappingComponents: false
             )!
         )!
         XCTAssertEqual(

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -5,6 +5,7 @@
 
 import io
 import json
+from pathlib import Path
 import re
 import shutil
 import sys
@@ -484,3 +485,60 @@ def test_configuration_property(safe_httpserver):
     request = safe_httpserver.requests[0]
     assert "baseline" in request.url
     assert "foo" == request.headers["X-Debug-Id"]
+
+
+def test_sending_deletion_ping_if_disabled_outside_of_run(safe_httpserver, tmpdir):
+    safe_httpserver.serve_content(b"", code=200)
+    Glean.reset()
+    config = Configuration(server_endpoint=safe_httpserver.url)
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=True,
+        data_dir=Path(str(tmpdir)),
+        configuration=config,
+    )
+
+    Glean.reset()
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=False,
+        data_dir=Path(str(tmpdir)),
+        configuration=config,
+    )
+
+    assert 1 == len(safe_httpserver.requests)
+
+    request = safe_httpserver.requests[0]
+    assert "deletion-request" in request.url
+
+
+def test_no_sending_deletion_ping_if_unchanged_outside_of_run(safe_httpserver, tmpdir):
+    safe_httpserver.serve_content(b"", code=200)
+    Glean.reset()
+    config = Configuration(server_endpoint=safe_httpserver.url)
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=False,
+        data_dir=Path(str(tmpdir)),
+        configuration=config,
+    )
+
+    assert 0 == len(safe_httpserver.requests)
+
+    Glean.reset()
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=False,
+        data_dir=Path(str(tmpdir)),
+        configuration=config,
+    )
+
+    assert 0 == len(safe_httpserver.requests)


### PR DESCRIPTION
I found a much simpler way forward here that really only adds some slightly different logic in `Glean::new` and a bit of a refactor.  I'm much happier with this than the earlier two approaches.

TODO:
- [x] Port new unit tests to Swift (I don't currently have access to a Mac -- volunteers?)