### PR TITLE
Fix `lifetime: application` metrics in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * General:
   * The version of glean_parser has been upgraded to v1.21.0
+* Python:
+  * BUGFIX: `lifetime: application` metrics are no longer recorded as `lifetime: user`. 
 
 # v30.1.0 (2020-05-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v30.1.0...master)
 
+* General:
+  * The version of glean_parser has been upgraded to v1.21.0
+
 # v30.1.0 (2020-05-22)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v30.0.0...v30.1.0)

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=1.20.4
+GLEAN_PARSER_VERSION=1.21.0
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -48,7 +48,7 @@ with (ROOT.parent / "Cargo.toml").open() as cargo:
 
 requirements = [
     "cffi>=1",
-    "glean_parser==1.20.4",
+    "glean_parser==1.21.0",
     "iso8601>=0.1.10; python_version<='3.6'",
 ]
 

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -18,7 +18,7 @@ from glean_parser import validate_ping
 import pytest
 
 
-from glean import Configuration, Glean
+from glean import Configuration, Glean, load_metrics
 from glean import __version__ as glean_version
 from glean import _builtins
 from glean import _util
@@ -29,6 +29,9 @@ from glean.testing import _RecordingUploader
 
 
 GLEAN_APP_ID = "glean-python-test"
+
+
+ROOT = Path(__file__).parent
 
 
 def test_setting_upload_enabled_before_initialization_should_not_crash():
@@ -614,10 +617,17 @@ def test_clear_application_lifetime_metrics(tmpdir):
         send_in_pings=["store1"],
     )
 
+    # Additionally get metrics using the loader.
+    metrics = load_metrics(ROOT / "data" / "core.yaml", config={"allow_reserved": True})
+
     counter_metric.add(10)
+    metrics.core_ping.seq.add(10)
 
     assert counter_metric.test_has_value()
     assert counter_metric.test_get_value() == 10
+
+    assert metrics.core_ping.seq.test_has_value()
+    assert metrics.core_ping.seq.test_get_value() == 10
 
     Glean._reset()
 
@@ -629,3 +639,4 @@ def test_clear_application_lifetime_metrics(tmpdir):
     )
 
     assert not counter_metric.test_has_value()
+    assert not metrics.core_ping.seq.test_has_value()

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -34,7 +34,7 @@ class GleanMetricsYamlTransform extends ArtifactTransform {
 @SuppressWarnings("GrPackage")
 class GleanPlugin implements Plugin<Project> {
     // The version of glean_parser to install from PyPI.
-    private String GLEAN_PARSER_VERSION = "1.20.4"
+    private String GLEAN_PARSER_VERSION = "1.21.0"
     // The version of Miniconda is explicitly specified.
     // Miniconda3-4.5.12 is known to not work on Windows.
     private String MINICONDA_VERSION = "4.5.11"


### PR DESCRIPTION
This PR makes sure such metrics don't get recorded as `lifetime: user`.