### PR TITLE
Bug 1650752 - Reapply async upload toggle after initialize

### DIFF
--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -70,12 +70,12 @@ namespace Mozilla.Glean
 
         /// <summary>
         /// Initialize the Glean SDK.
-        /// 
+        ///
         /// This should only be initialized once by the application, and not by
         /// libraries using the Glean SDK. A message is logged to error and no
         /// changes are made to the state if initialize is called a more than
         /// once.
-        /// 
+        ///
         /// This method must be called from the main thread.
         /// </summary>
         /// <param name="applicationId">The application id to use when sending pings.</param>
@@ -121,7 +121,9 @@ namespace Mozilla.Glean
             httpClient = new BaseUploader(configuration.httpClient);
             // this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR)
 
-            SetUploadEnabled(uploadEnabled);
+            // We know we're not initialized, so we can skip the check inside `setUploadEnabled`
+            // by setting the variable directly.
+            this.uploadEnabled = uploadEnabled;
 
             Dispatchers.ExecuteTask(() =>
             {
@@ -224,6 +226,14 @@ namespace Mozilla.Glean
                     InitializeCoreMetrics();
                 }
 
+                // Upload might have been changed in between the call to `initialize`
+                // and this task actually running.
+                // This actually enqueues a task, which will execute after other user-submitted tasks
+                // as part of the queue flush below.
+                if (this.uploadEnabled != uploadEnabled) {
+                    SetUploadEnabled(this.uploadEnabled);
+                }
+
                 // Signal Dispatcher that init is complete
                 Dispatchers.FlushQueuedInitialTasks();
                 /*
@@ -247,15 +257,15 @@ namespace Mozilla.Glean
 
         /// <summary>
         /// Enable or disable Glean collection and upload.
-        /// 
+        ///
         /// Metric collection is enabled by default.
-        /// 
+        ///
         /// When uploading is disabled, metrics aren't recorded at all and no data
         /// is uploaded.
-        /// 
+        ///
         /// When disabling, all pending metrics, events and queued pings are cleared
         /// and a `deletion-request` is generated.
-        /// 
+        ///
         /// When enabling, the core Glean metrics are recreated.
         /// </summary>
         /// <param name="enabled">When `true`, enable metric collection.</param>
@@ -264,7 +274,7 @@ namespace Mozilla.Glean
             if (IsInitialized())
             {
                 bool originalEnabled = GetUploadEnabled();
-    
+
                 Dispatchers.LaunchAPI(() => {
                 LibGleanFFI.glean_set_upload_enabled(enabled);
 
@@ -432,11 +442,11 @@ namespace Mozilla.Glean
 
         /// <summary>
         /// Collect and submit a ping for eventual upload.
-        /// 
+        ///
         /// The ping content is assembled as soon as possible, but upload is not
         /// guaranteed to happen immediately, as that depends on the upload
         /// policies.
-        /// 
+        ///
         /// If the ping currently contains no content, it will not be assembled and
         /// queued for sending.
         /// </summary>
@@ -449,14 +459,14 @@ namespace Mozilla.Glean
 
         /// <summary>
         /// Collect and submit a ping for eventual upload by name.
-        /// 
+        ///
         /// The ping will be looked up in the known instances of `PingType`. If the
         /// ping isn't known, an error is logged and the ping isn't queued for uploading.
-        /// 
+        ///
         /// The ping content is assembled as soon as possible, but upload is not
         /// guaranteed to happen immediately, as that depends on the upload
         /// policies.
-        /// 
+        ///
         /// If the ping currently contains no content, it will not be assembled and
         /// queued for sending, unless explicitly specified otherwise in the registry
         /// file.
@@ -473,14 +483,14 @@ namespace Mozilla.Glean
 
         /// <summary>
         /// Collect and submit a ping (by its name) for eventual upload, synchronously.
-        /// 
+        ///
         /// The ping will be looked up in the known instances of `PingType`. If the
         /// ping isn't known, an error is logged and the ping isn't queued for uploading.
-        /// 
+        ///
         /// The ping content is assembled as soon as possible, but upload is not
         /// guaranteed to happen immediately, as that depends on the upload
         /// policies.
-        /// 
+        ///
         /// If the ping currently contains no content, it will not be assembled and
         /// queued for sending, unless explicitly specified otherwise in the registry
         /// file.

--- a/glean-core/ios/GleanTests/TestUtils.swift
+++ b/glean-core/ios/GleanTests/TestUtils.swift
@@ -44,10 +44,8 @@ func stubServerReceive(callback: @escaping (String, [String: Any]?) -> Void) {
 
 /// Stringify a JSON object and if unable to, just return an empty string.
 func JSONStringify(_ json: Any) -> String {
-    var options: JSONSerialization.WritingOptions = JSONSerialization.WritingOptions.prettyPrinted
-
     do {
-        let data = try JSONSerialization.data(withJSONObject: json, options: options)
+        let data = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
         if let string = String(data: data, encoding: String.Encoding.utf8) {
             return string
         }

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -147,7 +147,7 @@ class Glean:
                 cls._application_build_id = application_build_id
 
             # We know we're not initialized,
-            # so we can skip the check inside `setUploadEnabled`
+            # so we can skip the check inside `set_upload_enabled`
             # by setting the variable directly.
             cls._upload_enabled = upload_enabled
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -146,7 +146,10 @@ class Glean:
             else:
                 cls._application_build_id = application_build_id
 
-            cls.set_upload_enabled(upload_enabled)
+            # We know we're not initialized,
+            # so we can skip the check inside `setUploadEnabled`
+            # by setting the variable directly.
+            cls._upload_enabled = upload_enabled
 
         # Use `Glean._execute_task` rather than `Glean.launch` here, since we
         # never want to put this work on the `Dispatcher._preinit_queue`.
@@ -202,6 +205,13 @@ class Glean:
             if not is_first_run:
                 _ffi.lib.glean_clear_application_lifetime_metrics()
                 cls._initialize_core_metrics()
+
+            # Upload might have been changed in between the call to `initialize`
+            # and this task actually running.
+            # This actually enqueues a task, which will execute after other user-submitted tasks
+            # as part of the queue flush below.
+            if cls._upload_enabled != upload_enabled:
+                cls.set_upload_enabled(cls._upload_enabled)
 
             Dispatcher.flush_queued_initial_tasks()
 


### PR DESCRIPTION
From the commit message:

The task running the intialization runs asynchronously.
It therefore can happen that we externally modify the uploadEnabled
flag.
Up to now we forgot to recheck it.
By doing this as the last thing before flushing the queue of tasks it
should be in the expected order for users:

1. First Glean fully initializes, with the uploadEnabled flag as set in
   the `initialize` call.
2. Potentially queued up tasks (such as metric recordings) are replayed
3. Finally toggling the flag is respected.

---

This fixes the one encountered issue where changes to the flag are simply not reflected at all.