### PR TITLE
Bug 1648094: Install ssh and git on Python Linux container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -792,6 +792,10 @@ jobs:
       # The official docker image for building manylinux1 wheels
       - image: quay.io/pypa/manylinux1_x86_64
     steps:
+      - run:
+          name: Install ssh and git packages
+          command: |
+            yum install -y openssh-clients git
       - install-rustup
       - setup-rust-toolchain
       - checkout


### PR DESCRIPTION
The container used to build Python packages for Linux doesn't have ssh and git preinstalled, so CircleCI spends 2m40 installing them (for some unknown reason).  Installing the RPM packages for them only takes 10s, so this saves us non-trivial amounts of time on release.