### PR TITLE
Add the missing 'Zlib' license to about.toml

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -6,6 +6,7 @@ accepted = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
+    "Zlib",
 ]
 
 # Subset of targets we build for


### PR DESCRIPTION
This is required for flate2/adler. Without this, cargo about will fail.