### PR TITLE
Use glean_parser 1.23.0 to fix event's key/value mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * General
     * Move debug view tag management to the Rust core. ([1640575](https://bugzilla.mozilla.org/show_bug.cgi?id=1640575), [#998](https://github.com/mozilla/glean/pull/998))
+    * BUGFIX: Fix mismatch in `event`s keys and values by using `glean_parser` version 1.23.0.
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.2.2...main)
 

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=1.22.0
+GLEAN_PARSER_VERSION=1.23.0
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -48,7 +48,7 @@ with (ROOT.parent / "Cargo.toml").open() as cargo:
 
 requirements = [
     "cffi>=1",
-    "glean_parser==1.22.0",
+    "glean_parser==1.23.0",
     "iso8601>=0.1.10; python_version<='3.6'",
 ]
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -34,7 +34,7 @@ class GleanMetricsYamlTransform extends ArtifactTransform {
 @SuppressWarnings("GrPackage")
 class GleanPlugin implements Plugin<Project> {
     // The version of glean_parser to install from PyPI.
-    private String GLEAN_PARSER_VERSION = "1.22.0"
+    private String GLEAN_PARSER_VERSION = "1.23.0"
     // The version of Miniconda is explicitly specified.
     // Miniconda3-4.5.12 is known to not work on Windows.
     private String MINICONDA_VERSION = "4.5.11"


### PR DESCRIPTION
When 2 or more extra_key are present in event definition, there could be a mismatch between the reported keys and their
value. This PR fixes the potential mismatch.