### PR TITLE
Add minimal language bindings for C#

### DIFF
--- a/glean-core/csharp/.gitignore
+++ b/glean-core/csharp/.gitignore
@@ -1,0 +1,7 @@
+*.suo
+*.user
+*.pubxml
+
+# Build output
+bin/
+obj/

--- a/glean-core/csharp/csharp.sln
+++ b/glean-core/csharp/csharp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30128.74
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Glean", "csharp\Glean.csproj", "{AC607140-A511-4AAD-A521-A344A94E79CA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3B955DBB-AAF7-4C8B-9F9F-D12743AD314A}
+	EndGlobalSection
+EndGlobal

--- a/glean-core/csharp/csharp/Configuration/Configuration.cs
+++ b/glean-core/csharp/csharp/Configuration/Configuration.cs
@@ -1,0 +1,38 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using Mozilla.Glean.FFI;
+
+namespace Mozilla.Glean
+{
+    public sealed class Configuration
+    {
+        /// <summary>
+        /// The default server pings are sent to.
+        /// </summary>
+        public const string DefaultTelemetryEndpoint = "https://incoming.telemetry.mozilla.org";
+
+        public string serverEndpoint;
+        public string channel;
+        public int? maxEvents;
+
+        /// <summary>
+        /// Configuration for Glean.
+        /// </summary>
+        /// <param name="serverEndpoint"> the server pings are sent to. Please note that this
+        /// is only meant to be changed for tests.</param>
+        /// <param name="channel">the release channel the application is on, if known. This will be
+        /// sent along with all the pings, in the `client_info` section.</param>
+        /// <param name="maxEvents">the number of events to store before the events ping is sent.</param>
+        public Configuration(
+            string serverEndpoint = DefaultTelemetryEndpoint,
+            string channel = null,
+            int? maxEvents = null)
+        {
+            this.serverEndpoint = serverEndpoint;
+            this.channel = channel;
+            this.maxEvents = maxEvents;
+        }
+    }
+}

--- a/glean-core/csharp/csharp/Dispatchers.cs
+++ b/glean-core/csharp/csharp/Dispatchers.cs
@@ -1,0 +1,26 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System;
+
+namespace Mozilla.Glean
+{
+    internal class Dispatchers
+    {
+        internal static void AssertInTestingMode()
+        {
+
+        }
+
+        internal static void LaunchAPI(Action action)
+        {
+            action();
+        }
+
+        internal static void FlushQueuedInitialTasks()
+        {
+
+        }
+    }
+}

