### PR TITLE
Bug 1640660 - Move Glean debug ping viewer documentation from dtmo

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
     - [Metric parameters](user/metric-parameters.md)
     - [Testing metrics](user/testing-metrics.md)
     - [Debugging products using Glean](user/debugging/index.md)
+        - [Glean Debug Ping View](user/debugging/debug-ping-view.md)
         - [Android](user/debugging/android.md)
         - [iOS](user/debugging/ios.md)
         - [Python](user/debugging/python.md)

--- a/docs/user/debugging/android.md
+++ b/docs/user/debugging/android.md
@@ -34,7 +34,9 @@ adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.Gl
   --es tagPings test-metrics-ping
 ```
 
-The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPing` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
+The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPing` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day.
+
+Note that if no metrics have been collected, then no pings will be sent *unless* [`send_if_empty` is set on your ping](../pings/custom.md#defining-a-custom-ping). See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
 
 Options that are set using the `adb` flags are not immediately reset and will
 persist until the application is closed or manually reset.

--- a/docs/user/debugging/android.md
+++ b/docs/user/debugging/android.md
@@ -34,7 +34,7 @@ adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.Gl
   --es tagPings test-metrics-ping
 ```
 
-The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPings` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
+The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPing` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
 
 Options that are set using the `adb` flags are not immediately reset and will
 persist until the application is closed or manually reset.

--- a/docs/user/debugging/android.md
+++ b/docs/user/debugging/android.md
@@ -21,7 +21,7 @@ In the above:
 |---|----|-----------|
 | `logPings` | boolean (`--ez`)  | If set to `true`, pings are dumped to logcat; defaults to `false` |
 | `sendPing` | string (`--es`)  | Sends the ping with the given name immediately |
-| `tagPings` | string (`--es`)  | Tags all outgoing pings as debug pings to make them available for real-time validation, on the [Glean Debug View](https://docs.telemetry.mozilla.org/concepts/glean/debug_ping_view.html). The value must match the pattern `[a-zA-Z0-9-]{1,20}` |
+| `tagPings` | string (`--es`)  | Tags all outgoing pings as debug pings to make them available for real-time validation, on the [Glean Debug View](./debug-ping-view.md). The value must match the pattern `[a-zA-Z0-9-]{1,20}` |
 
 > **Note:** Due to limitations on Android logcat message size, pings larger than 4KB are broken into multiple log messages when using `logPings`.
 
@@ -35,6 +35,9 @@ adb shell am start -n org.mozilla.samples.glean/mozilla.telemetry.glean.debug.Gl
 ```
 
 The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPings` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
+
+Options that are set using the `adb` flags are not immediately reset and will
+persist until the application is closed or manually reset.
 
 > **Note:** In previous versions of Glean the activity was available with the name `mozilla.components.service.glean.debug.GleanDebugActivity`.
 >

--- a/docs/user/debugging/debug-ping-view.md
+++ b/docs/user/debugging/debug-ping-view.md
@@ -1,0 +1,30 @@
+# Glean Debug Ping View
+
+<!-- toc -->
+
+## What is this good for?
+
+The [Glean Debug Ping View](debug_view) enables you to easily see in real-time what data your application is sending.
+
+This data is what actually arrives in our data pipeline, shown in a web
+interface that is automatically updated when new data arrives. Any data sent from a Glean SDK-instrumented application usually shows up within 10 seconds,
+updating the pages automatically. Pings are retained for 3 weeks.
+
+[debug_view]: https://debug-ping-preview.firebaseapp.com/
+
+## What setup is needed for applications?
+
+You need to tag each ping with a debugging tag. See the documentation on
+[debugging](./index.md) for information on how to do this for each platform and/or language.
+
+## Troubleshooting
+
+If nothing is showing up on the dashboard, try checking the following:
+
+- If you see _”Glean must be enabled before sending pings.”_ in the logs,
+  then the application has disabled Glean. Check with the application author
+  on how to re-enable it.
+- If no error is reported when triggering tagged pings, but the data won't
+  show up on the dashboard, check if the used `<application-id>` is the same
+  expected by the Glean pipeline (i.e. the one used to publish the
+  application on the Play Store).

--- a/docs/user/debugging/debug-ping-view.md
+++ b/docs/user/debugging/debug-ping-view.md
@@ -21,4 +21,4 @@ If nothing is showing up on the dashboard, try checking the following:
 - If no error is reported when triggering tagged pings, but the data won't
   show up on the dashboard, check if the `<application-id>` used is the same
   expected by the Glean pipeline (i.e. the one used to publish the
-  application on the Play Store).
+  application on the Google Play Store or Apple App Store).

