### PR TITLE
Bug 1628885: Use subprocess rather than multiprocessing for ping uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Python:
   * BUGFIX: The ping uploader will no longer display a trace back when the upload fails due to a failed DNS lookup, network outage, or related issues that prevent communication with the telemetry endpoint.
   * The dependency on `inflection` has been removed.
+  * The Python bindings now use `subprocess` rather than `multiprocessing` to perform ping uploading in a separate process. This should be more compatible on all of the platforms Glean supports.
 
 # v27.1.0 (2020-04-09)
 

--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -10,52 +10,46 @@ another worker process until the previous worker process has completed.
 This is used only by the PingUploadWorker (and the test-only feature to delete
 temporary data directories which has a potential race condition with the
 PingUploadWorker).
+
+This uses the lower level `subprocess` library rather than `multiprocessing` to
+avoid the unnecessary complexity and not place burdens on Glean's users to
+architect their application startup to be `multiprocessing` compatible on
+Windows.
 """
 
+import base64
+import pickle
+import subprocess
 import sys
-from typing import Optional, TYPE_CHECKING, Union
+from typing import Optional, Union
 
 
-if TYPE_CHECKING:
-    import multiprocessing  # noqa
-
-
-def _work_wrapper(func, args):
-    """
-    A wrapper to call a function in another process and convert its boolean
-    success value into a process exitcode.
-    """
-    success = func(*args)
-
-    if success:
-        sys.exit(0)
-    else:
-        sys.exit(1)
+from .subprocess import _process_dispatcher_helper
 
 
 class _SyncWorkWrapper:
     """
     A wrapper to synchronously call a function in the current process, but make
-    it have the same (limited) interface as if it were a
-    multiprocessing.Process:
+    it have the same (limited) interface as if it were a `subprocess.Popen`
+    object:
 
         >>> p = ProcessDispatcher.dispatch(myfunc, ())
-        >>> p.join()
-        >>> p.exitcode
+        >>> p.wait()
+        >>> p.returncode
         0
     """
 
     def __init__(self, func, args):
         self._result = func(*args)
-        self._joined = False
+        self._waited = False
 
-    def join(self):
-        self._joined = True
+    def wait(self):
+        self._waited = True
 
     @property
-    def exitcode(self):
+    def returncode(self):
         if not self._joined:
-            raise RuntimeError("join() must be called before exitcode is available")
+            raise RuntimeError("wait() must be called before returncode is available")
         if self._result:
             return 0
         else:
@@ -75,25 +69,27 @@ class ProcessDispatcher:
 
     # Store the last run process object so we can `join` it when starting
     # another process.
-    _last_process = None  # type: Optional[multiprocessing.Process]
+    _last_process = None  # type: Optional[subprocess.Popen]
 
     @classmethod
-    def dispatch(cls, func, args) -> Union[_SyncWorkWrapper, "multiprocessing.Process"]:
+    def dispatch(cls, func, args) -> Union[_SyncWorkWrapper, subprocess.Popen]:
         from . import Glean
 
         if Glean._configuration._allow_multiprocessing:
-            # Only import the multiprocessing library if it's actually needed
-            import multiprocessing  # noqa
-
             # We only want one of these processes running at a time, so if
             # there's already one, join on it. Therefore, this should not be
             # run from the main user thread.
             if cls._last_process is not None:
-                cls._last_process.join()
+                cls._last_process.wait()
                 cls._last_process = None
 
-            p = multiprocessing.Process(target=_work_wrapper, args=(func, args))
-            p.start()
+            p = subprocess.Popen(
+                [
+                    sys.executable,
+                    _process_dispatcher_helper.__file__,
+                    base64.b64encode(pickle.dumps((func, args))).decode("ascii"),
+                ]
+            )
 
             cls._last_process = p
 

--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -92,9 +92,9 @@ class ProcessDispatcher:
             # This sends the data over as a commandline argument, which has a
             # maximum length of:
             #   - 8191 characters on Windows
-            #     (see: https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation)
+            #     (see: https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation)  # noqa
             #   - As little as 4096 bytes on POSIX, though in practice much larger
-            #     (see _POSIX_ARG_MAX_: https://www.gnu.org/software/libc/manual/html_node/Minimums.html)
+            #     (see _POSIX_ARG_MAX_: https://www.gnu.org/software/libc/manual/html_node/Minimums.html)  # noqa
             # In practice, this is ~700 bytes, and the data is an implementation detail
             # that Glean controls. This approach may need to change to pass over a pipe
             # if it becomes too large.

--- a/glean-core/python/glean/config.py
+++ b/glean-core/python/glean/config.py
@@ -60,9 +60,8 @@ class Configuration:
                 uploading pings for debug view.
             ping_uploader (glean.net.BaseUploader): Optional. The ping uploader
                 implementation. Defaults to `glean.net.HttpClientUploader`.
-            allow_multiprocessing (bool): When True (default), use Python
-                multiprocessing to offload some work (such as ping uploading) to a
-                child process.
+            allow_multiprocessing (bool): When True (default), use a subprocess
+                to offload some work (such as ping uploading).
         """
         self._server_endpoint = server_endpoint
         if user_agent is None:

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -201,7 +201,7 @@ class Glean:
             # temporary directory, so there is no concern about delaying
             # application shutdown here.
             p = ProcessDispatcher.dispatch(_rmtree, (str(cls._data_dir),))
