### PR TITLE
Bug 1640575 - Move "debug view tagging" to Rust

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -586,6 +586,21 @@ open class GleanInternalAPI internal constructor () {
     }
 
     /**
+     * Set a tag to be applied to headers when uploading pings for debug view.
+     * This is only meant to be used internally by the `GleanDebugActivity`.
+     *
+     * @param value The value of the tag, which must be a valid HTTP header value.
+     */
+    fun setDebugViewTag(value: String): Boolean {
+        if (isInitialized()) {
+            return LibGleanFFI.INSTANCE.glean_set_debug_view_tag(value).toBoolean()
+        } else {
+            Log.e(LOG_TAG, "Glean must be initialized before setting a debug view tag.")
+            return false
+        }
+    }
+
+    /**
      * TEST ONLY FUNCTION.
      * This is called by the GleanTestRule, to enable test mode.
      *

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -55,8 +55,6 @@ internal class FfiConfiguration(
  * @property logPings whether to log ping contents to the console. This is only meant to be used
  *           internally by the `GleanDebugActivity`.
  * @property httpClient The HTTP client implementation to use for uploading pings.
- * @property pingTag String tag to be applied to headers when uploading pings for debug view.
- *           This is only meant to be used internally by the `GleanDebugActivity`.
  * @property channel the release channel the application is on, if known. This will be
  *           sent along with all the pings, in the `client_info` section.
  */
@@ -68,8 +66,7 @@ data class Configuration internal constructor(
     // NOTE: since only simple object or strings can be made `const val`s, if the
     // default values for the lines below are ever changed, they are required
     // to change in the public constructor below.
-    val httpClient: PingUploader = HttpURLConnectionUploader(),
-    val pingTag: String? = null
+    val httpClient: PingUploader = HttpURLConnectionUploader()
 ) {
     /**
      * Configuration for Glean.
@@ -97,7 +94,6 @@ data class Configuration internal constructor(
         maxEvents = maxEvents,
         logPings = DEFAULT_LOG_PINGS,
         httpClient = httpClient,
-        pingTag = null,
         channel = channel
     )
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
@@ -37,9 +37,6 @@ class GleanDebugActivity : Activity() {
          * The value must match the pattern `[a-zA-Z0-9-]{1,20}`.
          */
         const val TAG_DEBUG_VIEW_EXTRA_KEY = "tagPings"
-
-        // Regular expression filter for debugId
-        internal val pingTagPattern = "[a-zA-Z0-9-]{1,20}".toRegex()
     }
 
     // IMPORTANT: These activities are unsecured, and may be triggered by
