### PR TITLE
Pass a reason when collecting pings for tests or a null pointer.

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -474,8 +474,8 @@ open class GleanInternalAPI internal constructor () {
      * Collect a ping and return a string
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun testCollect(ping: PingTypeBase): String? {
-        return LibGleanFFI.INSTANCE.glean_ping_collect(ping.handle)?.getAndConsumeRustString()
+    internal fun testCollect(ping: PingTypeBase, reason: String? = null): String? {
+        return LibGleanFFI.INSTANCE.glean_ping_collect(ping.handle, reason)?.getAndConsumeRustString()
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -109,7 +109,7 @@ internal interface LibGleanFFI : Library {
 
     fun glean_is_upload_enabled(): Byte
 
-    fun glean_ping_collect(ping_type_handle: Long): Pointer?
+    fun glean_ping_collect(ping_type_handle: Long, reason: String?): Pointer?
 
     fun glean_submit_ping_by_name(
         ping_name: String,


### PR DESCRIPTION
Oh boy, this was driving me ... into the dark corners of debugging today.

We saw SEGFAULTS on CI happening more and more frequently recently. I
was able to reproduce it in 1 out of 5 runs inside the Docker container
also used for TaskCluster now.

The error we were seeing was attributed to libc as follows:

    C  [libc.so.6+0x18e5a1]

After some wrestling with the environmnet, installing gdb, enabling coredumps (`ulimit -c unlimited`),
adding debug info back to the build and reading 40-item long stacktrace,
that spans the JVM, C, our FFI part, our Rust implementation and the Rust standard library there, I found the culprit:
We don't pass it the data!

And because this is an optimized build and things get shuffled around it
might or might not be pointing to valid memory or be a null pointer.
But a null pointer is all we can check for.

Doing it right makes this go all right.

Just one more reason that we should auto-generate the LibGleanFFI.kt
file from Rust or our C headers.