### PR TITLE
Capture a potential core dump as a build artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,6 +404,9 @@ jobs:
       - store_artifacts:
           path: ~/test-results/tests
           destination: test-results
+      - store_artifacts:
+          path: glean-core/android/core
+          destination: coredump
       - store_test_results:
           path: ~/test-results
 


### PR DESCRIPTION
This might allow us to look into crashes we see on CI, a la:

    SIGSEGV (0xb) at pc=0x00007fd4a72c4181, pid=3244, tid=0x00007fd459891700

    JRE version: OpenJDK Runtime Environment (8.0_252-b09) (build 1.8.0_252-b09)
    Java VM: OpenJDK 64-Bit Server VM (25.252-b09 mixed mode linux-amd64 compressed oops)
    Problematic frame:
    C  [libc.so.6+0x15c181]

    Core dump written. Default location: /home/circleci/project/glean-core/android/core or core.3244


---

I've seen this now far too many times on CI. I'm getting worried, let's figure this out.