### PR TITLE
Bug 1649286 - Make Glean-iOS LabeledMetric subscript public

### DIFF
--- a/glean-core/ios/Glean/Metrics/LabeledMetric.swift
+++ b/glean-core/ios/Glean/Metrics/LabeledMetric.swift
@@ -104,7 +104,7 @@ public class LabeledMetricType<T> {
     /// - parameters:
     ///     * label: The label
     /// - returns: The specific metric for that label
-    subscript(label: String) -> T {
+    public subscript(label: String) -> T {
         // swiftlint:disable force_cast
         // REASON: We return the same type as the `subMetric` we match against
 


### PR DESCRIPTION
This makes the subscript access to the LabeledMetrics public, otherwise, consuming applications don't have access to record to the LabeledMetrics because the subscript defaults to internal access.