### PR TITLE
Python: Don't allow wheels to install on Python 3.5

### DIFF
--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -107,9 +107,9 @@ class BinaryDistribution(Distribution):
 class bdist_wheel(wheel.bdist_wheel.bdist_wheel):
     def get_tag(self):
         if platform == "linux":
-            return ("cp35", "abi3", "linux_x86_64")
+            return ("cp36", "abi3", "linux_x86_64")
         elif platform == "darwin":
-            return ("cp35", "abi3", "macosx_10_7_x86_64")
+            return ("cp36", "abi3", "macosx_10_7_x86_64")
         elif platform == "windows":
             if mingw_arch == "i686":
                 return ("py3", "none", "win32")


### PR DESCRIPTION
This fixes things so the wheel pattern matcher will refuse to install Glean on
Python 3.5

This should have been included in #987, but I just noticed it now.