### PR TITLE
Use absolute paths in `include` list for packaging

### DIFF
--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -9,12 +9,12 @@ license = "MPL-2.0"
 edition = "2018"
 keywords = ["telemetry"]
 include = [
-  "README.md",
-  "LICENSE",
-  "src/**/*",
-  "examples/**/*",
-  "tests/**/*",
-  "Cargo.toml"
+  "/README.md",
+  "/LICENSE",
+  "/src",
+  "/examples",
+  "/tests",
+  "/Cargo.toml"
 ]
 
 [badges]

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -9,13 +9,13 @@ license = "MPL-2.0"
 edition = "2018"
 keywords = ["telemetry"]
 include = [
-  "README.md",
-  "LICENSE",
-  "src/**/*",
-  "tests/**/*",
-  "Cargo.toml",
-  "cbindgen.toml",
-  "glean.h"
+  "/README.md",
+  "/LICENSE",
+  "/src",
+  "/tests",
+  "/Cargo.toml",
+  "/cbindgen.toml",
+  "/glean.h"
 ]
 
 [badges]

--- a/glean-core/preview/Cargo.toml
+++ b/glean-core/preview/Cargo.toml
@@ -9,12 +9,12 @@ license = "MPL-2.0"
 edition = "2018"
 keywords = ["telemetry", "glean"]
 include = [
-  "README.md",
-  "LICENSE",
-  "CHANGELOG.md",
-  "src/**/*",
-  "tests/**/*",
-  "Cargo.toml",
+  "/README.md",
+  "/LICENSE",
+  "/CHANGELOG.md",
+  "/src",
+  "/tests",
+  "/Cargo.toml",
 ]
 
 [badges]


### PR DESCRIPTION
The list contains "globs", meaning it previously looked for `README.md`
or `LICENSE` in all subfolders, leading to the inclusion of far too
many files, e.g. from a virtualenv.