### PR TITLE
[wip] 1626874: Enable the use of the testing APIs without Robolectric

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestNoUploads.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestNoUploads.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.testing
+
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.config.Configuration
+import mozilla.telemetry.glean.utils.AndroidBuildInfo
+import org.junit.rules.RuleChain
+import org.junit.rules.TemporaryFolder
+import org.junit.rules.TestRule
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * This implements a JUnit rule for writing tests for Glean SDK metrics.
+ *
+ * The rule takes care of resetting the Glean SDK between tests and
+ * initializing all the required dependencies.
+ *
+ * Example usage:
+ *
+ * ```
+ * // Add the following lines to you test class.
+ * @get:Rule
+ * val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+ * ```
+ *
+ * @param configToUse an optional [Configuration] to initialize the Glean SDK with
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+class GleanTestNoUploads(
+    private val configToUse: Configuration = Configuration()
+) : TestRule {
+    private val temporaryFolder = TemporaryFolder()
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return RuleChain
+            .outerRule(temporaryFolder)
+            .around(object : TestWatcher(){
+                /**
+                 * Invoked when a test is about to start.
+                 */
+                override fun starting(description: Description?) {
+                    Glean.resetGlean(
+                        context = StubAndroidContext(
+                            temporaryFolder.newFolder().absolutePath,
+                            "org.mozilla.gleantestnoupload"
+                        ),
+                        config = configToUse,
+                        clearStores = true,
+                        buildInfo = object : AndroidBuildInfo {
+                            override fun getSdkVersion(): String = "10"
+                            override fun getVersionString(): String = "glean-test-1.0"
+                            override fun getDeviceManufacturer(): String = "glean stubs, inc"
+                            override fun getDeviceModel(): String = "stub-dev-mk1"
+                            override fun getPreferredABI(): String = "gleanabi-v1"
+                        }
+                    )
+                }
+            })
+            .apply(base, description)
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/MockSharedPreferences.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/MockSharedPreferences.kt
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.testing
+
+import android.content.SharedPreferences
+
+internal class MockSharedPreferences : SharedPreferences {
+    override fun contains(key: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getInt(key: String?, defValue: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAll(): MutableMap<String, *> {
+        TODO("Not yet implemented")
+    }
+
+    override fun edit(): SharedPreferences.Editor = MockEditor()
+
+    override fun getLong(key: String?, defValue: Long): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFloat(key: String?, defValue: Float): Float {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getString(key: String?, defValue: String?): String? = null
+
+    class MockEditor : SharedPreferences.Editor {
+        override fun clear(): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putLong(key: String?, value: Long): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putInt(key: String?, value: Int): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun remove(key: String?): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun putStringSet(key: String?, values: MutableSet<String>?): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun commit(): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun putFloat(key: String?, value: Float): SharedPreferences.Editor {
+            TODO("Not yet implemented")
+        }
+
+        override fun apply() {
+            // TODO("Not yet implemented")
+            // Currently no-ops
+        }
+
+        override fun putString(key: String?, value: String?): SharedPreferences.Editor {
+            // TODO("Not yet implemented")
+            // Currently no-ops
+            return this
+        }
+
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/StubAndroidContext.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/StubAndroidContext.kt
@@ -1,0 +1,851 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.testing
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ContentResolver
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.IntentSender
+import android.content.ServiceConnection
+import android.content.SharedPreferences
+import android.content.BroadcastReceiver
+import android.content.pm.ActivityInfo
+import android.content.pm.ApplicationInfo
+import android.content.pm.ChangedPackages
+import android.content.pm.FeatureInfo
+import android.content.pm.InstrumentationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
+import android.content.pm.PermissionGroupInfo
+import android.content.pm.PermissionInfo
+import android.content.pm.ProviderInfo
+import android.content.pm.ResolveInfo
+import android.content.pm.ServiceInfo
+import android.content.pm.SharedLibraryInfo
+import android.content.pm.VersionedPackage
+import android.content.res.AssetManager
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.content.res.XmlResourceParser
+import android.database.DatabaseErrorHandler
+import android.database.sqlite.SQLiteDatabase
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.UserHandle
+import android.view.Display
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStream
+
+/**
+ * A stub [Context] used in unit tests for the Glean SDK.
+ * This is additionally used by the SDK test rules.
+ *
+ * @param fakeDataDir the path to an existing directory to be reported by
+ *        `ApplicationInfo.dataDir`.
+ * @param fakePackageName the package name to be reported by `getPackageName`.
+ */
+internal class StubAndroidContext(
+    private val fakeDataDir: String,
+    private val fakePackageName: String
+) : Context() {
+    override fun getApplicationContext(): Context {
+        TODO("Not yet implemented")
+    }
+
+    override fun setWallpaper(bitmap: Bitmap?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setWallpaper(data: InputStream?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeStickyBroadcastAsUser(intent: Intent?, user: UserHandle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkCallingOrSelfPermission(permission: String): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getClassLoader(): ClassLoader {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkCallingOrSelfUriPermission(uri: Uri?, modeFlags: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getObbDir(): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkUriPermission(uri: Uri?, pid: Int, uid: Int, modeFlags: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkUriPermission(uri: Uri?, readPermission: String?, writePermission: String?, pid: Int, uid: Int, modeFlags: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getExternalFilesDirs(type: String?): Array<File> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPackageResourcePath(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteSharedPreferences(name: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkPermission(permission: String, pid: Int, uid: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun startIntentSender(intent: IntentSender?, fillInIntent: Intent?, flagsMask: Int, flagsValues: Int, extraFlags: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun startIntentSender(intent: IntentSender?, fillInIntent: Intent?, flagsMask: Int, flagsValues: Int, extraFlags: Int, options: Bundle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences = MockSharedPreferences()
+
+    override fun sendStickyBroadcastAsUser(intent: Intent?, user: UserHandle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDataDir(): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun getWallpaper(): Drawable {
+        TODO("Not yet implemented")
+    }
+
+    override fun isDeviceProtectedStorage(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getExternalFilesDir(type: String?): File? {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendBroadcastAsUser(intent: Intent?, user: UserHandle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendBroadcastAsUser(intent: Intent?, user: UserHandle?, receiverPermission: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getExternalCacheDir(): File? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDatabasePath(name: String?): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFileStreamPath(name: String?): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun stopService(service: Intent?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkSelfPermission(permission: String): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun registerReceiver(receiver: BroadcastReceiver?, filter: IntentFilter?): Intent? {
+        TODO("Not yet implemented")
+    }
+
+    override fun registerReceiver(receiver: BroadcastReceiver?, filter: IntentFilter?, flags: Int): Intent? {
+        TODO("Not yet implemented")
+    }
+
+    override fun registerReceiver(receiver: BroadcastReceiver?, filter: IntentFilter?, broadcastPermission: String?, scheduler: Handler?): Intent? {
+        TODO("Not yet implemented")
+    }
+
+    override fun registerReceiver(receiver: BroadcastReceiver?, filter: IntentFilter?, broadcastPermission: String?, scheduler: Handler?, flags: Int): Intent? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSystemServiceName(serviceClass: Class<*>): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getMainLooper(): Looper {
+        TODO("Not yet implemented")
+    }
+
+    override fun enforceCallingOrSelfPermission(permission: String, message: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPackageCodePath(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkCallingUriPermission(uri: Uri?, modeFlags: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getWallpaperDesiredMinimumWidth(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun createDeviceProtectedStorageContext(): Context {
+        TODO("Not yet implemented")
+    }
+
+    override fun openFileInput(name: String?): FileInputStream {
+        TODO("Not yet implemented")
+    }
+
+    override fun getCodeCacheDir(): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun bindService(service: Intent?, conn: ServiceConnection, flags: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteDatabase(name: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAssets(): AssetManager {
+        TODO("Not yet implemented")
+    }
+
+    override fun getNoBackupFilesDir(): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun startActivities(intents: Array<out Intent>?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun startActivities(intents: Array<out Intent>?, options: Bundle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getResources(): Resources {
+        TODO("Not yet implemented")
+    }
+
+    override fun fileList(): Array<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun setTheme(resid: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun unregisterReceiver(receiver: BroadcastReceiver?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun enforcePermission(permission: String, pid: Int, uid: Int, message: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun openFileOutput(name: String?, mode: Int): FileOutputStream {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendStickyOrderedBroadcast(intent: Intent?, resultReceiver: BroadcastReceiver?, scheduler: Handler?, initialCode: Int, initialData: String?, initialExtras: Bundle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun createConfigurationContext(overrideConfiguration: Configuration): Context {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFilesDir(): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendBroadcast(intent: Intent?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendBroadcast(intent: Intent?, receiverPermission: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendOrderedBroadcastAsUser(intent: Intent?, user: UserHandle?, receiverPermission: String?, resultReceiver: BroadcastReceiver?, scheduler: Handler?, initialCode: Int, initialData: String?, initialExtras: Bundle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun grantUriPermission(toPackage: String?, uri: Uri?, modeFlags: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun enforceCallingUriPermission(uri: Uri?, modeFlags: Int, message: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getCacheDir(): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun clearWallpaper() {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendStickyOrderedBroadcastAsUser(intent: Intent?, user: UserHandle?, resultReceiver: BroadcastReceiver?, scheduler: Handler?, initialCode: Int, initialData: String?, initialExtras: Bundle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun startActivity(intent: Intent?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun startActivity(intent: Intent?, options: Bundle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPackageManager(): PackageManager = object : PackageManager() {
+        override fun getLaunchIntentForPackage(packageName: String): Intent? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getResourcesForApplication(app: ApplicationInfo): Resources {
+            TODO("Not yet implemented")
+        }
+
+        override fun getResourcesForApplication(packageName: String): Resources {
+            TODO("Not yet implemented")
+        }
+
+        override fun getReceiverInfo(component: ComponentName, flags: Int): ActivityInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryIntentActivityOptions(caller: ComponentName?, specifics: Array<out Intent>?, intent: Intent, flags: Int): MutableList<ResolveInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationIcon(info: ApplicationInfo): Drawable {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationIcon(packageName: String): Drawable {
+            TODO("Not yet implemented")
+        }
+
+        override fun extendVerificationTimeout(id: Int, verificationCodeAtTimeout: Int, millisecondsToDelay: Long) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationEnabledSetting(packageName: String): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryIntentServices(intent: Intent, flags: Int): MutableList<ResolveInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun isPermissionRevokedByPolicy(permissionName: String, packageName: String): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun checkPermission(permissionName: String, packageName: String): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun checkSignatures(packageName1: String, packageName2: String): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun checkSignatures(uid1: Int, uid2: Int): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun removePackageFromPreferred(packageName: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun addPermission(info: PermissionInfo): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun getDrawable(packageName: String, resid: Int, appInfo: ApplicationInfo?): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getChangedPackages(sequenceNumber: Int): ChangedPackages? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPackageInfo(packageName: String, flags: Int): PackageInfo {
+            val pi = PackageInfo()
+            @Suppress("DEPRECATION")
+            pi.versionCode = 12
+            pi.versionName = "glean-vname"
+            return pi
+        }
+
+        override fun getPackageInfo(versionedPackage: VersionedPackage, flags: Int): PackageInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPackagesHoldingPermissions(permissions: Array<String>, flags: Int): MutableList<PackageInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun addPermissionAsync(info: PermissionInfo): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun getSystemAvailableFeatures(): Array<FeatureInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getSystemSharedLibraryNames(): Array<String>? {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryIntentContentProviders(intent: Intent, flags: Int): MutableList<ResolveInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationBanner(info: ApplicationInfo): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationBanner(packageName: String): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPackageGids(packageName: String): IntArray {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPackageGids(packageName: String, flags: Int): IntArray {
+            TODO("Not yet implemented")
+        }
+
+        override fun getResourcesForActivity(activityName: ComponentName): Resources {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPackagesForUid(uid: Int): Array<String>? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPermissionGroupInfo(permissionName: String, flags: Int): PermissionGroupInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun addPackageToPreferred(packageName: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getComponentEnabledSetting(componentName: ComponentName): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun getLeanbackLaunchIntentForPackage(packageName: String): Intent? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getInstalledPackages(flags: Int): MutableList<PackageInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getAllPermissionGroups(flags: Int): MutableList<PermissionGroupInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getNameForUid(uid: Int): String? {
+            TODO("Not yet implemented")
+        }
+
+        override fun updateInstantAppCookie(cookie: ByteArray?) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationLogo(info: ApplicationInfo): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationLogo(packageName: String): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationLabel(info: ApplicationInfo): CharSequence {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPreferredActivities(outFilters: MutableList<IntentFilter>, outActivities: MutableList<ComponentName>, packageName: String?): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun setApplicationCategoryHint(packageName: String, categoryHint: Int) {
+            TODO("Not yet implemented")
+        }
+
+        override fun setInstallerPackageName(targetPackage: String, installerPackageName: String?) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getUserBadgedLabel(label: CharSequence, user: UserHandle): CharSequence {
+            TODO("Not yet implemented")
+        }
+
+        override fun canRequestPackageInstalls(): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun isInstantApp(): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun isInstantApp(packageName: String): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun getActivityIcon(activityName: ComponentName): Drawable {
+            TODO("Not yet implemented")
+        }
+
+        override fun getActivityIcon(intent: Intent): Drawable {
+            TODO("Not yet implemented")
+        }
+
+        override fun canonicalToCurrentPackageNames(packageNames: Array<String>): Array<String> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getProviderInfo(component: ComponentName, flags: Int): ProviderInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun clearPackagePreferredActivities(packageName: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPackageInstaller(): PackageInstaller {
+            TODO("Not yet implemented")
+        }
+
+        override fun resolveService(intent: Intent, flags: Int): ResolveInfo? {
+            TODO("Not yet implemented")
+        }
+
+        override fun verifyPendingInstall(id: Int, verificationCode: Int) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getInstantAppCookie(): ByteArray {
+            TODO("Not yet implemented")
+        }
+
+        override fun getText(packageName: String, resid: Int, appInfo: ApplicationInfo?): CharSequence? {
+            TODO("Not yet implemented")
+        }
+
+        override fun resolveContentProvider(authority: String, flags: Int): ProviderInfo? {
+            TODO("Not yet implemented")
+        }
+
+        override fun hasSystemFeature(featureName: String): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun hasSystemFeature(featureName: String, version: Int): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun getInstrumentationInfo(className: ComponentName, flags: Int): InstrumentationInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun getInstalledApplications(flags: Int): MutableList<ApplicationInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getUserBadgedDrawableForDensity(drawable: Drawable, user: UserHandle, badgeLocation: Rect?, badgeDensity: Int): Drawable {
+            TODO("Not yet implemented")
+        }
+
+        override fun getInstantAppCookieMaxBytes(): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun getDefaultActivityIcon(): Drawable {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPreferredPackages(flags: Int): MutableList<PackageInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun addPreferredActivity(filter: IntentFilter, match: Int, set: Array<ComponentName>?, activity: ComponentName) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getSharedLibraries(flags: Int): MutableList<SharedLibraryInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryIntentActivities(intent: Intent, flags: Int): MutableList<ResolveInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getActivityBanner(activityName: ComponentName): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getActivityBanner(intent: Intent): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun setComponentEnabledSetting(componentName: ComponentName, newState: Int, flags: Int) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getApplicationInfo(packageName: String, flags: Int): ApplicationInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun resolveActivity(intent: Intent, flags: Int): ResolveInfo? {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryBroadcastReceivers(intent: Intent, flags: Int): MutableList<ResolveInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getXml(packageName: String, resid: Int, appInfo: ApplicationInfo?): XmlResourceParser? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getActivityLogo(activityName: ComponentName): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun getActivityLogo(intent: Intent): Drawable? {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryPermissionsByGroup(permissionGroup: String, flags: Int): MutableList<PermissionInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryContentProviders(processName: String?, uid: Int, flags: Int): MutableList<ProviderInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPermissionInfo(permissionName: String, flags: Int): PermissionInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun removePermission(permissionName: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun queryInstrumentation(targetPackage: String, flags: Int): MutableList<InstrumentationInfo> {
+            TODO("Not yet implemented")
+        }
+
+        override fun clearInstantAppCookie() {
+            TODO("Not yet implemented")
+        }
+
+        override fun currentToCanonicalPackageNames(packageNames: Array<String>): Array<String> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getPackageUid(packageName: String, flags: Int): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun getUserBadgedIcon(drawable: Drawable, user: UserHandle): Drawable {
+            TODO("Not yet implemented")
+        }
+
+        override fun getActivityInfo(component: ComponentName, flags: Int): ActivityInfo {
+            TODO("Not yet implemented")
+        }
+
+        override fun isSafeMode(): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun getInstallerPackageName(packageName: String): String? {
+            TODO("Not yet implemented")
+        }
+
+        override fun setApplicationEnabledSetting(packageName: String, newState: Int, flags: Int) {
+            TODO("Not yet implemented")
+        }
+
+        override fun getServiceInfo(component: ComponentName, flags: Int): ServiceInfo {
+            TODO("Not yet implemented")
+        }
+
+    }
+
+    override fun openOrCreateDatabase(name: String?, mode: Int, factory: SQLiteDatabase.CursorFactory?): SQLiteDatabase {
+        TODO("Not yet implemented")
+    }
+
+    override fun openOrCreateDatabase(name: String?, mode: Int, factory: SQLiteDatabase.CursorFactory?, errorHandler: DatabaseErrorHandler?): SQLiteDatabase {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteFile(name: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun startService(service: Intent?): ComponentName? {
+        TODO("Not yet implemented")
+    }
+
+    override fun revokeUriPermission(uri: Uri?, modeFlags: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun revokeUriPermission(toPackage: String?, uri: Uri?, modeFlags: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun moveDatabaseFrom(sourceContext: Context?, name: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun startInstrumentation(className: ComponentName, profileFile: String?, arguments: Bundle?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendOrderedBroadcast(intent: Intent?, receiverPermission: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendOrderedBroadcast(intent: Intent, receiverPermission: String?, resultReceiver: BroadcastReceiver?, scheduler: Handler?, initialCode: Int, initialData: String?, initialExtras: Bundle?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun unbindService(conn: ServiceConnection) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getApplicationInfo(): ApplicationInfo {
+        val ai = ApplicationInfo()
+        ai.dataDir = fakeDataDir
+        return ai
+    }
+
+    override fun getWallpaperDesiredMinimumHeight(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun createDisplayContext(display: Display): Context {
+        TODO("Not yet implemented")
+    }
+
+    override fun createContextForSplit(splitName: String?): Context {
+        TODO("Not yet implemented")
+    }
+
+    override fun getTheme(): Resources.Theme {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPackageName(): String = fakePackageName
+
+    override fun getContentResolver(): ContentResolver {
+        TODO("Not yet implemented")
+    }
+
+    override fun getObbDirs(): Array<File> {
+        TODO("Not yet implemented")
+    }
+
+    override fun enforceCallingOrSelfUriPermission(uri: Uri?, modeFlags: Int, message: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun moveSharedPreferencesFrom(sourceContext: Context?, name: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getExternalMediaDirs(): Array<File> {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkCallingPermission(permission: String): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getExternalCacheDirs(): Array<File> {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendStickyBroadcast(intent: Intent?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun enforceCallingPermission(permission: String, message: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun peekWallpaper(): Drawable {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSystemService(name: String): Any? {
+        TODO("Not yet implemented")
+    }
+
+    override fun startForegroundService(service: Intent?): ComponentName? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDir(name: String?, mode: Int): File {
+        TODO("Not yet implemented")
+    }
+
+    override fun databaseList(): Array<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun createPackageContext(packageName: String?, flags: Int): Context {
+        TODO("Not yet implemented")
+    }
+
+    override fun enforceUriPermission(uri: Uri?, pid: Int, uid: Int, modeFlags: Int, message: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun enforceUriPermission(uri: Uri?, readPermission: String?, writePermission: String?, pid: Int, uid: Int, modeFlags: Int, message: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeStickyBroadcast(intent: Intent?) {
+        TODO("Not yet implemented")
+    }
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/AndroidBuildInfo.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/AndroidBuildInfo.kt
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean.utils
+
+internal interface AndroidBuildInfo {
+    fun getSdkVersion(): String
+    fun getVersionString(): String
+    fun getDeviceManufacturer(): String
+    fun getDeviceModel(): String
+    fun getPreferredABI(): String
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/RealBuildInfo.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/RealBuildInfo.kt
@@ -1,0 +1,12 @@
+package mozilla.telemetry.glean.utils
+
+import android.os.Build
+
+class RealBuildInfo : AndroidBuildInfo {
+    // https://developer.android.com/reference/android/os/Build.VERSION
+    override fun getSdkVersion(): String = Build.VERSION.SDK_INT.toString()
+    override fun getVersionString(): String = Build.VERSION.RELEASE
+    override fun getDeviceManufacturer(): String = Build.MANUFACTURER
+    override fun getDeviceModel(): String = Build.MODEL
+    override fun getPreferredABI(): String = Build.SUPPORTED_ABIS[0]
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/BooleanMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/BooleanMetricTypeTest.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* This file is based on the tests in the Glean android-components implentation.
+/* This file is based on the tests in the Glean android-components implementation.
  *
  * Care should be taken to not reorder elements in this file so it will be easier
  * to track changes in Glean android-components.
@@ -10,21 +10,17 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import java.lang.NullPointerException
 
-@RunWith(AndroidJUnit4::class)
 class BooleanMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CounterMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CounterMetricTypeTest.kt
@@ -10,23 +10,19 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class CounterMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CustomDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/CustomDistributionMetricTypeTest.kt
@@ -4,27 +4,23 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
 import java.lang.NullPointerException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
 class CustomDistributionMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/DatetimeMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/DatetimeMetricTypeTest.kt
@@ -10,15 +10,12 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import java.util.Calendar
 import java.util.Date
 import java.util.TimeZone
@@ -26,11 +23,10 @@ import java.util.TimeZone
 const val MILLIS_PER_SEC = 1000L
 private fun Date.asSeconds() = time / MILLIS_PER_SEC
 
-@RunWith(AndroidJUnit4::class)
 class DatetimeMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -11,8 +11,6 @@
 package mozilla.telemetry.glean.private
 
 import android.os.SystemClock
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.lang.NullPointerException
 import java.util.concurrent.TimeUnit
 import mozilla.telemetry.glean.Dispatchers
@@ -22,7 +20,7 @@ import mozilla.telemetry.glean.getContextWithMockedInfo
 import mozilla.telemetry.glean.getMockWebServer
 import mozilla.telemetry.glean.resetGlean
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import mozilla.telemetry.glean.triggerWorkManager
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -32,7 +30,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
 // Declared here, since Kotlin can not declare nested enum classes.
 enum class clickKeys {
@@ -48,11 +45,10 @@ enum class SomeExtraKeys {
     SomeExtra
 }
 
-@RunWith(AndroidJUnit4::class)
 class EventMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API records to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -25,6 +25,8 @@ class LabeledMetricTypeTest {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
+    // Note: this cannot use the `GleanTestNoUploads` because some test requires
+    // to call Glean.initialize directly.
     @get:Rule
     val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/MemoryDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/MemoryDistributionMetricTypeTest.kt
@@ -4,27 +4,23 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
 import java.lang.NullPointerException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
 class MemoryDistributionMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/QuantityMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/QuantityMetricTypeTest.kt
@@ -10,23 +10,19 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class QuantityMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringListMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringListMetricTypeTest.kt
@@ -10,23 +10,19 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class StringListMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine by first adding then setting`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringMetricTypeTest.kt
@@ -10,23 +10,19 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class StringMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimespanMetricTypeTest.kt
@@ -6,24 +6,20 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.lang.NullPointerException
 import mozilla.telemetry.glean.testing.ErrorType
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class TimespanMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API must record to its storage engine`() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/TimingDistributionMetricTypeTest.kt
@@ -28,6 +28,8 @@ class TimingDistributionMetricTypeTest {
     val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
+    // Note: this cannot use the `GleanTestNoUploads` because some test requires
+    // to call Glean.initialize directly.
     @get:Rule
     val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/UuidMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/UuidMetricTypeTest.kt
@@ -10,23 +10,19 @@
 
 package mozilla.telemetry.glean.private
 
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestNoUploads
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import java.lang.NullPointerException
 import java.util.UUID
 
-@RunWith(AndroidJUnit4::class)
 class UuidMetricTypeTest {
 
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestNoUploads()
 
     @Test
     fun `The API saves to its storage engine`() {


### PR DESCRIPTION
This is a PoC to show case the approach proposed by @mcomella in [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1626874).

This works kind of great: the reference test we're using goes from taking ~4s to run to about 380ms.

There's a bunch of things that still need figuring out:

- [ ] This mode of execution exclusively works with _real_ unit tests. This means we should not attempt to use `ProcessLifecycleOwner` or `WorkManager`, otherwise it will crash. Are we fine with allowing this? This should be safe when testing metrics APIs, but it's definitely unsafe if attempting to trigger pings or manually init glean.
- [ ] It requires stubbing & mocking quite a few things from Android. I did my best to keep the code the same, trying to inject dependencies as needed. This works poorly, though, due to `setUploadEnabled`. Not too much a big deal, I guess.
- [ ]  We should clearly document what's testable this way and what's not. Integration tests are a no-no, some classes of unit tests are ok.
- [ ] We should make sure there's no interaction between tests and that the "database isolation" using temporary directories work as expected.