### PR TITLE
Bug 1641793- Android: Export proguard rules in debug, as a consumer might still enable proguard/r8

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -48,6 +48,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Export our rules in debug, as a consumer might still enable proguard/r8
+            consumerProguardFiles "$projectDir/proguard-rules-consumer.pro"
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
[doc only]


---

don't need a full CI run on the PR here.