### PR TITLE
Python: Fix how locales are looked up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Python
     * Support for Python 3.5 was dropped.
     * Python wheels are now shipped with Glean release builds, resulting in much smaller libraries ([#1002](https://github.com/mozilla/glean/pull/1002))
+    * The Python bindings now use `locale.getdefaultlocale()` rather than `locale.getlocale()` to determine the locale.
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.1.2...main)
 

--- a/glean-core/python/glean/_util.py
+++ b/glean-core/python/glean/_util.py
@@ -16,7 +16,11 @@ def get_locale_tag() -> str:
     Returns:
         locale (str): The locale string.
     """
-    value = locale.getlocale()[0]
+    # getdefaultlocale() returns the default locale specified for a user on the
+    # system, and isn't affected by the locale that may have been explicitly
+    # set by the application. This is used primarily to have a cross-platform
+    # way to get the locale in RFC 1766 format.
+    value = locale.getdefaultlocale()[0]
 
     # In some contexts, especially on Windows, there is no locale set. Use "und"
     # to indicate "undetermined", as recommended by the Unicode TR35:


### PR DESCRIPTION
This is needed for Python 3.8 on Windows support