### PR TITLE
Bug 1628747 - Bring back deletion request pings

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -267,14 +267,20 @@ open class GleanInternalAPI internal constructor () {
                     // Cancel any pending workers here so that we don't accidentally upload or
                     // collect data after the upload has been disabled.
                     metricsPingScheduler.cancel()
-                    // Enqueue the PingUploadWorker to immediately upload the deletion-request ping.
-                    PingUploadWorker.enqueueWorker(applicationContext)
+                    // Cancel any pending workers here so that we don't accidentally upload or
+                    // collect data after the upload has been disabled.
+                    PingUploadWorker.cancel(applicationContext)
                 }
 
                 if (!originalEnabled && enabled) {
                     // If uploading is being re-enabled, we have to restore the
                     // application-lifetime metrics.
                     initializeCoreMetrics((this@GleanInternalAPI).applicationContext)
+                }
+
+                if (originalEnabled && !enabled) {
+                    // If uploading is disabled, we need to send the deletion-request ping
+                    PingUploadWorker.enqueueWorker(applicationContext)
                 }
             }
         } else {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -267,8 +267,8 @@ open class GleanInternalAPI internal constructor () {
                     // Cancel any pending workers here so that we don't accidentally upload or
                     // collect data after the upload has been disabled.
                     metricsPingScheduler.cancel()
-                    // Cancel any pending workers here so that we don't accidentally upload or
-                    // collect data after the upload has been disabled.
+                    // Cancel any pending workers here so that we don't accidentally upload
+                    // data after the upload has been disabled.
                     PingUploadWorker.cancel(applicationContext)
                 }
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -667,7 +667,7 @@ class GleanTest {
         )
 
         // Now trigger it to upload
-        triggerWorkManager(context, PingUploadWorker.PING_WORKER_TAG)
+        triggerWorkManager(context)
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         val docType = request.path.split("/")[3]

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -211,8 +211,9 @@ internal fun waitForEnqueuedWorker(
  * @param context the application [Context] to get the [WorkManager] instance for
  * @param workerTag the tag for the expected worker (default: `PingUploadWorker.PING_WORKER_TAG`)
  */
-internal fun triggerWorkManager(context: Context, workerTag: String = PingUploadWorker.PING_WORKER_TAG) {
+internal fun triggerWorkManager(context: Context) {
     // Check that the work is scheduled
+    val workerTag = PingUploadWorker.PING_WORKER_TAG
     val status = getWorkerStatus(context, workerTag)
     Assert.assertTrue("A scheduled $workerTag must exist",
         status.isEnqueued)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
@@ -19,6 +19,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.TimeUnit
 
+/**
+ * Testing correct behavior of the deletion ping.
+ *
+ * We already rely on the Rust side to do the right thing and delete pings at the right time.
+ * We still want to test this from the Kotlin side, as this is an important core part of Glean.
+ *
+ * Even if this seemingly duplicates some of the testing, this should be kept around.
+ */
 @RunWith(AndroidJUnit4::class)
 class DeletionPingTest {
     companion object {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
@@ -1,0 +1,92 @@
+package mozilla.telemetry.glean.scheduler
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.getContextWithMockedInfo
+import mozilla.telemetry.glean.getMockWebServer
+import mozilla.telemetry.glean.getWorkerStatus
+import mozilla.telemetry.glean.resetGlean
+import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.triggerWorkManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class DeletionPingTest {
+    companion object {
+        // This is the same deletion request ping directory as defined in `glean-core/src/lib.rs`.
+        // We want to test interoperation between the Swift and Rust parts.
+        private const val DELETION_PING_DIR: String = "deletion_request"
+    }
+
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+
+    @Test
+    fun `pending deletion-request pings are sent on startup`() {
+        // Create directory for pending deletion-request pings
+        val pendingDeletionRequestDir = File(Glean.getDataDir(), DELETION_PING_DIR)
+        pendingDeletionRequestDir.mkdirs()
+
+        // Write a deletion-request ping file
+        val pingId = "b4e4ede0-8716-4691-a3fa-493c56c5be2d"
+        val submitPath = "/submit/org-mozilla-samples-gleancore/deletion-request/1/$pingId"
+        val content = "$submitPath\n{}"
+        val pingFile = File(pendingDeletionRequestDir, pingId)
+        assertTrue(pingFile.createNewFile())
+        pingFile.writeText(content)
+
+        val server = getMockWebServer()
+        val context = getContextWithMockedInfo()
+
+        resetGlean(context, Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ), clearStores = true, uploadEnabled = false)
+        triggerWorkManager(context)
+
+        val request = server.takeRequest(2L, TimeUnit.SECONDS)
+        val docType = request.path.split("/")[3]
+        assertEquals("deletion-request", docType)
+    }
+
+    @Test
+    fun `deletion-request pings are only sent when toggled from on to off`() {
+        val server = getMockWebServer()
+        val context = getContextWithMockedInfo()
+
+        resetGlean(context, Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ), clearStores = true, uploadEnabled = true)
+
+        // Get directory for pending deletion-request pings
+        val pendingDeletionRequestDir = File(Glean.getDataDir(), DELETION_PING_DIR)
+
+        // Disabling upload generates a deletion ping
+        Glean.setUploadEnabled(false)
+        triggerWorkManager(context)
+
+        val request = server.takeRequest(2L, TimeUnit.SECONDS)
+        val docType = request.path.split("/")[3]
+        assertEquals("deletion-request", docType)
+
+        // File is deleted afterwards.
+        assertEquals(0, pendingDeletionRequestDir.listFiles()?.size)
+
+        // Re-setting upload to `false` should not generate an additional ping
+        // and no worker should be scheduled.
+        Glean.setUploadEnabled(false)
+
+        assertFalse(getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+        // No new file should have been written
+        assertEquals(0, pendingDeletionRequestDir.listFiles()?.size)
+    }
+}

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -121,7 +121,7 @@ impl PingUploadManager {
 
         queue.retain(|ping| ping.is_deletion_request());
         log::trace!(
-            "{} pings left in the queue (only deletion-request)",
+            "{} pings left in the queue (only deletion-request expected)",
             queue.len()
         );
         queue

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -101,6 +101,8 @@ impl PingUploadManager {
 
     /// Creates a `PingRequest` and adds it to the queue.
     pub fn enqueue_ping(&self, uuid: &str, path: &str, body: JsonValue) {
+        log::trace!("Enqueuing ping {} at {}", uuid, path);
+
         let mut queue = self
             .queue
             .write()
@@ -111,12 +113,17 @@ impl PingUploadManager {
 
     /// Clears the pending pings queue, leaves the deletion-request pings.
     pub fn clear_ping_queue(&self) -> RwLockWriteGuard<'_, VecDeque<PingRequest>> {
+        log::trace!("Clearing ping queue");
         let mut queue = self
             .queue
             .write()
             .expect("Can't write to pending pings queue.");
 
         queue.retain(|ping| ping.is_deletion_request());
+        log::trace!(
+            "{} pings left in the queue (only deletion-request)",
+            queue.len()
+        );
         queue
     }
 
@@ -139,7 +146,11 @@ impl PingUploadManager {
             .expect("Can't write to pending pings queue.");
         match queue.pop_front() {
             Some(request) => {
-                log::info!("New upload task with id {}", &request.uuid);
+                log::info!(
+                    "New upload task with id {} (path: {})",
+                    request.uuid,
+                    request.path
+                );
                 PingUploadTask::Upload(request)
             }
             None => {


### PR DESCRIPTION
As it turns out removing those tests indeed made us _miss_ some of the details of the deletion-request ping, but not for long.

I brought back the tests, rewrote them to work against the new mechanism and extended them slightly, just for good measure.

I also added some additional trace logging. It's only visible if `RUST_LOG=trace` is set, plus some cleanup.