### PR TITLE
Bug 1597714 - Build for release when assembling Python release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,12 +126,15 @@ commands:
       - run:
           name: Build Windows glean_ffi.dll
           command:
-            cargo build --target x86_64-pc-windows-gnu
+            cargo build --target x86_64-pc-windows-gnu --release
       - run:
           name: Build Windows wheel
           command: |
             cd glean-core/python
-            GLEAN_PYTHON_MINGW_X86_64_BUILD=1 .venv3.7/bin/python3 setup.py bdist_wheel
+            .venv3.7/bin/python3 setup.py bdist_wheel
+          environment:
+            GLEAN_PYTHON_MINGW_X86_64_BUILD: 1
+            GLEAN_BUILD_VARIANT: release
 
   build-windows-i686-wheel:
     steps:
@@ -146,12 +149,15 @@ commands:
       - run:
           name: Build Windows glean_ffi.dll
           command:
-            RUSTFLAGS="-C panic=abort" cargo build --target i686-pc-windows-gnu
+            RUSTFLAGS="-C panic=abort" cargo build --target i686-pc-windows-gnu --release
       - run:
           name: Build Windows wheel
           command: |
             cd glean-core/python
-            GLEAN_PYTHON_MINGW_I686_BUILD=1 .venv3.7/bin/python3 setup.py bdist_wheel
+             .venv3.7/bin/python3 setup.py bdist_wheel
+          environment:
+            GLEAN_PYTHON_MINGW_I686_BUILD: 1
+            GLEAN_BUILD_VARIANT: release
 
   install-python-windows-deps:
     steps:
@@ -894,6 +900,8 @@ jobs:
           name: Build Python extension
           command: |
             make build-python
+          environment:
+            GLEAN_BUILD_VARIANT: release
       - run:
           name: Build Linux wheel
           command: |
@@ -903,6 +911,8 @@ jobs:
             # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
             # variables are configured in CircleCI's environment variables.
             .venv3.7/bin/python3 -m twine upload wheelhouse/*
+          environment:
+            GLEAN_BUILD_VARIANT: release
       - install-ghr-linux
       - run:
           name: Publish to Github
@@ -921,6 +931,8 @@ jobs:
           name: Build and Test Python extension
           command: |
             make test-python
+          environment:
+            GLEAN_BUILD_VARIANT: release
       - run:
           name: Build macOS wheel
           command: |
@@ -929,6 +941,8 @@ jobs:
             # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
             # variables are configured in CircleCI's environment variables.
             .venv3.7/bin/python3 -m twine upload dist/*
+          environment:
+            GLEAN_BUILD_VARIANT: release
       - install-ghr-darwin
       - run:
           name: Publish to Github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     * BUGFIX: baseline pings with reason "dirty startup" are no longer sent if Glean did not full initialize in the previous run.
 * Python
     * Support for Python 3.5 was dropped.
+    * Python wheels are now shipped with Glean release builds, resulting in much smaller libraries ([#1002](https://github.com/mozilla/glean/pull/1002))
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.1.2...main)
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,16 @@ help:
 
 GLEAN_PYENV := $(shell python3 -c "import sys; print('glean-core/python/.venv' + '.'.join(str(x) for x in sys.version_info[:2]))")
 GLEAN_PYDEPS := ${GLEAN_PYDEPS}
+# Read the `GLEAN_BUILD_VARIANT` variable, default to debug.
+# If set it is passed as a flag to cargo, so we prefix it with `--`
+ifeq ($(GLEAN_BUILD_VARIANT),)
+GLEAN_BUILD_PROFILE :=
+else ifeq ($(GLEAN_BUILD_VARIANT),debug)
+# `--debug` is invalid and `--profile debug` is unstable.
+GLEAN_BUILD_PROFILE :=
+else
+GLEAN_BUILD_PROFILE := --$(GLEAN_BUILD_VARIANT)
+endif
 
 # Setup environments
 
@@ -27,7 +37,7 @@ $(GLEAN_PYENV)/bin/python3:
 build: build-rust
 
 build-rust: ## Build all Rust code
-	cargo build --all
+	cargo build --all $(GLEAN_BUILD_PROFILE)
 
 build-kotlin: ## Build all Kotlin code
 	./gradlew build -x test

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -54,12 +54,15 @@ requirements = [
 
 setup_requirements = ["cffi>=1.0.0"]
 
+# The environment variable `GLEAN_BUILD_VARIANT` can be set to `debug` or `release`
+buildvariant = os.environ.get("GLEAN_BUILD_VARIANT", "debug")
+
 if mingw_arch == "i686":
-    shared_object_build_dir = "../../target/i686-pc-windows-gnu/debug/"
+    shared_object_build_dir = "../../target/i686-pc-windows-gnu"
 elif mingw_arch == "x86_64":
-    shared_object_build_dir = "../../target/x86_64-pc-windows-gnu/debug/"
+    shared_object_build_dir = "../../target/x86_64-pc-windows-gnu"
 else:
-    shared_object_build_dir = "../../target/debug/"
+    shared_object_build_dir = "../../target"
 
 
 if platform == "linux":
@@ -73,6 +76,7 @@ elif platform.startswith("win"):
 else:
     raise ValueError(f"The platform {sys.platform} is not supported.")
 
+shared_object_path = f"{shared_object_build_dir}/{buildvariant}/{shared_object}"
 
 shutil.copyfile("../metrics.yaml", "glean/metrics.yaml")
 shutil.copyfile("../pings.yaml", "glean/pings.yaml")
@@ -81,7 +85,7 @@ shutil.copyfile("../pings.yaml", "glean/pings.yaml")
 # circumstances, this will still show up as an error when running the `build`
 # command as a missing `package_data` file.
 try:
-    shutil.copyfile(shared_object_build_dir + shared_object, "glean/" + shared_object)
+    shutil.copyfile(shared_object_path, "glean/" + shared_object)
 except FileNotFoundError:
     pass
 


### PR DESCRIPTION
As a first step to reduce the size of the library we ship this switches the Python build to contain the release builds.

I _think_ this works. Controlling it through an environment variable used by the Makefile seemed easy enough, additionally the Python setup script can read the same one.
For the Windows builds we're calling cargo directly, so we just pass `--release` directly.

We might lose some more readable stacktraces in case of bugs (but I guess so far we haven't received any of those anyway?) 