### PR TITLE
Bug 1641564: Add same thread safety guarantees as Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.0.2...master)
 
+* Python
+    * Additional safety guarantees for applications that use Python `threading`.
+
 # v31.0.2 (2020-05-29)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.0.1...v31.0.2)


### PR DESCRIPTION
Python isn't as problematic for threading as Kotlin. For one, the GIL means
there's no collections that completely fail when multithreaded. For another,
multithreading is less common due to the GIL. However, there are still logical
race conditions that could occur in a multithreaded application, and this
applies the same `synchronized` annotations that we have in Kotlin to Python to
prevent those.

---

Re-open of #946 -- was closed by accident. Original by @mdboom 