### PR TITLE
Run cbindgen on stable rust (but pretend it's nightly)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,8 +309,7 @@ jobs:
     steps:
       - checkout
       - skip-if-doc-only
-      - setup-rust-toolchain:
-          rust-version: "nightly"
+      - setup-rust-toolchain
       - run:
           name: FFI header consistency check
           command: |

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ android-emulator: ## Start the Android emulator with a predefined image
 .PHONY: android-emulator
 
 cbindgen: ## Regenerate the FFI header file
-	RUSTUP_TOOLCHAIN=nightly \
+	RUSTC_BOOTSTRAP=1 \
 	cbindgen glean-core/ffi --lockfile Cargo.lock -o glean-core/ffi/glean.h
 	cp glean-core/ffi/glean.h glean-core/ios/Glean/GleanFfi.h
 .PHONY: cbindgen


### PR DESCRIPTION
`RUSTC_BOOTSTRAP` turns a stable compiler into pretending it is nightly,
unlocking nightly-only features.
It shouldn't be used in a normal build, ever.

But here we _only_ need it for some special nightly-only output flags
for rustc, as used by cbindgen, to determine some metadata about the
crates it looks at.

A recent cargo nightly regression caused that to fail, so this will try
out if we can depend on (pseudo-)stable instead.