### PR TITLE
Bug 1628301, Bug 1628297: Fix race condition deleting tempdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * General:
   * BUGFIX: baseline pings sent at startup with the `dirty_startup` reason will now include application lifetime metrics.
+* Python
+  * BUGFIX: Fixed a race condition between uploading pings and deleting the temporary directory on shutdown of the process.
 
 # v27.0.0 (2020-04-08)
 

--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This module implements a class to dispatch work to another process.
+This work always happens one-at-a-time.  That is, it doesn't create
+another worker process until the previous worker process has completed.
+
+This is used only by the PingUploadWorker (and the test-only feature to delete
+temporary data directories which has a potential race condition with the
+PingUploadWorker).
+"""
+
+import sys
+from typing import Optional, TYPE_CHECKING, Union
+
+
+if TYPE_CHECKING:
+    import multiprocessing  # noqa
+
+
+def _work_wrapper(func, args):
+    """
+    A wrapper to call a function and convert its boolean success value into a
+    process exitcode.
+    """
+    success = func(*args)
+
+    if success:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+class ProcessDispatcher:
+    """
+    A class to dispatch work to another process. This work always happens
+    one-at-a-time. That is, it doesn't create another worker process until the
+    previous worker process has completed.
+
+    Since running a second process might block, this should only be used from
+    the worker thread in `_dispatcher.Dispatcher.
+    """
+
+    # Store the last run process object so we can `join` it when starting
+    # another process.
+    _last_process = None  # type: Optional[multiprocessing.Process]
+
+    @classmethod
+    def dispatch(cls, func, args) -> Union[bool, "multiprocessing.Process"]:
+        from . import Glean
+
+        if Glean._configuration._allow_multiprocessing:
+            # Only import the multiprocessing library if it's actually needed
+            import multiprocessing  # noqa
+
+            # We only want one of these processes running at a time, so if there's
+            # already one, join on it. PingUploadWorker.process is only triggered
+            # from a worker thread anyway, so this blocking will not block the main
+            # user thread.
+            if cls._last_process is not None:
+                cls._last_process.join()
+                cls._last_process = None
+
+            p = multiprocessing.Process(target=_work_wrapper, args=(func, args))
+            p.start()
+
+            cls._last_process = p
+
+            return p
+        else:
+            return func(*args)
+
+
+__all__ = ["ProcessDispatcher"]

--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -56,7 +56,7 @@ class ProcessDispatcher:
             import multiprocessing  # noqa
 
             # We only want one of these processes running at a time, so if there's
-            # already one, join on it. PingUploadWorker.process is only triggered
+            # already one, join on it. ProcessDispatcher.dispatch is only triggered
             # from a worker thread anyway, so this blocking will not block the main
             # user thread.
             if cls._last_process is not None:

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -195,10 +195,13 @@ class Glean:
         cls._initialized = False
         if cls._destroy_data_dir and cls._data_dir.exists():
             # This needs to be run in the same one-at-a-time process as the
-            # PingUploadWorker to avoid a race condition.
+            # PingUploadWorker to avoid a race condition. This will block the
+            # main thread waiting for all pending uploads to complete, but this
+            # only happens during testing when the data directory is a
+            # temporary directory, so there is no concern about delaying
+            # application shutdown here.
             p = ProcessDispatcher.dispatch(_rmtree, (str(cls._data_dir),))
-            if not isinstance(p, bool):
-                p.join()
+            p.join()
 
     @classmethod
     def is_initialized(cls) -> bool:

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -22,6 +22,7 @@ from ._dispatcher import Dispatcher
 from . import _ffi
 from .net import PingUploadWorker
 from .net import DeletionPingUploadWorker
+from ._process_dispatcher import ProcessDispatcher
 from . import _util
 
 
@@ -32,6 +33,15 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+def _rmtree(path) -> bool:
+    """
+    A small wrapper around shutil.rmtree to make it runnable on the
+    ProcessDispatcher.
+    """
+    shutil.rmtree(path)
+    return True
 
 
 class Glean:
@@ -169,17 +179,26 @@ class Glean:
         return cls._configuration
 
     @classmethod
-    def reset(cls):
+    def _reset(cls):
         """
         Resets the Glean singleton.
         """
         # TODO: 1594184 Send the metrics ping
+
+        # WARNING: Do not run any tasks on the Dispatcher from here since this
+        # is called atexit, which also waits for the Dispatcher queue to
+        # complete.
+
         Dispatcher.reset()
         if cls._initialized:
             _ffi.lib.glean_destroy_glean()
         cls._initialized = False
         if cls._destroy_data_dir and cls._data_dir.exists():
-            shutil.rmtree(str(cls._data_dir))
+            # This needs to be run in the same one-at-a-time process as the
+            # PingUploadWorker to avoid a race condition.
+            p = ProcessDispatcher.dispatch(_rmtree, (str(cls._data_dir),))
+            if not isinstance(p, bool):
+                p.join()
 
     @classmethod
     def is_initialized(cls) -> bool:
@@ -436,4 +455,4 @@ class Glean:
 __all__ = ["Glean"]
 
 
-atexit.register(Glean.reset)
+atexit.register(Glean._reset)

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -61,11 +61,8 @@ class PingUploadWorker:
         assert Dispatcher._testing_mode is True
 
         p = cls._process()
-        if isinstance(p, bool):
-            return p
-        else:
-            p.join()
-            return p.exitcode == 0
+        p.join()
+        return p.exitcode == 0
 
 
 # Ping files are UUIDs.  This matches UUIDs for filtering purposes.

--- a/glean-core/python/glean/testing/__init__.py
+++ b/glean-core/python/glean/testing/__init__.py
@@ -43,7 +43,7 @@ def reset_glean(
         Glean._destroy_data_dir = False
         data_dir = Glean._data_dir
 
-    Glean.reset()
+    Glean._reset()
     Glean.initialize(
         application_id=application_id,
         application_version=application_version,

--- a/glean-core/python/tests/metrics/test_labeled.py
+++ b/glean-core/python/tests/metrics/test_labeled.py
@@ -215,7 +215,7 @@ def test_other_label_without_predefined_labels_before_glean_init():
         send_in_pings=["metrics"],
     )
 
-    Glean.reset()
+    Glean._reset()
     Dispatcher.set_task_queueing(True)
 
     for i in range(21):

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -81,3 +81,31 @@ def test_unknown_scheme():
         fd.write(b"{}\n")
 
     assert False is PingUploadWorker._test_process_sync()
+
+
+def test_ping_upload_worker_single_process(safe_httpserver):
+    safe_httpserver.serve_content(b"", code=200)
+    Glean._configuration.server_endpoint = safe_httpserver.url
+
+    pings_dir = PingUploadWorker.storage_directory()
+    pings_dir.mkdir()
+
+    for i in range(100):
+        with (pings_dir / str(uuid.uuid4())).open("wb") as fd:
+            fd.write(b"/data/path/\n")
+            fd.write(b"{}\n")
+
+    # Fire off two PingUploadWorker processing tasks at the same time. If
+    # working correctly, p1 should finish entirely before p2 starts.
+    # If these actually run in parallel, one or the other will try to send
+    # deleted queued ping files and fail.
+    p1 = PingUploadWorker._process()
+    p2 = PingUploadWorker._process()
+
+    p1.join()
+    assert p1.exitcode == 0
+
+    p2.join()
+    assert p2.exitcode == 0
+
+    assert 100 == len(safe_httpserver.requests)


### PR DESCRIPTION
`Glean._reset` is called:

1) as part of resetting every unit test, both within Glean and for our users
   writing Glean-aware unit tests,

2) atexit

Glean._reset deletes the Glean data directory if it's a temporary directory
(but not under normal circumstances where a permanent location is used).

There is a race condition between the ping uploader and Glean._reset if
the data directory is deleted while pings are still being uploaded. This
solves that by always firing off a single ping uploader process at a time,
and running both ping uploaders and the temporary directory deletion on that
same one-at-a-time process.

It does not use a Process pool to keep a single process around, because
that would add a lot of complexity to handle a daemon process, vs. this
"fire and forget" process.

This also makes Glean._reset private.

This does not address the broader question of multiple top-level application processes running at the same time and having a race condition between each of their ping uploaders.  See https://bugzilla.mozilla.org/show_bug.cgi?id=1628294 for information on that.