### PR TITLE
Update the Python glean.h when regenerating it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ cbindgen: ## Regenerate the FFI header file
 	RUSTUP_TOOLCHAIN=nightly \
 	cbindgen glean-core/ffi --lockfile Cargo.lock -o glean-core/ffi/glean.h
 	cp glean-core/ffi/glean.h glean-core/ios/Glean/GleanFfi.h
+	cp glean-core/ffi/glean.h glean-core/python/glean/glean.h
 .PHONY: cbindgen
 
 rust-coverage: export CARGO_INCREMENTAL=0


### PR DESCRIPTION
While we were updating the one for iOS, we were failing to update the one needed by Python.