### PR TITLE
Add "SetUploadEnabled"

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -68,16 +68,6 @@ class GleanTest {
     }
 
     @Test
-    fun `setting uploadEnabled before initialization should not crash`() {
-        // Can't use resetGlean directly
-        Glean.testDestroyGleanHandle()
-
-        val config = Configuration()
-
-        Glean.initialize(context, true, config)
-    }
-
-    @Test
     fun `getting uploadEnabled before initialization should not crash`() {
         // Can't use resetGlean directly
         Glean.testDestroyGleanHandle()

--- a/glean-core/csharp/Glean/LibGleanFFI.cs
+++ b/glean-core/csharp/Glean/LibGleanFFI.cs
@@ -106,7 +106,7 @@ namespace Mozilla.Glean.FFI
         internal static extern void glean_enable_logging();
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void glean_set_upload_enabled(byte flag);
+        internal static extern void glean_set_upload_enabled(bool flag);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern byte glean_is_upload_enabled();

--- a/glean-core/csharp/GleanTests/GleanTests.cs
+++ b/glean-core/csharp/GleanTests/GleanTests.cs
@@ -2,16 +2,47 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+using System.IO;
 using Xunit;
+using static Mozilla.Glean.Glean;
 
 namespace Mozilla.Glean.Tests
 {
     public class GleanTests
     {
-        [Fact]
-        public void SampleTest()
+        public GleanTests()
         {
-            Assert.True(true);
+            // Get a random test directory just for this single test.
+            string tempDataDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            // In xUnit, the constructor will be called before each test. This
+            // feels like a natural place to initialize / reset Glean.
+            GleanInstance.Reset(
+                applicationId: "org.mozilla.csharp.tests",
+                applicationVersion: "1.0-test",
+                uploadEnabled: true,
+                configuration: new Configuration(),
+                dataDir: tempDataDir
+                );
+        }
+
+        [Fact]
+        public void GettingUploadEnabledBeforeInitShouldNotCrash()
+        {
+            // Can't use resetGlean directly
+            GleanInstance.TestDestroyGleanHandle();
+
+            GleanInstance.SetUploadEnabled(true);
+            Assert.True(GleanInstance.GetUploadEnabled());
+
+            string tempDataDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            GleanInstance.Initialize(
+                applicationId: "org.mozilla.csharp.tests",
+                applicationVersion: "1.0-test",
+                uploadEnabled: true,
+                configuration: new Configuration(),
+                dataDir: tempDataDir
+                );
         }
     }
 }


### PR DESCRIPTION
This adds the two APIs to control upload enabled.

We have no uploader yet, so I had to leave a bunch of TODOs. That's fine, since this already unblock a clean initial integration with our consumers.