### PR TITLE
Only link against libm for the Windows GNU target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,6 @@ dependencies = [
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iso8601 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -36,7 +36,6 @@ regex = { version = "1.3.3", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 chrono = { version = "0.4.10", features = ["serde"] }
 once_cell = "1.2.0"
-libc = "0.2.0"
 
 [dev-dependencies]
 env_logger = { version = "0.7.1", default-features = false, features = ["termcolor", "atty", "humantime"] }

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -119,9 +119,14 @@ pub(crate) fn truncate_string_at_boundary_with_error<S: Into<String>>(
 // to match our other targets and platforms.
 //
 // See https://bugzilla.mozilla.org/show_bug.cgi?id=1623335 for additional context.
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", target_env = "gnu"))]
 pub mod floating_point_context {
-    use libc::size_t;
+    // `size_t` is "pointer size", which is equivalent to Rust's `usize`.
+    // It's defined as such in libc:
+    // * https://github.com/rust-lang/libc/blob/bcbfeb5516cd5bb055198dbfbddf8d626fa2be07/src/unix/mod.rs#L19
+    // * https://github.com/rust-lang/libc/blob/bcbfeb5516cd5bb055198dbfbddf8d626fa2be07/src/windows/mod.rs#L16
+    #[allow(non_camel_case_types)]
+    type size_t = usize;
 
     #[link(name = "m")]
     extern "C" {
@@ -163,7 +168,7 @@ pub mod floating_point_context {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(all(target_os = "windows", target_env = "gnu")))]
 pub mod floating_point_context {
     pub struct FloatingPointContext {}
 


### PR DESCRIPTION
Otherwise this will fail with a error on MSVC:

  fatal error LNK1181: cannot open input file 'm.lib'

We also don't need libc. `size_t` is properly defined, so we can
replicate that.

Additionally, applying the `controlfp` changes on MSVC seem to break the
tests anyway.