### PR TITLE
Always fetch the "latest" schema from the master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
       - run:
           name: Check vendored schema for upstream updates
           command: |
-            bin/update-schema.sh latest
+            bin/update-schema.sh master
             if ! git diff --exit-code HEAD -- glean-core/preview/tests/glean.1.schema.json; then
               echo "===================================="
               echo "Latest schema from upstream changed."

--- a/bin/update-schema.sh
+++ b/bin/update-schema.sh
@@ -16,18 +16,13 @@
 #
 # Environment:
 #
-# DRY_RUN - Do not modify files or run destructive commands when set.
 # VERB    - Log commands that are run when set.
 
 set -eo pipefail
 
 run() {
   [ "${VERB:-0}" != 0 ] && echo "+ $*"
-  if [ "$DOIT" = y ]; then
-      "$@"
-  else
-      true
-  fi
+  "$@"
 }
 
 update() {
@@ -39,38 +34,15 @@ update() {
   run curl --silent --fail --show-error --location --retry 5 --retry-delay 10 "$FULL_URL" --output "$SCHEMA_PATH"
 }
 
-get_latest() {
-  API_URL="https://api.github.com/repos/mozilla-services/mozilla-pipeline-schemas/commits?path=schemas%2Fglean%2Fglean%2Fglean.1.schema.json&page=1&per_page=1"
-  SHA="$(curl --silent --fail --show-error --location --retry 5 --retry-delay 10 "$API_URL" | grep --max-count=1 sha)"
-
-  echo "$SHA" | $SED -E -e 's/.+: "([^"]+)".*/\1/'
-}
-
-SED=sed
-if command -v gsed >/dev/null; then
-    SED=gsed
-fi
-
-DOIT=y
-if [[ -n "$DRY_RUN" ]]; then
-    echo "Dry-run. Not modifying files."
-    DOIT=n
-fi
-
 WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
 SCHEMA_URL="https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/%s/schemas/glean/glean/glean.1.schema.json"
 
 if [ -z "$1" ]; then
-    echo "Usage: $(basename $0) <commit hash>"
+    echo "Usage: $(basename $0) <commit hash or branch name>"
     echo
     echo "Update schema version to test"
     exit 1
 fi
 
 COMMIT_HASH="$1"
-
-if [ "$COMMIT_HASH" = "latest" ]; then
-  COMMIT_HASH="$(get_latest)"
-fi
-
 update "$COMMIT_HASH"


### PR DESCRIPTION
As discovered in #877.
We can avoid using the API and thus running into rate limits by just always fetching from the main branch 