### PR TITLE
Bug 1625207 - device manufacturer & model are now optional

### DIFF
--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -46,8 +46,8 @@ Optional fields are marked accordingly.
 | `app_display_version` | String | The user-visible version string (e.g. "1.0.3") |
 | `architecture` | String | The architecture of the device (e.g. "arm", "x86") |
 | `client_id` | UUID |  *Optional* A UUID identifying a profile and allowing user-oriented correlation of data |
-| `device_manufacturer` | String | The manufacturer of the device |
-| `device_model` | String | The model name of the device. On Android, this is [`Build.MODEL`], the user-visible name of the device. |
+| `device_manufacturer` | String | *Optional* The manufacturer of the device |
+| `device_model` | String | *Optional* The model name of the device. On Android, this is [`Build.MODEL`], the user-visible name of the device. |
 | `first_run_date` | Datetime | The date of the first run of the application, in local time and with day precision, including timezone information. |
 | `os` | String | The name of the operating system (e.g. "linux", "Android", "ios") |
 | `os_version` | String | The user-visible version of the operating system (e.g. "1.2.3") |

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -81,6 +81,7 @@ glean.internal.metrics:
       - glean_client_info
     description: |
       The manufacturer of the device the application is running on.
+      Not set if the device manufacturer can't be determined (e.g. on Desktop).
     bugs:
       - https://bugzilla.mozilla.org/1522552
     data_reviews:
@@ -98,6 +99,7 @@ glean.internal.metrics:
       The model of the device the application is running on.
       On Android, this is Build.MODEL, the user-visible marketing name,
       like "Pixel 2 XL".
+      Not set if the device model can't be determined (e.g. on Desktop).
     bugs:
       - https://bugzilla.mozilla.org/1522552
     data_reviews:

--- a/glean.1.schema.json
+++ b/glean.1.schema.json
@@ -59,8 +59,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "device_manufacturer",
-        "device_model",
         "first_run_date",
         "os",
         "os_version",


### PR DESCRIPTION
Needs upstream schema to be deployed.

I also intend to update the schema in this repository once that is done.