### PR TITLE
CI: Pin Rust to 1.43.0 for Python builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,8 @@ commands:
   build-windows-i686-wheel:
     steps:
       - install-rustup
-      - setup-rust-toolchain
+      - setup-rust-toolchain:
+          rust-version: "1.43.0"
       - install-mingw
       - run:
           name: Install Python development tools for host


### PR DESCRIPTION
Something in 1.44.0 (released 2020-06-04) broke the Windows build,
resulting in an error like:

    undefined reference to `_Unwind_Resume'

We already build with `panic=abort`.
For now this will reenable working builds until we figure out what's
broken.