### PR TITLE
Bug 1628323 - Change Glean iOS to use Application Support directory

### DIFF
--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -84,7 +84,7 @@ public class Glean {
                 // The FileManager returns `file://` URLS with absolute paths.
                 // The Rust side expects normal path strings to be used.
                 // `relativePath` for a file URL gives us the absolute filesystem path.
-                dataDir: getDocumentsDirectory().relativePath,
+                dataDir: getGleanDirectory().relativePath,
                 packageName: AppInfo.name,
                 uploadEnabled: uploadEnabled,
                 configuration: configuration

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -181,7 +181,7 @@ public class HttpPingUploader {
     ///
     /// - returns: File `URL` representing the ping directory
     func getOrCreatePingDirectory() -> URL {
-        let dataPath = getDocumentsDirectory().appendingPathComponent(self.pingDirectory)
+        let dataPath = getGleanDirectory().appendingPathComponent(self.pingDirectory)
 
         if !FileManager.default.fileExists(atPath: dataPath.relativePath) {
             do {

--- a/glean-core/ios/Glean/Utils/Utils.swift
+++ b/glean-core/ios/Glean/Utils/Utils.swift
@@ -98,11 +98,11 @@ extension String {
     }
 }
 
-/// Helper function to retrive the application's Documents directory for persistent file storage
+/// Helper function to retrive the application's Application Support directory for persistent file storage
 ///
-/// - returns: `String` representation of the path to the Documents directory
-func getDocumentsDirectory() -> URL {
-    let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+/// - returns: `URL` of the Application Support directory
+func getGleanDirectory() -> URL {
+    let paths = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
     let documentsDirectory = paths[0]
     return documentsDirectory.appendingPathComponent("glean_data")
 }

--- a/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
+++ b/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
@@ -67,7 +67,7 @@ class DeletionRequestPingTests: XCTestCase {
         glean.enableTestingMode()
 
         // Create directory for pending deletion-request pings
-        let pendingDeletionRequestDir = getDocumentsDirectory().appendingPathComponent("deletion_request")
+        let pendingDeletionRequestDir = getGleanDirectory().appendingPathComponent("deletion_request")
         try! FileManager.default.createDirectory(
             atPath: pendingDeletionRequestDir.path,
             withIntermediateDirectories: true,


### PR DESCRIPTION
This updates the Glean-iOS bindings to use the Application Support directory rather than the Documents directory.  It also renames the `getDocumentsDirectory` utility function to be more appropriately named.