### PR TITLE
Clear `lifetime: application` metrics in the Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   * Ping payloads are now compressed using gzip.
 * iOS
   * `Glean.initialize` is now a no-op if called from an embedded extension. This means that Glean will only run in the base application process in order to prevent extensions from behaving like separate applications with different client ids from the base application. Applications are responsible for ensuring that extension metrics are only collected within the base application.
+* Python
+  * `lifetime: application` metrics are now cleared after the Glean-owned pings are sent,
+    after the product starts.
 
 # v30.0.0 (2020-05-13)
 

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -594,3 +594,38 @@ def test_dont_allow_multiprocessing(monkeypatch, safe_httpserver):
     assert process.returncode == 0
 
     assert 1 == len(safe_httpserver.requests)
+
+
+def test_clear_application_lifetime_metrics(tmpdir):
+    Glean._reset()
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=True,
+        data_dir=Path(str(tmpdir)),
+    )
+
+    counter_metric = CounterMetricType(
+        disabled=False,
+        category="test.telemetry",
+        lifetime=Lifetime.APPLICATION,
+        name="lifetime_reset",
+        send_in_pings=["store1"],
+    )
+
+    counter_metric.add(10)
+
+    assert counter_metric.test_has_value()
+    assert counter_metric.test_get_value() == 10
+
+    Glean._reset()
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=True,
+        data_dir=Path(str(tmpdir)),
+    )
+
+    assert not counter_metric.test_has_value()


### PR DESCRIPTION
This makes the Python bindings have the same semantics of the other bindings, i.e. application lifetime metrics are cleared on the next startup after the Glean-owned pings are generated.