### PR TITLE
Add a default ping uploader in C#

### DIFF
--- a/glean-core/csharp/Glean/Configuration/Configuration.cs
+++ b/glean-core/csharp/Glean/Configuration/Configuration.cs
@@ -43,7 +43,7 @@ namespace Mozilla.Glean
             this.serverEndpoint = serverEndpoint;
             this.channel = channel;
             this.maxEvents = maxEvents;
-            this.httpClient = httpClient;
+            this.httpClient = httpClient ?? new HttpClientUploader();
             this.logPings = logPings;
             this.pingTag = pingTag;
         }

--- a/glean-core/csharp/Glean/Net/HttpClientUploader.cs
+++ b/glean-core/csharp/Glean/Net/HttpClientUploader.cs
@@ -1,0 +1,91 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Net.Http;
+
+namespace Mozilla.Glean.Net
+{
+    /// <summary>
+    /// A simple ping uploader that uses the `HttpClient` C# object.
+    /// </summary>
+    public class HttpClientUploader : IPingUploader
+    {
+        // The timeout, in milliseconds, to use when connecting to the server.
+        internal const int DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
+
+        internal readonly HttpClient httpClient;
+
+        public HttpClientUploader() : this(null)
+        {
+        }
+
+        // This constructor is only meant to be used for testing.
+        internal HttpClientUploader(HttpMessageHandler customHandler)
+        {
+            if (customHandler != null)
+            {
+                httpClient = new HttpClient(customHandler);
+            }
+            else
+            {
+                httpClient = new HttpClient();
+            }
+
+            httpClient.Timeout = TimeSpan.FromMilliseconds(DEFAULT_CONNECTION_TIMEOUT_MS);
+        }
+
+        public UploadResult Upload(string url, byte[] data, (string, string)[] headers)
+        {
+            try
+            {
+                HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("POST"), url);
+
+                // TODO: Verify that cookies are not being sent in bug 1646778
+
+                // Create `request.Content` first, as we might need to slap headers on it.
+                request.Content = new ByteArrayContent(data);
+
+                foreach ((string name, string value) header in headers)
+                {
+                    // The `HttpRequestMessage` separates the headers in categories: 'Content-*' headers
+                    // have to be set in `request.Content.Headers.*` while other headers can be set
+                    // through `request.Headers`. Let's try to deal with this by checking the header name.
+                    // The following code will throw an exception if glean-core sends an header that's
+                    // mistakenly routed to the wrong category, but that's fine: we'll hopefully catch that
+                    // in integration tests.
+                    if (header.name.StartsWith("Content-", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        request.Content.Headers.Add(header.name, header.value);
+                        continue;
+                    }
+
+                    // Ok, that's not a content header. Try with a request header.
+                    request.Headers.Add(header.name, header.value);
+                }
+
+                // While `SendAsync` is triggering an off-the-main thread request, we synchronously wait
+                // for it to finish by adding `.Result`. We're fine with doing that as we want the non-blocking
+
+                var httpResponseMessage = httpClient.SendAsync(request).Result;
+
+                return new HttpResponse((int)httpResponseMessage.StatusCode);
+            }
+            catch (UriFormatException)
+            {
+                // There's nothing we can do to recover from this here. So let's just log an error and
+                // notify the service that this job has been completed - even though we didn't upload
+                // anything to the server.
+                Console.WriteLine("Glean - Could not upload telemetry due to malformed URL");
+                return new UnrecoverableFailure();
+            }
+            catch (HttpRequestException)
+            {
+                // The request failed due to an underlying issue such as network connectivity.
+                Console.WriteLine("Glean - there was a problem while performing the network request.");
+                return new RecoverableFailure();
+            }
+        }
+    }
+}

