### PR TITLE
Bug 1628310: Don't raise HTTPException or socket.gaierror

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 164 utf-8
+personal_ws-1.1 en 165 utf-8
 AAR
 AARs
 APIs
@@ -12,6 +12,7 @@ CODEOWNERS
 Cartfile
 CircleCI
 Ciufo
+DNS
 Datetime
 Datetimes
 Fenix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v27.1.0...master)
 
+* Python:
+  * BUGFIX: The ping uploader will no longer display a trace back when the upload fails due to a failed DNS lookup, network outage, or related issues that prevent communication with the telemetry endpoint.
+
 # v27.1.0 (2020-04-09)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v27.0.0...v27.1.0)

--- a/glean-core/python/glean/net/http_client.py
+++ b/glean-core/python/glean/net/http_client.py
@@ -60,10 +60,10 @@ class HttpClientUploader(base_uploader.BaseUploader):
             )
             response = conn.getresponse()
         except http.client.HTTPException as e:
-            log.debug("http.client.HTTPException: {}".format(e))
+            log.error("http.client.HTTPException: {}".format(e))
             return False
         except socket.gaierror as e:
-            log.debug("socket.gaierror: {}".format(e))
+            log.error("socket.gaierror: {}".format(e))
             return False
 
         log.debug("Ping upload: {}".format(response.status))

--- a/glean-core/python/glean/net/http_client.py
+++ b/glean-core/python/glean/net/http_client.py
@@ -10,6 +10,7 @@ module.
 
 import http.client
 import logging
+import socket
 from typing import List, Tuple
 import urllib.parse
 
@@ -50,10 +51,20 @@ class HttpClientUploader(base_uploader.BaseUploader):
         else:
             raise ValueError("Unknown URL scheme {}".format(parsed_url.scheme))
 
-        conn.request(
-            "POST", parsed_url.path, body=data.encode("utf-8"), headers=dict(headers),
-        )
-        response = conn.getresponse()
+        try:
+            conn.request(
+                "POST",
+                parsed_url.path,
+                body=data.encode("utf-8"),
+                headers=dict(headers),
+            )
+            response = conn.getresponse()
+        except http.client.HTTPException as e:
+            log.debug("http.client.HTTPException: {}".format(e))
+            return False
+        except socket.gaierror as e:
+            log.debug("socket.gaierror: {}".format(e))
+            return False
 
         log.debug("Ping upload: {}".format(response.status))
 

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -114,4 +114,4 @@ def test_ping_upload_worker_single_process(safe_httpserver):
 
 def test_unknown_url_no_exception():
     # Shouldn't leak any socket or HTTPExceptions
-    assert not HttpClientUploader.upload("http://nowhere.mozilla.org", "{}", [])
+    assert not HttpClientUploader.upload("http://nowhere.example.com", "{}", [])

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -8,6 +8,7 @@ import uuid
 
 from glean import Glean
 from glean.net import PingUploadWorker
+from glean.net.http_client import HttpClientUploader
 
 
 def test_invalid_filename():
@@ -109,3 +110,8 @@ def test_ping_upload_worker_single_process(safe_httpserver):
     assert p2.exitcode == 0
 
     assert 100 == len(safe_httpserver.requests)
+
+
+def test_unknown_url_no_exception():
+    # Shouldn't leak any socket or HTTPExceptions
+    assert not HttpClientUploader.upload("http://nowhere.mozilla.org", "{}", [])


### PR DESCRIPTION
These exceptions occur when the network is down, the URL doesn't resolve,
and a bunch of other things. If any of these fail, we should just log and return
False so the ping uploader can move on to other pings or try again next time.
This is preferable to displaying a long (but ultimately harmless) traceback.