@@ -83,19 +80,15 @@ class GleanDebugActivity : Activity() {
 
             // Check for ping debug view tag to apply to the X-Debug-ID header when uploading the
             // ping to the endpoint
-            var pingTag: String? = intent.getStringExtra(TAG_DEBUG_VIEW_EXTRA_KEY)
+            var debugViewTag: String? = intent.getStringExtra(TAG_DEBUG_VIEW_EXTRA_KEY)
 
-            // Validate the ping tag against the regex pattern
-            pingTag?.let {
-                if (!pingTagPattern.matches(it)) {
-                    Log.e(LOG_TAG, "tagPings value $it does not match accepted pattern $pingTagPattern")
-                    pingTag = null
-                }
+            // Set the debug view tag, if the tag is invalid it won't be set
+            debugViewTag?.let {
+                Glean.setDebugViewTag(debugViewTag)
             }
 
             val debugConfig = Glean.configuration.copy(
-                logPings = intent.getBooleanExtra(LOG_PINGS_EXTRA_KEY, Glean.configuration.logPings),
-                pingTag = pingTag
+                logPings = intent.getBooleanExtra(LOG_PINGS_EXTRA_KEY, Glean.configuration.logPings)
             )
 
             // Finally set the default configuration before starting

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/net/Upload.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/net/Upload.kt
@@ -10,7 +10,6 @@ import org.json.JSONException
 import com.sun.jna.Structure
 import com.sun.jna.Pointer
 import com.sun.jna.Union
-import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.rust.getRustString
 import mozilla.telemetry.glean.rust.RustBuffer
 
@@ -91,10 +90,6 @@ internal class PingRequest(
             // it's very unlikely that we get an exception here
             // unless there is some sort of memory corruption.
             Log.e(LOG_TAG, "Error while parsing headers for ping $documentId")
-        }
-
-        Glean.configuration.pingTag?.let {
-            headers.add(Pair("X-Debug-ID", it))
         }
 
         return headers

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -560,6 +560,8 @@ internal interface LibGleanFFI : Library {
 
     fun glean_process_ping_upload_response(task: FfiPingUploadTask.ByReference, status: Int)
 
+    fun glean_set_debug_view_tag(value: String): Byte
+
     // Misc
 
     fun glean_str_free(ptr: Pointer)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -104,14 +104,14 @@ class GleanTest {
     }
 
     @Test
-    fun `X-Debug-ID header is correctly added when pingTag is not null`() {
+    fun `X-Debug-ID header is correctly added when debug view tag is set`() {
         val server = getMockWebServer()
         resetGlean(context, Glean.configuration.copy(
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
-            logPings = true,
-            pingTag = "this-ping-is-tagged"
+            logPings = true
         ))
 
+        Glean.setDebugViewTag("this-ping-is-tagged")
         Glean.handleBackgroundEvent()
 
         // Now trigger it to upload

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -642,6 +642,8 @@ uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 void glean_register_ping_type(uint64_t ping_type_handle);
 
+uint8_t glean_set_debug_view_tag(FfiStr tag);
+
 void glean_set_dirty_flag(uint8_t flag);
 
 void glean_set_experiment_active(FfiStr experiment_id,

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -492,4 +492,12 @@ pub extern "C" fn glean_initialize_standalone_uploader(data_dir: FfiStr) -> u8 {
     })
 }
 
+#[no_mangle]
+pub extern "C" fn glean_set_debug_view_tag(tag: FfiStr) -> u8 {
+    with_glean_mut(|glean| {
+        let tag = tag.to_string_fallible()?;
+        Ok(glean.set_debug_view_tag(&tag))
+    })
+}
+
 define_string_destructor!(glean_str_free);

--- a/glean-core/ios/Glean/Config/Configuration.swift
+++ b/glean-core/ios/Glean/Config/Configuration.swift
@@ -8,7 +8,6 @@ public struct Configuration {
     let serverEndpoint: String
     var logPings: Bool
     let maxEvents: Int32?
-    var pingTag: String?
     let channel: String?
 
     struct Constants {
@@ -24,21 +23,17 @@ public struct Configuration {
     ///   * logPings: whether to log ping contents to the console.
     ///     This is only meant to be used internally by the `GleanDebugActivity`.
     ///   * maxEvents: the number of events to store before the events ping is sent.
-    ///   * pingTag: String tag to be applied to headers when uploading pings for debug view.
-    ///     Used internally by the `GleanDebugActivity`.
     ///   * channel: the release channel the application is on, if known.
     ///     This will be sent along with all the pings, in the `client_info` section.
     internal init(
         serverEndpoint: String = Constants.defaultTelemetryEndpoint,
         logPings: Bool = Constants.defaultLogPings,
         maxEvents: Int32? = nil,
-        pingTag: String? = nil,
         channel: String? = nil
     ) {
         self.serverEndpoint = serverEndpoint
         self.logPings = logPings
         self.maxEvents = maxEvents
-        self.pingTag = pingTag
         self.channel = channel
     }
 
@@ -56,7 +51,6 @@ public struct Configuration {
         self.serverEndpoint = serverEndpoint ?? Constants.defaultTelemetryEndpoint
         self.logPings = Constants.defaultLogPings
         self.maxEvents = maxEvents
-        self.pingTag = nil
         self.channel = channel
     }
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -435,6 +435,20 @@ public class Glean {
         }
     }
 
+    /// Set a tag to be applied to headers when uploading pings for debug view.
+    /// This is only meant to be used internally by the `GleanDebugActivity`.
+    ///
+    /// - parameters:
+    ///     * value: The value of the tag, which must be a valid HTTP header value.
+    public func setDebugViewTag(_ value: String) -> Bool {
+        if self.isInitialized() {
+            return glean_set_debug_view_tag(value).toBool()
+        } else {
+            self.logger.error("Glean must be initialized before setting a debug view tag.")
+            return false
+        }
+    }
+
     /// When applications are launched using the custom URL scheme, this helper function will process
     /// the URL and parse the debug commands
     ///

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -642,6 +642,8 @@ uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 void glean_register_ping_type(uint64_t ping_type_handle);
 
+uint8_t glean_set_debug_view_tag(FfiStr tag);
+
 void glean_set_dirty_flag(uint8_t flag);
 
 void glean_set_experiment_active(FfiStr experiment_id,

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -87,10 +87,6 @@ public class HttpPingUploader {
             // See https://github.com/AliSoftware/OHHTTPStubs#known-limitations.
             request.httpBody = data
 
-            if let tag = config.pingTag {
-                request.addValue(tag, forHTTPHeaderField: "X-Debug-ID")
-            }
-
             return request
         }
 

--- a/glean-core/ios/Glean/Net/Upload.swift
+++ b/glean-core/ios/Glean/Net/Upload.swift
@@ -59,12 +59,6 @@ struct PingRequest {
         self.documentId = documentId
         self.path = path
         self.body = body
-
-        var headers = headers
-        if let pingTag = Glean.shared.configuration?.pingTag {
-            headers["X-Debug-ID"] = pingTag
-        }
-
         self.headers = headers
     }
 }

--- a/glean-core/ios/GleanTests/Config/ConfigurationTests.swift
+++ b/glean-core/ios/GleanTests/Config/ConfigurationTests.swift
@@ -32,10 +32,6 @@ class ConfigurationTests: XCTestCase {
             "Default max events are set"
         )
         XCTAssertNil(
-            config?.pingTag,
-            "Default pingTag is set"
-        )
-        XCTAssertNil(
             config?.channel,
             "Default channel is set"
         )

--- a/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
+++ b/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
@@ -19,25 +19,6 @@ class GleanDebugUtilityTests: XCTestCase {
         OHHTTPStubs.removeAllStubs()
     }
 
-    func testHandleCustomUrlTagPings() {
-        // Check invalid tags: This should have the configuration keep the
-        // default value of nil because they don't match the accepted
-        // regex for ping tag names.
-        var url = URL(string: "test://glean?tagPings=This-tag-is-not-valid-because-it-is-too-long")
-        Glean.shared.handleCustomUrl(url: url!)
-        XCTAssertNil(Glean.shared.configuration?.pingTag)
-
-        url = URL(string: "test://glean?tagPings=Invalid_Chars@!!$")
-        Glean.shared.handleCustomUrl(url: url!)
-        XCTAssertNil(Glean.shared.configuration?.pingTag)
-
-        // Check valid tag: This should update the pingTag value of the
-        // configuration object.
-        url = URL(string: "test://glean?tagPings=Glean-Ping")
-        Glean.shared.handleCustomUrl(url: url!)
-        XCTAssertEqual("Glean-Ping", Glean.shared.configuration?.pingTag)
-    }
-
     func testHandleCustomUrlLogPings() {
         // Test initial state
         XCTAssertFalse(Glean.shared.configuration!.logPings)

--- a/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
+++ b/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
@@ -12,8 +12,7 @@ class HttpPingUploaderTests: XCTestCase {
     private let testPath = "/some/random/path/not/important"
     private let testPing = "{ \"ping\": \"test\" }"
     private let testConfig = Configuration(
-        logPings: true,
-        pingTag: "Tag"
+        logPings: true
     )
 
     override func tearDown() {

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -763,3 +763,18 @@ fn timing_distribution_truncation_accumulate() {
         assert!(snapshot.values.len() < 316);
     }
 }
+
+#[test]
+fn test_setting_debug_view_tag() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let (mut glean, _) = new_glean(Some(dir));
+
+    let valid_tag = "valid-tag";
+    assert_eq!(true, glean.set_debug_view_tag(valid_tag));
+    assert_eq!(valid_tag, glean.debug_view_tag().unwrap());
+
+    let invalid_tag = "invalid tag";
+    assert_eq!(false, glean.set_debug_view_tag(invalid_tag));
+    assert_eq!(valid_tag, glean.debug_view_tag().unwrap());
+}

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -113,7 +113,7 @@ impl PingDirectoryManager {
         let mut lines = BufReader::new(file).lines();
         if let (Some(Ok(path)), Some(Ok(body))) = (lines.next(), lines.next()) {
             if let Ok(parsed_body) = serde_json::from_str::<JsonValue>(&body) {
-                return Some(PingRequest::new(document_id, &path, parsed_body));
+                return Some(PingRequest::new(document_id, &path, parsed_body, None));
             } else {
                 log::warn!(
                     "Error processing ping file: {}. Can't parse ping contents as JSON.",

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -238,14 +238,20 @@ impl PingUploadManager {
     }
 
     /// Creates a `PingRequest` and adds it to the queue.
-    pub fn enqueue_ping(&self, document_id: &str, path: &str, body: JsonValue) {
+    pub fn enqueue_ping(
+        &self,
+        document_id: &str,
+        path: &str,
+        body: JsonValue,
+        debug_view_tag: Option<&String>,
+    ) {
         log::trace!("Enqueuing ping {} at {}", document_id, path);
 
         let mut queue = self
             .queue
             .write()
             .expect("Can't write to pending pings queue.");
-        let request = PingRequest::new(document_id, path, body);
+        let request = PingRequest::new(document_id, path, body, debug_view_tag);
         queue.push_back(request);
     }
 
@@ -504,7 +510,7 @@ mod test {
         }
 
         // Enqueue a ping
-        upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}));
+        upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
 
         // Try and get the next request.
         // Verify request was returned
@@ -528,7 +534,7 @@ mod test {
         // Enqueue a ping multiple times
         let n = 10;
         for _ in 0..n {
-            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}));
+            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
         }
 
         // Verify a request is returned for each submitted ping
@@ -600,7 +606,7 @@ mod test {
 
         // Enqueue a ping multiple times
         for _ in 0..10 {
-            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}));
+            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
         }
 
         // Clear the queue
@@ -861,7 +867,7 @@ mod test {
         let path2 = format!("/submit/app_id/test-ping/1/{}", doc2);
 
         // Enqueue a ping
-        upload_manager.enqueue_ping(doc1, &path1, json!({}));
+        upload_manager.enqueue_ping(doc1, &path1, json!({}), None);
 
         // Try and get the first request.
         let req = match upload_manager.get_upload_task(false) {
@@ -871,7 +877,7 @@ mod test {
         assert_eq!(doc1, req.document_id);
 
         // Schedule the next one while the first one is "in progress"
-        upload_manager.enqueue_ping(doc2, &path2, json!({}));
+        upload_manager.enqueue_ping(doc2, &path2, json!({}), None);
 
         // Mark as processed
         upload_manager.process_ping_upload_response(&req.document_id, HttpStatus(200));

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -179,6 +179,42 @@ pub mod floating_point_context {
     }
 }
 
+/// The debug view tag is the value for the `X-Debug-Id` header of tagged ping requests,
+/// thus is it must be a valid header value.
+///
+/// In other words, it must match the regex: "[a-zA-Z0-9-]{1,20}"
+///
+/// The regex crate isn't used here because it adds to the binary size,
+/// and the Glean SDK doesn't use regular expressions anywhere else.
+pub fn validate_debug_view_tag(value: &str) -> Option<String> {
+    if value.is_empty() {
+        log::error!("Debug view tag must have at least one character.");
+        return None;
+    }
+
+    let mut iter = value.chars();
+    let mut count = 0;
+
+    loop {
+        match iter.next() {
+            // We are done, so the whole expression is valid.
+            None => return Some(value.into()),
+            // Valid characters.
+            Some('-') | Some('a'..='z') | Some('A'..='Z') | Some('0'..='9') => (),
+            // An invalid character
+            Some(c) => {
+                log::error!("Invalid character '{}' in debug view tag.", c);
+                return None;
+            }
+        }
+        count += 1;
+        if count == 20 {
+            log::error!("Debug view tag cannot exceed 20 characters");
+            return None;
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -269,5 +305,16 @@ mod test {
         // Ensure that truncating the naïve way on this string would panic
         let value = "电脑坏了".to_string();
         value[0..10].to_string();
+    }
+
+    #[test]
+    fn validates_debug_view_tag_correctly() {
+        assert!(validate_debug_view_tag("valid-value").is_some());
+        assert!(validate_debug_view_tag("-also-valid-value").is_some());
+        assert!(validate_debug_view_tag("invalid_value").is_none());
+        assert!(validate_debug_view_tag("invalid value").is_none());
+        assert!(validate_debug_view_tag("!nv@lid-val*e").is_none());
+        assert!(validate_debug_view_tag("invalid-value-because-way-too-long").is_none());
+        assert!(validate_debug_view_tag("").is_none());
     }
 }

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -10,15 +10,8 @@ use glean_core::ping::PingMaker;
 use glean_core::{CommonMetricData, Glean, Lifetime};
 
 fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
-    let (t, tmpname) = tempdir();
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
-    let mut glean = Glean::new(cfg).unwrap();
+    let (tempdir, _) = tempdir();
+    let (mut glean, t) = new_glean(Some(tempdir));
     let ping_maker = PingMaker::new();
     let ping_type = PingType::new("store1", true, false, vec![]);
     glean.register_ping_type(&ping_type);

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -12,27 +12,20 @@ use serde_json::json;
 use glean_core::metrics::*;
 use glean_core::storage::StorageManager;
 use glean_core::{test_get_num_recorded_errors, ErrorType};
-use glean_core::{CommonMetricData, Glean, Lifetime};
+use glean_core::{CommonMetricData, Lifetime};
 
 // Tests ported from glean-ac
 
 #[test]
 fn serializer_should_correctly_serialize_timing_distribution() {
-    let (_t, tmpname) = tempdir();
+    let (mut tempdir, _) = tempdir();
 
     let duration = 60;
     let time_unit = TimeUnit::Nanosecond;
 
-    let cfg = glean_core::Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-    };
-
     {
-        let glean = Glean::new(cfg.clone()).unwrap();
+        let (glean, dir) = new_glean(Some(tempdir));
+        tempdir = dir;
 
         let mut metric = TimingDistributionMetric::new(
             CommonMetricData {
@@ -59,7 +52,7 @@ fn serializer_should_correctly_serialize_timing_distribution() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let glean = Glean::new(cfg).unwrap();
+        let (glean, _) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();


### PR DESCRIPTION
Fixes [Bug 1640575](https://bugzilla.mozilla.org/show_bug.cgi?id=1640575).

~As a bonus also fixes (or at least partially fixes) [Bug 1605097](https://bugzilla.mozilla.org/show_bug.cgi?id=1605097), because persisting the tag was the best way I found to move it to Rust.~ Not anymore, this was defered to a later PR. Because the tag was not being persisted any longer, I had to drop the commit where I removed the debug view tag management from python in favour of the rust implementation. Since python instantiates a standalone upload manager to do the upload, without persisting the tag we don't pck up on it during upload. When I work on the PR to persist the headers I can bring the python commit back.

I realized after the fact that this could be broken down into smaller PRs, which can stil be done if you prefer since this is already broken down into coherent commits. Please let me know and I'll close this if necessary.