### PR TITLE
Fix the `Date` header generated by glean-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.1.1...main)
 
+* General
+    * BUGFIX: Correctly format the date and time in the `Date` header. 
 * Python
     * BUGFIX: Additional time is taken at shutdown to make sure pings are sent and telemetry is recorded. ([1646173](https://bugzilla.mozilla.org/show_bug.cgi?id=1646173))
 


### PR DESCRIPTION
Drop the sub-second precision and report GMT
as timezone identifier, as required by https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date