### PR TITLE
Revert "Bug 1648094: Install ssh and git on Python Linux container"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -795,10 +795,6 @@ jobs:
       # The official docker image for building manylinux1 wheels
       - image: quay.io/pypa/manylinux1_x86_64
     steps:
-      - run:
-          name: Install ssh and git packages
-          command: |
-            yum install -y openssh-clients git
       - install-rustup
       - setup-rust-toolchain
       - checkout


### PR DESCRIPTION
Reverts mozilla/glean#1038

This fixes bug 1652137.  It's easiest just to revert this commit -- it worked fine before only slowly.  Finding the correct way to install ssh that has the correct algorithms installed to communicate with Github's much newer ssh server may take some time (and IMHO isn't a high priority).