### PR TITLE
Rename default branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
       - run:
           name: Check vendored schema for upstream updates
           command: |
-            bin/update-schema.sh master
+            bin/update-schema.sh HEAD
             if ! git diff --exit-code HEAD -- glean-core/preview/tests/glean.1.schema.json; then
               echo "===================================="
               echo "Latest schema from upstream changed."
@@ -1082,17 +1082,17 @@ workflows:
       - Rust tests - minimum version
       - C tests
       - Android tests
-      # iOS jobs run only on master by default, see below for manual-approved jobs
+      # iOS jobs run only on main by default, see below for manual-approved jobs
       - iOS build and test:
           filters:
             branches:
-              only: master
+              only: main
       - iOS integration test:
           requires:
             - iOS build and test
           filters:
             branches:
-              only: master
+              only: main
       - Python 3_5 tests
       - Python 3_5 tests minimum dependencies
       - Python 3_6 tests
@@ -1121,7 +1121,7 @@ workflows:
             - iOS build and test
           filters:
             branches:
-              only: master
+              only: main
 
   # iOS jobs require manual approval on PRs
   iOS:
@@ -1130,19 +1130,19 @@ workflows:
           type: approval
           filters:
             branches:
-              ignore: master
+              ignore: main
       - iOS build and test:
           requires:
             - hold
           filters:
             branches:
-              ignore: master
+              ignore: main
       - iOS integration test:
           requires:
             - iOS build and test
           filters:
             branches:
-              ignore: master
+              ignore: main
 
   release:
     jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v31.0.2...master)
