### PR TITLE
Bug 1634310: Python: Fix race condition in atexit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v28.0.0...master)
 
+* Python:
+  * BUGFIX: Fixed a race condition in the `atexit` handler, that would have resulted in the message "No database found".  See [bug 1634310](https://bugzilla.mozilla.org/show_bug.cgi?id=1634310).
+
 # v28.0.0 (2020-04-23)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v27.1.0...v28.0.0)

--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -78,6 +78,12 @@ class ProcessDispatcher:
     _last_process = None  # type: Optional[subprocess.Popen]
 
     @classmethod
+    def _wait_for_last_process(cls):
+        if cls._last_process is not None:
+            cls._last_process.wait()
+            cls._last_process = None
+
+    @classmethod
     def dispatch(cls, func, args) -> Union[_SyncWorkWrapper, subprocess.Popen]:
         from . import Glean
 
@@ -85,9 +91,7 @@ class ProcessDispatcher:
             # We only want one of these processes running at a time, so if
             # there's already one, join on it. Therefore, this should not be
             # run from the main user thread.
-            if cls._last_process is not None:
-                cls._last_process.wait()
-                cls._last_process = None
+            cls._wait_for_last_process()
 
             # This sends the data over as a commandline argument, which has a
             # maximum length of:

--- a/glean-core/python/glean/net/http_client.py
+++ b/glean-core/python/glean/net/http_client.py
@@ -68,6 +68,9 @@ class HttpClientUploader(base_uploader.BaseUploader):
         except OSError as e:
             log.error("OSError: '{}' {}".format(url, e))
             return False
+        except Exception as e:
+            log.error("Unknown Exception: '{}' {}".format(url, e))
+            return False
 
         log.debug("Ping upload: {}".format(response.status))
 

--- a/glean-core/python/glean/net/http_client.py
+++ b/glean-core/python/glean/net/http_client.py
@@ -60,10 +60,13 @@ class HttpClientUploader(base_uploader.BaseUploader):
             )
             response = conn.getresponse()
         except http.client.HTTPException as e:
-            log.error("http.client.HTTPException: {}".format(e))
+            log.error("http.client.HTTPException: '{}' {}".format(url, e))
             return False
         except socket.gaierror as e:
-            log.error("socket.gaierror: {}".format(e))
+            log.error("socket.gaierror: '{}' {}".format(url, e))
+            return False
+        except OSError as e:
+            log.error("OSError: '{}' {}".format(url, e))
             return False
 
         log.debug("Ping upload: {}".format(response.status))

--- a/glean-core/python/glean/testing/__init__.py
+++ b/glean-core/python/glean/testing/__init__.py
@@ -42,6 +42,10 @@ def reset_glean(
         data_dir = Glean._data_dir
 
     Glean._reset()
+
+    # `_testing_mode` should be changed *after* `Glean._reset()` is run, so
+    # that `Glean` properly joins on the worker thread when `_testing_mode` is
+    # False.
     Dispatcher._testing_mode = True
 
     Glean.initialize(

--- a/glean-core/python/glean/testing/__init__.py
+++ b/glean-core/python/glean/testing/__init__.py
@@ -36,14 +36,14 @@ def reset_glean(
     from glean import Glean
     from glean._dispatcher import Dispatcher
 
-    Dispatcher._testing_mode = True
-
     data_dir = None  # type: Optional[Path]
     if not clear_stores:
         Glean._destroy_data_dir = False
         data_dir = Glean._data_dir
 
     Glean._reset()
+    Dispatcher._testing_mode = True
+
     Glean.initialize(
         application_id=application_id,
         application_version=application_version,


### PR DESCRIPTION
Fixes a race condition in the `atexit` handlers.

Glean currently has two atexit handlers: (a) to make sure the thread worked completes all of its tasks, and (b) that (among other things) deletes the data directory if it's a tmpdir. atexit handlers are run sequentially on the main thread, but the ordering is based on the order in which they are registered, which is somewhat non-deterministic in Glean.

If (b) runs before (a), the data directory is deleted, and then any operations that might be waiting the thread queue will fail with "Database not found".

The fix is to combine the atexit handlers into one, and join on the thread queue before deleting the tempdir.

This raised another issue in my mind that using a tempdir by default is probably not a good choice, and we are seeing this bug in burnham only because burnham doesn't override the data dir (as other "real" apps, such as mozregression have done). Changing the default to a retained directory probably makes sense, and I created bug 1634410 to track that work.