### PR TITLE
iOS: Remove all stubs on teardown of tests

### DIFF
--- a/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
+++ b/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
@@ -16,6 +16,7 @@ class GleanDebugUtilityTests: XCTestCase {
 
     override func tearDown() {
         Glean.shared.setUploadEnabled(true)
+        OHHTTPStubs.removeAllStubs()
     }
 
     func testHandleCustomUrlTagPings() {

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -17,6 +17,7 @@ class GleanTests: XCTestCase {
     override func tearDown() {
         Glean.shared.setUploadEnabled(true)
         expectation = nil
+        OHHTTPStubs.removeAllStubs()
     }
 
     func testInitializeGlean() {

--- a/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
@@ -57,6 +57,7 @@ class EventMetricTypeTests: XCTestCase {
     override func tearDown() {
         lastPingJson = nil
         expectation = nil
+        OHHTTPStubs.removeAllStubs()
     }
 
     func testEventSavesToStorage() {

--- a/glean-core/ios/GleanTests/Metrics/PingTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/PingTests.swift
@@ -17,6 +17,7 @@ class PingTests: XCTestCase {
     override func tearDown() {
         lastPingJson = nil
         expectation = nil
+        OHHTTPStubs.removeAllStubs()
     }
 
     private func setupHttpResponseStub(_ expectedPingType: String) {

--- a/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
+++ b/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
@@ -30,6 +30,7 @@ class DeletionRequestPingTests: XCTestCase {
     override func tearDown() {
         lastPingJson = nil
         expectation = nil
+        OHHTTPStubs.removeAllStubs()
     }
 
     func testDeletionRequestPingsAreSentWhenUploadDisabled() {

--- a/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
+++ b/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
@@ -20,6 +20,7 @@ class HttpPingUploaderTests: XCTestCase {
     override func tearDown() {
         // Reset expectations
         expectation = nil
+        OHHTTPStubs.removeAllStubs()
     }
 
     func getOrCreatePingDirectory(_ pingDirectory: String) -> URL {

--- a/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
+++ b/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
@@ -15,6 +15,7 @@ class MetricsPingSchedulerTests: XCTestCase {
 
     override func tearDown() {
         expectation = nil
+        OHHTTPStubs.removeAllStubs()
     }
 
     func testIsAfterDueTime() {


### PR DESCRIPTION
This is recommended to ensure they don't linger around across tests:
https://github.com/AliSoftware/OHHTTPStubs#using-ohhttpstubs-in-your-unit-tests

We didn't have issues with this yet, but ... I let you decide if we pull this in :P 