### PR TITLE
Bug 1626542 - Rename `metric_name` to `metric_id` for clarification

### DIFF
--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -39,7 +39,7 @@ pub enum ErrorType {
 }
 
 impl ErrorType {
-    /// The error type's metric name
+    /// The error type's metric id
     pub fn as_str(&self) -> &'static str {
         match self {
             ErrorType::InvalidValue => "invalid_value",
@@ -101,7 +101,7 @@ fn get_error_metric_for_metric(meta: &CommonMetricData, error: ErrorType) -> Cou
 /// * meta - The metric's meta data
 /// * error -  The error type to record
 /// * message - The message to log. This message is not sent with the ping.
-///             It does not need to include the metric name, as that is automatically prepended to the message.
+///             It does not need to include the metric id, as that is automatically prepended to the message.
 ///  * num_errors - The number of errors of the same type to report.
 pub fn record_error<O: Into<Option<i32>>>(
     glean: &Glean,

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -31,7 +31,7 @@ fn snapshot_labeled_metrics(
     let map = snapshot.entry(ping_section).or_insert_with(HashMap::new);
 
     let mut s = metric_id.splitn(2, '/');
-    let metric_id = s.next().unwrap(); // Safe unwrap, the function is only called when the name does contain a '/'
+    let metric_id = s.next().unwrap(); // Safe unwrap, the function is only called when the id does contain a '/'
     let label = s.next().unwrap(); // Safe unwrap, the function is only called when the name does contain a '/'
 
     let obj = map.entry(metric_id.into()).or_insert_with(|| json!({}));

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -17,24 +17,24 @@ use crate::Lifetime;
 /// Snapshot metrics from the underlying database.
 pub struct StorageManager;
 
-/// Labeled metrics are stored as `<metric name>/<label>`.
+/// Labeled metrics are stored as `<metric id>/<label>`.
 /// They need to go into a nested object in the final snapshot.
 ///
-/// We therefore extract the metric name and the label from the key and construct the new object or
+/// We therefore extract the metric id and the label from the key and construct the new object or
 /// add to it.
 fn snapshot_labeled_metrics(
     snapshot: &mut HashMap<String, HashMap<String, JsonValue>>,
-    metric_name: &str,
+    metric_id: &str,
     metric: &Metric,
 ) {
     let ping_section = format!("labeled_{}", metric.ping_section());
     let map = snapshot.entry(ping_section).or_insert_with(HashMap::new);
 
-    let mut s = metric_name.splitn(2, '/');
-    let metric_name = s.next().unwrap(); // Safe unwrap, the function is only called when the name does contain a '/'
+    let mut s = metric_id.splitn(2, '/');
+    let metric_id = s.next().unwrap(); // Safe unwrap, the function is only called when the name does contain a '/'
     let label = s.next().unwrap(); // Safe unwrap, the function is only called when the name does contain a '/'
 
-    let obj = map.entry(metric_name.into()).or_insert_with(|| json!({}));
+    let obj = map.entry(metric_id.into()).or_insert_with(|| json!({}));
     let obj = obj.as_object_mut().unwrap(); // safe unwrap, we constructed the object above
     obj.insert(label.into(), metric.as_json());
 }
@@ -82,15 +82,15 @@ impl StorageManager {
     ) -> Option<JsonValue> {
         let mut snapshot: HashMap<String, HashMap<String, JsonValue>> = HashMap::new();
 
-        let mut snapshotter = |metric_name: &[u8], metric: &Metric| {
-            let metric_name = String::from_utf8_lossy(metric_name).into_owned();
-            if metric_name.contains('/') {
-                snapshot_labeled_metrics(&mut snapshot, &metric_name, &metric);
+        let mut snapshotter = |metric_id: &[u8], metric: &Metric| {
+            let metric_id = String::from_utf8_lossy(metric_id).into_owned();
+            if metric_id.contains('/') {
+                snapshot_labeled_metrics(&mut snapshot, &metric_id, &metric);
             } else {
                 let map = snapshot
                     .entry(metric.ping_section().into())
                     .or_insert_with(HashMap::new);
-                map.insert(metric_name, metric.as_json());
+                map.insert(metric_id, metric.as_json());
             }
         };
 
@@ -132,9 +132,9 @@ impl StorageManager {
     ) -> Option<Metric> {
         let mut snapshot: Option<Metric> = None;
 
-        let mut snapshotter = |metric_name: &[u8], metric: &Metric| {
-            let metric_name = String::from_utf8_lossy(metric_name).into_owned();
-            if metric_name == metric_id {
+        let mut snapshotter = |id: &[u8], metric: &Metric| {
+            let id = String::from_utf8_lossy(id).into_owned();
+            if id == metric_id {
                 snapshot = Some(metric.clone())
             }
         };
@@ -177,10 +177,10 @@ impl StorageManager {
     ) -> Option<JsonValue> {
         let mut snapshot: HashMap<String, JsonValue> = HashMap::new();
 
-        let mut snapshotter = |metric_name: &[u8], metric: &Metric| {
-            let metric_name = String::from_utf8_lossy(metric_name).into_owned();
-            if metric_name.ends_with("#experiment") {
-                let name = metric_name.splitn(2, '#').next().unwrap(); // safe unwrap, first field of a split always valid
+        let mut snapshotter = |metric_id: &[u8], metric: &Metric| {
+            let metric_id = String::from_utf8_lossy(metric_id).into_owned();
+            if metric_id.ends_with("#experiment") {
+                let name = metric_id.splitn(2, '#').next().unwrap(); // safe unwrap, first field of a split always valid
                 snapshot.insert(name.to_string(), metric.as_json());
             }
         };


### PR DESCRIPTION
This renames usage of `metric_name` to `metric_id` to be more clear about what is being used.