### PR TITLE
Bug 1651669: Fix warnings about outdated pip

### DIFF
--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -37,7 +37,7 @@ class GleanPlugin implements Plugin<Project> {
     private String GLEAN_PARSER_VERSION = "1.24.0"
     // The version of Miniconda is explicitly specified.
     // Miniconda3-4.5.12 is known to not work on Windows.
-    private String MINICONDA_VERSION = "4.5.11"
+    private String MINICONDA_VERSION = "py38_4.8.3"
 
     private String TASK_NAME_PREFIX = "gleanGenerateMetrics"
 


### PR DESCRIPTION
This just simply upgrades miniconda to the latest version available.

We had held it back previously due to breakage on Windows, so we need
to confirm that has been fixed by:

1) Deleting the `~/.gradle/glean` directory
2) Building a clean build of Glean inside AndroidStudio

That should be sufficient to confirm this change works.

This is the *easy* solution that doesn't require forcibly updating pip etc.