### PR TITLE
Support BooleanMetricType in C# binding.

### DIFF
--- a/glean-core/csharp/Glean/LibGleanFFI.cs
+++ b/glean-core/csharp/Glean/LibGleanFFI.cs
@@ -124,7 +124,6 @@ namespace Mozilla.Glean.FFI
             {
                 if (!this.IsInvalid)
                 {
-                    Console.WriteLine("Freeing string metric type handle");
                     glean_destroy_string_metric(handle);
                 }
 
@@ -160,6 +159,46 @@ namespace Mozilla.Glean.FFI
              Int32 error_type,
              string storage_name
          );
+
+        // Boolean
+
+        /// <summary>
+        /// A handle for the boolean metric type, which performs cleanup.
+        /// </summary>
+        internal sealed class BooleanMetricTypeHandle : BaseGleanHandle
+        {
+            protected override bool ReleaseHandle()
+            {
+                if (!this.IsInvalid)
+                {
+                    glean_destroy_boolean_metric(handle);
+                }
+
+                return true;
+            }
+        }
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern BooleanMetricTypeHandle glean_new_boolean_metric(
+            string category,
+            string name,
+            string[] send_in_pings,
+            Int32 send_in_pings_len,
+            Int32 lifetime,
+            bool disabled
+        );
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_destroy_boolean_metric(IntPtr handle);
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void glean_boolean_set(BooleanMetricTypeHandle metric_id, byte value);
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte glean_boolean_test_get_value(BooleanMetricTypeHandle metric_id, string storage_name);
+
+        [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte glean_boolean_test_has_value(BooleanMetricTypeHandle metric_id, string storage_name);
 
         // Misc
 

--- a/glean-core/csharp/Glean/Metrics/BooleanMetricType.cs
+++ b/glean-core/csharp/Glean/Metrics/BooleanMetricType.cs
@@ -1,0 +1,108 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using Mozilla.Glean.FFI;
+using System;
+
+namespace Mozilla.Glean.Private
+{
+    public sealed class BooleanMetricType
+    {
+        private bool disabled;
+        private string[] sendInPings;
+        private LibGleanFFI.BooleanMetricTypeHandle handle;
+
+        public BooleanMetricType(
+            bool disabled,
+            string category,
+            Lifetime lifetime,
+            string name,
+            string[] sendInPings
+            ) : this(new LibGleanFFI.BooleanMetricTypeHandle(), disabled, sendInPings)
+        {
+            handle = LibGleanFFI.glean_new_boolean_metric(
+                        category: category,
+                        name: name,
+                        send_in_pings: sendInPings,
+                        send_in_pings_len: sendInPings.Length,
+                        lifetime: (int)lifetime,
+                        disabled: disabled);
+        }
+
+        internal BooleanMetricType(
+            LibGleanFFI.BooleanMetricTypeHandle handle,
+            bool disabled,
+            string[] sendInPings
+            )
+        {
+            this.disabled = disabled;
+            this.sendInPings = sendInPings;
+            this.handle = handle;
+        }
+
+        /// <summary>
+        /// Set a boolean value.
+        /// </summary>
+        /// <param name="value"> This is a user defined boolean value.
+        public void Set(bool value)
+        {
+            if (disabled)
+            {
+                return;
+            }
+
+            Dispatchers.LaunchAPI(() => {
+                SetSync(value);
+            });
+        }
+
+        /// <summary>
+        /// Internal only, synchronous API for setting a boolean value.
+        /// </summary>
+        /// <param name="value">This is a user defined boolean value.</param>
+        internal void SetSync(bool value)
+        {
+            LibGleanFFI.glean_boolean_set(this.handle, Convert.ToByte(value));
+        }
+
+
+        /// <summary>
+        /// Tests whether a value is stored for the metric for testing purposes only. This function will
+        /// attempt to await the last task (if any) writing to the the metric's storage engine before
+        /// returning a value.
+        /// </summary>
+        /// <param name="pingName">represents the name of the ping to retrieve the metric for Defaults
+        /// to the first value in `sendInPings`</param>
+        /// <returns>true if metric value exists, otherwise false</returns>
+        public bool TestHasValue(string pingName = null)
+        {
+            Dispatchers.AssertInTestingMode();
+
+            string ping = pingName ?? sendInPings[0];
+            return LibGleanFFI.glean_boolean_test_has_value(this.handle, ping) != 0;
+        }
+
+        /// <summary>
+        /// Returns the stored value for testing purposes only. This function will attempt to await the
+        /// last task (if any) writing to the the metric's storage engine before returning a value.
+        /// @throws [NullPointerException] if no value is stored
+        /// </summary>
+        /// <param name="pingName">represents the name of the ping to retrieve the metric for.
+        /// Defaults to the first value in `sendInPings`</param>
+        /// <returns>value of the stored metric</returns>
+        /// <exception cref="System.NullReferenceException">Thrown when the metric contains no value</exception>
+        public bool TestGetValue(string pingName = null)
+        {
+            Dispatchers.AssertInTestingMode();
+
+            if (!TestHasValue(pingName))
+            {
+                throw new NullReferenceException();
+            }
+
+            string ping = pingName ?? sendInPings[0];
+            return LibGleanFFI.glean_boolean_test_get_value(this.handle, ping) != 0;
+        }
+    }
+}

--- a/glean-core/csharp/GleanTests/Metrics/BooleanMetricTypeTest.cs
+++ b/glean-core/csharp/GleanTests/Metrics/BooleanMetricTypeTest.cs
@@ -1,0 +1,109 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System;
+using System.IO;
+using Xunit;
+using static Mozilla.Glean.Glean;
+
+namespace Mozilla.Glean.Tests.Metrics
+{
+    public class BooleanMetricTypeTest
+    {
+        public BooleanMetricTypeTest()
+        {
+            // Get a random test directory just for this single test.
+            string tempDataDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            // In xUnit, the constructor will be called before each test. This
+            // feels like a natural place to initialize / reset Glean.
+            GleanInstance.Reset(
+	            applicationId: "org.mozilla.csharp.tests",
+                applicationVersion: "1.0-test",
+                uploadEnabled: true,
+                configuration: new Configuration(),
+                dataDir: tempDataDir
+                );
+        }
+
+        [Fact]
+        public void APISavesToStorage()
+        {
+            Private.BooleanMetricType booleanMetric = new Private.BooleanMetricType(
+                category: "telemetry",
+                disabled: false,
+                lifetime: Private.Lifetime.Application,
+                name: "boolean_metric",
+                sendInPings: new string[] { "store1" }
+            );
+
+            // Record two strings of the same type, with a little delay.
+            booleanMetric.Set(true);
+
+            // Check that data was properly recorded.
+            Assert.True(booleanMetric.TestHasValue());
+            Assert.True(booleanMetric.TestGetValue());
+
+            booleanMetric.Set(true);
+
+            // Check that data was properly recorded.
+            Assert.True(booleanMetric.TestHasValue());
+            Assert.True(booleanMetric.TestGetValue());
+        }
+
+        [Fact]
+        public void DisabledstringsMustNotRecordData()
+        {
+            Private.BooleanMetricType booleanMetric = new Private.BooleanMetricType(
+                category: "telemetry",
+                disabled: true,
+                lifetime: Private.Lifetime.Application,
+                name: "boolean_metric",
+                sendInPings: new string[] { "store1" }
+            );
+
+            // Attempt to store the string.
+            booleanMetric.Set(true);
+            // Check that nothing was recorded.
+            Assert.False(booleanMetric.TestHasValue(), "Booleans must not be recorded if they are disabled");
+        }
+
+        [Fact]
+        public void TestGetValueThrows()
+        {
+            Private.BooleanMetricType booleanMetric = new Private.BooleanMetricType(
+                category: "telemetry",
+                disabled: true,
+                lifetime: Private.Lifetime.Application,
+                name: "boolean_metric",
+                sendInPings: new string[] { "store1" }
+            );
+            Assert.Throws<NullReferenceException>(() => booleanMetric.TestGetValue());
+        }
+
+        [Fact]
+        public void APISavesToSecondaryPings()
+        {
+            Private.BooleanMetricType booleanMetric = new Private.BooleanMetricType(
+                category: "telemetry",
+                disabled: false,
+                lifetime: Private.Lifetime.Application,
+                name: "boolean_metric",
+                sendInPings: new string[] { "store1", "store2" }
+            );
+
+            // Record two strings of the same type, with a little delay.
+            booleanMetric.Set(true);
+
+            // Check that data was properly recorded in the second ping.
+            Assert.True(booleanMetric.TestHasValue("store2"));
+            Assert.True(booleanMetric.TestGetValue("store2"));
+
+            booleanMetric.Set(false);
+            // Check that data was properly recorded in the second ping.
+            Assert.True(booleanMetric.TestHasValue("store2"));
+            Assert.False(booleanMetric.TestGetValue("store2"));
+        }
+    }
+}


### PR DESCRIPTION
- [x] Adding BooleanMetricType for Glean C# binding

- [x] Tests for BooleanMetricType for Glean C# binding

---

Re-open of #959 -- that was closed by accident. Original by @daoshengmu. The old PR already had a r+ review, with minimal nits and comments.