--- a/glean-core/csharp/Glean/Net/PingUploader.cs
+++ b/glean-core/csharp/Glean/Net/PingUploader.cs
@@ -24,7 +24,7 @@ namespace Mozilla.Glean.Net
     /// </summary>
     public class HttpResponse : UploadResult
     {
-        private readonly int statusCode;
+        internal readonly int statusCode;
 
         public HttpResponse(int statusCode)
         {

--- a/glean-core/csharp/GleanTests/Net/HttpClientUploaderTest.cs
+++ b/glean-core/csharp/GleanTests/Net/HttpClientUploaderTest.cs
@@ -1,0 +1,124 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using Mozilla.Glean.Net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mozilla.Glean.Tests.Net
+{
+    public class HttpClientUploaderTest
+    {
+        private const string TEST_URL = "http://example.com/some/random/path/not/important";
+        private const string TEST_PING = "{ 'ping': 'test' }";
+
+        private class FakeHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Action<HttpRequestMessage> requestAction;
+            private readonly HttpStatusCode returnCode;
+
+            public FakeHttpMessageHandler(
+                Action<HttpRequestMessage> requestAction,
+                HttpStatusCode returnCode
+                )
+            {
+                this.requestAction = requestAction;
+                this.returnCode = returnCode;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var taskCompletionSource = new TaskCompletionSource<HttpResponseMessage>();
+
+                // Invoke the handler.
+                requestAction.Invoke(request);
+
+                // Generate a result to return.
+                taskCompletionSource.SetResult(new HttpResponseMessage
+                {
+                    StatusCode = returnCode,
+                    Content = new StringContent("Response-Test-Data")
+                });
+
+                return taskCompletionSource.Task;
+            }
+        }
+
+        [Fact]
+        public void TestTimeoutsProperlySet()
+        {
+            HttpClientUploader uploader = new HttpClientUploader();
+            Assert.Equal(HttpClientUploader.DEFAULT_CONNECTION_TIMEOUT_MS, uploader.httpClient.Timeout.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void TestGleanHeadersAreCorrectlyDispatched()
+        {
+            (string, string)[] expectedHeaders = {
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Test-header", "SomeValue"),
+                ("OtherHeader", "Glean/Test 25.0.2")
+            };
+
+            List<(string, string)> receivedHeaders = new List<(string, string)>();
+
+            HttpClientUploader uploader = new HttpClientUploader(new FakeHttpMessageHandler((request) =>
+            {
+                // Get both content and request headers.
+                foreach (var h in request.Headers)
+                {
+                    receivedHeaders.Add((h.Key, string.Join(",", h.Value.ToArray())));
+                }
+
+                foreach (var h in request.Content.Headers)
+                {
+                    receivedHeaders.Add((h.Key, string.Join(",", h.Value.ToArray())));
+                }
+            }, HttpStatusCode.OK));
+            uploader.Upload(TEST_URL, Encoding.UTF8.GetBytes(TEST_PING), expectedHeaders);
+
+            Assert.Equal(expectedHeaders.Length, receivedHeaders.Count);
+            // For some reason checking `expectedHeaders.SequenceEqual(receivedHeaders.ToArray())`
+            // does not work: it always fails. Computing the intersection of the two lists work, though.
+            // As long as the size of the intersection equals that of the expected headers, we should be
+            // fine.
+            Assert.Equal(expectedHeaders.Length, receivedHeaders.Intersect(expectedHeaders).ToArray().Length);
+        }
+
+        [Fact]
+        public void TestUploadReturnsTheStatusCodeForSuccessfulRequests()
+        {
+            // Create a fake uploader that always reports 200.
+            HttpClientUploader uploader =
+                new HttpClientUploader(new FakeHttpMessageHandler((_) => { }, HttpStatusCode.OK));
+            var result = uploader.Upload(TEST_URL, Encoding.UTF8.GetBytes(TEST_PING), new (string, string)[]{ });
+            // Check if we received 200.
+            Assert.IsType<HttpResponse>(result);
+            Assert.Equal((int)HttpStatusCode.OK, ((HttpResponse)result).statusCode);
+        }
+
+        [Fact]
+        public void TestUploadCorrectlyUploadsThePingData()
+        {
+            // Create a fake uploader that always reports 200.
+            HttpClientUploader uploader = new HttpClientUploader(new FakeHttpMessageHandler((request) =>
+            {
+                Assert.Equal(TEST_PING, Encoding.UTF8.GetString(request.Content.ReadAsByteArrayAsync().Result));
+            }, HttpStatusCode.OK));
+            var result = uploader.Upload(TEST_URL, Encoding.UTF8.GetBytes(TEST_PING), new (string, string)[] { });
+
+            // We received a result, the content  will be checked in the fake handler above.
+            Assert.IsType<HttpResponse>(result);
+        }
+
+        // TODO: Add cookie related tests with bug 1646778
+    }
+}


### PR DESCRIPTION
This adds an HTTP stack to enable ping sending. This is modelled after the Kotlin implementation.