### PR TITLE
Bug 1639158: Fix Python coverage testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = glean

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ rust-coverage: ## Generate code coverage information for Rust code
 .PHONY: rust-coverage
 
 python-coverage: build-python ## Generate a code coverage report for Python
-	$(GLEAN_PYENV)/bin/python3 -m coverage run --parallel-mode -m pytest
+	GLEAN_COVERAGE=1 $(GLEAN_PYENV)/bin/python3 -m coverage run --parallel-mode -m pytest
 	$(GLEAN_PYENV)/bin/python3 -m coverage combine
 	$(GLEAN_PYENV)/bin/python3 -m coverage html
 .PHONY: python-coverage

--- a/glean-core/python/glean/_subprocess/_process_dispatcher_helper.py
+++ b/glean-core/python/glean/_subprocess/_process_dispatcher_helper.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":  # pragma: no cover
     import sys
 
     # Run coverage in the subprocess if necessary
-    if "COVERAGE_PROCESS_START" in os.environ:
+    if "GLEAN_COVERAGE" in os.environ and "COVERAGE_PROCESS_START" in os.environ:
         import coverage  # type: ignore
 
         config_path = os.environ.get("COVERAGE_PROCESS_START")


### PR DESCRIPTION
This adds an extra environment variable set only when running the Glean coverage tests, so the multiprocess coverage feature doesn't kick in when Glean-using libraries are running *their* coverage tests.