--- a/glean-core/csharp/csharp/Glean.cs
+++ b/glean-core/csharp/csharp/Glean.cs
@@ -1,0 +1,176 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using Mozilla.Glean.FFI;
+using System;
+
+namespace Mozilla.Glean
+{
+    /// <summary>
+    /// The Glean Gneral API.
+    /// </summary>
+    public sealed class Glean
+    {
+        // Initialize the singleton using the `Lazy` facilities.
+        private static readonly Lazy<Glean>
+          lazy = new Lazy<Glean>(() => new Glean());
+        public static Glean GleanInstance => lazy.Value;
+
+        private Glean()
+        {
+            // Private constructor to disallow instantiation since
+            // this is meant to be a singleton. It only wires up the
+            // glean-core logging on the Rust side.
+            LibGleanFFI.glean_enable_logging();
+        }
+
+        /// <summary>
+        /// Initialize the Glean SDK.
+        /// 
+        /// This should only be initialized once by the application, and not by
+        /// libraries using the Glean SDK. A message is logged to error and no
+        /// changes are made to the state if initialize is called a more than
+        /// once.
+        /// 
+        /// This method must be called from the main thread.
+        /// </summary>
+        /// <param name="applicationId">The application id to use when sending pings.</param>
+        /// <param name="applicationVersion">The version of the application sending
+        /// Glean data.</param>
+        /// <param name="uploadEnabled">A `bool` that determines whether telemetry is enabled.
+        /// If disabled, all persisted metrics, events and queued pings (except first_run_date)
+        /// are cleared.</param>
+        /// <param name="configuration">A Glean `Configuration` object with global settings</param>
+        /// <param name="dataDir">The path to the Glean data directory.If not provided, uses
+        /// a temporary directory.</param>
+        public void Initialize(
+            string applicationId,
+            string applicationVersion,
+            bool uploadEnabled,
+            Configuration configuration,
+            string dataDir
+            )
+        {
+            Console.WriteLine("Glean.init dir: {0}", dataDir);
+
+            /*
+            // Glean initialization must be called on the main thread, or lifecycle
+            // registration may fail. This is also enforced at build time by the
+            // @MainThread decorator, but this run time check is also performed to
+            // be extra certain.
+            ThreadUtils.assertOnUiThread()
+
+            // In certain situations Glean.initialize may be called from a process other than the main
+            // process.  In this case we want initialize to be a no-op and just return.
+            if (!isMainProcess(applicationContext)) {
+                Log.e(LOG_TAG, "Attempted to initialize Glean on a process other than the main process")
+                return
+            }
+
+            if (isInitialized()) {
+                Log.e(LOG_TAG, "Glean should not be initialized multiple times")
+                return
+            }
+
+            this.applicationContext = applicationContext
+
+            this.configuration = configuration
+            this.httpClient = BaseUploader(configuration.httpClient)
+            this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR)
+
+            setUploadEnabled(uploadEnabled)
+             */
+
+            Dispatchers.LaunchAPI(() => {
+                // TODO: registerPings(Pings)
+
+                LibGleanFFI.FfiConfiguration cfg = new LibGleanFFI.FfiConfiguration
+                {
+                    data_dir = dataDir,
+                    package_name = applicationId,
+                    upload_enabled = uploadEnabled,
+                    max_events = (int)configuration.maxEvents, // TODO: can we pass in null?
+                    delay_ping_lifetime_io = false
+                };
+
+                bool initialized = LibGleanFFI.glean_initialize(cfg) != 0;
+
+                // If initialization of Glean fails we bail out and don't initialize further.
+                if (!initialized)
+                {
+                    return;
+                }
+
+                /* TODO:
+                // If any pings were registered before initializing, do so now.
+                // We're not clearing this queue in case Glean is reset by tests.
+                synchronized(this@GleanInternalAPI) {
+                    pingTypeQueue.forEach { registerPingType(it) }
+                }
+                */
+
+                // If this is the first time ever the Glean SDK runs, make sure to set
+                // some initial core metrics in case we need to generate early pings.
+                // The next times we start, we would have them around already.
+                bool isFirstRun = LibGleanFFI.glean_is_first_run() != 0;
+                if (isFirstRun)
+                {
+                    InitializeCoreMetrics();
+                }
+
+
+                // Deal with any pending events so we can start recording new ones
+                bool pingSubmitted = LibGleanFFI.glean_on_ready_to_submit_pings() != 0;
+
+                // We need to enqueue the PingUploadWorker in these cases:
+                // 1. Pings were submitted through Glean and it is ready to upload those pings;
+                // 2. Upload is disabled, to upload a possible deletion-request ping.
+                if (pingSubmitted || !uploadEnabled)
+                {
+                    //PingUploadWorker.enqueueWorker(applicationContext)
+                    Console.WriteLine("TODO: trigger ping upload now");
+                }
+                /*
+                // Set up information and scheduling for Glean owned pings. Ideally, the "metrics"
+                // ping startup check should be performed before any other ping, since it relies
+                // on being dispatched to the API context before any other metric.
+                metricsPingScheduler = MetricsPingScheduler(applicationContext)
+                metricsPingScheduler.schedule()
+
+                // Check if the "dirty flag" is set. That means the product was probably
+                // force-closed. If that's the case, submit a 'baseline' ping with the
+                // reason "dirty_startup". We only do that from the second run.
+                if (!isFirstRun && LibGleanFFI.INSTANCE.glean_is_dirty_flag_set().toBoolean()) {
+                    submitPingByNameSync("baseline", "dirty_startup")
+                    // Note: while in theory we should set the "dirty flag" to true
+                    // here, in practice it's not needed: if it hits this branch, it
+                    // means the value was `true` and nothing needs to be done.
+                }*/
+
+                // From the second time we run, after all startup pings are generated,
+                // make sure to clear `lifetime: application` metrics and set them again.
+                // Any new value will be sent in newly generated pings after startup.
+                if (!isFirstRun) {
+                    LibGleanFFI.glean_clear_application_lifetime_metrics();
+                    InitializeCoreMetrics();
+                }
+
+                // Signal Dispatcher that init is complete
+                Dispatchers.FlushQueuedInitialTasks();
+                /*
+                // At this point, all metrics and events can be recorded.
+                // This should only be called from the main thread. This is enforced by
+                // the @MainThread decorator and the `assertOnUiThread` call.
+                MainScope().launch {
+                    ProcessLifecycleOwner.get().lifecycle.addObserver(gleanLifecycleObserver)
+                }*/
+            });
+        }
+
+        private void InitializeCoreMetrics()
+        {
+            // TODO:
+        }
+    }
+}

