### PR TITLE
Bug 1648695 - Fix failing rust upload tests on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased changes
 
+* General
+    * Move debug view tag management to the Rust core. ([1640575](https://bugzilla.mozilla.org/show_bug.cgi?id=1640575), [#998](https://github.com/mozilla/glean/pull/998))
+
 [Full changelog](https://github.com/mozilla/glean/compare/v31.2.2...main)
 
 # v31.2.2 (2020-06-26)

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -457,7 +457,7 @@ pub unsafe extern "C" fn glean_process_ping_upload_response(
                 let document_id_str = CStr::from_ptr(document_id)
                     .to_str()
                     .map_err(|_| glean_core::Error::utf8_error())?;
-                ping_uploader.process_ping_upload_response(document_id_str, status.into());
+                ping_uploader.process_ping_upload_response(document_id_str, status.into(), None);
             };
             Ok(())
         });

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -499,7 +499,7 @@ impl Glean {
         }
 
         self.upload_manager
-            .process_ping_upload_response(uuid, status);
+            .process_ping_upload_response(uuid, status, self.debug_view_tag());
     }
 
     /// Take a snapshot for the given store and optionally clear it.

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -225,7 +225,7 @@ impl PingUploadManager {
         self.processed_pending_pings.load(Ordering::SeqCst)
     }
 
