### PR TITLE
Bug 1626258 - Better handling of global object in a threadsafe manner.

### DIFF
--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -48,10 +48,17 @@ where
     R: IntoFfi,
 {
     let mut error = ffi_support::ExternError::success();
-    let res = ffi_support::abort_on_panic::call_with_result(&mut error, || {
-        let glean = glean_core::global_glean().lock().unwrap();
-        callback(&glean)
-    });
+    let res =
+        ffi_support::abort_on_panic::call_with_result(
+            &mut error,
+            || match glean_core::global_glean() {
+                Some(glean) => {
+                    let glean = glean.lock().unwrap();
+                    callback(&glean)
+                }
+                None => Err(glean_core::Error::not_initialized()),
+            },
+        );
     handlemap_ext::log_if_error(error);
     res
 }
@@ -69,10 +76,17 @@ where
     R: IntoFfi,
 {
     let mut error = ffi_support::ExternError::success();
-    let res = ffi_support::abort_on_panic::call_with_result(&mut error, || {
-        let mut glean = glean_core::global_glean().lock().unwrap();
-        callback(&mut glean)
-    });
+    let res =
+        ffi_support::abort_on_panic::call_with_result(
+            &mut error,
+            || match glean_core::global_glean() {
+                Some(glean) => {
+                    let mut glean = glean.lock().unwrap();
+                    callback(&mut glean)
+                }
+                None => Err(glean_core::Error::not_initialized()),
+            },
+        );
     handlemap_ext::log_if_error(error);
     res
 }

--- a/glean-core/preview/src/lib.rs
+++ b/glean-core/preview/src/lib.rs
@@ -86,7 +86,8 @@ fn with_glean<F, R>(f: F) -> R
 where
     F: Fn(&Glean) -> R,
 {
-    let lock = global_glean().lock().unwrap();
+    let glean = global_glean().expect("Global Glean object not initialized");
+    let lock = glean.lock().unwrap();
     f(&lock)
 }
 
@@ -94,7 +95,8 @@ fn with_glean_mut<F, R>(f: F) -> R
 where
     F: Fn(&mut Glean) -> R,
 {
-    let mut lock = global_glean().lock().unwrap();
+    let glean = global_glean().expect("Global Glean object not initialized");
+    let mut lock = glean.lock().unwrap();
     f(&mut lock)
 }
 

--- a/glean-core/src/error.rs
+++ b/glean-core/src/error.rs
@@ -54,6 +54,9 @@ pub enum ErrorKind {
     /// Unknown error
     Utf8Error,
 
+    /// Glean not initialized
+    NotInitialized,
+
     #[doc(hidden)]
     __NonExhaustive,
 }
@@ -75,6 +78,13 @@ impl Error {
             kind: ErrorKind::Utf8Error,
         }
     }
+
+    /// Indicates an error that no global Glean object is initialized
+    pub fn not_initialized() -> Error {
+        Error {
+            kind: ErrorKind::NotInitialized,
+        }
+    }
 }
 
 impl std::error::Error for Error {}
@@ -92,7 +102,8 @@ impl Display for Error {
             MemoryUnit(m) => write!(f, "MemoryUnit conversion from {} failed", m),
             HistogramType(h) => write!(f, "HistogramType conversion from {} failed", h),
             OsString(s) => write!(f, "OsString conversion from {:?} failed", s),
-            Utf8Error => write!(f, "Invalid  UTF-8 byte sequence in string."),
+            Utf8Error => write!(f, "Invalid  UTF-8 byte sequence in string"),
+            NotInitialized => write!(f, "Global Glean object missing"),
             __NonExhaustive => write!(f, "Unknown error"),
         }
     }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -79,10 +79,8 @@ pub(crate) const DELETION_REQUEST_PINGS_DIRECTORY: &str = "deletion_request";
 static GLEAN: OnceCell<Mutex<Glean>> = OnceCell::new();
 
 /// Get a reference to the global Glean object.
-///
-/// Panics if no global Glean object was set.
-pub fn global_glean() -> &'static Mutex<Glean> {
-    GLEAN.get().unwrap()
+pub fn global_glean() -> Option<&'static Mutex<Glean>> {
+    GLEAN.get()
 }
 
 /// Set or replace the global Glean object.


### PR DESCRIPTION
This has two things:

* Getting the global object now gives an option and thus the FFI layer can return an error instead of panicking.
* Better docs on why the other code is ok, with the addition of logging an error instead of panicking.

Again: it is unlikely to ever hit any of these cases for our current wrappers, as they only initialize once.