### PR TITLE
Bug 1640201 - Add the high level design docs for the upload module [doc only]

### DIFF
--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -14,7 +14,7 @@ API docs are also generated from docstrings for Rust, Kotlin, Swift and Python.
 The `mdbook` crate is required in order to build the narrative documentation:
 
 ```sh
-cargo install mdbook
+cargo install mdbook mdbook-mermaid mdbook-open-on-gh
 ```
 
 Then both the narrative and Rust API docs can be built with:


### PR DESCRIPTION
This is a braindump of the desired architecture for the upload modules implemented in the language bindings, that directly interact with the lower level upload module in glean-core.

A preview of the mermaid plot:

![image](https://user-images.githubusercontent.com/883721/87287520-7f9bb380-c4fa-11ea-9700-6285a1cbc054.png)
