### PR TITLE
Bug 1628057: Include app lifetime metrics in dirty_startup baseline pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v27.0.0...master)
 
+* General:
+  * BUGFIX: baseline pings sent at startup with the `dirty_startup` reason will now include application lifetime metrics.
+
 # v27.0.0 (2020-04-08)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v26.0.0...v27.0.0)
 
 * General:
-  * BUGFIX: baseline pings sent at startup with the `dirty_startup` reason will now include application lifetime metrics.
   * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running (e.g. between the runs of a Python command using the Glean SDK), the database is correctly cleared and a deletion request ping is sent. See [#791](https://github.com/mozilla/glean/pull/791).
   * The `events` ping now includes a reason code: `startup`, `background` or `max_capacity`.
 * iOS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v26.0.0...v27.0.0)
 
 * General:
+  * BUGFIX: baseline pings sent at startup with the `dirty_startup` reason will now include application lifetime metrics.
   * Glean will now detect when the upload enabled flag changes outside of the application, for example due to a change in a config file. This means that if upload is disabled while the application wasn't running (e.g. between the runs of a Python command using the Glean SDK), the database is correctly cleared and a deletion request ping is sent. See [#791](https://github.com/mozilla/glean/pull/791).
   * The `events` ping now includes a reason code: `startup`, `background` or `max_capacity`.
 * iOS:

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -122,6 +122,18 @@ public class Glean {
             // Check for overdue metrics pings
             self.metricsPingScheduler.schedule()
 
+            // Check if the "dirty flag" is set. That means the product was probably
+            // force-closed. If that's the case, submit a 'baseline' ping with the
+            // reason "dirty_startup". We only do that from the second run.
+            if !isFirstRun {
+                if glean_is_dirty_flag_set().toBool() {
+                    self.submitPingByNameSync(
+                        pingName: "baseline",
+                        reason: "dirty_startup"
+                    )
+                }
+            }
+
             // From the second time we run, after all startup pings are generated,
             // make sure to clear `lifetime: application` metrics and set them again.
             // Any new value will be sent in newly generted pings after startup.
@@ -135,18 +147,6 @@ public class Glean {
 
             // Signal Dispatcher that init is complete
             Dispatchers.shared.flushQueuedInitialTasks()
-
-            // Check if the "dirty flag" is set. That means the product was probably
-            // force-closed. If that's the case, submit a 'baseline' ping with the
-            // reason "dirty_startup". We only do that from the second run.
-            if !isFirstRun {
-                if glean_is_dirty_flag_set().toBool() {
-                    self.submitPingByNameSync(
-                        pingName: "baseline",
-                        reason: "dirty_startup"
-                    )
-                }
-            }
 
             self.observer = GleanLifecycleObserver()
 


### PR DESCRIPTION
TODO:
 
- [x] Port to iOS.