### PR TITLE
Drop the version requirement for lifecycle extensions down again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         androidx_core: '1.2.0',
         androidx_espresso: '3.2.0',
         androidx_junit: '1.1.1',
-        androidx_lifecycle_extensions: '2.2.0',
+        androidx_lifecycle_extensions: '2.1.0',
         androidx_test: '1.2.0',
         androidx_work: '2.2.0',
         androidx_uiautomator: '2.2.0',


### PR DESCRIPTION
Partial revert of ce019d2ba11307c7e82af446f7101d3db8ed823d