### PR TITLE
Add a new task to run Rust tests

### DIFF
--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -13,7 +13,6 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 use serde::{Deserialize, Serialize};
-use serde_json;
 use serde_json::{json, Value as JsonValue};
 
 use crate::CommonMetricData;

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -9,7 +9,6 @@ use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-use log;
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
 

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock, RwLockWriteGuard};
 use std::thread;
 
-use log;
 use serde_json::Value as JsonValue;
 
 use directory::PingDirectoryManager;
@@ -305,7 +304,7 @@ mod test {
         }
 
         // Clear the queue
-        let _ = upload_manager.clear_ping_queue();
+        drop(upload_manager.clear_ping_queue());
 
         // Verify there really isn't any ping in the queue
         assert_eq!(upload_manager.get_upload_task(), PingUploadTask::Done);
@@ -332,7 +331,7 @@ mod test {
             .unwrap();
 
         // Clear the queue
-        let _ = glean.upload_manager.clear_ping_queue();
+        drop(glean.upload_manager.clear_ping_queue());
 
         let upload_task = glean.get_upload_task();
         match upload_task {

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -11,9 +11,7 @@ use std::fs::{read_dir, File};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-use chrono;
 use chrono::offset::TimeZone;
-use iso8601;
 use iso8601::Date::YMD;
 use serde_json::Value as JsonValue;
 

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -5,8 +5,6 @@
 mod common;
 use crate::common::*;
 
-use iso8601;
-
 use glean_core::metrics::*;
 use glean_core::ping::PingMaker;
 use glean_core::{CommonMetricData, Glean, Lifetime};

--- a/taskcluster/ci/rust/kind.yml
+++ b/taskcluster/ci/rust/kind.yml
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+  - glean_taskgraph.transforms.script_to_run_task:transforms
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.task:transforms
+
+job-defaults:
+  worker-type: b-linux
+  worker:
+    docker-image: {in-tree: linux}
+    max-run-time: 1800
+  run:
+    using: run-task
+    cwd: '{checkout}'
+
+jobs:
+  clippy:
+    description: 'Rust: Clippy'
+    run:
+      script: |
+          . ./taskcluster/scripts/rust/rustup-setup.sh
+          rustup component add clippy
+          cargo clippy --version
+          cargo clippy --all --all-targets --all-features -- -D warnings
+  tests:
+    description: 'Rust: Tests'
+    run:
+      script: |
+          . ./taskcluster/scripts/rust/rustup-setup.sh
+          cargo test --all --verbose

--- a/taskcluster/glean_taskgraph/transforms/__init__.py
+++ b/taskcluster/glean_taskgraph/transforms/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/taskcluster/glean_taskgraph/transforms/script_to_run_task.py
+++ b/taskcluster/glean_taskgraph/transforms/script_to_run_task.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+def script_to_bash_command(script):
+    return [
+        "/bin/bash",
+        "--login",
+        "-c",
+        "cat <<'SCRIPT' > ../script.sh && bash -e ../script.sh\n{}\nSCRIPT".format(script)
+    ]
+
+
+@transforms.add
+def build_task(config, tasks):
+    for task in tasks:
+        print(task)
+        script = task["run"].pop("script")
+        bash_command = script_to_bash_command(script)
+        task["run"]["command"] = bash_command
+
+        yield task

--- a/taskcluster/scripts/rust/rustup-setup.sh
+++ b/taskcluster/scripts/rust/rustup-setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+export RUST_BACKTRACE='1'
+export RUSTFLAGS='-Dwarnings'
+export CARGO_INCREMENTAL='0'
+export CI='1'
+export CCACHE='sccache'
+export RUSTC_WRAPPER='sccache'
+export SCCACHE_IDLE_TIMEOUT='1200'
+export SCCACHE_CACHE_SIZE='40G'
+export SCCACHE_ERROR_LOG='/builds/worker/sccache.log'
+export RUST_LOG='sccache=info'
+
+# Rust
+set -eux; \
+    RUSTUP_PLATFORM='x86_64-unknown-linux-gnu'; \
+    RUSTUP_VERSION='1.21.1'; \
+    RUSTUP_SHA256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b'; \
+    curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain none; \
+    rm rustup-init
+export PATH=$HOME/.cargo/bin:$PATH
+
+
+rustup toolchain install stable
+rustup default stable


### PR DESCRIPTION
cc @MihaiTabara 

Just extending TaskCluster by 2 tasks:
* Rust tests
* Rust clippy (linting)

(meanwhile also fixes some clippy warnings)

Did this to play around with TaskCluster a bit more and understand how transforms work and how new tasks are added.

Contains `[ci skip]`, so CircleCI tasks won't run.