### PR TITLE
[doc only] Bug 1623506 - Clarify documentation that pings will not be logged until submitted

### DIFF
--- a/docs/user/debugging/android.md
+++ b/docs/user/debugging/android.md
@@ -34,6 +34,8 @@ adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.Gl
   --es tagPings test-metrics-ping
 ```
 
+The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPings` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
+
 > **Note:** In previous versions of Glean the activity was available with the name `mozilla.components.service.glean.debug.GleanDebugActivity`.
 >
 > If you're debugging an old build, try running:

--- a/docs/user/debugging/ios.md
+++ b/docs/user/debugging/ios.md
@@ -26,6 +26,7 @@ There are a few things to consider when creating the custom URL:
 - Invalid commands will log an error and cause the entire URL to be ignored.
 - Not all commands are required to be encoded in the URL, you can mix and match the commands that you need.
 - Multiple instances of commands are not allowed in the same URL and, if present, will cause the entire URL to be ignored.
+- The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPings` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
 
 ### Instrumenting the application for Glean debug functionality
 


### PR DESCRIPTION
This clarifies the documentation around logging pings with the Glean debug utilities by stating that pings will not be logged until submitted, along with giving information on how to trigger ping submission on normal ping schedules.