### PR TITLE
Fix iOS tests

### DIFF
--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -291,5 +291,8 @@ class GleanTests: XCTestCase {
 
         // Check to see if Glean is initialized
         XCTAssertFalse(Glean.shared.isInitialized())
+
+        // Reset variable so as to not interfere with other tests.
+        Glean.shared.isMainProcess = true
     }
 }


### PR DESCRIPTION
This adds a line to reset the cache variable tracking running in other processes so that it doesn't interfere with other tests ran after this test.