### PR TITLE
Bug 1644359: Support error reporting in Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     * BUGFIX: raise an error if Glean is initialized with an empty string as the `application_id`.
 * Python
     * BUGFIX: correctly set the `app_build` metric to the newly provided `application_build_id` initialization option.
+    * The Python bindings now report networking errors in the `glean.upload.ping_upload_failure` metric (like all the other bindings).
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.2.3...main)
 

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -427,7 +427,12 @@ void glean_get_upload_task(FfiPingUploadTask *result, uint8_t log_ping);
  */
 uint8_t glean_initialize(const FfiConfiguration *cfg);
 
-uint8_t glean_initialize_standalone_uploader(FfiStr data_dir, FfiStr language_binding_name);
+/**
+ * # Safety
+ *
+ * A valid and non-null configuration object is required for this function.
+ */
+uint8_t glean_initialize_for_subprocess(const FfiConfiguration *cfg);
 
 uint8_t glean_is_dirty_flag_set(void);
 

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -427,7 +427,12 @@ void glean_get_upload_task(FfiPingUploadTask *result, uint8_t log_ping);
  */
 uint8_t glean_initialize(const FfiConfiguration *cfg);
 
-uint8_t glean_initialize_standalone_uploader(FfiStr data_dir, FfiStr language_binding_name);
+/**
+ * # Safety
+ *
+ * A valid and non-null configuration object is required for this function.
+ */
+uint8_t glean_initialize_for_subprocess(const FfiConfiguration *cfg);
 
 uint8_t glean_is_dirty_flag_set(void);
 

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -7,6 +7,7 @@ import json
 import logging
 from pathlib import Path
 import re
+import sys
 import time
 from typing import List, Tuple
 
@@ -50,7 +51,7 @@ class PingUploadWorker:
         from .. import Glean
 
         return ProcessDispatcher.dispatch(
-            _process, (Glean._data_dir, Glean._configuration)
+            _process, (Glean._data_dir, Glean._application_id, Glean._configuration)
         )
 
     @classmethod
