### PR TITLE
Use Path.* methods for path handling

### DIFF
--- a/samples/csharp/Program.cs
+++ b/samples/csharp/Program.cs
@@ -13,7 +13,7 @@ namespace csharp
     {
         static void Main(string[] args)
         {
-            string gleanDataDir = Directory.GetCurrentDirectory() + "\\glean_data";
+            string gleanDataDir = Path.Combine(Directory.GetCurrentDirectory(), "glean_data");
             Console.WriteLine("Adding Glean data to {0}", gleanDataDir);
 
             GleanInstance.Initialize(


### PR DESCRIPTION
Windows uses a backward slash (`\`),
*nix uses a forward slash (`/`).
Let's use a function to do the right thing here.