### PR TITLE
Unregister the atexit handler in Glean._reset

### DIFF
--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -218,6 +218,10 @@ class Glean:
             _ffi.lib.glean_destroy_glean()
         cls._initialized = False
 
+        # Remove the atexit handler or it will get called multiple times at
+        # exit.
+        atexit.unregister(cls._reset)
+
         if cls._destroy_data_dir and cls._data_dir.exists():
             # This needs to be run in the same one-at-a-time process as the
             # PingUploadWorker to avoid a race condition. This will block the


### PR DESCRIPTION
Since Glean.initialize is called multiple times during the running of
the test suite, it actually registers the atexit handler multiple times,
which results in it running multiple times at exit.

This behavior is undocumented in the atexit documentation, but a short test
script shows that multiply-registered functions are called multiple times at
exit.

As far as I can tell, this is only an issue during testing, not in normal
app usage where Glean.initialize is a no-op after the first time it is called.
However, this saves a bit of time at completion for our own test suite and
probably also for users' test suites that use the `testing.reset_glean` helper.