### PR TITLE
Limit the number of ping upload requests per minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased changes
 
+* General
+    * Add rate limiting capabilities to the upload manager. ([1543612](https://bugzilla.mozilla.org/show_bug.cgi?id=1543612))
+
 [Full changelog](https://github.com/mozilla/glean/compare/v31.1.2...main)
 
 # v31.1.2 (2020-06-23)

--- a/docs/dev/core/internal/upload.md
+++ b/docs/dev/core/internal/upload.md
@@ -19,7 +19,7 @@ sequenceDiagram
     participant Server
 
     Glean wrapper->>Glean core: get_upload_task()
-    Glean core->>Glean wrapper: Task::Upload(task)
+    Glean core->>Glean wrapper: Task::Upload(PingRequest)
     Glean wrapper-->>Server: POST /submit/{task.id}
     Server-->>Glean wrapper: 200 OK
     Glean wrapper->>Glean core: upload_response(200)
@@ -27,9 +27,9 @@ sequenceDiagram
     Glean core->>Glean wrapper: Task::Done
 ```
 
-Glean core will take care of file management, cleanup, rescheduling and throttling[^1].
+Glean core will take care of file management, cleanup, rescheduling and rate limiting[^1].
 
-> [^1] Note: At this point throttling is not implemented. Follow [Bug 1543612](https://bugzilla.mozilla.org/show_bug.cgi?id=1543612) for updates.
+> [^1] Rate limiting is achieved by limiting the amount of times a language binding is allowed to get a `Task::Upload(PingRequest)` from `get_upload_task` in a given time interval. Currently, the default limit is for a maximum of 10 upload tasks every 60 seconds and there are no exposed methods that allow changing this default (follow [Bug 1647630](https://bugzilla.mozilla.org/show_bug.cgi?id=1647630) for updates). If the caller has reached the maximum tasks for the current interval, they will get a `Task::Wait` regardless if there are other `Task::Upload(PingRequest)`s queued.
 
 ## Available APIs
 

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -79,6 +79,9 @@ See [Using the Experiments API](../experiments-api.md) on how to record experime
 ## Ping submission
 
 The pings that the Glean SDK generates are submitted to the Mozilla servers at specific paths, in order to provide additional metadata without the need to unpack the ping payload.
+
+> **Note**: To keep resource usage in check, the Glean SDK allows only up to 10 ping submissions every 60 seconds. There are no exposed methods to change these rate limiting defaults yet, follow [Bug 1647630](https://bugzilla.mozilla.org/show_bug.cgi?id=1647630) for updates.
+
 A typical submission URL looks like
 
   `"<server-address>/submit/<application-id>/<doc-type>/<glean-schema-version>/<document-id>"`
@@ -101,6 +104,7 @@ A pre-defined set of headers is additionally sent along with the submitted ping:
 | `Date` | e.g. `Mon, 23 Jan 2019 10:10:10 GMT+00:00` | Submission date/time in GMT/UTC+0 offset |
 | `X-Client-Type` | `Glean` | Custom header to support handling of Glean pings in the legacy pipeline |
 | `X-Client-Version` | e.g. `0.40.0` | The Glean SDK version, sent as a custom header to support handling of Glean pings in the legacy pipeline |
+
 
 ## Defining foreground and background state
 

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -104,7 +104,7 @@ impl RateLimiter {
     /// The counter should reset if
     ///
     /// 1. It has never started;
-    /// 2. It has been started more than one minute ago;
+    /// 2. It has been started more than the interval time ago;
     /// 3. Something goes wrong while trying to calculate the elapsed time since the last reset.
     fn should_reset(&self) -> bool {
         if self.started.is_none() {
@@ -219,9 +219,12 @@ impl PingUploadManager {
         self.processed_pending_pings.load(Ordering::SeqCst)
     }
 
-    /// Adds rate limiting capability to this upload manager.
+    /// Adds rate limiting capability to this upload manager. The rate limiter
+    /// will limit the amount of calls to `get_upload_task` per interval.
     ///
-    /// The rate limiter will limit the amount of calls to `get_upload_task` per interval.
+    /// Setting will restart count and timer, in case there was a previous rate limiter set
+    /// (e.g. if we have reached the current limit and call this function, we start counting again
+    /// and the caller is allowed to asks for tasks).
     ///
     /// ## Arguments
     ///

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -9,16 +9,12 @@
 //! * Exposes `process_ping_upload_response` API to check the HTTP response from the ping upload
 //!   and either delete the corresponding ping from disk or re-enqueue it for sending.
 
-// !IMPORTANT!
-// Remove the next line when this module's functionality is in the Glean object.
-// This is here just to not have lint error for now.
-#![allow(dead_code)]
-
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use once_cell::sync::OnceCell;
 use serde_json::Value as JsonValue;
@@ -69,6 +65,77 @@ pub fn setup_upload_manager(upload_manager: PingUploadManager) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
+struct RateLimiter {
+    /// The instant the current interval has started.
+    started: Option<Instant>,
+    /// The count for the current interval.
+    count: u32,
+    /// The duration of each interval.
+    interval: Duration,
+    /// The maximum count per interval.
+    max_count: u32,
+}
+
+/// An enum to represent the current state of the RateLimiter.
+#[derive(PartialEq)]
+enum RateLimiterState {
+    /// The RateLimiter has not reached the maximum count and is still incrementing.
+    Incrementing,
+    /// The RateLimiter has reached the maximum count for the  current interval.
+    Throttled,
+}
+
+impl RateLimiter {
+    pub fn new(interval: Duration, max_count: u32) -> Self {
+        Self {
+            started: None,
+            count: 0,
+            interval,
+            max_count,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.started = Some(Instant::now());
+        self.count = 0;
+    }
+
+    /// The counter should reset if
+    ///
+    /// 1. It has never started;
+    /// 2. It has been started more than one minute ago;
+    /// 3. Something goes wrong while trying to calculate the elapsed time since the last reset.
+    fn should_reset(&self) -> bool {
+        if self.started.is_none() {
+            return true;
+        }
+
+        // Safe unwrap, we already stated that `self.started` is not `None` above.
+        let elapsed = self.started.unwrap().elapsed();
+        if elapsed > self.interval {
+            return true;
+        }
+
+        false
+    }
+
+    /// Tries to increment the internal counter
+    /// and returns the current state of the RateLimiter.
+    pub fn get_state(&mut self) -> RateLimiterState {
+        if self.should_reset() {
+            self.reset();
+        }
+
+        if self.count == self.max_count {
+            return RateLimiterState::Throttled;
+        }
+
+        self.count += 1;
+        RateLimiterState::Incrementing
+    }
+}
+
 /// When asking for the next ping request to upload,
 /// the requester may receive one out of three possible tasks.
 ///
@@ -94,6 +161,11 @@ pub struct PingUploadManager {
     directory_manager: PingDirectoryManager,
     /// A flag signaling if we are done processing the pending pings directories.
     processed_pending_pings: Arc<AtomicBool>,
+    /// A ping counter to help rate limit the ping uploads.
+    ///
+    /// To keep resource usage in check,
+    /// we may want to limit the amount of pings sent in a given interval.
+    rate_limiter: Option<RwLock<RateLimiter>>,
 }
 
 impl PingUploadManager {
@@ -139,11 +211,27 @@ impl PingUploadManager {
             queue,
             processed_pending_pings,
             directory_manager,
+            rate_limiter: None,
         }
     }
 
     fn has_processed_pings_dir(&self) -> bool {
         self.processed_pending_pings.load(Ordering::SeqCst)
+    }
+
+    /// Adds rate limiting capability to this upload manager.
+    ///
+    /// The rate limiter will limit the amount of calls to `get_upload_task` per interval.
+    ///
+    /// ## Arguments
+    ///
+    /// * `interval` - the amount of seconds in each rate limiting window.
+    /// * `max_tasks` - the maximum amount of task requests allowed per interval.
+    pub fn set_rate_limiter(&mut self, interval: u64, max_tasks: u32) {
+        self.rate_limiter = Some(RwLock::new(RateLimiter::new(
+            Duration::from_secs(interval),
+            max_tasks,
+        )));
     }
 
     /// Creates a `PingRequest` and adds it to the queue.
@@ -195,8 +283,20 @@ impl PingUploadManager {
             .queue
             .write()
             .expect("Can't write to pending pings queue.");
-        match queue.pop_front() {
+        match queue.front() {
             Some(request) => {
+                if let Some(rate_limiter) = &self.rate_limiter {
+                    let mut rate_limiter = rate_limiter
+                        .write()
+                        .expect("Can't write to the rate limiter.");
+                    if rate_limiter.get_state() == RateLimiterState::Throttled {
+                        log::info!(
+                            "Tried getting an upload task, but we are throttled at the moment."
+                        );
+                        return PingUploadTask::Wait;
+                    }
+                }
+
                 log::info!(
                     "New upload task with id {} (path: {})",
                     request.document_id,
@@ -211,7 +311,7 @@ impl PingUploadManager {
                     }
                 }
 
-                PingUploadTask::Upload(request)
+                PingUploadTask::Upload(queue.pop_front().unwrap())
             }
             None => {
                 log::info!("No more pings to upload! You are done.");
@@ -438,6 +538,50 @@ mod test {
 
         // Verify that after all requests are returned, none are left
         assert_eq!(upload_manager.get_upload_task(false), PingUploadTask::Done);
+    }
+
+    #[test]
+    fn test_limits_the_number_of_pings_when_there_is_rate_limiting() {
+        // Create a new upload_manager
+        let dir = tempfile::tempdir().unwrap();
+        let mut upload_manager = PingUploadManager::new(dir.path(), false);
+
+        // Add a rate limiter to the upload mangager with max of 10 pings every 3 seconds.
+        let secs_per_interval = 3;
+        let max_pings_per_interval = 10;
+        upload_manager.set_rate_limiter(secs_per_interval, 10);
+
+        // Wait for processing of pending pings directory to finish.
+        while upload_manager.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        // Enqueue a ping multiple times
+        for _ in 0..max_pings_per_interval {
+            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}));
+        }
+
+        // Verify a request is returned for each submitted ping
+        for _ in 0..max_pings_per_interval {
+            match upload_manager.get_upload_task(false) {
+                PingUploadTask::Upload(_) => {}
+                _ => panic!("Expected upload manager to return the next request!"),
+            }
+        }
+
+        // Enqueue just one more ping.
+        // We should still be within the default rate limit time.
+        upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}));
+
+        // Verify that we are indeed told to wait because we are at capacity
+        assert_eq!(PingUploadTask::Wait, upload_manager.get_upload_task(false));
+
+        thread::sleep(Duration::from_secs(secs_per_interval));
+
+        match upload_manager.get_upload_task(false) {
+            PingUploadTask::Upload(_) => {}
+            _ => panic!("Expected upload manager to return the next request!"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Related to [Bug 1543612](https://bugzilla.mozilla.org/show_bug.cgi?id=1543612)

I wanted to get some feedback on my approach to this problem before I continued. My goal here was to try and replicate [what Firefox does to rate limit ping uploads](https://searchfox.org/mozilla-central/rev/4bb2401ecbfce89af06fb2b4d0ea3557682bd8ff/toolkit/components/telemetry/app/TelemetrySend.jsm#84), specifically:
> Only allow up to 10 ping uploads per minute.

This turned out to be tricky. The challenges on the current implementation and how I decided to solve them are:
- It doesn't really know exactly when the ping is uploaded.
   - My solution here was to ignore this fact and just try to limit the number of times `get_upload_task` can be called per minute.
- It sends pings to upload one at a time, not in batches.
   - I created a counter to know how many pings have been sent out in the past minute.

NOTE: I am aware this breaks the ffi code and all the bindings, I'll deal with that after.