### PR TITLE
Fix PyPI Linux releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,7 +801,7 @@ jobs:
       - run:
           name: Setup default Python version
           command: |
-            echo "export PATH=/opt/python/cp38-cp38m/bin:$PATH" >> $BASH_ENV
+            echo "export PATH=/opt/python/cp38-cp38/bin:$PATH" >> $BASH_ENV
       - run:
           name: Build Python extension
           command: |


### PR DESCRIPTION
Python 3.8 dropped the "m" ABI flag (which indicates the use of pymalloc vs.
system malloc) since both modes of building are now ABI compatible.