### PR TITLE
Solving InvalidOperationException when assigning a null max_events in C# config

### DIFF
--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -90,7 +90,7 @@ namespace Mozilla.Glean
                     data_dir = dataDir,
                     package_name = applicationId,
                     upload_enabled = uploadEnabled,
-                    max_events = (int)configuration.maxEvents, // TODO: can we pass in null?
+                    max_events = configuration.maxEvents ?? null,
                     delay_ping_lifetime_io = false
                 };
 

--- a/glean-core/csharp/Glean/LibGleanFFI.cs
+++ b/glean-core/csharp/Glean/LibGleanFFI.cs
@@ -21,7 +21,7 @@ namespace Mozilla.Glean.FFI
             public string data_dir;
             public string package_name;
             public bool upload_enabled;
-            public Int32 max_events;
+            public Int32? max_events;
             public bool delay_ping_lifetime_io;
         }
 


### PR DESCRIPTION
STR:
```
GleanInstance.Initialize("fxrpc",  "0.1.1",  true, 
  new Configuration(Configuration.DefaultTelemetryEndpoint, null, null), "data");
```

It will have InvalidOperationException at https://github.com/mozilla/glean/blob/b949d4927a1e86b4ba469653cc62fc52eecf6add/glean-core/csharp/Glean/Glean.cs#L93
