### PR TITLE
Get upload tasks using an output parameter 

### DIFF
--- a/docs/dev/core/internal/upload.md
+++ b/docs/dev/core/internal/upload.md
@@ -62,10 +62,10 @@ For FFI consumers (e.g. Kotlin/Swift/Python implementations) these functions are
 
 ```rust
 /// Gets the next task for an uploader. Which can be either:
-extern "C" fn glean_get_upload_task() -> FfiPingUploadTask
+extern "C" fn glean_get_upload_task(result: *mut FfiPingUploadTask)
 
 /// Processes the response from an attempt to upload a ping.
-extern "C" fn glean_process_ping_upload_response(task: FfiPingUploadTask, status: u32)
+extern "C" fn glean_process_ping_upload_response(task: *mut FfiPingUploadTask, status: u32)
 ```
 
 See the documentation for additional information about the types:

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/net/Upload.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/net/Upload.kt
@@ -48,7 +48,7 @@ internal open class FfiPingUploadTask(
     @JvmField var tag: Byte = UploadTaskTag.Done.ordinal.toByte(),
     @JvmField var upload: UploadBody = UploadBody()
 ) : Union() {
-    class ByValue : FfiPingUploadTask(), Structure.ByValue
+    class ByReference : FfiPingUploadTask(), Structure.ByReference
 
     init {
         // Initialize to be the `tag`-only variant

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -556,9 +556,9 @@ internal interface LibGleanFFI : Library {
         storage_name: String
     ): Int
 
-    fun glean_get_upload_task(): FfiPingUploadTask.ByValue
+    fun glean_get_upload_task(task: FfiPingUploadTask.ByReference)
 
-    fun glean_process_ping_upload_response(task: FfiPingUploadTask.ByValue, status: Int)
+    fun glean_process_ping_upload_response(task: FfiPingUploadTask.ByReference, status: Int)
 
     // Misc
 

--- a/glean-core/ffi/examples/glean_app.c
+++ b/glean-core/ffi/examples/glean_app.c
@@ -41,16 +41,17 @@ int main(void)
   // 1 - "upload", there is a new ping to upload and the task will also include the request data;
   // 2 - "done", there are no more pings to upload.
   //
-  //  NOTE: If, there are other ping files inside tmp/glean_data directory
+  // NOTE: If, there are other ping files inside tmp/glean_data directory
   // they will also be consumed here by `glean_process_ping_upload_response`.
-  FfiPingUploadTask task = glean_get_upload_task();
-  while (task.tag == 1) {
+  FfiPingUploadTask task;
+  glean_get_upload_task(&task);
+  while (task.tag != 2) {
     printf("tag: %d\n", task.tag);
     printf("path: %s\n", task.upload.path);
     printf("body: %s\n", task.upload.body);
 
-    glean_process_ping_upload_response(task, 200);
-    task = glean_get_upload_task();
+    glean_process_ping_upload_response(&task, 200);
+    glean_get_upload_task(&task);
   }
   printf("tag: %d\n", task.tag);
 

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -278,7 +278,7 @@ char *glean_experiment_test_get_data(FfiStr experiment_id);
 
 uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
 
-FfiPingUploadTask glean_get_upload_task(void);
+void glean_get_upload_task(FfiPingUploadTask *result);
 
 /**
  * # Safety

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -475,7 +475,19 @@ uint8_t glean_on_ready_to_submit_pings(void);
 
 char *glean_ping_collect(uint64_t ping_type_handle, FfiStr reason);
 
-void glean_process_ping_upload_response(FfiPingUploadTask task, uint32_t status);
+/**
+ * Process and free a `FfiPingUploadTask`.
+ *
+ * We need to pass the whole task instead of only the document id,
+ * so that we can free the strings properly on Drop.
+ *
+ * After return the `task` should not be used further by the caller.
+ *
+ * # Safety
+ *
+ * A valid and non-null upload task object is required for this function.
+ */
+void glean_process_ping_upload_response(FfiPingUploadTask *task, uint32_t status);
 
 void glean_quantity_set(uint64_t metric_id, int64_t value);
 

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -278,7 +278,7 @@ char *glean_experiment_test_get_data(FfiStr experiment_id);
 
 uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
 
-FfiPingUploadTask glean_get_upload_task(void);
+void glean_get_upload_task(FfiPingUploadTask *result);
 
 /**
  * # Safety

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -475,7 +475,19 @@ uint8_t glean_on_ready_to_submit_pings(void);
 
 char *glean_ping_collect(uint64_t ping_type_handle, FfiStr reason);
 
-void glean_process_ping_upload_response(FfiPingUploadTask task, uint32_t status);
+/**
+ * Process and free a `FfiPingUploadTask`.
+ *
+ * We need to pass the whole task instead of only the document id,
+ * so that we can free the strings properly on Drop.
+ *
+ * After return the `task` should not be used further by the caller.
+ *
+ * # Safety
+ *
+ * A valid and non-null upload task object is required for this function.
+ */
+void glean_process_ping_upload_response(FfiPingUploadTask *task, uint32_t status);
 
 void glean_quantity_set(uint64_t metric_id, int64_t value);
 

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -100,13 +100,14 @@ public class HttpPingUploader {
     /// It will continue upload as long as it can fetch new tasks.
     func process() {
         while true {
-            let incomingTask = glean_get_upload_task()
+            var incomingTask = FfiPingUploadTask()
+            glean_get_upload_task(&incomingTask)
             let task = incomingTask.toPingUploadTask()
 
             switch task {
             case let .upload(request):
                 self.upload(path: request.path, data: request.body, headers: request.headers) { result in
-                    glean_process_ping_upload_response(incomingTask, result.toFfi())
+                    glean_process_ping_upload_response(&incomingTask, result.toFfi())
                 }
             case .wait:
                 continue


### PR DESCRIPTION
Due to the way we use CFFI in Python, we cannot use a `union` type as a return value. On the other
hand, this works fine with output parameters. This commit changes the API to use output parameters
to accommodate all the supported language bindings.