-            p.join()
+            p.wait()
 
     @classmethod
     def is_initialized(cls) -> bool:

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -61,8 +61,8 @@ class PingUploadWorker:
         assert Dispatcher._testing_mode is True
 
         p = cls._process()
-        p.join()
-        return p.exitcode == 0
+        p.wait()
+        return p.returncode == 0
 
 
 # Ping files are UUIDs.  This matches UUIDs for filtering purposes.

--- a/glean-core/python/glean/subprocess/__init__.py
+++ b/glean-core/python/glean/subprocess/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/glean-core/python/glean/subprocess/_process_dispatcher_helper.py
+++ b/glean-core/python/glean/subprocess/_process_dispatcher_helper.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+The main entry point for work performed on a worker process by
+_dispatcher_subprocess.
+
+This needs to be here and not at the top-level of the package to avoid
+ambiguity between the `glean` and `glean.glean` import paths.
+"""
+
+
+if __name__ == "__main__":
+    import base64
+    import pickle
+    import sys
+
+    __builtins__.IN_GLEAN_SUBPROCESS = True  # type: ignore
+
+    func, args = pickle.loads(base64.b64decode(sys.argv[1]))
+
+    success = func(*args)
+
+    if success:
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/glean-core/python/glean/testing/__init__.py
+++ b/glean-core/python/glean/testing/__init__.py
@@ -53,4 +53,21 @@ def reset_glean(
     )
 
 
+class _RecordingUploader:
+    """
+    A ping uploader that saves the results to disk for later inspection.
+
+    This is used for testing only, but it needs to be importable from the Glean
+    package since it runs in the ping upload worker subprocess.
+    """
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+
+    def do_upload(self, url_path, serialized_ping, configuration):
+        with self.file_path.open("w") as fd:
+            fd.write(str(url_path) + "\n")
+            fd.write(serialized_ping + "\n")
+
+
 __all__ = ["reset_glean", "ErrorType"]

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -589,4 +589,8 @@ def test_dont_allow_multiprocessing(monkeypatch, safe_httpserver):
 
     custom_ping.submit()
 
+    process = PingUploadWorker._process()
+    process.wait()
+    assert process.returncode == 0
+
     assert 1 == len(safe_httpserver.requests)

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -103,11 +103,11 @@ def test_ping_upload_worker_single_process(safe_httpserver):
     p1 = PingUploadWorker._process()
     p2 = PingUploadWorker._process()
 
-    p1.join()
-    assert p1.exitcode == 0
+    p1.wait()
+    assert p1.returncode == 0
 
-    p2.join()
-    assert p2.exitcode == 0
+    p2.wait()
+    assert p2.returncode == 0
 
     assert 100 == len(safe_httpserver.requests)
 


### PR DESCRIPTION
This avoids a number of features that are tricky on Windows, especially on MSYS, such as
duplicating file handles to a spawned subprocess.