### PR TITLE
Bug 1648784: fix an initialization crash when Glean is used in Unity

### DIFF
--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -127,7 +127,19 @@ namespace Mozilla.Glean
                     delay_ping_lifetime_io = false
                 };
 
-                initialized = LibGleanFFI.glean_initialize(cfg) != 0;
+                // To work around a bug in the version of Mono shipped with Unity 2019.4.1f1,
+                // copy the FFI configuration structure to unmanaged memory and pass that over
+                // to glean-core, otherwise calling `glean_initialize` will crash and have
+                // `__icall_wrapper_mono_struct_delete_old` in the stack. See bug 1648784 for
+                // more details.
+                IntPtr ptrCfg = Marshal.AllocHGlobal(Marshal.SizeOf(cfg));
+                Marshal.StructureToPtr(cfg, ptrCfg, false);
+
+                initialized = LibGleanFFI.glean_initialize(ptrCfg) != 0;
+
+                // We were able to call `glean_initialize`, free the memory allocated for the
+                // FFI configuration object.
+                Marshal.FreeHGlobal(ptrCfg);
 
                 // If initialization of Glean fails we bail out and don't initialize further.
                 if (!initialized)

--- a/glean-core/csharp/Glean/LibGleanFFI.cs
+++ b/glean-core/csharp/Glean/LibGleanFFI.cs
@@ -141,7 +141,7 @@ namespace Mozilla.Glean.FFI
         // Glean top-level API.
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern byte glean_initialize(FfiConfiguration cfg);
+        internal static extern byte glean_initialize(IntPtr cfg);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void glean_clear_application_lifetime_metrics();

--- a/glean-core/csharp/Glean/LibGleanFFI.cs
+++ b/glean-core/csharp/Glean/LibGleanFFI.cs
@@ -79,7 +79,7 @@ namespace Mozilla.Glean.FFI
             public string data_dir;
             public string package_name;
             public bool upload_enabled;
-            public Int32? max_events;
+            public IntPtr max_events;
             public bool delay_ping_lifetime_io;
         }
 

--- a/glean-core/csharp/GleanTests/GleanTests.cs
+++ b/glean-core/csharp/GleanTests/GleanTests.cs
@@ -52,5 +52,19 @@ namespace Mozilla.Glean.Tests
             // We should take `GleanTest.kt` as a reference to implement. 
             GleanInstance.HandleBackgroundEvent();
         }
+
+        [Fact]
+        public void SettingMaxEventsDoesNotCrash()
+        {
+            string tempDataDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            GleanInstance.Reset(
+                applicationId: "org.mozilla.csharp.tests",
+                applicationVersion: "1.0-test",
+                uploadEnabled: true,
+                configuration: new Configuration(maxEvents: 500),
+                dataDir: tempDataDir
+                );
+        }
     }
 }


### PR DESCRIPTION
See the individual commit messages for the explanation.  This was tested locally with [this repo](https://github.com/daoshengmu/GleanUnity/tree/master/GleanUnity)