### PR TITLE
Changelog updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -988,12 +988,12 @@ jobs:
 
   docs-spellcheck:
     docker:
-      # Use Debian Sid so we get aspell 0.60.8 or later (which contains markdown support)
-      - image: circleci/buildpack-deps:sid
+      # Use Ubuntu Focal (20.04) so we get aspell 0.60.8 or later (which contains markdown support)
+      - image: circleci/buildpack-deps:focal
     steps:
       - checkout
       - run:
-          name: Upgrade Debian packages
+          name: Upgrade packages
           command: sudo apt update
       - run:
           name: Install aspell

--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 169 utf-8
+personal_ws-1.1 en 170 utf-8
 AAR
 AARs
 APIs
@@ -147,6 +147,7 @@ schemas
 sdk
 serializable
 serializer
+setuptools
 stateful
 struct
 subprocess

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,18 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v28.0.0...master)
 
 * General:
-  * The version of glean_parser has been upgraded to v1.20.2:
+  * The version of glean_parser has been upgraded to v1.20.2 ([#827](https://github.com/mozilla/glean/pull/827)):
     * **Breaking change:** glinter errors found during code generation will now return an error code.
     * `glean_parser` now produces a linter warning when `user` lifetime metrics are set to expire. See [bug 1604854](https://bugzilla.mozilla.org/show_bug.cgi?id=1604854) for additional context.
 * Android
-  * The `PingType.submit()` can now be called without a `null` by Java consumers.
+  * The `PingType.submit()` can now be called without a `null` by Java consumers ([#853](https://github.com/mozilla/glean/pull/853)).
 * Python:
-  * BUGFIX: Fixed a race condition in the `atexit` handler, that would have resulted in the message "No database found".  See [bug 1634310](https://bugzilla.mozilla.org/show_bug.cgi?id=1634310).
-  * The Glean FFI header is now parsed at build time rather than runtime. Relevant for packaging in `PyInstaller`, the wheel no longer includes `glean.h` and adds `_glean_ffi.py`.
+  * BUGFIX: Fixed a race condition in the `atexit` handler, that would have resulted in the message "No database found" ([#854](https://github.com/mozilla/glean/pull/854)).
+  * The Glean FFI header is now parsed at build time rather than runtime. Relevant for packaging in `PyInstaller`, the wheel no longer includes `glean.h` and adds `_glean_ffi.py` ([#852](https://github.com/mozilla/glean/pull/852)).
   * The minimum versions of many secondary dependencies have been lowered to make the Glean SDK compatible with more environments.
-  * Dependencies that depend on the version of Python being used are now specified using the `Declaring platform specific dependencies syntax in setuptools <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies>`__. This means that more recent versions of dependencies are likely to be installed on Python 3.6 and later, and unnecessary backport libraries won't be installed on more recent Python versions.
+  * Dependencies that depend on the version of Python being used are now specified using the [Declaring platform specific dependencies syntax in setuptools](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies). This means that more recent versions of dependencies are likely to be installed on Python 3.6 and later, and unnecessary backport libraries won't be installed on more recent Python versions.
 * iOS:
-  * Glean for iOS is now being built with Xcode 11.4.1
+  * Glean for iOS is now being built with Xcode 11.4.1 ([#856](https://github.com/mozilla/glean/pull/856))
 
 # v28.0.0 (2020-04-23)
 


### PR DESCRIPTION
the spellcheck task broke on master, so I figured it'd be easier to fix that first before cutting a release.

Let's run it and see what happens.