### PR TITLE
Python: Parse glean.h header at build time

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 167 utf-8
+personal_ws-1.1 en 169 utf-8
 AAR
 AARs
 APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Unreleased changes
 
-* Android
-  * The `PingType.submit()` can now be called without a `null` by Java consumers.
-
 [Full changelog](https://github.com/mozilla/glean/compare/v28.0.0...master)
 
 * General:
   * The version of glean_parser has been upgraded to v1.20.2:
     * **Breaking change:** glinter errors found during code generation will now return an error code.
     * `glean_parser` now produces a linter warning when `user` lifetime metrics are set to expire. See [bug 1604854](https://bugzilla.mozilla.org/show_bug.cgi?id=1604854) for additional context.
+* Android
+  * The `PingType.submit()` can now be called without a `null` by Java consumers.
 * Python:
   * BUGFIX: Fixed a race condition in the `atexit` handler, that would have resulted in the message "No database found".  See [bug 1634310](https://bugzilla.mozilla.org/show_bug.cgi?id=1634310).
+  * The Glean FFI header is now parsed at build time rather than runtime. Relevant for packaging in `PyInstaller`, the wheel no longer includes `glean.h` and adds `_glean_ffi.py`.
   * The minimum versions of many secondary dependencies have been lowered to make the Glean SDK compatible with more environments.
   * Dependencies that depend on the version of Python being used are now specified using the `Declaring platform specific dependencies syntax in setuptools <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies>`__. This means that more recent versions of dependencies are likely to be installed on Python 3.6 and later, and unnecessary backport libraries won't be installed on more recent Python versions.
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ shellcheck: ## Run shellcheck against important shell scripts
 
 pythonlint: python-setup ## Run flake8 and black to lint Python code
 	$(GLEAN_PYENV)/bin/python3 -m flake8 glean-core/python/glean glean-core/python/tests
-	$(GLEAN_PYENV)/bin/python3 -m black --check --exclude .venv\* glean-core/python
+	$(GLEAN_PYENV)/bin/python3 -m black --check --exclude \(.venv\*\)\|\(.eggs\) glean-core/python
 	$(GLEAN_PYENV)/bin/python3 -m mypy glean-core/python/glean
 
 .PHONY: lint clippy ktlint swiftlint yamllint

--- a/glean-core/python/ffi_build.py
+++ b/glean-core/python/ffi_build.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+A helper script to build the CFFI wrappers at build time.
+Run as part of the setup.py script.
+
+This is the "out-of-line", "ABI mode" option, described in the CFFI docs here:
+
+    https://cffi.readthedocs.io/en/latest/cdef.html
+"""
+
+
+import cffi
+
+
+def _load_header(path: str) -> str:
+    """
+    Load a C header file and convert it to something parseable by cffi.
+    """
+    with open(path, encoding="utf-8") as fd:
+        data = fd.read()
+    return "\n".join(
+        line for line in data.splitlines() if not line.startswith("#include")
+    )
+
+
+ffibuilder = cffi.FFI()
+ffibuilder.set_source("glean._glean_ffi", None)
+ffibuilder.cdef(_load_header("../ffi/glean.h"))
+
+
+if __name__ == "__main__":
+    ffibuilder.compile()

--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -1,4 +1,5 @@
 auditwheel==2.1.1
+cffi==1.13.1
 coverage==4.5.2
 flake8==3.7.8
 jsonschema==3.2.0

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -52,7 +52,7 @@ requirements = [
     "iso8601>=0.1.10; python_version<='3.6'",
 ]
 
-setup_requirements = []
+setup_requirements = ["cffi>=1.0.0"]
 
 if mingw_arch == "i686":
     shared_object_build_dir = "../../target/i686-pc-windows-gnu/debug/"
@@ -72,7 +72,6 @@ else:
     raise ValueError("The platform {} is not supported.".format(sys.platform))
 
 
-shutil.copyfile("../ffi/glean.h", "glean/glean.h")
 shutil.copyfile("../metrics.yaml", "glean/metrics.yaml")
 shutil.copyfile("../pings.yaml", "glean/pings.yaml")
 # When running inside of `requirements-builder`, the Rust shared object may not
@@ -143,9 +142,10 @@ setup(
     version=version,
     packages=find_packages(include=["glean", "glean.*"]),
     setup_requires=setup_requirements,
+    cffi_modules=["ffi_build.py:ffibuilder"],
     url="https://github.com/mozilla/glean",
     zip_safe=False,
-    package_data={"glean": ["glean.h", shared_object, "metrics.yaml", "pings.yaml"]},
+    package_data={"glean": [shared_object, "metrics.yaml", "pings.yaml"]},
     distclass=BinaryDistribution,
     cmdclass={"install": InstallPlatlib, "bdist_wheel": bdist_wheel},
 )


### PR DESCRIPTION
This uses the instructions in the [CFFI docs](https://cffi.readthedocs.io/en/latest/cdef.html) to parse the glean.h header at build time, rather than run time.

This improves the time of `import glean` from 301ms to 0.3ms.  Seems like a big win, particularly for commandline apps that may run multiple times as part of a build, etc.