### PR TITLE
Return the undefined locale for Swift if it can't be otherwise determined

### DIFF
--- a/docs/user/collected-metrics/metrics.md
+++ b/docs/user/collected-metrics/metrics.md
@@ -60,7 +60,7 @@ The following metrics are added to the ping:
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
 | glean.baseline.duration |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The duration of the last foreground session.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
-| glean.baseline.locale |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The locale of the application (e.g. "es-ES"). If the locale can't be determined on the system, the value is "und", to indicate "undetermined".  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
+| glean.baseline.locale |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The locale of the application (e.g. "es-ES"). If the locale can't be determined on the system, the value is ["und"](https://unicode.org/reports/tr35/#Unknown_or_Invalid_Identifiers), to indicate "undetermined".  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |
 
 ## deletion-request
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/LocaleUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/LocaleUtils.kt
@@ -9,6 +9,8 @@ import java.util.Locale
 /**
  * Gets a gecko-compatible locale string (e.g. "es-ES" instead of Java [Locale]
  * "es_ES") for the default locale.
+ * If the locale can't be determined on the system, the value is "und",
+ * to indicate "undetermined".
  *
  * This method approximates the API21 method [Locale.toLanguageTag].
  *
@@ -24,7 +26,12 @@ internal fun getLocaleTag(): String {
     val locale = Locale.getDefault()
     val language = getLanguageFromLocale(locale)
     val country = locale.country // Can be an empty string.
-    return if (country.isEmpty()) language else "$language-$country"
+
+    return when {
+        language.isEmpty() -> "und"
+        country.isEmpty() -> language
+        else -> "$language-$country"
+    }
 }
 
 /**

--- a/glean-core/ios/Glean/Utils/Utils.swift
+++ b/glean-core/ios/Glean/Utils/Utils.swift
@@ -202,11 +202,13 @@ func timestampNanos() -> UInt64 {
 }
 
 /// Gets a gecko-compatible locale string (e.g. "es-ES")
+// If the locale can't be determined on the system, the value is "und",
+// to indicate "undetermined".
 ///
 /// - returns: a locale string that supports custom injected locale/languages.
 func getLocaleTag() -> String {
     if NSLocale.current.languageCode == nil {
-        return "??"
+        return "und"
     } else {
         if NSLocale.current.regionCode == nil {
             return NSLocale.current.languageCode!

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -32,7 +32,8 @@ glean.baseline:
       - baseline
     description: |
       The locale of the application (e.g. "es-ES").
-      If the locale can't be determined on the system, the value is "und",
+      If the locale can't be determined on the system, the value is
+      ["und"](https://unicode.org/reports/tr35/#Unknown_or_Invalid_Identifiers),
       to indicate "undetermined".
     bugs:
       - https://bugzilla.mozilla.org/1512938
@@ -209,7 +210,8 @@ glean.internal.metrics:
       - glean_client_info
     description: |
       The locale of the application (e.g. "es-ES").
-      If the locale can't be determined on the system, the value is "und",
+      If the locale can't be determined on the system, the value is
+      ["und"](https://unicode.org/reports/tr35/#Unknown_or_Invalid_Identifiers),
       to indicate "undetermined".
     bugs:
       - https://bugzilla.mozilla.org/1601489

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -209,6 +209,8 @@ glean.internal.metrics:
       - glean_client_info
     description: |
       The locale of the application (e.g. "es-ES").
+      If the locale can't be determined on the system, the value is "und",
+      to indicate "undetermined".
     bugs:
       - https://bugzilla.mozilla.org/1601489
     data_reviews:


### PR DESCRIPTION
this also updates the metrics.yaml in one place, as right now we're still sending that metric.

I looked at the Kotlin code and it seems it "can, but never should be" an empty string, instead of our now "und" string.
Want me to also catch that?

See https://github.com/mozilla/glean/blob/undefined-locale-swift/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/LocaleUtils.kt#L39