--- a/docs/user/debugging/debug-ping-view.md
+++ b/docs/user/debugging/debug-ping-view.md
@@ -1,16 +1,10 @@
 # Glean Debug Ping View
 
-<!-- toc -->
-
-## What is this good for?
-
-The [Glean Debug Ping View](debug_view) enables you to easily see in real-time what data your application is sending.
+The [Glean Debug Ping View](https://debug-ping-preview.firebaseapp.com/) enables you to easily see in real-time what data your application is sending.
 
 This data is what actually arrives in our data pipeline, shown in a web
 interface that is automatically updated when new data arrives. Any data sent from a Glean SDK-instrumented application usually shows up within 10 seconds,
 updating the pages automatically. Pings are retained for 3 weeks.
-
-[debug_view]: https://debug-ping-preview.firebaseapp.com/
 
 ## What setup is needed for applications?
 

--- a/docs/user/debugging/debug-ping-view.md
+++ b/docs/user/debugging/debug-ping-view.md
@@ -20,5 +20,5 @@ If nothing is showing up on the dashboard, try checking the following:
   on how to re-enable it.
 - If no error is reported when triggering tagged pings, but the data won't
   show up on the dashboard, check if the `<application-id>` used is the same
-  expected by the Glean pipeline (i.e. the one used to publish the
+  as expected by the Glean pipeline (i.e. the one used to publish the
   application on the Google Play Store or Apple App Store).

--- a/docs/user/debugging/debug-ping-view.md
+++ b/docs/user/debugging/debug-ping-view.md
@@ -13,12 +13,4 @@ You need to tag each ping with a debugging tag. See the documentation on
 
 ## Troubleshooting
 
-If nothing is showing up on the dashboard, try checking the following:
-
-- If you see _”Glean must be enabled before sending pings.”_ in the logs,
-  then the application has disabled Glean. Check with the application author
-  on how to re-enable it.
-- If no error is reported when triggering tagged pings, but the data won't
-  show up on the dashboard, check if the `<application-id>` used is the same
-  as expected by the Glean pipeline (i.e. the one used to publish the
-  application on the Google Play Store or Apple App Store).
+If nothing is showing up on the dashboard, and you see `Glean must be enabled before sending pings.` in the logs, then the application has disabled Glean. Check with the application author on how to re-enable it.

--- a/docs/user/debugging/debug-ping-view.md
+++ b/docs/user/debugging/debug-ping-view.md
@@ -19,6 +19,6 @@ If nothing is showing up on the dashboard, try checking the following:
   then the application has disabled Glean. Check with the application author
   on how to re-enable it.
 - If no error is reported when triggering tagged pings, but the data won't
-  show up on the dashboard, check if the used `<application-id>` is the same
+  show up on the dashboard, check if the `<application-id>` used is the same
   expected by the Glean pipeline (i.e. the one used to publish the
   application on the Play Store).

--- a/docs/user/debugging/python.md
+++ b/docs/user/debugging/python.md
@@ -4,7 +4,7 @@ Glean provides a couple of configuration flags to assist with debugging Python a
 
 ## Tagging pings
 
-The `Glean.configuration.ping_tag` property can be used to add a special flag to the HTTP header so that the ping will end up in the [Glean Debug View](https://docs.telemetry.mozilla.org/concepts/glean/debug_ping_view.html).
+The `Glean.configuration.ping_tag` property can be used to add a special flag to the HTTP header so that the ping will end up in the [Glean Debug View](./debug-ping-view.md).
 
 You can set it after `Glean.initialize` is called:
 


### PR DESCRIPTION
At the same time, remove some notes which were redundant
with what was already present in the Glean documentation.

Original document: https://docs.telemetry.mozilla.org/concepts/glean/debug_ping_view.html