### PR TITLE
Synchronously scan for pings in stand alone upload processes

### DIFF
--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -476,7 +476,10 @@ pub unsafe extern "C" fn glean_process_ping_upload_response(
 #[no_mangle]
 pub extern "C" fn glean_initialize_standalone_uploader(data_dir: FfiStr) -> u8 {
     handlemap_ext::handle_result(|| {
-        let upload_manager = PingUploadManager::new(data_dir.to_string_fallible()?);
+        // Init the upload manager to perform a synchronous ping directory scan.
+        // Since this method is meant to be called from a process used exclusively
+        // for uploading, this is fine.
+        let upload_manager = PingUploadManager::new(data_dir.to_string_fallible()?, true);
         glean_core::upload::setup_upload_manager(upload_manager)?;
         log::info!("Glean initialized in upload-only mode");
         Ok(true)

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -196,7 +196,7 @@ impl Glean {
             event_data_store,
             core_metrics: CoreMetrics::new(),
             internal_pings: InternalPings::new(),
-            upload_manager: PingUploadManager::new(&cfg.data_path),
+            upload_manager: PingUploadManager::new(&cfg.data_path, false),
             data_path: PathBuf::from(cfg.data_path),
             application_id,
             ping_registry: HashMap::new(),


### PR DESCRIPTION
By doing this we don't erroneously wait at least 1 second, at startup, in the Python language bindings.