--- a/glean-core/csharp/csharp/Glean.csproj
+++ b/glean-core/csharp/csharp/Glean.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Authors>Mozilla</Authors>
+    <RepositoryUrl>https://github.com/mozilla/glean</RepositoryUrl>
+    <Description>The Glean SDK is a modern approach for a telemetry library by Mozilla.</Description>
+    <Version>0.0.1</Version>
+    <RootNamespace>Mozilla.Glean</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Make sure to pack the glean-core DLL in the final package -->
+    <!-- TODO: pick the appropriate DLL depending on the target -->
+    <Content Include="../../../target/debug/glean_ffi.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>lib\$(TargetFramework)</PackagePath>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/glean-core/csharp/csharp/LibGleanFFI.cs
+++ b/glean-core/csharp/csharp/LibGleanFFI.cs
@@ -1,0 +1,65 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Mozilla.Glean.FFI
+{
+    static class LibGleanFFI
+    {
+        private const string SharedGleanLibrary = "glean_ffi.dll";
+
+        // Define the order of fields as laid out in memory.
+        // **CAUTION**: This must match _exactly_ the definition on the Rust side.
+        //  If this side is changed, the Rust side need to be changed, too.
+        [StructLayout(LayoutKind.Sequential)]
+        internal class FfiConfiguration
+        {
+            public string data_dir;
+            public string package_name;
+            public bool upload_enabled;
+            public Int32 max_events;
+            public bool delay_ping_lifetime_io;
+        }
+
+        // Glean top-level API.
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte glean_initialize(FfiConfiguration cfg);
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_clear_application_lifetime_metrics();
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_set_dirty_flag(byte flag);
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte glean_is_dirty_flag_set();
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_test_clear_all_stores();
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte glean_is_first_run();
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_destroy_glean();
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte glean_on_ready_to_submit_pings();
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_enable_logging();
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_set_upload_enabled(byte flag);
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte glean_is_upload_enabled();
+
+        // TODO: add the rest of the ffi.
+    }
+}

--- a/samples/csharp/csharp.sln
+++ b/samples/csharp/csharp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30128.74
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "csharp", "csharp\csharp.csproj", "{F620BC23-2FE6-4FF8-9DAC-88370F9C9503}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F620BC23-2FE6-4FF8-9DAC-88370F9C9503}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F620BC23-2FE6-4FF8-9DAC-88370F9C9503}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F620BC23-2FE6-4FF8-9DAC-88370F9C9503}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F620BC23-2FE6-4FF8-9DAC-88370F9C9503}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {41D77231-180B-4E9D-B083-20E700942C81}
+	EndGlobalSection
+EndGlobal

--- a/samples/csharp/csharp/Program.cs
+++ b/samples/csharp/csharp/Program.cs
@@ -1,0 +1,28 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using Mozilla.Glean;
+using System;
+using System.IO;
+using static Mozilla.Glean.Glean;
+
+namespace csharp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string gleanDataDir = Directory.GetCurrentDirectory() + "\\glean_data";
+            Console.WriteLine("Adding Glean data to {0}", gleanDataDir);
+
+            GleanInstance.Initialize(
+                applicationId: "org.mozilla.glean.csharp.sample",
+                applicationVersion: "1.0",
+                uploadEnabled: true,
+                configuration: new Configuration(maxEvents: 37),
+                dataDir: gleanDataDir
+                );
+        }
+    }
+}

--- a/samples/csharp/csharp/csharp.csproj
+++ b/samples/csharp/csharp/csharp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Glean" Version="0.0.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR sets up the language binding structure and provides a minimal API surface to use them.

It additionally commits a sample application to test the bindings.

The plan:

- attempt to merge this PR, keeping followin PRs small and focused;
- mockup most of the system;
- scale up with other devs after the first metric type is merged.

Things it does:

- Picks the `glean_ffi.dll` and allows to call glean-core functions;
- Defines the project structure;
- Initializes Glean and wires up Rust logging.
- Adds a sample c# application that uses nuGet to consume the library.

This PR will **NOT** cover:

- adding a proper logging system;
- adding a new metric type;
- initialize core metrics;
- properly initialize Glean;
- add test coverage for the basic functionalities;
- make sure it picks the right dll on macos