### PR TITLE
Bug 1640692: Python: Use Rust as canonical source for enum values

### DIFF
--- a/glean-core/ffi/cbindgen.toml
+++ b/glean-core/ffi/cbindgen.toml
@@ -19,3 +19,6 @@ crates = ["glean-ffi"]
 [parse]
 parse_deps = true
 include = ["glean-core", "ffi-support"]
+
+[enum]
+prefix_with_name = true

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -34,6 +34,87 @@
 #define UPLOAD_RESULT_UNRECOVERABLE 2
 
 /**
+ * The supported metrics' lifetimes.
+ *
+ * A metric's lifetime determines when its stored data gets reset.
+ */
+enum Lifetime {
+  /**
+   * The metric is reset with each sent ping
+   */
+  Lifetime_Ping,
+  /**
+   * The metric is reset on application restart
+   */
+  Lifetime_Application,
+  /**
+   * The metric is reset with each user profile
+   */
+  Lifetime_User,
+};
+typedef int32_t Lifetime;
+
+/**
+ * Different resolutions supported by the memory related metric types (e.g.
+ * MemoryDistributionMetric).
+ */
+enum MemoryUnit {
+  /**
+   * 1 byte
+   */
+  MemoryUnit_Byte,
+  /**
+   * 2^10 bytes
+   */
+  MemoryUnit_Kilobyte,
+  /**
+   * 2^20 bytes
+   */
+  MemoryUnit_Megabyte,
+  /**
+   * 2^30 bytes
+   */
+  MemoryUnit_Gigabyte,
+};
+typedef int32_t MemoryUnit;
+
+/**
+ * Different resolutions supported by the time related
+ * metric types (e.g. DatetimeMetric).
+ */
+enum TimeUnit {
+  /**
+   * Truncate to nanosecond precision.
+   */
+  TimeUnit_Nanosecond,
+  /**
+   * Truncate to microsecond precision.
+   */
+  TimeUnit_Microsecond,
+  /**
+   * Truncate to millisecond precision.
+   */
+  TimeUnit_Millisecond,
+  /**
+   * Truncate to second precision.
+   */
+  TimeUnit_Second,
+  /**
+   * Truncate to minute precision.
+   */
+  TimeUnit_Minute,
+  /**
+   * Truncate to hour precision.
+   */
+  TimeUnit_Hour,
+  /**
+   * Truncate to day precision.
+   */
+  TimeUnit_Day,
+};
+typedef int32_t TimeUnit;
+
+/**
  * `FfiStr<'a>` is a safe (`#[repr(transparent)]`) wrapper around a
  * nul-terminated `*const c_char` (e.g. a C string). Conceptually, it is
  * similar to [`std::ffi::CStr`], except that it may be used in the signatures
@@ -399,21 +480,21 @@ uint64_t glean_new_boolean_metric(FfiStr category,
                                   FfiStr name,
                                   RawStringArray send_in_pings,
                                   int32_t send_in_pings_len,
-                                  int32_t lifetime,
+                                  Lifetime lifetime,
                                   uint8_t disabled);
 
 uint64_t glean_new_counter_metric(FfiStr category,
                                   FfiStr name,
                                   RawStringArray send_in_pings,
                                   int32_t send_in_pings_len,
-                                  int32_t lifetime,
+                                  Lifetime lifetime,
                                   uint8_t disabled);
 
 uint64_t glean_new_custom_distribution_metric(FfiStr category,
                                               FfiStr name,
                                               RawStringArray send_in_pings,
                                               int32_t send_in_pings_len,
-                                              int32_t lifetime,
+                                              Lifetime lifetime,
                                               uint8_t disabled,
                                               uint64_t range_min,
                                               uint64_t range_max,
@@ -424,9 +505,9 @@ uint64_t glean_new_datetime_metric(FfiStr category,
                                    FfiStr name,
                                    RawStringArray send_in_pings,
                                    int32_t send_in_pings_len,
-                                   int32_t lifetime,
+                                   Lifetime lifetime,
                                    uint8_t disabled,
-                                   int32_t time_unit);
+                                   TimeUnit time_unit);
 
 uint64_t glean_new_event_metric(FfiStr category,
                                 FfiStr name,
@@ -477,9 +558,9 @@ uint64_t glean_new_memory_distribution_metric(FfiStr category,
                                               FfiStr name,
                                               RawStringArray send_in_pings,
                                               int32_t send_in_pings_len,
-                                              int32_t lifetime,
+                                              Lifetime lifetime,
                                               uint8_t disabled,
-                                              int32_t memory_unit);
+                                              MemoryUnit memory_unit);
 
 uint64_t glean_new_ping_type(FfiStr ping_name,
                              uint8_t include_client_id,
@@ -491,28 +572,28 @@ uint64_t glean_new_quantity_metric(FfiStr category,
                                    FfiStr name,
                                    RawStringArray send_in_pings,
                                    int32_t send_in_pings_len,
-                                   int32_t lifetime,
+                                   Lifetime lifetime,
                                    uint8_t disabled);
 
 uint64_t glean_new_string_list_metric(FfiStr category,
                                       FfiStr name,
                                       RawStringArray send_in_pings,
                                       int32_t send_in_pings_len,
-                                      int32_t lifetime,
+                                      Lifetime lifetime,
                                       uint8_t disabled);
 
 uint64_t glean_new_string_metric(FfiStr category,
                                  FfiStr name,
                                  RawStringArray send_in_pings,
                                  int32_t send_in_pings_len,
-                                 int32_t lifetime,
+                                 Lifetime lifetime,
                                  uint8_t disabled);
 
 uint64_t glean_new_timespan_metric(FfiStr category,
                                    FfiStr name,
                                    RawStringArray send_in_pings,
                                    int32_t send_in_pings_len,
-                                   int32_t lifetime,
+                                   Lifetime lifetime,
                                    uint8_t disabled,
                                    int32_t time_unit);
 
@@ -520,15 +601,15 @@ uint64_t glean_new_timing_distribution_metric(FfiStr category,
                                               FfiStr name,
                                               RawStringArray send_in_pings,
                                               int32_t send_in_pings_len,
-                                              int32_t lifetime,
+                                              Lifetime lifetime,
                                               uint8_t disabled,
-                                              int32_t time_unit);
+                                              TimeUnit time_unit);
 
 uint64_t glean_new_uuid_metric(FfiStr category,
                                FfiStr name,
                                RawStringArray send_in_pings,
                                int32_t send_in_pings_len,
-                               int32_t lifetime,
+                               Lifetime lifetime,
                                uint8_t disabled);
 
 uint8_t glean_on_ready_to_submit_pings(void);

--- a/glean-core/ffi/src/boolean.rs
+++ b/glean-core/ffi/src/boolean.rs
@@ -4,7 +4,7 @@
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value, Lifetime};
 
 define_metric!(BooleanMetric => BOOLEAN_METRICS {
     new           -> glean_new_boolean_metric(),

--- a/glean-core/ffi/src/counter.rs
+++ b/glean-core/ffi/src/counter.rs
@@ -4,7 +4,7 @@
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value, Lifetime};
 
 define_metric!(CounterMetric => COUNTER_METRICS {
     new           -> glean_new_counter_metric(),

--- a/glean-core/ffi/src/custom_distribution.rs
+++ b/glean-core/ffi/src/custom_distribution.rs
@@ -8,7 +8,7 @@ use ffi_support::FfiStr;
 
 use crate::{
     define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, with_glean_value,
-    RawInt64Array,
+    Lifetime, RawInt64Array,
 };
 
 define_metric!(CustomDistributionMetric => CUSTOM_DISTRIBUTION_METRICS {

--- a/glean-core/ffi/src/datetime.rs
+++ b/glean-core/ffi/src/datetime.rs
@@ -6,10 +6,12 @@ use std::os::raw::c_char;
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
+use crate::{
+    define_metric, handlemap_ext::HandleMapExtension, with_glean_value, Lifetime, TimeUnit,
+};
 
 define_metric!(DatetimeMetric => DATETIME_METRICS {
-    new           -> glean_new_datetime_metric(time_unit: i32),
+    new           -> glean_new_datetime_metric(time_unit: TimeUnit),
     test_get_num_recorded_errors -> glean_datetime_test_get_num_recorded_errors,
     destroy       -> glean_destroy_datetime_metric,
 });

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -9,9 +9,12 @@ use std::panic::UnwindSafe;
 
 use ffi_support::{define_string_destructor, ConcurrentHandleMap, FfiStr, IntoFfi};
 
+pub use glean_core::metrics::MemoryUnit;
+pub use glean_core::metrics::TimeUnit;
 pub use glean_core::upload::ffi_upload_result::*;
 use glean_core::upload::PingUploadManager;
 use glean_core::Glean;
+pub use glean_core::Lifetime;
 
 mod macros;
 

--- a/glean-core/ffi/src/macros.rs
+++ b/glean-core/ffi/src/macros.rs
@@ -53,7 +53,7 @@ macro_rules! define_metric {
             name: ffi_support::FfiStr,
             send_in_pings: crate::RawStringArray,
             send_in_pings_len: i32,
-            lifetime: i32,
+            lifetime: Lifetime,
             disabled: u8,
             $($new_argname: $new_argtyp),*
         ) -> u64 {

--- a/glean-core/ffi/src/memory_distribution.rs
+++ b/glean-core/ffi/src/memory_distribution.rs
@@ -8,11 +8,11 @@ use ffi_support::FfiStr;
 
 use crate::{
     define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, with_glean_value,
-    RawInt64Array,
+    Lifetime, MemoryUnit, RawInt64Array,
 };
 
 define_metric!(MemoryDistributionMetric => MEMORY_DISTRIBUTION_METRICS {
-    new           -> glean_new_memory_distribution_metric(memory_unit: i32),
+    new           -> glean_new_memory_distribution_metric(memory_unit: MemoryUnit),
     test_get_num_recorded_errors -> glean_memory_distribution_test_get_num_recorded_errors,
     destroy       -> glean_destroy_memory_distribution_metric,
     accumulate    -> glean_memory_distribution_accumulate(sample: u64),

--- a/glean-core/ffi/src/quantity.rs
+++ b/glean-core/ffi/src/quantity.rs
@@ -4,7 +4,7 @@
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value, Lifetime};
 
 define_metric!(QuantityMetric => QUANTITY_METRICS {
     new           -> glean_new_quantity_metric(),

--- a/glean-core/ffi/src/string.rs
+++ b/glean-core/ffi/src/string.rs
@@ -8,7 +8,7 @@ use ffi_support::FfiStr;
 
 use crate::{
     define_metric, ffi_string_ext::FallibleToString, handlemap_ext::HandleMapExtension,
-    with_glean_value,
+    with_glean_value, Lifetime,
 };
 
 define_metric!(StringMetric => STRING_METRICS {

--- a/glean-core/ffi/src/string_list.rs
+++ b/glean-core/ffi/src/string_list.rs
@@ -8,7 +8,7 @@ use ffi_support::FfiStr;
 
 use crate::{
     define_metric, ffi_string_ext::FallibleToString, from_raw_string_array,
-    handlemap_ext::HandleMapExtension, with_glean_value, RawStringArray,
+    handlemap_ext::HandleMapExtension, with_glean_value, Lifetime, RawStringArray,
 };
 
 define_metric!(StringListMetric => STRING_LIST_METRICS {

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use ffi_support::FfiStr;
 
-use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value};
+use crate::{define_metric, handlemap_ext::HandleMapExtension, with_glean_value, Lifetime};
 
 define_metric!(TimespanMetric => TIMESPAN_METRICS {
     new           -> glean_new_timespan_metric(time_unit: i32),

--- a/glean-core/ffi/src/timing_distribution.rs
+++ b/glean-core/ffi/src/timing_distribution.rs
@@ -8,12 +8,12 @@ use ffi_support::FfiStr;
 
 use crate::{
     define_metric, from_raw_int64_array, handlemap_ext::HandleMapExtension, with_glean_value,
-    RawInt64Array,
+    Lifetime, RawInt64Array, TimeUnit,
 };
 use glean_core::metrics::TimerId;
 
 define_metric!(TimingDistributionMetric => TIMING_DISTRIBUTION_METRICS {
-    new           -> glean_new_timing_distribution_metric(time_unit: i32),
+    new           -> glean_new_timing_distribution_metric(time_unit: TimeUnit),
     test_get_num_recorded_errors -> glean_timing_distribution_test_get_num_recorded_errors,
     destroy       -> glean_destroy_timing_distribution_metric,
 });

--- a/glean-core/ffi/src/uuid.rs
+++ b/glean-core/ffi/src/uuid.rs
@@ -8,7 +8,7 @@ use ffi_support::FfiStr;
 
 use crate::{
     define_metric, ffi_string_ext::FallibleToString, handlemap_ext::HandleMapExtension,
-    with_glean_value,
+    with_glean_value, Lifetime,
 };
 
 define_metric!(UuidMetric => UUID_METRICS {

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -34,6 +34,87 @@
 #define UPLOAD_RESULT_UNRECOVERABLE 2
 
 /**
+ * The supported metrics' lifetimes.
+ *
+ * A metric's lifetime determines when its stored data gets reset.
+ */
+enum Lifetime {
+  /**
+   * The metric is reset with each sent ping
+   */
+  Lifetime_Ping,
+  /**
+   * The metric is reset on application restart
+   */
+  Lifetime_Application,
+  /**
+   * The metric is reset with each user profile
+   */
+  Lifetime_User,
+};
+typedef int32_t Lifetime;
+
+/**
+ * Different resolutions supported by the memory related metric types (e.g.
+ * MemoryDistributionMetric).
+ */
+enum MemoryUnit {
+  /**
+   * 1 byte
+   */
+  MemoryUnit_Byte,
+  /**
+   * 2^10 bytes
+   */
+  MemoryUnit_Kilobyte,
+  /**
+   * 2^20 bytes
+   */
+  MemoryUnit_Megabyte,
+  /**
+   * 2^30 bytes
+   */
+  MemoryUnit_Gigabyte,
+};
+typedef int32_t MemoryUnit;
+
+/**
+ * Different resolutions supported by the time related
+ * metric types (e.g. DatetimeMetric).
+ */
+enum TimeUnit {
+  /**
+   * Truncate to nanosecond precision.
+   */
+  TimeUnit_Nanosecond,
+  /**
+   * Truncate to microsecond precision.
+   */
+  TimeUnit_Microsecond,
+  /**
+   * Truncate to millisecond precision.
+   */
+  TimeUnit_Millisecond,
+  /**
+   * Truncate to second precision.
+   */
+  TimeUnit_Second,
+  /**
+   * Truncate to minute precision.
+   */
+  TimeUnit_Minute,
+  /**
+   * Truncate to hour precision.
+   */
+  TimeUnit_Hour,
+  /**
+   * Truncate to day precision.
+   */
+  TimeUnit_Day,
+};
+typedef int32_t TimeUnit;
+
+/**
  * `FfiStr<'a>` is a safe (`#[repr(transparent)]`) wrapper around a
  * nul-terminated `*const c_char` (e.g. a C string). Conceptually, it is
  * similar to [`std::ffi::CStr`], except that it may be used in the signatures
@@ -399,21 +480,21 @@ uint64_t glean_new_boolean_metric(FfiStr category,
                                   FfiStr name,
                                   RawStringArray send_in_pings,
                                   int32_t send_in_pings_len,
-                                  int32_t lifetime,
+                                  Lifetime lifetime,
                                   uint8_t disabled);
 
 uint64_t glean_new_counter_metric(FfiStr category,
                                   FfiStr name,
                                   RawStringArray send_in_pings,
                                   int32_t send_in_pings_len,
-                                  int32_t lifetime,
+                                  Lifetime lifetime,
                                   uint8_t disabled);
 
 uint64_t glean_new_custom_distribution_metric(FfiStr category,
                                               FfiStr name,
                                               RawStringArray send_in_pings,
                                               int32_t send_in_pings_len,
-                                              int32_t lifetime,
+                                              Lifetime lifetime,
                                               uint8_t disabled,
                                               uint64_t range_min,
                                               uint64_t range_max,
@@ -424,9 +505,9 @@ uint64_t glean_new_datetime_metric(FfiStr category,
                                    FfiStr name,
                                    RawStringArray send_in_pings,
                                    int32_t send_in_pings_len,
-                                   int32_t lifetime,
+                                   Lifetime lifetime,
                                    uint8_t disabled,
-                                   int32_t time_unit);
+                                   TimeUnit time_unit);
 
 uint64_t glean_new_event_metric(FfiStr category,
                                 FfiStr name,
@@ -477,9 +558,9 @@ uint64_t glean_new_memory_distribution_metric(FfiStr category,
                                               FfiStr name,
                                               RawStringArray send_in_pings,
                                               int32_t send_in_pings_len,
-                                              int32_t lifetime,
+                                              Lifetime lifetime,
                                               uint8_t disabled,
-                                              int32_t memory_unit);
+                                              MemoryUnit memory_unit);
 
 uint64_t glean_new_ping_type(FfiStr ping_name,
                              uint8_t include_client_id,
@@ -491,28 +572,28 @@ uint64_t glean_new_quantity_metric(FfiStr category,
                                    FfiStr name,
                                    RawStringArray send_in_pings,
                                    int32_t send_in_pings_len,
-                                   int32_t lifetime,
+                                   Lifetime lifetime,
                                    uint8_t disabled);
 
 uint64_t glean_new_string_list_metric(FfiStr category,
                                       FfiStr name,
                                       RawStringArray send_in_pings,
                                       int32_t send_in_pings_len,
-                                      int32_t lifetime,
+                                      Lifetime lifetime,
                                       uint8_t disabled);
 
 uint64_t glean_new_string_metric(FfiStr category,
                                  FfiStr name,
                                  RawStringArray send_in_pings,
                                  int32_t send_in_pings_len,
-                                 int32_t lifetime,
+                                 Lifetime lifetime,
                                  uint8_t disabled);
 
 uint64_t glean_new_timespan_metric(FfiStr category,
                                    FfiStr name,
                                    RawStringArray send_in_pings,
                                    int32_t send_in_pings_len,
-                                   int32_t lifetime,
+                                   Lifetime lifetime,
                                    uint8_t disabled,
                                    int32_t time_unit);
 
@@ -520,15 +601,15 @@ uint64_t glean_new_timing_distribution_metric(FfiStr category,
                                               FfiStr name,
                                               RawStringArray send_in_pings,
                                               int32_t send_in_pings_len,
-                                              int32_t lifetime,
+                                              Lifetime lifetime,
                                               uint8_t disabled,
-                                              int32_t time_unit);
+                                              TimeUnit time_unit);
 
 uint64_t glean_new_uuid_metric(FfiStr category,
                                FfiStr name,
                                RawStringArray send_in_pings,
                                int32_t send_in_pings_len,
-                               int32_t lifetime,
+                               Lifetime lifetime,
                                uint8_t disabled);
 
 uint8_t glean_on_ready_to_submit_pings(void);

--- a/glean-core/python/glean/metrics/lifetime.py
+++ b/glean-core/python/glean/metrics/lifetime.py
@@ -5,6 +5,9 @@
 from enum import Enum
 
 
+from .. import _ffi
+
+
 class Lifetime(Enum):
     """
     An enumeration for the different metric lifetimes that Glean supports.
@@ -12,17 +15,17 @@ class Lifetime(Enum):
     Metric lifetimes define when a metric is reset.
     """
 
-    PING = 0
+    PING = _ffi.lib.Lifetime_Ping
     """
     The metric is reset with each sent ping
     """
 
-    APPLICATION = 1
+    APPLICATION = _ffi.lib.Lifetime_Application
     """
     The metric is reset on application restart
     """
 
-    USER = 2
+    USER = _ffi.lib.Lifetime_User
     """
     The metric is reset with each user profile
     """

--- a/glean-core/python/glean/metrics/memoryunit.py
+++ b/glean-core/python/glean/metrics/memoryunit.py
@@ -6,6 +6,9 @@
 from enum import IntEnum
 
 
+from .. import _ffi
+
+
 class MemoryUnit(IntEnum):
     """
     An enumeration of different resolutions supported by the
@@ -15,22 +18,22 @@ class MemoryUnit(IntEnum):
     pedantically a Kibibyte.
     """
 
-    BYTE = 0
+    BYTE = _ffi.lib.MemoryUnit_Byte
     """
     Byte: 1 byte.
     """
 
-    KILOBYTE = 1
+    KILOBYTE = _ffi.lib.MemoryUnit_Kilobyte
     """
     Kilobyte: 2^10 bytes
     """
 
-    MEGABYTE = 2
+    MEGABYTE = _ffi.lib.MemoryUnit_Megabyte
     """
     Megabyte: 2^20 bytes
     """
 
-    GIGABYTE = 3
+    GIGABYTE = _ffi.lib.MemoryUnit_Gigabyte
     """
     Gigabyte: 2^30 bytes
     """

--- a/glean-core/python/glean/metrics/timeunit.py
+++ b/glean-core/python/glean/metrics/timeunit.py
@@ -6,43 +6,46 @@
 from enum import IntEnum
 
 
+from .. import _ffi
+
+
 class TimeUnit(IntEnum):
     """
     An enumeration of different resolutions supported by the time-related
     metric types.
     """
 
-    NANOSECOND = 0
+    NANOSECOND = _ffi.lib.TimeUnit_Nanosecond
     """
     Represents nanosecond precision.
     """
 
-    MICROSECOND = 1
+    MICROSECOND = _ffi.lib.TimeUnit_Microsecond
     """
     Represents microsecond precision.
     """
 
-    MILLISECOND = 2
+    MILLISECOND = _ffi.lib.TimeUnit_Millisecond
     """
     Represents millisecond precision.
     """
 
-    SECOND = 3
+    SECOND = _ffi.lib.TimeUnit_Second
     """
     Represents second precision.
     """
 
-    MINUTE = 4
+    MINUTE = _ffi.lib.TimeUnit_Minute
     """
     Represents minute precision.
     """
 
-    HOUR = 5
+    HOUR = _ffi.lib.TimeUnit_Hour
     """
     Represents hour precision.
     """
 
-    DAY = 6
+    DAY = _ffi.lib.TimeUnit_Day
     """
     Represents day precision.
     """

--- a/glean-core/python/glean/net/upload_task_tag.py
+++ b/glean-core/python/glean/net/upload_task_tag.py
@@ -5,24 +5,25 @@
 from enum import IntEnum
 
 
+from .. import _ffi
+
+
 class UploadTaskTag(IntEnum):
     """
     An enumeration for the different upload tasks that the Glean uploader supports.
-
-    This *MUST* have the same order as the variants in `glean-core/ffi/src/upload.rs`.
     """
 
-    UPLOAD = 0
+    UPLOAD = _ffi.lib.FfiPingUploadTask_Upload
     """
     Ping data is available for upload
     """
 
-    WAIT = 1
+    WAIT = _ffi.lib.FfiPingUploadTask_Wait
     """
     Caller needs to wait before requesting new data
     """
 
-    DONE = 2
+    DONE = _ffi.lib.FfiPingUploadTask_Done
     """
     No data available
     """

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -15,6 +15,9 @@ import uuid
 
 
 from glean_parser import validate_ping
+from glean_parser.metrics import Lifetime as ParserLifetime
+from glean_parser.metrics import TimeUnit as ParserTimeUnit
+from glean_parser.metrics import MemoryUnit as ParserMemoryUnit
 import pytest
 
 
@@ -23,7 +26,14 @@ from glean import __version__ as glean_version
 from glean import _builtins
 from glean import _util
 from glean._dispatcher import Dispatcher
-from glean.metrics import CounterMetricType, Lifetime, PingType, StringMetricType
+from glean.metrics import (
+    CounterMetricType,
+    Lifetime,
+    MemoryUnit,
+    PingType,
+    StringMetricType,
+    TimeUnit,
+)
 from glean.net import PingUploadWorker
 from glean.testing import _RecordingUploader
 
@@ -644,3 +654,20 @@ def test_clear_application_lifetime_metrics(tmpdir):
 
     assert not counter_metric.test_has_value()
     assert not metrics.core_ping.seq.test_has_value()
+
+
+def test_confirm_enums_match_values_in_glean_parser():
+    """
+    Make sure the values in the glean_parser enums match those in Glean's enums
+    (which come directly from the canonical source in the Rust implementation).
+
+    This should ensure we never update to a glean_parser version with incorrect
+    enumeration values.
+    """
+    for g_enum, gp_enum in [
+        (Lifetime, ParserLifetime),
+        (TimeUnit, ParserTimeUnit),
+        (MemoryUnit, ParserMemoryUnit),
+    ]:
+        for name in gp_enum.__members__.keys():
+            assert g_enum[name.upper()].value == gp_enum[name].value

--- a/glean-core/src/common_metric_data.rs
+++ b/glean-core/src/common_metric_data.rs
@@ -12,6 +12,7 @@ use crate::Glean;
 ///
 /// A metric's lifetime determines when its stored data gets reset.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(i32)] // Use i32 to be compatible with our JNA definition
 pub enum Lifetime {
     /// The metric is reset with each sent ping
     Ping,

--- a/glean-core/src/metrics/memory_unit.rs
+++ b/glean-core/src/metrics/memory_unit.rs
@@ -12,14 +12,15 @@ use crate::error::{Error, ErrorKind};
 /// MemoryDistributionMetric).
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
+#[repr(i32)] // use i32 to be compatible with our JNA definition
 pub enum MemoryUnit {
-    ///
+    /// 1 byte
     Byte,
-    ///
+    /// 2^10 bytes
     Kilobyte,
-    ///
+    /// 2^20 bytes
     Megabyte,
-    ///
+    /// 2^30 bytes
     Gigabyte,
 }
 

--- a/glean-core/src/metrics/time_unit.rs
+++ b/glean-core/src/metrics/time_unit.rs
@@ -13,6 +13,7 @@ use crate::error::{Error, ErrorKind};
 /// metric types (e.g. DatetimeMetric).
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[repr(i32)] // use i32 to be compatible with our JNA definition
 pub enum TimeUnit {
     /// Truncate to nanosecond precision.
     Nanosecond,


### PR DESCRIPTION
This was prompted by the recent bug in the Python bindings that the `Lifetime` enum in glean_parser and glean-core didn't match.  I think that rather than treating glean_parser as the canonical source of values, we should treat the Rust glean-core as the canonical source of values and get them from there where possible.

This exposes the C-like enums (Rust empty enums) through cbindgen so we can use them directly from Python and not have to make sure that the values are in sync.

Then to make sure glean_parser is correct (since glean_parser doesn't / can't have a dependency on glean-core), this just adds a test to make sure its enums are in sync with glean-core's.  It does mean we won't catch those issues until upgrading the version of glean_parser in glean, but that should be more than good enough for most things.

There might be a way to do a similar thing for Swift (I just don't know one way or the other), but I haven't been able to find a way for Kotlin/JNA (and I doubt there is one).