### PR TITLE
Remove the double spacing in the Utf8Error message

### DIFF
--- a/glean-core/src/error.rs
+++ b/glean-core/src/error.rs
@@ -102,7 +102,7 @@ impl Display for Error {
             MemoryUnit(m) => write!(f, "MemoryUnit conversion from {} failed", m),
             HistogramType(h) => write!(f, "HistogramType conversion from {} failed", h),
             OsString(s) => write!(f, "OsString conversion from {:?} failed", s),
-            Utf8Error => write!(f, "Invalid  UTF-8 byte sequence in string"),
+            Utf8Error => write!(f, "Invalid UTF-8 byte sequence in string"),
             NotInitialized => write!(f, "Global Glean object missing"),
             __NonExhaustive => write!(f, "Unknown error"),
         }


### PR DESCRIPTION
Spotted by @badboy 