### PR TITLE
Bug 1652139: Fix Python macos releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,10 +847,10 @@ jobs:
           name: Build macOS wheel
           command: |
             cd glean-core/python
-            .venv3.8/bin/python3 setup.py bdist_wheel
+            .venv3.7/bin/python3 setup.py bdist_wheel
             # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
             # variables are configured in CircleCI's environment variables.
-            .venv3.8/bin/python3 -m twine upload dist/*
+            .venv3.7/bin/python3 -m twine upload dist/*
           environment:
             GLEAN_BUILD_VARIANT: release
       - install-ghr-darwin


### PR DESCRIPTION
The Mac container doesn't have Python 3.8, it has 3.7.  This wasn't
caught in #995 because the release jobs weren't tested.