### PR TITLE
MAINT: Python collect coverage across processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ rust-coverage: ## Generate code coverage information for Rust code
 .PHONY: rust-coverage
 
 python-coverage: build-python ## Generate a code coverage report for Python
-	cd glean-core/python
-	$(GLEAN_PYENV)/bin/python3 -m coverage run --source glean -m pytest
+	$(GLEAN_PYENV)/bin/python3 -m coverage run --parallel-mode -m pytest
+	$(GLEAN_PYENV)/bin/python3 -m coverage combine
 	$(GLEAN_PYENV)/bin/python3 -m coverage html
 .PHONY: python-coverage

--- a/glean-core/python/glean/_subprocess/_process_dispatcher_helper.py
+++ b/glean-core/python/glean/_subprocess/_process_dispatcher_helper.py
@@ -11,10 +11,23 @@ ambiguity between the `glean` and `glean.glean` import paths.
 """
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import base64
+    import os
     import pickle
     import sys
+
+    # Run coverage in the subprocess if necessary
+    if "COVERAGE_PROCESS_START" in os.environ:
+        import coverage  # type: ignore
+
+        config_path = os.environ.get("COVERAGE_PROCESS_START")
+
+        cov = coverage.Coverage(data_suffix=True, config_file=config_path)
+        cov.start()
+        cov._warn_no_data = False
+        cov._warn_unimported_source = False
+        cov._auto_save = True
 
     __builtins__.IN_GLEAN_SUBPROCESS = True  # type: ignore
 


### PR DESCRIPTION
When ping uploading was moved to a separate process, that meant we
weren't collecting coverage from anything happening in the subprocess.
This fixes that by telling the subprocess when coverage is being run (using
an environment variable), enabling it in the subprocess, and then combining
the results before generating the HTML.