### PR TITLE
Bug 1649926 - Always enqueue an async task to change upload and deprecate `getUploadEnabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * General
   * Implement JWE metric type ([#1073](https://github.com/mozilla/glean/pull/1073), [#1062](https://github.com/mozilla/glean/pull/1062)).
+  * DEPRECATION: `getUploadEnabled` is deprecated (respectively `get_upload_enabled` in Python) ([#1046](https://github.com/mozilla/glean/pull/1046))
+    * Due to Glean's asynchronous initialization the return value can be incorrect.
+      Applications should not rely on Glean's internal state.
+      Upload enabled status should be tracked by the application and communicated to Glean if it changes.
+      Note: The method was removed from the C# and Python implementation.
 
 # v31.5.0 (2020-07-22)
 

--- a/docs/user/general-api.md
+++ b/docs/user/general-api.md
@@ -18,7 +18,6 @@ The Glean SDK provides a general API that supports the following operations. See
 | --------- | ----------- | ----- |
 | `initialize` | Configure and initialize the Glean SDK. | [Initializing the Glean SDK](#initializing-the-glean-sdk) |
 | `setUploadEnabled` | Enable or disable Glean collection and upload. | [Enabling and disabling Metrics](#enabling-and-disabling-metrics) |
-| `getUploadEnabled` | Get whether or not Glean is allowed to record and upload data. | |
 | `registerPings` | Register custom pings generated from `pings.yaml`. | [Custom pings][custom-pings] |
 | `setExperimentActive` | Indicate that an experiment is running. | [Using the Experiments API][experiments-api] |
 | `setExperimentInactive` | Indicate that an experiment is no longer running.. | [Using the Experiments API][experiments-api] |

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -293,7 +293,7 @@ open class GleanInternalAPI internal constructor () {
         // we can safely enqueue here and it will execute after initialization.
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
-            val originalEnabled = getUploadEnabled()
+            val originalEnabled = internalGetUploadEnabled()
             LibGleanFFI.INSTANCE.glean_set_upload_enabled(enabled.toByte())
 
             if (!enabled) {
@@ -322,8 +322,25 @@ open class GleanInternalAPI internal constructor () {
      * Get whether or not Glean is allowed to record and upload data.
      *
      * Caution: the result is only correct if Glean is already initialized.
+     *
+     * **THIS METHOD IS DEPRECATED.**
+     * Applications should not rely on Glean's internal state.
+     * Upload enabled status should be tracked by the application and communicated to Glean if it changes.
      */
+    @Deprecated("Upload enabled should be tracked by the application and communicated to Glean if it changes")
     fun getUploadEnabled(): Boolean {
+        return internalGetUploadEnabled()
+    }
+
+    /**
+     * Get whether or not Glean is allowed to record and upload data.
+     *
+     * Caution: the result is only correct if Glean is already initialized.
+     *
+     * Note: due to the deprecation notice and because warnings break the build,
+     * we pull out the implementation into an internal method.
+     */
+    internal fun internalGetUploadEnabled(): Boolean {
         if (isInitialized()) {
             return LibGleanFFI.INSTANCE.glean_is_upload_enabled().toBoolean()
         } else {
@@ -593,7 +610,7 @@ open class GleanInternalAPI internal constructor () {
             return
         }
 
-        if (!getUploadEnabled()) {
+        if (!internalGetUploadEnabled()) {
             Log.e(LOG_TAG, "Glean disabled: not submitting any pings.")
             return
         }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -344,7 +344,7 @@ open class GleanInternalAPI internal constructor () {
         if (isInitialized()) {
             return LibGleanFFI.INSTANCE.glean_is_upload_enabled().toBoolean()
         } else {
-            return true
+            return false
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -776,8 +776,12 @@ open class GleanInternalAPI internal constructor () {
         }
 
         LibGleanFFI.INSTANCE.glean_destroy_glean()
-        initialized = false
+
+        // Reset all state.
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.setTaskQueueing(true)
         initFinished = false
+        initialized = false
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -296,7 +296,7 @@ open class GleanInternalAPI internal constructor () {
             Pass the correct state into `Glean.initialize()`.
             See documentation at https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk
             """.trimIndent()
-            Log.w(LOG_TAG, msg)
+            Log.e(LOG_TAG, msg)
             return
         }
         // Changing upload enabled always happens asynchronous.

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -67,20 +67,6 @@ class GleanTest {
         Glean.setUploadEnabled(true)
     }
 
-    @Test
-    fun `getting uploadEnabled before initialization should not crash`() {
-        // Can't use resetGlean directly
-        Glean.testDestroyGleanHandle()
-
-        val config = Configuration()
-
-        Glean.setUploadEnabled(true)
-        assertTrue(Glean.getUploadEnabled())
-
-        Glean.initialize(context, true, config)
-        assertTrue(Glean.getUploadEnabled())
-    }
-
     // New from glean-core.
     @Test
     fun `send a ping`() {
@@ -131,7 +117,7 @@ class GleanTest {
                 sendInPings = listOf("store1")
         )
         Glean.setUploadEnabled(false)
-        assertEquals(false, Glean.getUploadEnabled())
+
         stringMetric.set("foo")
         assertFalse(stringMetric.testHasValue())
     }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -73,7 +73,7 @@ internal fun checkPingSchema(content: JSONObject) {
     }
 
     val exitCode = process.waitFor()
-    assert(exitCode == 0)
+    Assert.assertEquals("glean_parser check failed with exit code $exitCode", 0, exitCode)
 }
 
 /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -209,13 +209,11 @@ class EventMetricTypeTest {
             sendInPings = listOf("store1"),
             allowedExtraKeys = listOf("test_name")
         )
-        assertEquals(true, Glean.getUploadEnabled())
         Glean.setUploadEnabled(true)
         eventMetric.record(mapOf(testNameKeys.testName to "event1"))
         val snapshot1 = eventMetric.testGetValue()
         assertEquals(1, snapshot1.size)
         Glean.setUploadEnabled(false)
-        assertEquals(false, Glean.getUploadEnabled())
         eventMetric.record(mapOf(testNameKeys.testName to "event2"))
         @Suppress("EmptyCatchBlock")
         try {

--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -298,7 +298,7 @@ namespace Mozilla.Glean
         /// Caution: the result is only correct if Glean is already initialized.
         /// </summary>
         /// <returns>`true` if Glean is allowed to record and upload data.</returns>
-        public bool GetUploadEnabled()
+        bool GetUploadEnabled()
         {
             if (IsInitialized())
             {

--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -306,7 +306,7 @@ namespace Mozilla.Glean
             }
             else
             {
-                return true;
+                return false;
             }
         }
 

--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -29,9 +29,6 @@ namespace Mozilla.Glean
 
         private bool initialized = false;
 
-        // Keep track of this flag before Glean is initialized
-        private bool uploadEnabled = true;
-
         // Keep track of ping types that have been registered before Glean is initialized.
         private HashSet<PingTypeBase> pingTypeQueue = new HashSet<PingTypeBase>();
 
@@ -120,10 +117,6 @@ namespace Mozilla.Glean
             this.applicationVersion = applicationVersion;
             httpClient = new BaseUploader(configuration.httpClient);
             // this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR)
-
-            // We know we're not initialized, so we can skip the check inside `setUploadEnabled`
-            // by setting the variable directly.
-            this.uploadEnabled = uploadEnabled;
 
             Dispatchers.ExecuteTask(() =>
             {
@@ -226,14 +219,6 @@ namespace Mozilla.Glean
                     InitializeCoreMetrics();
                 }
 
-                // Upload might have been changed in between the call to `initialize`
-                // and this task actually running.
-                // This actually enqueues a task, which will execute after other user-submitted tasks
-                // as part of the queue flush below.
-                if (this.uploadEnabled != uploadEnabled) {
-                    SetUploadEnabled(this.uploadEnabled);
-                }
-
                 // Signal Dispatcher that init is complete
                 Dispatchers.FlushQueuedInitialTasks();
                 /*
@@ -271,11 +256,14 @@ namespace Mozilla.Glean
         /// <param name="enabled">When `true`, enable metric collection.</param>
         public void SetUploadEnabled(bool enabled)
         {
-            if (IsInitialized())
-            {
-                bool originalEnabled = GetUploadEnabled();
-
-                Dispatchers.LaunchAPI(() => {
+            // Changing upload enabled always happens asynchronous.
+            // That way it follows what a user expect when calling it inbetween other calls:
+            // It executes in the right order.
+            //
+            // Because the dispatch queue is halted until Glean is fully initialized
+            // we can safely enqueue here and it will execute after initialization.
+            Dispatchers.LaunchAPI(() => {
+                bool originalEnabled = this.GetUploadEnabled();
                 LibGleanFFI.glean_set_upload_enabled(enabled);
 
                 if (!enabled)
@@ -301,16 +289,13 @@ namespace Mozilla.Glean
                     // If uploading is disabled, we need to send the deletion-request ping
                     httpClient.TriggerUpload(configuration);
                 }
-                });
-            }
-            else
-            {
-                uploadEnabled = enabled;
-            }
+            });
         }
 
         /// <summary>
         /// Get whether or not Glean is allowed to record and upload data.
+        ///
+        /// Caution: the result is only correct if Glean is already initialized.
         /// </summary>
         /// <returns>`true` if Glean is allowed to record and upload data.</returns>
         public bool GetUploadEnabled()
@@ -321,7 +306,7 @@ namespace Mozilla.Glean
             }
             else
             {
-                return uploadEnabled;
+                return true;
             }
         }
 

--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -266,7 +266,7 @@ namespace Mozilla.Glean
                 string msg = "Changing upload enabled before Glean is initialized is not supported.\n" +
                     "Pass the correct state into `Glean.initialize()`.\n" +
                     "See documentation at https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk";
-                Log.Warning(msg);
+                Log.Error(msg);
 
                 return;
             }

--- a/glean-core/csharp/GleanTests/GleanTests.cs
+++ b/glean-core/csharp/GleanTests/GleanTests.cs
@@ -27,25 +27,6 @@ namespace Mozilla.Glean.Tests
         }
 
         [Fact]
-        public void GettingUploadEnabledBeforeInitShouldNotCrash()
-        {
-            // Can't use resetGlean directly
-            GleanInstance.TestDestroyGleanHandle();
-
-            GleanInstance.SetUploadEnabled(true);
-            Assert.True(GleanInstance.GetUploadEnabled());
-
-            string tempDataDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            GleanInstance.Initialize(
-                applicationId: "org.mozilla.csharp.tests",
-                applicationVersion: "1.0-test",
-                uploadEnabled: true,
-                configuration: new Configuration(),
-                dataDir: tempDataDir
-                );
-        }
-
-        [Fact]
         public void SendAPing()
         {
             // TODO: This test needs a server to verify data are submitted successfully.

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -18,8 +18,7 @@ public class Glean {
     /// The main Glean object.
     ///
     /// ```swift