+[Full changelog](https://github.com/mozilla/glean/compare/v31.0.2...main)
 
 * General:
     * The `regex` crate is no longer required, making the Glean binary smaller.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![License: MPL-2.0](https://img.shields.io/crates/l/glean-core)](https://github.com/mozilla/glean/blob/main/LICENSE)
 [![The Glean SDK book](https://img.shields.io/badge/Docs-Glean%20SDK-brightgreen)][book]
 [![Build Status](https://img.shields.io/circleci/build/github/mozilla/glean/main)](https://circleci.com/gh/mozilla/glean)
-[![Code coverage](https://img.shields.io/codecov/c/github/mozilla/glean)](https://codecov.io/gh/mozilla/glean)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![Glean logo](docs/glean.jpeg)
 
 [![glean-core on crates.io](http://meritbadge.herokuapp.com/glean-core)](https://crates.io/crates/glean-core)
-[![License: MPL-2.0](https://img.shields.io/crates/l/glean-core)](https://github.com/mozilla/glean/blob/master/LICENSE)
+[![License: MPL-2.0](https://img.shields.io/crates/l/glean-core)](https://github.com/mozilla/glean/blob/main/LICENSE)
 [![The Glean SDK book](https://img.shields.io/badge/Docs-Glean%20SDK-brightgreen)][book]
-[![Build Status](https://img.shields.io/circleci/build/github/mozilla/glean/master)](https://circleci.com/gh/mozilla/glean)
+[![Build Status](https://img.shields.io/circleci/build/github/mozilla/glean/main)](https://circleci.com/gh/mozilla/glean)
 [![Code coverage](https://img.shields.io/codecov/c/github/mozilla/glean)](https://codecov.io/gh/mozilla/glean)
 
 ## Documentation

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -129,7 +129,7 @@ run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 FILE=CHANGELOG.md
 run $SED -i.bak -E \
     -e "s/# Unreleased changes/# v${NEW_VERSION} (${DATE})/" \
-    -e "s/\.\.\.master/...v${NEW_VERSION}/" \
+    -e "s/\.\.\.main/...v${NEW_VERSION}/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
@@ -138,7 +138,7 @@ if [ "$DOIT" = y ]; then
     cat > "${WORKSPACE_ROOT}/${FILE}" <<EOL
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v${NEW_VERSION}...master)
+[Full changelog](https://github.com/mozilla/glean/compare/v${NEW_VERSION}...main)
 
 ${CHANGELOG}
 EOL

--- a/bin/spellcheck.sh
+++ b/bin/spellcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copied, and modified, from the Rust Cookbook.
-# https://github.com/rust-lang-nursery/rust-cookbook/blob/master/ci/spellcheck.sh
+# https://github.com/rust-lang-nursery/rust-cookbook/blob/HEAD/ci/spellcheck.sh
 
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to the Glean SDK
 
-Anyone is welcome to help with the Glean SDK project. Feel free to get in touch with other community members on `chat.mozilla.org` 
+Anyone is welcome to help with the Glean SDK project. Feel free to get in touch with other community members on `chat.mozilla.org`
 or through issues on GitHub or Bugzilla.
 
 - Matrix: [#glean channel on chat.mozilla.org](https://chat.mozilla.org/#/room/#glean:mozilla.org)
@@ -34,7 +34,7 @@ make test-rust
 ```
 
 If you plan to work on the Android component bindings, you should also review
-the instructions for [setting up an Android build environment](https://github.com/mozilla/glean/blob/master/docs/dev/setup-android-build-environment.md)
+the instructions for [setting up an Android build environment](dev/android/setup-android-build-environment.md).
 
 To run all Kotlin tests:
 
@@ -74,7 +74,7 @@ Before submitting a PR:
 
 When submitting a PR:
 - You agree to license your code under the project's open source license ([MPL 2.0](https://mozilla.org/MPL/2.0/)).
-- Base your branch off the current `master` (see below for an example workflow).
+- Base your branch off the current `main`.
 - Add both your code and new tests if relevant.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 
@@ -84,7 +84,7 @@ This project is production Mozilla code and subject to our
 [engineering practices and quality standards](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Committing_Rules_and_Responsibilities).
 Every patch must be peer reviewed by a member of the Glean core team.
 
-Reviewers are defined in the [CODEOWNERS](https://github.com/mozilla/glean/blob/master/.github/CODEOWNERS) file
+Reviewers are defined in the [CODEOWNERS](https://github.com/mozilla/glean/blob/main/.github/CODEOWNERS) file
 and are automatically added for every pull request.
 Every pull request needs to be approved by at least one of these people before landing.
 

--- a/docs/dev/android/development-with-android-components.md
+++ b/docs/dev/android/development-with-android-components.md
@@ -21,7 +21,7 @@ git clone https://github.com/mozilla-mobile/android-components
 By default when building Android Components using gradle, the gradle-cargo plugin will compile Glean for every possible platform,
 which might end up in failures.
 You can customize which targets are built in `glean/local.properties`
-([more information](https://github.com/ncalexan/rust-android-gradle/blob/master/README.md#specifying-local-targets)):
+([more information](https://github.com/ncalexan/rust-android-gradle/blob/HEAD/README.md#specifying-local-targets)):
 
 ```
 # For physical devices:
@@ -76,6 +76,6 @@ Other tests like `:service-glean:testDebugUnitTest` or `:support-sync-telemetry:
 ## Notes
 
 This document is based on the equivalent documentation for application-services:
-[Development with the Reference Browser](https://github.com/mozilla/application-services/blob/master/docs/howtos/working-with-reference-browser.md)
+[Development with the Reference Browser](https://github.com/mozilla/application-services/blob/HEAD/docs/howtos/working-with-reference-browser.md)
 
 1. Transitive substitutions (as shown above) work but require newer Gradle versions (4.10+).

--- a/docs/dev/android/locally-published-components-in-fenix.md
+++ b/docs/dev/android/locally-published-components-in-fenix.md
@@ -91,7 +91,7 @@ You should now be able to build and run Fenix (assuming you could before all thi
 ## Notes
 
 This document is based on the equivalent documentation for application-services:
-[Using locally-published components in Fenix](https://github.com/mozilla/application-services/blob/master/docs/howtos/locally-published-components-in-fenix.md)
+[Using locally-published components in Fenix](https://github.com/mozilla/application-services/blob/HEAD/docs/howtos/locally-published-components-in-fenix.md)
 
 ---
 
@@ -101,8 +101,8 @@ so we avoid it.
 Additionally, while the `$N` we have used in our running example has matched
 (e.g. all of the identifiers ended in `-TESTING1`, this is not required, so long as you match everything up correctly at the end).
 
-[glean-yaml]: https://github.com/mozilla/glean/blob/master/.buildconfig.yml#L1
-[android-components-yaml]: https://github.com/mozilla-mobile/android-components/blob/master/.buildconfig.yml#L1
+[glean-yaml]: https://github.com/mozilla/glean/blob/main/.buildconfig.yml#L1
+[android-components-yaml]: https://github.com/mozilla-mobile/android-components/blob/HEAD/.buildconfig.yml#L1
 [android-components-deps]: https://github.com/mozilla-mobile/android-components/blob/50a2f28027f291bf1c6056d42b55e75ba3c050db/buildSrc/src/main/java/Dependencies.kt#L32
 [android-components-build-gradle]: https://github.com/mozilla-mobile/android-components/blob/b98206cf8de818499bdc87c00de942a41f8aa2fb/build.gradle#L28
 [fenix-build-gradle-1]: https://github.com/mozilla-mobile/fenix/blob/f897c2e295cd1b97d4024c7a9cb45dceb7a2fa89/build.gradle#L26

--- a/docs/dev/core/internal/payload.md
+++ b/docs/dev/core/internal/payload.md
@@ -7,7 +7,7 @@ This is less relevant for end users of the Glean SDK.
 ## JSON Schema
 
 Glean's ping payloads have a formal JSON schema defined in the [mozilla-pipeline-schemas](https://github.com/mozilla-services/mozilla-pipeline-schemas/) project.
-It is written as a set of [templates](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/master/templates/include/glean) that are expanded by the mozilla-pipeline-schemas build infrastructure into a [fully expanded schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/glean/baseline/baseline.1.schema.json).
+It is written as a set of [templates](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/HEAD/templates/include/glean) that are expanded by the mozilla-pipeline-schemas build infrastructure into a [fully expanded schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/HEAD/schemas/glean/baseline/baseline.1.schema.json).
 
 ## Metric types
 
@@ -190,7 +190,7 @@ Each event object has the following keys:
 ]
 ```
 
-Also see [the JSON schema for events](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/templates/include/glean/event.1.schema.json).
+Also see [the JSON schema for events](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/HEAD/templates/include/glean/event.1.schema.json).
 
 To avoid losing events when the application is killed by the operating system, events are queued on disk as they are recorded.
 When the application starts up again, there is no good way to determine if the device has rebooted since the last run and therefore any timestamps recorded in the new run could not be guaranteed to be consistent with those recorded in the previous run.

--- a/docs/dev/cut-a-new-release.md
+++ b/docs/dev/cut-a-new-release.md
@@ -30,16 +30,16 @@ The development & release process roughly follows the [GitFlow model](https://nv
 
 Releases can only be done by one of the Glean maintainers.
 
-* Main development branch: `master`
+* Main development branch: `main`
 * Main release branch: `release`
 * Specific release branch: `release-vX.Y.Z`
 * Hotfix branch: `hotfix-X.Y.(Z+1)`
 
 ### Create a release branch
 
-1. Create a release branch from the `master` branch:
+1. Create a release branch from the `main` branch:
     ```
-    git checkout -b release-v25.0.0 master
+    git checkout -b release-v25.0.0 main
     ```
 2. Update the changelog .
     1. Add any missing important changes under the `Unreleased changes` headline.
@@ -53,7 +53,7 @@ Releases can only be done by one of the Glean maintainers.
     ```
 5. Wait for CI to finish on that branch and ensure it's green: <https://circleci.com/gh/mozilla/glean/tree/release-v25.0.0>
 6. Apply additional commits for bug fixes to this branch.
-    * Adding large new features here is strictly prohibited. They need to go to the `master` branch and wait for the next release.
+    * Adding large new features here is strictly prohibited. They need to go to the `main` branch and wait for the next release.
 
 ### Finish a release branch
 
@@ -85,9 +85,9 @@ When CI has finished and is green for your specific release branch, you are read
     cd ffi
     cargo publish --verbose
     ```
-7. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla/glean/compare/master...release-v25.0.0?expand=1>
+7. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla/glean/compare/main...release-v25.0.0?expand=1>
     * This is important so that no changes are lost.
-    * This might have merge conflicts with the `master` branch, which you need to fix before it is merged.
+    * This might have merge conflicts with the `main` branch, which you need to fix before it is merged.
 8. Once the above pull request lands, delete the specific release branch.
 
 ## Hotfix release for latest version
@@ -145,9 +145,9 @@ When CI has finished and is green for your hotfix branch, you are ready to cut a
     cd ffi
     cargo publish --verbose
     ```
-7. Send a pull request to merge back the hotfix branch to the development branch: <https://github.com/mozilla/glean/compare/master...hotfix-v25.0.1?expand=1>
+7. Send a pull request to merge back the hotfix branch to the development branch: <https://github.com/mozilla/glean/compare/main...hotfix-v25.0.1?expand=1>
     * This is important so that no changes are lost.
-    * This might have merge conflicts with the `master` branch, which you need to fix before it is merged.
+    * This might have merge conflicts with the `main` branch, which you need to fix before it is merged.
 8. Once the above pull request lands, delete the hotfix branch.
 
 ## Hotfix release for previous version
@@ -201,9 +201,9 @@ If you need to release a hotfix for a previously released version (that is: not 
     cd ffi
     cargo publish --verbose
     ```
-7. Send a pull request to merge back any bug fixes to the development branch: <https://github.com/mozilla/glean/compare/master...support/v24.0?expand=1>
+7. Send a pull request to merge back any bug fixes to the development branch: <https://github.com/mozilla/glean/compare/main...support/v24.0?expand=1>
     * This is important so that no changes are lost.
-    * This might have merge conflicts with the `master` branch, which you need to fix before it is merged.
+    * This might have merge conflicts with the `main` branch, which you need to fix before it is merged.
 8. Once the above pull request lands, delete the support branch.
 
 ## Upgrading android-components to a new version of Glean
@@ -223,7 +223,7 @@ After following one of the above instructions to make a Glean SDK release:
 
    - The Glean version is updated in the `mozilla_glean` variable in the [`buildSrc/src/main/java/Dependencies.kt`](https://github.com/mozilla-mobile/android-components/blob/69546999739ab19d21425e9a98e107e438a3f905/buildSrc/src/main/java/Dependencies.kt#L32) file.
 
-   - The relevant parts of the Glean changelog copied into the top part of the [`android-components` changelog](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
+   - The relevant parts of the Glean changelog copied into the top part of the [`android-components` changelog](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md).
      This involves copying the Android-specific changes and the general changes to Glean, but can omit other platform-specific changes.
 
 **IMPORTANT:** Until the [Glean Gradle plugin work is complete](https://bugzilla.mozilla.org/show_bug.cgi?id=1592947), all downstream consumers of android-components will also need to update their version of Glean to match the version used in android-components so that their unit tests can run correctly.

--- a/docs/dev/ios/debug-glean-on-ios.md
+++ b/docs/dev/ios/debug-glean-on-ios.md
@@ -9,10 +9,10 @@ Since Glean is consumed through [Carthage](https://github.com/Carthage/Carthage)
 For consuming the latest version of Glean, the Cartfile contents would include the following line:
 
 ```
-github "mozilla/glean" "master"
+github "mozilla/glean" "main"
 ```
 
-This will fetch and compile Glean from the [mozilla/glean GitHub](https://github.com/mozilla/glean/) repository from the "master" branch.
+This will fetch and compile Glean from the [mozilla/glean GitHub](https://github.com/mozilla/glean/) repository from the "main" branch.
 
 ## Building against a specific release of Glean
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -73,7 +73,7 @@ and click on the arrow in the left margin next to the test.
 
 ## Testing in CI
 
-We run multiple tests on CI for every Pull Request and every commit to the `master` branch.
+We run multiple tests on CI for every Pull Request and every commit to the `main` branch.
 These include:
 
 * Full Android tests

--- a/docs/user/adding-glean-to-your-project.md
+++ b/docs/user/adding-glean-to-your-project.md
@@ -22,7 +22,7 @@ Products using the Glean SDK to collect telemetry **must**:
 
 Glean is published on [maven.mozilla.org](https://maven.mozilla.org/).
 To use it, you need to add the following to your project's top-level build file,
-in the `allprojects` block (see e.g. [Glean's own `build.gradle`](https://github.com/mozilla/glean/blob/master/build.gradle)):
+in the `allprojects` block (see e.g. [Glean's own `build.gradle`](https://github.com/mozilla/glean/blob/main/build.gradle)):
 
 ```Groovy
 repositories {
@@ -134,7 +134,7 @@ To learn more, see [adding new metrics](adding-new-metrics.md).
 
 In order for the Glean SDK to generate an API for your metrics, two Gradle plugins must be included in your build:
 
-- The [Glean Gradle plugin](https://github.com/mozilla/glean/tree/master/gradle-plugin/)
+- The [Glean Gradle plugin](https://github.com/mozilla/glean/tree/main/gradle-plugin/)
 - JetBrains' [Python envs plugin](https://github.com/JetBrains/gradle-python-envs/)
 
 The Glean Gradle plugin is distributed through Mozilla's Maven, so we need to tell your build where to look for it by adding the following to the top of your `build.gradle`:

--- a/docs/user/instrument-android-crashes-example.md
+++ b/docs/user/instrument-android-crashes-example.md
@@ -6,7 +6,7 @@ basic strategy for instrumenting an Android application with crash telemetry usi
 **Note:**  This is a _very_ simple example of instrumenting crashes using the Glean SDK.  There will be challenges to
 using this approach in a production application that should be considered.  For instance, when an app crashes it can be in an
 unknown state and may not be able to do things like upload data to a server.  The recommended way of instrumenting crashes with
-Android Components is called [lib-crash](https://github.com/mozilla-mobile/android-components/tree/master/components/lib/crash), which takes into consideration things like multiple processes and persistence.
+Android Components is called [lib-crash](https://github.com/mozilla-mobile/android-components/tree/HEAD/components/lib/crash), which takes into consideration things like multiple processes and persistence.
 
 ## Before You Start
 
@@ -67,7 +67,7 @@ is important to note here that it has a value of `- crash`.  This means that the
 ping named `crash` (which hasn't been created yet).  Finally, note the `extra_keys` field which has two keys defined, `cause`
 and `message`.  This allows for sending additional information along with the event to be associated with these keys.
 
-**Note:**  For Mozilla applications, a mandatory [data review](https://github.com/mozilla/data-review/blob/master/request.md) is required in order to collect information with the Glean SDK.
+**Note:**  For Mozilla applications, a mandatory [data review](https://github.com/mozilla/data-review/blob/HEAD/request.md) is required in order to collect information with the Glean SDK.
 
 ### Add A Custom Ping
 
@@ -98,7 +98,7 @@ to execute and generate the API files that represent the metric and ping that we
 building any time one of the Glean YAML files has been modified.  
 
 It is recommended that Glean be initialized as early in the application startup as possible, which is why it's good to use a
-custom `Application`, like the Glean Sample App [`GleanApplication.kt`](https://github.com/mozilla/glean/blob/master/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt).
+custom `Application`, like the Glean Sample App [`GleanApplication.kt`](https://github.com/mozilla/glean/blob/main/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt).
 
 Initializing Glean in the `Application.onCreate()` is ideal for this purpose.  Start by adding the import statement to allow
 the usage of the custom ping that was created, adding the following to the top of the file:

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [badges]
-circle-ci = { repository = "mozilla/glean", branch = "master" }
+circle-ci = { repository = "mozilla/glean", branch = "main" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]

--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [badges]
-circle-ci = { repository = "mozilla/glean", branch = "master" }
+circle-ci = { repository = "mozilla/glean", branch = "main" }
 maintenance = { status = "actively-developed" }
 
 [lib]

--- a/glean-core/preview/Cargo.toml
+++ b/glean-core/preview/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [badges]
-circle-ci = { repository = "mozilla/glean", branch = "master" }
+circle-ci = { repository = "mozilla/glean", branch = "main" }
 maintenance = { status = "actively-developed" }
 
 [dependencies.glean-core]

--- a/samples/ios/app/Cartfile
+++ b/samples/ios/app/Cartfile
@@ -1,3 +1,3 @@
 github "httpswift/swifter" ~> 1.4.7
 github "1024jp/GzipSwift" "5.1.1"
-github "mozilla/glean" "master"
+github "mozilla/glean" "main"


### PR DESCRIPTION
This switches all docs and config over to the default branch named "main".
When this lands we need to change the default branch on GitHub to "main": https://github.com/mozilla/glean/settings/branches

For your local checkout the following commands will allow you to fetch the new default branch and delete the old one:

```
git fetch upstream
git checkout main
git branch --delete master
```