### PR TITLE
Bug 1634353 - Test upload behavior for pings in quick succession 

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.telemetry.glean.scheduler
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
@@ -1,0 +1,108 @@
+package mozilla.telemetry.glean.scheduler
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.getContextWithMockedInfo
+import mozilla.telemetry.glean.getMockWebServer
+import mozilla.telemetry.glean.private.NoReasonCodes
+import mozilla.telemetry.glean.private.PingType
+import mozilla.telemetry.glean.resetGlean
+import mozilla.telemetry.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.triggerWorkManager
+import mozilla.telemetry.glean.utils.tryGetLong
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/**
+ * Testing behavior of custom pings.
+ *
+ * We already rely on the Rust side to test custom pings,
+ * but this enables us to test the upload mechanism specifically.
+ *
+ * Even if this seemingly duplicates some of the testing, this should be kept around.
+ */
+@RunWith(AndroidJUnit4::class)
+class CustomPingTest {
+    private val context = getContextWithMockedInfo()
+
+    @get:Rule
+    val gleanRule = GleanTestRule(context)
+
+    @Test
+    fun `sends empty custom ping`() {
+        // a smoke test for custom pings
+
+        val server = getMockWebServer()
+
+        resetGlean(context, Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ), clearStores = true, uploadEnabled = true)
+
+        // Define a new custom ping inline.
+        val customPing = PingType<NoReasonCodes>(
+            name = "custom-ping",
+            includeClientId = true,
+            sendIfEmpty = true,
+            reasonCodes = emptyList()
+        )
+
+        customPing.submit()
+        triggerWorkManager(context)
+
+        val request = server.takeRequest(2L, TimeUnit.SECONDS)
+        val docType = request.path.split("/")[3]
+        assertEquals("custom-ping", docType)
+    }
+
+    @Test
+    fun `multiple pings in one go`() {
+        val server = getMockWebServer()
+
+        resetGlean(context, Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ), clearStores = true, uploadEnabled = true)
+
+        // Define a new custom ping inline.
+        val customPing = PingType<NoReasonCodes>(
+            name = "custom-ping",
+            includeClientId = true,
+            sendIfEmpty = true,
+            reasonCodes = emptyList()
+        )
+
+        // Trigger the ping twice.
+        customPing.submit()
+        customPing.submit()
+
+        // Trigger work manager once.
+        // This should launch one worker that handles all pending pings.
+        triggerWorkManager(context)
+
+        // Receive the first ping.
+        var request = server.takeRequest(2L, TimeUnit.SECONDS)
+        var docType = request.path.split("/")[3]
+        assertEquals("custom-ping", docType)
+
+        // Not much data in these pings,
+        // but order should be preserved, so we can check the sequence number.
+
+        var pingJson = JSONObject(request.body.readUtf8())
+        var pingInfo = pingJson.getJSONObject("ping_info")
+        assertEquals(0L, pingInfo.tryGetLong("seq"))
+
+        // Receive the second ping.
+        request = server.takeRequest(2L, TimeUnit.SECONDS)
+        docType = request.path.split("/")[3]
+        assertEquals("custom-ping", docType)
+
+        pingJson = JSONObject(request.body.readUtf8())
+        pingInfo = pingJson.getJSONObject("ping_info")
+        assertEquals(1L, pingInfo.tryGetLong("seq")!!)
+    }
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.telemetry.glean.scheduler
 
 import androidx.test.core.app.ApplicationProvider


### PR DESCRIPTION
Unfortunately we can't really test concurrent submissions, because that's essentially a race condition afterall:

1. If ping is submitted while old worker is not finished yet it will pick it up. The Rust test shows that. The upload mechanism keeps an in-memory list during runtime.
2. If ping is submitted and the old worker is already finished, the new worker will start.
3. If ping is submitted and the old worker is about to end, but the new worker still sees it, the ping won't get uploaded and the new worker will not do any work.

At worst we're acting slightly better than the old mechanism.
Case 3 is for such a small window, it's not worth tackling (and again: no data is loss, latest at the next submission or startup the pending ping gets submitted).