-    /// Glean.shared.setUploadEnabled(true)
-    /// Glean.shared.initialize()
+    /// Glean.shared.initialize(uploadEnabled: true)
     /// ```
     public static let shared = Glean()
 
@@ -228,7 +227,7 @@ public class Glean {
             // at which point it will pick up scheduled pings before the setting was toggled.
             // Or it is scheduled afterwards and will not schedule or find any left-over pings to send.
 
-            let originalEnabled = getUploadEnabled()
+            let originalEnabled = self.internalGetUploadEnabled()
             glean_set_upload_enabled(enabled.toByte())
 
             if !enabled {
@@ -254,7 +253,19 @@ public class Glean {
     ///
     /// Caution: the result is only correct if Glean is already initialized.
     ///
+    /// **THIS METHOD IS DEPRECATED.**
+    /// Applications should not rely on Glean's internal state.
+    /// Upload enabled status should be tracked by the application and communicated to Glean if it changes.
+    @available(*, deprecated,
+               message: "Upload enabled should be tracked by the application and communicated to Glean if it changes")
     public func getUploadEnabled() -> Bool {
+        return internalGetUploadEnabled()
+    }
+
+    /// Get whether or not Glean is allowed to record and upload data.
+    ///
+    /// Caution: the result is only correct if Glean is already initialized.
+    func internalGetUploadEnabled() -> Bool {
         if isInitialized() {
             return glean_is_upload_enabled() != 0
         } else {
@@ -405,7 +416,7 @@ public class Glean {
             return
         }
 
-        if !self.getUploadEnabled() {
+        if !self.internalGetUploadEnabled() {
             self.logger.error("Glean disabled: not submitting any pings")
             return
         }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -269,7 +269,7 @@ public class Glean {
         if isInitialized() {
             return glean_is_upload_enabled() != 0
         } else {
-            return true
+            return false
         }
     }
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -229,7 +229,7 @@ public class Glean {
             Pass the correct state into `Glean.initialize()`.
             See documentation at https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk
             """
-            self.logger.warn(msg)
+            self.logger.error(msg)
 
             return
         }

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -23,7 +23,6 @@ class GleanTests: XCTestCase {
     func testInitializeGlean() {
         // Glean is already initialized by the `setUp()` function
         XCTAssert(Glean.shared.isInitialized(), "Glean should be initialized")
-        XCTAssert(Glean.shared.getUploadEnabled(), "Upload is enabled by default")
     }
 
     func testExperimentRecording() {

--- a/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
@@ -194,18 +194,15 @@ class EventMetricTypeTests: XCTestCase {
         )
 
         Glean.shared.setUploadEnabled(true)
-        XCTAssert(Glean.shared.getUploadEnabled())
         metric.record(extra: [.testName: "event1"])
         let snapshot1 = try! metric.testGetValue()
         XCTAssertEqual(1, snapshot1.count)
 
         Glean.shared.setUploadEnabled(false)
-        XCTAssertFalse(Glean.shared.getUploadEnabled())
         metric.record(extra: [.testName: "event2"])
         XCTAssertFalse(metric.testHasValue())
 
         Glean.shared.setUploadEnabled(true)
-        XCTAssert(Glean.shared.getUploadEnabled())
         metric.record(extra: [.testName: "event3"])
         let snapshot3 = try! metric.testGetValue()
         XCTAssertEqual(1, snapshot3.count)

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -311,18 +311,18 @@ class Glean:
         # we can safely enqueue here and it will execute after initialization.
         @Dispatcher.launch
         def set_upload_enabled():
-            original_enabled = cls.get_upload_enabled()
+            original_enabled = cls._get_upload_enabled()
             _ffi.lib.glean_set_upload_enabled(enabled)
 
-            if original_enabled is False and cls.get_upload_enabled() is True:
+            if original_enabled is False and cls._get_upload_enabled() is True:
                 cls._initialize_core_metrics()
 
-            if original_enabled is True and cls.get_upload_enabled() is False:
+            if original_enabled is True and cls._get_upload_enabled() is False:
                 # If uploading is disabled, we need to send the deletion-request ping
                 PingUploadWorker.process()
 
     @classmethod
-    def get_upload_enabled(cls) -> bool:
+    def _get_upload_enabled(cls) -> bool:
         """
         Get whether or not Glean is allowed to record and upload data.
 
@@ -501,7 +501,7 @@ class Glean:
             log.error("Glean must be initialized before submitting pings.")
             return
 
-        if not cls.get_upload_enabled():
+        if not cls._get_upload_enabled():
             log.error("Glean disabled: not submitting any pings.")
             return
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -318,7 +318,7 @@ class Glean:
                   See documentation at
                   https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk
                   """
-            log.warning(inspect.cleandoc(msg))
+            log.error(inspect.cleandoc(msg))
             return
 
         # Changing upload enabled always happens asynchronous.

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -331,7 +331,7 @@ class Glean:
         if cls.is_initialized():
             return bool(_ffi.lib.glean_is_upload_enabled())
         else:
-            return True
+            return False
 
     @classmethod
     def set_experiment_active(

--- a/glean-core/python/tests/metrics/test_event.py
+++ b/glean-core/python/tests/metrics/test_event.py
@@ -181,13 +181,11 @@ def test_events_should_not_record_when_upload_is_disabled():
         allowed_extra_keys=["test_name"],
     )
 
-    assert Glean.get_upload_enabled()
     Glean.set_upload_enabled(True)
     event_metric.record({EventKeys.TEST_NAME: "event1"})
     snapshot1 = event_metric.test_get_value()
     assert 1 == len(snapshot1)
     Glean.set_upload_enabled(False)
-    assert not Glean.get_upload_enabled()
     event_metric.record({EventKeys.TEST_NAME: "event2"})
     with pytest.raises(ValueError):
         event_metric.test_get_value()

--- a/glean-core/python/tests/metrics/test_event.py
+++ b/glean-core/python/tests/metrics/test_event.py
@@ -257,9 +257,7 @@ def test_flush_queued_events_on_startup_and_correctly_handle_preinit_events(
         application_id="glean-python-test",
         application_version=glean_version,
         clear_stores=False,
-        configuration=Configuration(
-            server_endpoint=safe_httpserver.url
-        ),
+        configuration=Configuration(server_endpoint=safe_httpserver.url),
     )
 
     event.record(extra={EventKeys.SOME_EXTRA: "post-init"})

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -54,20 +54,6 @@ def test_setting_upload_enabled_before_initialization_should_not_crash():
     )
 
 
-def test_getting_upload_enabled_before_initialization_should_not_crash():
-    Glean._reset()
-
-    Glean.set_upload_enabled(True)
-    assert Glean.get_upload_enabled()
-
-    Glean.initialize(
-        application_id=GLEAN_APP_ID,
-        application_version=glean_version,
-        upload_enabled=True,
-    )
-    assert Glean.get_upload_enabled()
-
-
 def test_submit_a_ping(safe_httpserver):
     safe_httpserver.serve_content(b"", code=200)
 
@@ -108,7 +94,6 @@ def test_disabling_upload_should_disable_metrics_recording():
     )
 
     Glean.set_upload_enabled(False)
-    assert False is Glean.get_upload_enabled()
     counter_metric.add(1)
     assert False is counter_metric.test_has_value()
 

--- a/samples/android/app/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -44,7 +44,6 @@ open class MainActivity : AppCompatActivity() {
             )
         }
 
-        uploadSwitch.setChecked(Glean.getUploadEnabled())
         uploadSwitch.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
                 gleanEnabledText.setText("Glean is enabled")


### PR DESCRIPTION
Replicating the commit messages for information:

    Always enqueue an async task to change upload

    That way it follows what a user expect when calling it in between other calls:
    It executes in the right order.

    Because the dispatch queue is halted until Glean is fully initialized
    we can safely enqueue here and it will execute after initialization.

and

    Deprecate `getUploadEnabled()` across all implementations

    Due to Glean's asynchronous initialization the return value can be incorrect.
    Applications should not rely on Glean's internal state.
    Upload enabled status should be tracked by the application and communicated to Glean if it changes.
    Note: The method was removed from the C# implementation.


--- 

This probably deserves some extra eyes on it. Putting you 3 on it, but maybe one or 2 should be enough.

I'm now reasonably sure it does what we expect it to do and the tests capture that.
However the tests are a bit brittle and (at least in some cases) might pass just fine on the old code base too.

Getting rid of `getUploadEnabled` means we also don't need to additionally track that upload enabled flag anymore.

Unfortunately I can't write a C# test because we don't have all the necessary utilities in place yet.
I did verify that adding `GleanInstance.SetUploadEnabled(false);` in the sample app just after `Initialize` does NOT send the custom ping, but DOES send the deletion-request ping.