### PR TITLE
Add brief overview section on book's main page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,22 @@ To contact us you can:
 
 The source code is available [on GitHub](https://github.com/mozilla/glean/).
 
-## License
+## Using this book
 
-This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+This book is divided into 3 main chapters:
+
+### [Using the Glean SDK](user/index.html)
+
+If you want to use the Glean SDK to report data then this is the section you should read.
+It explains the first steps from integrating Glean into your project,
+contains details about all available metric types
+and how to do send your own custom pings.
+
+### [Metrics collected by the Glean SDK](user/collected-metrics/metrics.md)
+
+This chapter lists all metrics collected by the Glean SDK itself.
+
+### [Developing the Glean SDK](dev/index.md)
+
+This chapter describes how to develop the Glean SDK and its various implementations.
+This is relevant if you plan to contribute to the Glean SDK code base.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,3 +36,8 @@ This is relevant if you plan to contribute to the Glean SDK code base.
 
 “This Week in Glean” is a series of blog posts that the Glean Team at Mozilla is using to try to communicate better about our work.
 They could be release notes, documentation, hopes, dreams, or whatever: so long as it is inspired by Glean.
+
+## License
+
+The Glean SDK Source Code is subject to the terms of the Mozilla Public License v2.0.
+You can obtain a copy of the MPL at <https://mozilla.org/MPL/2.0/>.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ The source code is available [on GitHub](https://github.com/mozilla/glean/).
 
 ## Using this book
 
-This book is divided into 3 main chapters:
+This book is divided into 4 main chapters:
 
 ### [Using the Glean SDK](user/index.html)
 
@@ -31,3 +31,8 @@ This chapter lists all metrics collected by the Glean SDK itself.
 
 This chapter describes how to develop the Glean SDK and its various implementations.
 This is relevant if you plan to contribute to the Glean SDK code base.
+
+### [This Week in Glean](appendix/twig.md)
+
+“This Week in Glean” is a series of blog posts that the Glean Team at Mozilla is using to try to communicate better about our work.
+They could be release notes, documentation, hopes, dreams, or whatever: so long as it is inspired by Glean.

--- a/docs/appendix/twig.md
+++ b/docs/appendix/twig.md
@@ -28,3 +28,4 @@ They could be release notes, documentation, hopes, dreams, or whatever: so long 
 * 2020-05-08: [mozregression telemetry (part 2)](https://wlach.github.io/blog/2020/05/this-week-in-glean-mozregression-telemetry-part-2/)
 * 2020-05-26: [How does the Glean SDK send gzipped pings](https://blog.mozilla.org/data/2020/05/26/how-does-the-glean-sdk-send-gzipped-pings/)
 * 2020-06-03: [The Glean SDK and iOS Application Extensions, or a Tale of Two Sandboxes](https://blog.mozilla.org/data/2020/06/03/this-week-in-glean-the-glean-sdk-and-ios-application-extensions-or-a-tale-of-two-sandboxes/)
+* 2020-06-12: [Project FOG Update, end of H12020](https://blog.mozilla.org/data/2020/06/12/this-week-in-glean-project-fog-update-end-of-h12020/)


### PR DESCRIPTION
I remember we talked about this briefly, don't remember if we filed a bug.

But I wanted to get _something_ done today.
I felt that there's only 3 big chapters worth listing, but then also mentioning the TWiG felt like the right thing to do.