### PR TITLE
Bug 1649925 - Make sure Glean C# doesn't crash on x86

### DIFF
--- a/glean-core/csharp/Glean/Glean.csproj
+++ b/glean-core/csharp/Glean/Glean.csproj
@@ -25,6 +25,7 @@
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <!--

--- a/glean-core/csharp/Glean/LibGleanFFI.cs
+++ b/glean-core/csharp/Glean/LibGleanFFI.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using Serilog;
 
 namespace Mozilla.Glean.FFI
 {
@@ -84,27 +83,6 @@ namespace Mozilla.Glean.FFI
             public bool delay_ping_lifetime_io;
         }
 
-        /// <summary>
-        /// A base handle class meant to be extended by the different metric types to allow
-        /// for calling metric specific clearing functions.
-        /// </summary>
-        internal class BaseGleanHandle : SafeHandle
-        {
-            public BaseGleanHandle() : base(invalidHandleValue: IntPtr.Zero, ownsHandle: true) { }
-
-            public override bool IsInvalid
-            {
-                get { return this.handle == IntPtr.Zero; }
-            }
-
-            protected override bool ReleaseHandle()
-            {
-                // Note: this is meant to be implemented by the inheriting class in order to
-                // provide a specific cleanup action.
-                return false;
-            }
-        }
-
         public static string GetFromRustString(IntPtr pointer)
         {
             int len = 0;
@@ -175,7 +153,7 @@ namespace Mozilla.Glean.FFI
         internal static extern byte glean_is_upload_enabled();
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern StringAsReturnValue glean_ping_collect(PingTypeHandle ping_type_handle, string reason);
+        internal static extern StringAsReturnValue glean_ping_collect(UInt64 ping_type_handle, string reason);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern byte glean_submit_ping_by_name(string ping_name, string reason);
@@ -184,24 +162,8 @@ namespace Mozilla.Glean.FFI
 
         // String
 
-        /// <summary>
-        /// A handle for the string metric type, which performs cleanup.
-        /// </summary>
-        internal sealed class StringMetricTypeHandle : BaseGleanHandle
-        {
-            protected override bool ReleaseHandle()
-            {
-                if (!this.IsInvalid)
-                {
-                    glean_destroy_string_metric(handle);
-                }
-
-                return true;
-            }
-        }
-
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern StringMetricTypeHandle glean_new_string_metric(
+        internal static extern UInt64 glean_new_string_metric(
             string category,
             string name,
             string[] send_in_pings,
@@ -211,44 +173,28 @@ namespace Mozilla.Glean.FFI
         );
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void glean_destroy_string_metric(IntPtr handle);
+        internal static extern void glean_destroy_string_metric(UInt64 handle);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void glean_string_set(StringMetricTypeHandle metric_id, string value);
+        internal static extern void glean_string_set(UInt64 metric_id, string value);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern StringAsReturnValue glean_string_test_get_value(StringMetricTypeHandle metric_id, string storage_name);
+        internal static extern StringAsReturnValue glean_string_test_get_value(UInt64 metric_id, string storage_name);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern byte glean_string_test_has_value(StringMetricTypeHandle metric_id, string storage_name);
+        internal static extern byte glean_string_test_has_value(UInt64 metric_id, string storage_name);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern Int32 glean_string_test_get_num_recorded_errors(
-             StringMetricTypeHandle metric_id,
+             UInt64 metric_id,
              Int32 error_type,
              string storage_name
         );
 
         // Boolean
 
-        /// <summary>
-        /// A handle for the boolean metric type, which performs cleanup.
-        /// </summary>
-        internal sealed class BooleanMetricTypeHandle : BaseGleanHandle
-        {
-            protected override bool ReleaseHandle()
-            {
-                if (!this.IsInvalid)
-                {
-                    glean_destroy_boolean_metric(handle);
-                }
-
-                return true;
-            }
-        }
-
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern BooleanMetricTypeHandle glean_new_boolean_metric(
+        internal static extern UInt64 glean_new_boolean_metric(
             string category,
             string name,
             string[] send_in_pings,
@@ -261,34 +207,18 @@ namespace Mozilla.Glean.FFI
         internal static extern void glean_destroy_boolean_metric(IntPtr handle);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void glean_boolean_set(BooleanMetricTypeHandle metric_id, byte value);
+        internal static extern void glean_boolean_set(UInt64 metric_id, byte value);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern byte glean_boolean_test_get_value(BooleanMetricTypeHandle metric_id, string storage_name);
+        internal static extern byte glean_boolean_test_get_value(UInt64 metric_id, string storage_name);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern byte glean_boolean_test_has_value(BooleanMetricTypeHandle metric_id, string storage_name);
+        internal static extern byte glean_boolean_test_has_value(UInt64 metric_id, string storage_name);
 
         // Uuid
 
-        /// <summary>
-        /// A handle for the uuid metric type, which performs cleanup.
-        /// </summary>
-        internal sealed class UuidMetricTypeHandle : BaseGleanHandle
-        {
-            protected override bool ReleaseHandle()
-            {
-                if (!this.IsInvalid)
-                {
-                    glean_destroy_uuid_metric(handle);
-                }
-
-                return true;
-            }
-        }
-
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern UuidMetricTypeHandle glean_new_uuid_metric(
+        internal static extern UInt64 glean_new_uuid_metric(
             string category,
             string name,
             string[] send_in_pings,
@@ -301,34 +231,18 @@ namespace Mozilla.Glean.FFI
         internal static extern void glean_destroy_uuid_metric(IntPtr handle);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void glean_uuid_set(UuidMetricTypeHandle metric_id, string value);
+        internal static extern void glean_uuid_set(UInt64 metric_id, string value);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern StringAsReturnValue glean_uuid_test_get_value(UuidMetricTypeHandle metric_id, string storage_name);
+        internal static extern StringAsReturnValue glean_uuid_test_get_value(UInt64 metric_id, string storage_name);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern byte glean_uuid_test_has_value(UuidMetricTypeHandle metric_id, string storage_name);
+        internal static extern byte glean_uuid_test_has_value(UInt64 metric_id, string storage_name);
 
         // Datetime
 
-        /// <summary>
-        /// A handle for the datetime metric type, which performs cleanup.
-        /// </summary>
-        internal sealed class DatetimeMetricTypeHandle : BaseGleanHandle
-        {
-            protected override bool ReleaseHandle()
-            {
-                if (!this.IsInvalid)
-                {
-                    glean_destroy_datetime_metric(handle);
-                }
-
-                return true;
-            }
-        }
-
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern DatetimeMetricTypeHandle glean_new_datetime_metric(
+        internal static extern UInt64 glean_new_datetime_metric(
             string category,
             string name,
             string[] send_in_pings,
@@ -342,42 +256,26 @@ namespace Mozilla.Glean.FFI
         internal static extern void glean_destroy_datetime_metric(IntPtr handle);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void glean_datetime_set(DatetimeMetricTypeHandle metric_id, Int32 year,
+        internal static extern void glean_datetime_set(UInt64 metric_id, Int32 year,
             Int32 month, Int32 day, Int32 hour, Int32 minute, Int32 second, long nano, Int32 offset_seconds);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern byte glean_datetime_test_has_value(DatetimeMetricTypeHandle metric_id, string storage_name);
+        internal static extern byte glean_datetime_test_has_value(UInt64 metric_id, string storage_name);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern StringAsReturnValue glean_datetime_test_get_value_as_string(DatetimeMetricTypeHandle metric_id, string storage_name);
+        internal static extern StringAsReturnValue glean_datetime_test_get_value_as_string(UInt64 metric_id, string storage_name);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern Int32 glean_datetime_test_get_num_recorded_errors(
-             DatetimeMetricTypeHandle metric_id,
+             UInt64 metric_id,
              Int32 error_type,
              string storage_name
         );
 
         // Custom pings
 
-        /// <summary>
-        /// A handle for the ping metric type, which performs cleanup.
-        /// </summary>
-        internal sealed class PingTypeHandle : BaseGleanHandle
-        {
-            protected override bool ReleaseHandle()
-            {
-                if (!this.IsInvalid)
-                {
-                    glean_destroy_ping_type(handle);
-                }
-
-                return true;
-            }
-        }
-
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern PingTypeHandle glean_new_ping_type(
+        internal static extern UInt64 glean_new_ping_type(
             string name,
             byte include_client_id,
             byte send_if_empty,
@@ -389,7 +287,7 @@ namespace Mozilla.Glean.FFI
         internal static extern void glean_destroy_ping_type(IntPtr handle);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void glean_register_ping_type(PingTypeHandle ping_type_handle);
+        internal static extern void glean_register_ping_type(UInt64 ping_type_handle);
 
         [DllImport(SharedGleanLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern byte glean_test_has_ping_type(string ping_name);

--- a/glean-core/csharp/Glean/Metrics/BooleanMetricType.cs
+++ b/glean-core/csharp/Glean/Metrics/BooleanMetricType.cs
@@ -21,7 +21,7 @@ namespace Mozilla.Glean.Private
     {
         private bool disabled;
         private string[] sendInPings;
-        private LibGleanFFI.BooleanMetricTypeHandle handle;
+        private UInt64 handle;
 
         /// <summary>
         /// The public constructor used by automatically generated metrics.
@@ -32,7 +32,7 @@ namespace Mozilla.Glean.Private
             Lifetime lifetime,
             string name,
             string[] sendInPings
-            ) : this(new LibGleanFFI.BooleanMetricTypeHandle(), disabled, sendInPings)
+            ) : this(0, disabled, sendInPings)
         {
             handle = LibGleanFFI.glean_new_boolean_metric(
                         category: category,
@@ -44,7 +44,7 @@ namespace Mozilla.Glean.Private
         }
 
         internal BooleanMetricType(
-            LibGleanFFI.BooleanMetricTypeHandle handle,
+            UInt64 handle,
             bool disabled,
             string[] sendInPings
             )

--- a/glean-core/csharp/Glean/Metrics/DatetimeMetricType.cs
+++ b/glean-core/csharp/Glean/Metrics/DatetimeMetricType.cs
@@ -18,7 +18,7 @@ namespace Mozilla.Glean.Private
     {
         private bool disabled;
         private string[] sendInPings;
-        private LibGleanFFI.DatetimeMetricTypeHandle handle;
+        private UInt64 handle;
 
         /// <summary>
         /// The public constructor used by automatically generated metrics.
@@ -30,7 +30,7 @@ namespace Mozilla.Glean.Private
             string name,
             string[] sendInPings,
             TimeUnit timeUnit = TimeUnit.Minute
-            ) : this(new LibGleanFFI.DatetimeMetricTypeHandle(), disabled, sendInPings)
+            ) : this(0, disabled, sendInPings)
         {
             handle = LibGleanFFI.glean_new_datetime_metric(
                        category: category,
@@ -43,7 +43,7 @@ namespace Mozilla.Glean.Private
         }
 
         internal DatetimeMetricType(
-           LibGleanFFI.DatetimeMetricTypeHandle handle,
+           UInt64 handle,
            bool disabled,
            string[] sendInPings
            )

--- a/glean-core/csharp/Glean/Metrics/PingType.cs
+++ b/glean-core/csharp/Glean/Metrics/PingType.cs
@@ -23,7 +23,7 @@ namespace Mozilla.Glean.Private
     public class PingTypeBase
     {
         internal string name;
-        internal LibGleanFFI.PingTypeHandle handle;
+        internal UInt64 handle;
 
         protected internal PingTypeBase() { }
     }

--- a/glean-core/csharp/Glean/Metrics/StringMetricType.cs
+++ b/glean-core/csharp/Glean/Metrics/StringMetricType.cs
@@ -19,7 +19,7 @@ namespace Mozilla.Glean.Private
     {
         private readonly bool disabled;
         private readonly string[] sendInPings;
-        private readonly LibGleanFFI.StringMetricTypeHandle handle;
+        private readonly UInt64 handle;
 
         public StringMetricType(
             bool disabled,
@@ -27,7 +27,7 @@ namespace Mozilla.Glean.Private
             Lifetime lifetime,
             string name,
             string[] sendInPings
-            ) : this(new LibGleanFFI.StringMetricTypeHandle(), disabled, sendInPings)
+            ) : this(0, disabled, sendInPings)
         {
             handle = LibGleanFFI.glean_new_string_metric(
                     category: category,
@@ -39,7 +39,7 @@ namespace Mozilla.Glean.Private
         }
 
         internal StringMetricType(
-            LibGleanFFI.StringMetricTypeHandle handle,
+            UInt64 handle,
             bool disabled,
             string[] sendInPings
             )

--- a/glean-core/csharp/Glean/Metrics/UuidMetricType.cs
+++ b/glean-core/csharp/Glean/Metrics/UuidMetricType.cs
@@ -21,7 +21,7 @@ namespace Mozilla.Glean.Private
     {
         private bool disabled;
         private string[] sendInPings;
-        private LibGleanFFI.UuidMetricTypeHandle handle;
+        private UInt64 handle;
 
         /// <summary>
         /// The public constructor used by automatically generated metrics.
@@ -32,7 +32,7 @@ namespace Mozilla.Glean.Private
             Lifetime lifetime,
             string name,
             string[] sendInPings
-            ) : this(new LibGleanFFI.UuidMetricTypeHandle(), disabled, sendInPings)
+            ) : this(0, disabled, sendInPings)
         {
             handle = LibGleanFFI.glean_new_uuid_metric(
                        category: category,
@@ -44,7 +44,7 @@ namespace Mozilla.Glean.Private
         }
 
         internal UuidMetricType(
-           LibGleanFFI.UuidMetricTypeHandle handle,
+           UInt64 handle,
            bool disabled,
            string[] sendInPings
            )

--- a/glean-core/csharp/GleanTests/GleanTests.csproj
+++ b/glean-core/csharp/GleanTests/GleanTests.csproj
@@ -11,6 +11,7 @@
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/glean-core/csharp/csharp.sln
+++ b/glean-core/csharp/csharp.sln
@@ -12,21 +12,35 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AC607140-A511-4AAD-A521-A344A94E79CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AC607140-A511-4AAD-A521-A344A94E79CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Debug|x86.ActiveCfg = Debug|x86
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Debug|x86.Build.0 = Debug|x86
 		{AC607140-A511-4AAD-A521-A344A94E79CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC607140-A511-4AAD-A521-A344A94E79CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Release|x86.ActiveCfg = Release|x86
+		{AC607140-A511-4AAD-A521-A344A94E79CA}.Release|x86.Build.0 = Release|x86
 		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Debug|x86.ActiveCfg = Debug|x86
+		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Debug|x86.Build.0 = Debug|x86
 		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Release|x86.ActiveCfg = Release|x86
+		{F0CBD450-0A95-4D2C-8AAF-149329F9B559}.Release|x86.Build.0 = Release|x86
 		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Debug|x86.ActiveCfg = Debug|x86
+		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Debug|x86.Build.0 = Debug|x86
 		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Release|x86.ActiveCfg = Release|x86
+		{B15FB0D6-7C0C-4DE9-A922-3972F9BE5179}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/csharp/Sample.csproj
+++ b/samples/csharp/Sample.csproj
@@ -11,6 +11,7 @@
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This replaces the use of `SafeHandle`-derived classes when passing Glean handles back and forth from the FFI layer. It was crashing on x86 because, while Glean correctly uses uint64 as handles, `SafeHandle` was using `IntPtr` under the hood, which is 4 bytes on 32 bit architectures.

This made glean-core panic because it was seeing an unknown handle when it was passed back from C# to glean-core over the FFI.

All in all, we don't really need `SafeHandle`(s) for everything: we just need it for Win32 handles or pointers coming from the FFI. Moreover, we don't really care yet about cleaning up, so no need to get desperate about re-implementing `SafeHandle`-like mechanism for uint64: that would also be complicated, because the .NET marshaler knows about `SafeHandle` and behaves in a special way with that, when doing P/Invoke on native libraries.