### PR TITLE
Bug 1647736: Make glean_parser glinter and error output more obvious

### DIFF
--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -66,11 +66,16 @@ if found_version != expected_version:
         '--upgrade',
         f'{module_name}=={expected_version}'
     ])
-subprocess.check_call([
-    sys.executable,
-    '-m',
-    module_name
-] + sys.argv[3:])
+try:
+    subprocess.check_call([
+        sys.executable,
+        '-m',
+        module_name
+    ] + sys.argv[3:])
+except:
+    # We don't need to show a traceback in this helper script.
+    # Only the output of the subprocess is interesting.
+    sys.exit(1)
 """
 
     static File getPythonCommand(File condaDir) {
@@ -177,7 +182,7 @@ subprocess.check_call([
                 errorOutput = standardOutput
                 doLast {
                     if (execResult.exitValue != 0) {
-                        throw new GradleException("Process '${commandLine}' finished with non-zero exit value ${execResult.exitValue}:\n\n${standardOutput.toString()}")
+                        throw new GradleException("Glean code generation failed.\n\n${standardOutput.toString()}")
                     }
                 }
             }
@@ -244,7 +249,7 @@ subprocess.check_call([
                 errorOutput = standardOutput
                 doLast {
                     if (execResult.exitValue != 0) {
-                        throw new GradleException("Process '${commandLine}' finished with non-zero exit value ${execResult.exitValue}:\n\n${standardOutput.toString()}")
+                        throw new GradleException("Glean documentation generation failed.\n\n${standardOutput.toString()}")
                     }
                 }
             }


### PR DESCRIPTION
The errors from glean_parser during an Android application/library build were a bit hidden by noise that's probably only meaningful to Glean internal developers but not our users.

1) It would show the entire commandline used to call Python, which included a longish trampoline script.

2) It would show a traceback in the trampoline script which isn't really relevant to the failure in glean_parser itself.

This is should make it easier to spot glinter information or syntax errors in metrics.yaml files.