@@ -101,21 +102,21 @@ def _parse_ping_headers(
     return headers
 
 
-def _process(data_dir: Path, configuration) -> bool:
+def _process(data_dir: Path, application_id: str, configuration) -> bool:
 
     # Import here to avoid cyclical import
     from ..glean import Glean
 
     if not Glean.is_initialized():
-        # Always load the Glean shared object / dll even if we're in a (ping upload worker)
-        # subprocess.
-        # To make startup time better in subprocesses, consumers can initialize just the
-        # ping upload manager.
-        data_dir = ffi_support.new("char[]", _ffi.ffi_encode_string(str(data_dir)))
-        language_binding_name = ffi_support.new(
-            "char[]", _ffi.ffi_encode_string(_ffi.LANGUAGE_BINDING_NAME)
+        # We don't want to send pings or otherwise update the database during
+        # initialization in a subprocess, so we use
+        # `glean_initialize_for_subprocess` rather than `glean_initialize` here.
+        cfg = _ffi.make_config(
+            data_dir, application_id, True, configuration.max_events,
         )
-        _ffi.lib.glean_initialize_standalone_uploader(data_dir, language_binding_name)
+        if _ffi.lib.glean_initialize_for_subprocess(cfg) == 0:
+            log.error("Couldn't initialize Glean in subprocess")
+            sys.exit(1)
 
     wait_attempts = 0
 

--- a/glean-core/python/tests/conftest.py
+++ b/glean-core/python/tests/conftest.py
@@ -43,6 +43,24 @@ def safe_httpserver(httpserver):
 
 
 @pytest.fixture
+def slow_httpserver(httpserver):
+    """
+    An httpserver that takes 0.5 seconds to respond.
+    """
+    wait_for_server(httpserver)
+
+    orig_call = httpserver.__call__
+
+    def __call__(self, *args, **kwargs):
+        time.sleep(0.5)
+        return orig_call(*args, **kwargs)
+
+    httpserver.__call__ = __call__
+
+    return httpserver
+
+
+@pytest.fixture
 def safe_httpsserver(httpsserver):
     wait_for_server(httpsserver)
     return httpsserver

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -43,9 +43,11 @@ def test_400_error(safe_httpserver):
     assert 1 == len(safe_httpserver.requests)
 
 
-def test_400_error_submit(safe_httpserver):
+def test_400_error_submit(safe_httpserver, monkeypatch):
     safe_httpserver.serve_content(b"", code=400)
 
+    # Force the ping upload worker into a separate process
+    monkeypatch.setattr(PingUploadWorker, "process", PingUploadWorker._process)
     Glean._configuration._server_endpoint = safe_httpserver.url
     Glean._submit_ping_by_name("baseline")
     ProcessDispatcher._wait_for_last_process()
@@ -69,9 +71,11 @@ def test_500_error(safe_httpserver):
     assert 1 == len(safe_httpserver.requests)
 
 
-def test_500_error_submit(safe_httpserver):
+def test_500_error_submit(safe_httpserver, monkeypatch):
     safe_httpserver.serve_content(b"", code=500)
 
+    # Force the ping upload worker into a separate process
+    monkeypatch.setattr(PingUploadWorker, "process", PingUploadWorker._process)
     Glean._configuration._server_endpoint = safe_httpserver.url
     Glean._submit_ping_by_name("baseline")
     ProcessDispatcher._wait_for_last_process()
@@ -82,6 +86,42 @@ def test_500_error_submit(safe_httpserver):
     metric = get_upload_failure_metric()
     assert not metric["status_code_4xx"].test_has_value()
     assert 10 == metric["status_code_5xx"].test_get_value()
+
+
+def test_500_error_submit_concurrent_writing(slow_httpserver, monkeypatch):
+    # This tests that concurrently writing to the database from the main process
+    # and the ping uploading subprocess.
+    slow_httpserver.serve_content(b"", code=500)
+
+    counter = metrics.CounterMetricType(
+        disabled=False,
+        category="test",
+        name="counter",
+        send_in_pings=["metrics"],
+        lifetime=metrics.Lifetime.PING,
+    )
+
+    # Force the ping upload worker into a separate process
+    monkeypatch.setattr(PingUploadWorker, "process", PingUploadWorker._process)
+    Glean._configuration._server_endpoint = slow_httpserver.url
+    Glean._submit_ping_by_name("baseline")
+
+    # While the uploader is running, increment the counter as fast as we can
+    times = 0
+    last_process = ProcessDispatcher._last_process
+    while last_process.poll() is None:
+        counter.add()
+        times += 1
+
+    # This kind of recoverable error will be tried 10 times
+    assert 10 == len(slow_httpserver.requests)
+
+    metric = get_upload_failure_metric()
+    assert not metric["status_code_4xx"].test_has_value()
+    assert 10 == metric["status_code_5xx"].test_get_value()
+
+    assert times > 0
+    assert times == counter.test_get_value()
 
 
 def test_unknown_scheme():

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -7,9 +7,28 @@ import uuid
 
 
 from glean import Glean
+from glean import metrics
+from glean._process_dispatcher import ProcessDispatcher
 from glean.net import PingUploadWorker
 from glean.net.http_client import HttpClientUploader
 from glean.net import ping_uploader
+
+
+def get_upload_failure_metric():
+    return metrics.LabeledCounterMetricType(
+        disabled=False,
+        send_in_pings=["metrics"],
+        name="ping_upload_failure",
+        category="glean.upload",
+        labels=[
+            "status_code_4xx",
+            "status_code_5xx",
+            "status_code_unknown",
+            "unrecoverable",
+            "recoverable",
+        ],
+        lifetime=metrics.Lifetime.PING,
+    )
 
 
 def test_400_error(safe_httpserver):
@@ -24,6 +43,20 @@ def test_400_error(safe_httpserver):
     assert 1 == len(safe_httpserver.requests)
 
 
+def test_400_error_submit(safe_httpserver):
+    safe_httpserver.serve_content(b"", code=400)
+
+    Glean._configuration._server_endpoint = safe_httpserver.url
+    Glean._submit_ping_by_name("baseline")
+    ProcessDispatcher._wait_for_last_process()
+
+    assert 1 == len(safe_httpserver.requests)
+
+    metric = get_upload_failure_metric()
+    assert 1 == metric["status_code_4xx"].test_get_value()
+    assert not metric["status_code_5xx"].test_has_value()
+
+
 def test_500_error(safe_httpserver):
     safe_httpserver.serve_content(b"", code=500)
 
@@ -34,6 +67,21 @@ def test_500_error(safe_httpserver):
     assert type(response) is ping_uploader.HttpResponse
     assert 500 == response._status_code
     assert 1 == len(safe_httpserver.requests)
+
+
+def test_500_error_submit(safe_httpserver):
+    safe_httpserver.serve_content(b"", code=500)
+
+    Glean._configuration._server_endpoint = safe_httpserver.url
+    Glean._submit_ping_by_name("baseline")
+    ProcessDispatcher._wait_for_last_process()
+
+    # This kind of recoverable error will be tried 10 times
+    assert 10 == len(safe_httpserver.requests)
+
+    metric = get_upload_failure_metric()
+    assert not metric["status_code_4xx"].test_has_value()
+    assert 10 == metric["status_code_5xx"].test_get_value()
 
 
 def test_unknown_scheme():

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -210,7 +210,7 @@ impl Glean {
             core_metrics: CoreMetrics::new(),
             internal_pings: InternalPings::new(),
             upload_manager,
-            data_path: PathBuf::from(cfg.data_path.to_string()),
+            data_path: PathBuf::from(&cfg.data_path),
             application_id,
             ping_registry: HashMap::new(),
             start_time: local_now_with_offset(),

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -12,13 +12,10 @@
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockWriteGuard};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use once_cell::sync::OnceCell;
-
-use crate::error::Result;
 use directory::PingDirectoryManager;
 pub use request::{HeaderMap, PingRequest};
 pub use result::{ffi_upload_result, UploadResult};
@@ -26,43 +23,6 @@ pub use result::{ffi_upload_result, UploadResult};
 mod directory;
 mod request;
 mod result;
-
-/// A global Glean upload manager instance.
-///
-/// This is only used by processes who exclusively need to manage
-/// ping upload and do not want to perform a full Glean initialization.
-static UPLOAD_MANAGER: OnceCell<Mutex<PingUploadManager>> = OnceCell::new();
-
-/// Get a reference to the global Upload Manager object.
-pub fn global_upload_manager() -> Option<&'static Mutex<PingUploadManager>> {
-    UPLOAD_MANAGER.get()
-}
-
-/// Set or replace the global Glean object.
-pub fn setup_upload_manager(upload_manager: PingUploadManager) -> Result<()> {
-    // The `OnceCell` type wrapping our PingUploadManager is thread-safe and can only be set once.
-    // Therefore even if our check for it being empty succeeds, setting it could fail if a
-    // concurrent thread is quicker in setting it.
-    // However this will not cause a bigger problem, as the second `set` operation will just fail.
-    // We can log it and move on.
-    //
-    // For all wrappers this is not a problem, as the uploader object is intialized exactly once on
-    // calling the FFI `glean_standalone_uploader`.
-    if UPLOAD_MANAGER.get().is_none() {
-        if UPLOAD_MANAGER.set(Mutex::new(upload_manager)).is_err() {
-            log::error!(
-                "Global Upload Manager object is initialized already. This probably happened concurrently."
-            )
-        }
-    } else {
-        // We allow overriding the global upload manager object to support test mode.
-        // In test mode the upload manager object is fully destroyed and recreated.
-        // This all happens behind a mutex and is therefore also thread-safe..
-        let mut lock = UPLOAD_MANAGER.get().unwrap().lock().unwrap();
-        *lock = upload_manager;
-    }
-    Ok(())
-}
 
 #[derive(Debug)]
 struct RateLimiter {


### PR DESCRIPTION
This works by initializing a full Glean in the subprocess that
*doesn't* do any startup work such as setting metrics or submitting
pings. This makes it safe to initialize Glean in the subprocess,
and thus errors can be reported there.