### PR TITLE
Don't crash on invalid UUIDs in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * General:
   * The version of glean_parser has been upgraded to v1.21.0
 * Python:
-  * BUGFIX: `lifetime: application` metrics are no longer recorded as `lifetime: user`. 
+  * BUGFIX: `lifetime: application` metrics are no longer recorded as `lifetime: user`.
+  * BUGFIX: glean-core is no longer crashing when calling `uuid.set` with invalid UUIDs. 
 
 # v30.1.0 (2020-05-22)
 

--- a/glean-core/ffi/src/uuid.rs
+++ b/glean-core/ffi/src/uuid.rs
@@ -21,8 +21,14 @@ pub extern "C" fn glean_uuid_set(metric_id: u64, value: FfiStr) {
     with_glean_value(|glean| {
         UUID_METRICS.call_with_log(metric_id, |metric| {
             let value = value.to_string_fallible()?;
-            let uuid = uuid::Uuid::parse_str(&value);
-            metric.set(glean, uuid.unwrap());
+            if let Ok(uuid) = uuid::Uuid::parse_str(&value) {
+                metric.set(glean, uuid);
+            } else {
+                log::error!(
+                    "Unexpected `uuid` value coming from platform code '{}'",
+                    value
+                );
+            }
             Ok(())
         })
     })

--- a/glean-core/python/tests/metrics/test_uuid.py
+++ b/glean-core/python/tests/metrics/test_uuid.py
@@ -84,3 +84,19 @@ def test_the_api_saves_to_secondary_pings():
     # Check that the data was properly recorded
     assert uuid_metric.test_has_value("store2")
     assert uuid2 == uuid_metric.test_get_value("store2")
+
+
+def test_invalid_uuid_must_not_crash():
+    uuid_metric = metrics.UuidMetricType(
+        disabled=False,
+        category="telemetry",
+        lifetime=Lifetime.PING,
+        name="uuid_metric",
+        send_in_pings=["store1"],
+    )
+
+    # Attempt to set an invalid UUID.
+    uuid_metric.set("well, this is not a UUID")
+
+    # Check that no value was stored.
+    assert not uuid_metric.test_has_value()


### PR DESCRIPTION
This adds a log error when invalid UUIDs are passed to UUID metric types instead of attempting to unwrap, which would panic on invalid UUIDs.