### PR TITLE
Bug 1639183 - Android builds on TaskCluster

### DIFF
--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.task:transforms
+
+jobs:
+  pr:
+    attributes:
+      run-on-pr-type: normal-ci
+    add-megazord-checks: true
+    needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
+    run-on-tasks-for: [github-pull-request]
+    description: Build and test (Android - linux-x86-64)
+    scopes:
+      - project:releng:services/tooltool/api/download/internal
+    worker-type: b-linux
+    worker:
+      docker-image: { in-tree: linux }
+      max-run-time: 1800
+      env: {}
+    run:
+      pre-gradlew:
+        # XXX: scripts subshell at runtime so we need to source this here
+        # to be able to access `rustup` and `rustc` from within the cc script
+        # and the gradle command. Another options could be to set those env vars
+        # here like: [export, 'PATH=$HOME/.cargo/bin:$PATH'
+        - [source, taskcluster/scripts/rust/rustup-setup.sh]
+        - [rsync, '-a', /builds/worker/fetches/libs/, /builds/worker/checkouts/src/libs/]
+        - [bash, '-c', 'echo "rust.targets=linux-x86-64,x86_64\n" > local.properties']
+      gradlew:
+        - 'clean'
+        - 'assembleDebugUnitTest'
+        - 'testDebugUnitTest'
+      using: gradlew
+      use-caches: true

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -26,7 +26,6 @@ jobs:
         # and the gradle command. Another options could be to set those env vars
         # here like: [export, 'PATH=$HOME/.cargo/bin:$PATH'
         - [source, taskcluster/scripts/rust/rustup-setup.sh]
-        - [rsync, '-a', /builds/worker/fetches/libs/, /builds/worker/checkouts/src/libs/]
         - [bash, '-c', 'echo "rust.targets=linux-x86-64,x86_64\n" > local.properties']
       gradlew:
         - 'clean'

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -11,7 +11,6 @@ transforms:
 
 jobs:
   pr:
-    add-megazord-checks: true
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
     run-on-tasks-for: [github-pull-request]
     description: Build and test (Android - linux-x86-64)

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -11,8 +11,6 @@ transforms:
 
 jobs:
   pr:
-    attributes:
-      run-on-pr-type: normal-ci
     add-megazord-checks: true
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
     run-on-tasks-for: [github-pull-request]

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -14,8 +14,6 @@ jobs:
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
     run-on-tasks-for: [github-pull-request]
     description: Build and test (Android - linux-x86-64)
-    scopes:
-      - project:releng:services/tooltool/api/download/internal
     worker-type: b-linux
     worker:
       docker-image: { in-tree: linux }

--- a/taskcluster/glean_taskgraph/job.py
+++ b/taskcluster/glean_taskgraph/job.py
@@ -94,7 +94,7 @@ def _extract_gradlew_command(run):
         _generate_secret_command(secret) for secret in run.get("secrets", [])
     ]
 
-    gradle_command = ["./gradlew", "--no-daemon"] + run.pop("gradlew")
+    gradle_command = ["./gradlew"] + run.pop("gradlew")
     post_gradle_commands = run.pop("post-gradlew", [])
 
     commands = pre_gradle_commands + [gradle_command] + post_gradle_commands

--- a/taskcluster/scripts/rust/rustup-setup.sh
+++ b/taskcluster/scripts/rust/rustup-setup.sh
@@ -30,3 +30,4 @@ export PATH=$HOME/.cargo/bin:$PATH
 
 rustup toolchain install stable
 rustup default stable
+rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android


### PR DESCRIPTION
This is the next step in our taskcluster support: building & running the Kotlin code & tests on CI.

cc @MihaiTabara 