### PR TITLE
Verify if *only* deletion request was sent on android sample app tests

### DIFF
--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BaselinePingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BaselinePingTest.kt
@@ -47,7 +47,7 @@ class BaselinePingTest {
         device.pressHome()
 
         // Validate the received data.
-        val baselinePing = waitForPingContent("baseline", server)!!
+        val baselinePing = waitForPingContent("baseline", "background", server)!!
 
         val metrics = baselinePing.getJSONObject("metrics")
 

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
@@ -43,13 +43,17 @@ class DeletionRequestPingTest {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         device.waitForIdle()
 
-        // Disable upload by toggline the switch
+        // Wait for any ping to make sure there are no pending requests before going forward
+        waitForPingContent("", server)
+
+        // Disable upload by toggling the switch
         onView(withId(R.id.uploadSwitch))
             .perform(closeSoftKeyboard())
             .perform(click())
 
-        // We might receive previous baseline or events ping, let's ignore that
-        val deletionPing = waitForPingContent("deletion-request", server)!!
+        // We must get the deletion request on the first attempt,
+        // no other ping should be sent after disabling upload
+        val deletionPing = waitForPingContent("deletion-request", server, 1)!!
 
         // Validate the received data.
 

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
@@ -44,7 +44,7 @@ class DeletionRequestPingTest {
         device.waitForIdle()
 
         // Wait for any ping to make sure there are no pending requests before going forward
-        waitForPingContent("", server)
+        waitForPingContent("", null, server)
 
         // Disable upload by toggling the switch
         onView(withId(R.id.uploadSwitch))
@@ -53,7 +53,7 @@ class DeletionRequestPingTest {
 
         // We must get the deletion request on the first attempt,
         // no other ping should be sent after disabling upload
-        val deletionPing = waitForPingContent("deletion-request", server, 1)!!
+        val deletionPing = waitForPingContent("deletion-request", null, server, 1)!!
 
         // Validate the received data.
 
@@ -68,7 +68,7 @@ class DeletionRequestPingTest {
         device.pressHome()
 
         // Validate the received data.
-        val baselinePing = waitForPingContent("baseline", server)!!
+        val baselinePing = waitForPingContent("baseline", null, server)!!
 
         clientInfo = baselinePing.getJSONObject("client_info")
 

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
@@ -10,8 +10,10 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.json.JSONObject
+import java.io.BufferedReader
 import java.io.ByteArrayInputStream
 import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
 
 /**
  * Create a mock webserver that accepts all requests and replies with "OK".
@@ -28,6 +30,32 @@ internal fun createMockWebServer(): MockWebServer {
 }
 
 /**
+ * Decompress the GZIP returned by the glean-core layer.
+ *
+ * @param data the gzipped [ByteArray] to decompress
+ * @return a [String] containing the uncompressed data.
+ */
+fun decompressGZIP(data: ByteArray): String {
+    return GZIPInputStream(ByteArrayInputStream(data)).bufferedReader().use(BufferedReader::readText)
+}
+
+/**
+ * Convenience method to get the body of a request as a String.
+ * The UTF8 representation of the request body will be returned.
+ * If the request body is gzipped, it will be decompressed first.
+ *
+ * @return a [String] containing the body of the request.
+ */
+fun RecordedRequest.getPlainBody(): String {
+    return if (this.getHeader("Content-Encoding") == "gzip") {
+        val bodyInBytes = this.body.readByteArray()
+        decompressGZIP(bodyInBytes)
+    } else {
+        this.body.readUtf8()
+    }
+}
+
+/**
  * Waits for ping with the given name to be received
  * in the test ping server.
  *
@@ -36,6 +64,7 @@ internal fun createMockWebServer(): MockWebServer {
  */
 fun waitForPingContent(
     pingName: String,
+    pingReason: String?,
     server: MockWebServer,
     maxAttempts: Int = 3
 ): JSONObject?
@@ -46,11 +75,17 @@ fun waitForPingContent(
         val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
         val docType = request.path.split("/")[3]
         if (pingName == docType) {
-            return if (request.getHeader("Content-Encoding") == "gzip") {
-                val bodyInBytes = ByteArrayInputStream(request.body.readByteArray()).readBytes()
-                JSONObject(decompressGZIP(bodyInBytes))
-            } else {
-                JSONObject(request.body.readUtf8())
+            if (pingName == docType) {
+                val parsedPayload = JSONObject(request.getPlainBody())
+                if (pingReason == null) {
+                    return parsedPayload
+                }
+
+                // If we requested a specific ping reason, look for it.
+                val reason = parsedPayload.getJSONObject("ping_info").getString("reason")
+                if (reason == pingReason) {
+                    return parsedPayload
+                }
             }
         }
     } while (attempts < maxAttempts)

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
@@ -73,7 +73,7 @@ fun waitForPingContent(
     var attempts = 0
     do {
         attempts += 1
-        val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: continue
+        val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
         val docType = request.path.split("/")[3]
         if (pingName == docType) {
             parsedPayload = JSONObject(request.getPlainBody())

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
@@ -75,17 +75,15 @@ fun waitForPingContent(
         val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
         val docType = request.path.split("/")[3]
         if (pingName == docType) {
-            if (pingName == docType) {
-                val parsedPayload = JSONObject(request.getPlainBody())
-                if (pingReason == null) {
-                    return parsedPayload
-                }
+            val parsedPayload = JSONObject(request.getPlainBody())
+            if (pingReason == null) {
+                return parsedPayload
+            }
 
-                // If we requested a specific ping reason, look for it.
-                val reason = parsedPayload.getJSONObject("ping_info").getString("reason")
-                if (reason == pingReason) {
-                    return parsedPayload
-                }
+            // If we requested a specific ping reason, look for it.
+            val reason = parsedPayload.getJSONObject("ping_info").getString("reason")
+            if (reason == pingReason) {
+                return parsedPayload
             }
         }
     } while (attempts < maxAttempts)

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
@@ -43,7 +43,7 @@ fun waitForPingContent(
     var attempts = 0
     do {
         attempts += 1
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
         val docType = request.path.split("/")[3]
         if (pingName == docType) {
             return if (request.getHeader("Content-Encoding") == "gzip") {

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/SharedTestUtils.kt
@@ -69,24 +69,25 @@ fun waitForPingContent(
     maxAttempts: Int = 3
 ): JSONObject?
 {
+    var parsedPayload: JSONObject? = null
     var attempts = 0
     do {
         attempts += 1
-        val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
+        val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: continue
         val docType = request.path.split("/")[3]
         if (pingName == docType) {
-            val parsedPayload = JSONObject(request.getPlainBody())
+            parsedPayload = JSONObject(request.getPlainBody())
             if (pingReason == null) {
-                return parsedPayload
+                break
             }
 
             // If we requested a specific ping reason, look for it.
             val reason = parsedPayload.getJSONObject("ping_info").getString("reason")
             if (reason == pingReason) {
-                return parsedPayload
+                break
             }
         }
     } while (attempts < maxAttempts)
 
-    return null
+    return parsedPayload
 }


### PR DESCRIPTION
Fixes [Bug 1620673](https://bugzilla.mozilla.org/show_bug.cgi?id=1620673)

As an extra, I noticed the `validateBaselinePing` integration test was also failing and fixed it. It was a known issue of getting the `foreground` ping instead of the `background` one, which doesn't have a `duration` field and fails the test. This has been fixed in a-c and fenix already.