-    /// Gets the ping queue and checks in a ping with a certain document_id is already enqueued.
+    /// Checks if a ping with a certain `document_id` is already enqueued.
     fn is_enqueued(queue: &VecDeque<PingRequest>, document_id: &str) -> bool {
         queue
             .iter()

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -620,6 +620,11 @@ mod test {
     fn test_clearing_the_queue_doesnt_clear_deletion_request_pings() {
         let (mut glean, _) = new_glean(None);
 
+        // Wait for processing of pending pings directory to finish.
+        while glean.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
+
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
         glean.register_ping_type(&ping_type);
@@ -652,6 +657,11 @@ mod test {
     #[test]
     fn test_fills_up_queue_successfully_from_disk() {
         let (mut glean, _) = new_glean(None);
+
+        // Wait for processing of pending pings directory to finish.
+        while glean.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
 
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
@@ -688,6 +698,11 @@ mod test {
     fn test_processes_correctly_success_upload_response() {
         let (mut glean, dir) = new_glean(None);
 
+        // Wait for processing of pending pings directory to finish.
+        while glean.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
+
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
         glean.register_ping_type(&ping_type);
@@ -718,6 +733,11 @@ mod test {
     fn test_processes_correctly_client_error_upload_response() {
         let (mut glean, dir) = new_glean(None);
 
+        // Wait for processing of pending pings directory to finish.
+        while glean.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
+
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
         glean.register_ping_type(&ping_type);
@@ -747,6 +767,11 @@ mod test {
     #[test]
     fn test_processes_correctly_server_error_upload_response() {
         let (mut glean, _) = new_glean(None);
+
+        // Wait for processing of pending pings directory to finish.
+        while glean.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
 
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
@@ -779,6 +804,11 @@ mod test {
     #[test]
     fn test_processes_correctly_unrecoverable_upload_response() {
         let (mut glean, dir) = new_glean(None);
+
+        // Wait for processing of pending pings directory to finish.
+        while glean.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
 
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
@@ -850,10 +880,7 @@ mod test {
         upload_manager.process_ping_upload_response(&req.document_id, HttpStatus(200));
 
         // ... and then we're done.
-        match upload_manager.get_upload_task(false) {
-            PingUploadTask::Done => {}
-            _ => panic!("Expected upload manager to return the next request!"),
-        }
+        assert_eq!(upload_manager.get_upload_task(false), PingUploadTask::Done);
     }
 
     #[test]
@@ -870,6 +897,12 @@ mod test {
     #[test]
     fn test_adds_debug_view_header_to_requests_when_tag_is_set() {
         let (mut glean, _) = new_glean(None);
+
+        // Wait for processing of pending pings directory to finish.
+        while glean.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
+
         glean.set_debug_view_tag("valid-tag");
 
         // Register a ping for testing

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -196,7 +196,13 @@ impl PingUploadManager {
                 let mut local_queue = local_queue
                     .write()
                     .expect("Can't write to pending pings queue.");
-                local_queue.extend(local_manager.process_dir());
+                for (document_id, path, body) in local_manager.process_dir() {
+                    if Self::has_enqueued(&local_queue, &document_id) {
+                        continue;
+                    }
+                    let request = PingRequest::new(&document_id, &path, body, None);
+                    local_queue.push_back(request);
+                }
                 local_flag.store(true, Ordering::SeqCst);
             })
             .expect("Unable to spawn thread to process pings directories.");
@@ -219,6 +225,16 @@ impl PingUploadManager {
         self.processed_pending_pings.load(Ordering::SeqCst)
     }
 
+    /// Gets the ping queue and checks in a ping with a certain document_id is already enqueued.
+    fn has_enqueued(
+        queue: &RwLockWriteGuard<'_, VecDeque<PingRequest>>,
+        document_id: &str,
+    ) -> bool {
+        queue
+            .iter()
+            .any(|request| request.document_id == document_id)
+    }
+
     /// Adds rate limiting capability to this upload manager. The rate limiter
     /// will limit the amount of calls to `get_upload_task` per interval.
     ///
@@ -238,6 +254,8 @@ impl PingUploadManager {
     }
 
     /// Creates a `PingRequest` and adds it to the queue.
+    ///
+    /// Duplicate requests won't be added.
     pub fn enqueue_ping(
         &self,
         document_id: &str,
@@ -245,13 +263,23 @@ impl PingUploadManager {
         body: JsonValue,
         debug_view_tag: Option<&String>,
     ) {
-        log::trace!("Enqueuing ping {} at {}", document_id, path);
-
         let mut queue = self
             .queue
             .write()
             .expect("Can't write to pending pings queue.");
-        let request = PingRequest::new(document_id, path, body, debug_view_tag);
+
+        // Check if a request with the same document_id is already enqueued.
+        if Self::has_enqueued(&queue, document_id) {
+            log::trace!(
+                "Attempted to enqueue a duplicate ping {} at {}.",
+                document_id,
+                path
+            );
+            return;
+        }
+
+        log::trace!("Enqueuing ping {} at {}", document_id, path);
+        let request = PingRequest::new(&document_id, &path, body, debug_view_tag);
         queue.push_back(request);
     }
 
@@ -366,7 +394,12 @@ impl PingUploadManager {
     ///
     /// `document_id` - The UUID of the ping in question.
     /// `status` - The HTTP status of the response.
-    pub fn process_ping_upload_response(&self, document_id: &str, status: UploadResult) {
+    pub fn process_ping_upload_response(
+        &self,
+        document_id: &str,
+        status: UploadResult,
+        debug_view_tag: Option<&String>,
+    ) {
         use UploadResult::*;
         match status {
             HttpStatus(status @ 200..=299) => {
@@ -389,12 +422,10 @@ impl PingUploadManager {
                     document_id,
                     status
                 );
-                if let Some(request) = self.directory_manager.process_file(document_id) {
-                    let mut queue = self
-                        .queue
-                        .write()
-                        .expect("Can't write to pending pings queue.");
-                    queue.push_back(request);
+                if let Some((document_id, path, body)) =
+                    self.directory_manager.process_file(document_id)
+                {
+                    self.enqueue_ping(&document_id, &path, body, debug_view_tag);
                 }
             }
         };
@@ -473,13 +504,13 @@ mod test {
     use std::time::Duration;
 
     use serde_json::json;
+    use uuid::Uuid;
 
     use super::UploadResult::*;
     use super::*;
     use crate::metrics::PingType;
     use crate::{tests::new_glean, PENDING_PINGS_DIRECTORY};
 
-    const DOCUMENT_ID: &str = "40e31919-684f-43b0-a5aa-e15c2d56a674"; // Just a random UUID.
     const PATH: &str = "/submit/app_id/ping_name/schema_version/doc_id";
 
     #[test]
@@ -510,7 +541,7 @@ mod test {
         }
 
         // Enqueue a ping
-        upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
+        upload_manager.enqueue_ping(&Uuid::new_v4().to_string(), PATH, json!({}), None);
 
         // Try and get the next request.
         // Verify request was returned
@@ -534,7 +565,7 @@ mod test {
         // Enqueue a ping multiple times
         let n = 10;
         for _ in 0..n {
-            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
+            upload_manager.enqueue_ping(&Uuid::new_v4().to_string(), PATH, json!({}), None);
         }
 
         // Verify a request is returned for each submitted ping
@@ -567,7 +598,7 @@ mod test {
 
         // Enqueue a ping multiple times
         for _ in 0..max_pings_per_interval {
-            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
+            upload_manager.enqueue_ping(&Uuid::new_v4().to_string(), PATH, json!({}), None);
         }
 
         // Verify a request is returned for each submitted ping
@@ -580,7 +611,7 @@ mod test {
 
         // Enqueue just one more ping.
         // We should still be within the default rate limit time.
-        upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
+        upload_manager.enqueue_ping(&Uuid::new_v4().to_string(), PATH, json!({}), None);
 
         // Verify that we are indeed told to wait because we are at capacity
         assert_eq!(PingUploadTask::Wait, upload_manager.get_upload_task(false));
@@ -606,7 +637,7 @@ mod test {
 
         // Enqueue a ping multiple times
         for _ in 0..10 {
-            upload_manager.enqueue_ping(DOCUMENT_ID, PATH, json!({}), None);
+            upload_manager.enqueue_ping(&Uuid::new_v4().to_string(), PATH, json!({}), None);
         }
 
         // Clear the queue
@@ -847,14 +878,14 @@ mod test {
             thread::sleep(Duration::from_millis(10));
         }
 
-        let doc1 = "684fa150-8dff-11ea-8faf-cb1ff3b11119";
+        let doc1 = Uuid::new_v4().to_string();
         let path1 = format!("/submit/app_id/test-ping/1/{}", doc1);
 
-        let doc2 = "74f14e9a-8dff-11ea-b45a-6f936923f639";
+        let doc2 = Uuid::new_v4().to_string();
         let path2 = format!("/submit/app_id/test-ping/1/{}", doc2);
 
         // Enqueue a ping
-        upload_manager.enqueue_ping(doc1, &path1, json!({}), None);
+        upload_manager.enqueue_ping(&doc1, &path1, json!({}), None);
 
         // Try and get the first request.
         let req = match upload_manager.get_upload_task(false) {
@@ -864,10 +895,10 @@ mod test {
         assert_eq!(doc1, req.document_id);
 
         // Schedule the next one while the first one is "in progress"
-        upload_manager.enqueue_ping(doc2, &path2, json!({}), None);
+        upload_manager.enqueue_ping(&doc2, &path2, json!({}), None);
 
         // Mark as processed
-        upload_manager.process_ping_upload_response(&req.document_id, HttpStatus(200));
+        upload_manager.process_ping_upload_response(&req.document_id, HttpStatus(200), None);
 
         // Get the second request.
         let req = match upload_manager.get_upload_task(false) {
@@ -877,7 +908,7 @@ mod test {
         assert_eq!(doc2, req.document_id);
 
         // Mark as processed
-        upload_manager.process_ping_upload_response(&req.document_id, HttpStatus(200));
+        upload_manager.process_ping_upload_response(&req.document_id, HttpStatus(200), None);
 
         // ... and then we're done.
         assert_eq!(upload_manager.get_upload_task(false), PingUploadTask::Done);
@@ -919,5 +950,33 @@ mod test {
             }
             _ => panic!("Expected upload manager to return the next request!"),
         }
+    }
+
+    #[test]
+    fn test_duplicates_are_not_enqueued() {
+        // Create a new upload_manager
+        let dir = tempfile::tempdir().unwrap();
+        let upload_manager = PingUploadManager::new(dir.path(), false);
+
+        // Wait for processing of pending pings directory to finish.
+        while upload_manager.get_upload_task(false) == PingUploadTask::Wait {
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let doc_id = Uuid::new_v4().to_string();
+        let path = format!("/submit/app_id/test-ping/1/{}", doc_id);
+
+        // Try to enqueue a ping with the same doc_id twice
+        upload_manager.enqueue_ping(&doc_id, &path, json!({}), None);
+        upload_manager.enqueue_ping(&doc_id, &path, json!({}), None);
+
+        // Get a task once
+        match upload_manager.get_upload_task(false) {
+            PingUploadTask::Upload(_) => {}
+            _ => panic!("Expected upload manager to return the next request!"),
+        }
+
+        // There should be no more queued tasks
+        assert_eq!(upload_manager.get_upload_task(false), PingUploadTask::Done);
     }
 }


### PR DESCRIPTION
The tests on the upload module either used a standalone upload manager or the upload manager that is created when you create a new Glean instance. When creating a standalone one, the tests "wait" for upload manager to be done scanning the pending pings directory. When using the one inside Glean the don't.

This is most probably not causing the CI failures, if it is that would mean I understand those failures even less than I thought. Still, it is a good thing to add to the tests.

Also, opening this PR will allow me to send new commits to test fixes to the CI problem.