### PR TITLE
Fix the docs for `RUST_LOG` verbose logging [doc only]

### DIFF
--- a/docs/dev/python/setting-up-python-build-environment.md
+++ b/docs/dev/python/setting-up-python-build-environment.md
@@ -137,7 +137,7 @@ The log level can be controlled with the `RUST_LOG` environment variable:
 
 ```python
 import os
-os.environ["RUST_LOG"] = "DEBUG"
+os.environ["RUST_LOG"] = "glean_core=DEBUG"
 ```
 
 ## Linting, formatting and type checking


### PR DESCRIPTION
The documented value doesn't work for me, locally. This works and matches what we advertise for the android bindings.