### PR TITLE
Fix doc-only builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,6 +701,7 @@ jobs:
       - image: circleci/python:3.7.6
     steps:
       - checkout
+      - skip-if-doc-only
       - test-python
       - persist_to_workspace:
           root: glean-core/python/
@@ -711,7 +712,6 @@ jobs:
       - image: circleci/python:3.8.2
     steps:
       - checkout
-      - skip-if-doc-only
       - test-python
       - persist_to_workspace:
           root: glean-core/python/


### PR DESCRIPTION
A full Python build needs to run in order for a Python documentation build to work.

As of #995, the Python 3.8 test job needs to run even for doc-only builds,
rather than the Python 3.7 test job.