### PR TITLE
Fix errors surfaced by new rust stable version 1.45.0

### DIFF
--- a/glean-core/src/error.rs
+++ b/glean-core/src/error.rs
@@ -23,6 +23,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// This list is intended to grow over time and it is not recommended to
 /// exhaustively match against it.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Lifetime conversion failed
     Lifetime(i32),
@@ -59,9 +60,6 @@ pub enum ErrorKind {
 
     /// Glean not initialized
     NotInitialized,
-
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 /// A specialized [`Error`] type for this crate's operations.
@@ -108,7 +106,6 @@ impl Display for Error {
             Utf8Error => write!(f, "Invalid UTF-8 byte sequence in string"),
             InvalidConfig => write!(f, "Invalid Glean configuration provided"),
             NotInitialized => write!(f, "Global Glean object missing"),
-            __NonExhaustive => write!(f, "Unknown error"),
         }
     }
 }

--- a/glean-core/src/histogram/functional.rs
+++ b/glean-core/src/histogram/functional.rs
@@ -42,7 +42,7 @@ impl Functional {
         // Set the FPU control flag to the required state within this function
         let _fpc = FloatingPointContext::new();
 
-        ((sample + 1) as f64).log(self.exponent) as u64
+        ((sample.saturating_add(1)) as f64).log(self.exponent) as u64
     }
 
     /// Determines the minimum value of a bucket, given a bucket index.

--- a/glean-core/src/metrics/experiment.rs
+++ b/glean-core/src/metrics/experiment.rs
@@ -148,7 +148,7 @@ impl ExperimentMetric {
         };
 
         // Apply limits to extras
-        let truncated_extras = extra.and_then(|extra| {
+        let truncated_extras = extra.map(|extra| {
             if extra.len() > MAX_EXPERIMENTS_EXTRAS_SIZE {
                 let msg = format!(
                     "Extra hash map length {} exceeds maximum of {}",
@@ -183,7 +183,7 @@ impl ExperimentMetric {
 
                 temp_map.insert(truncated_key, truncated_value);
             }
-            Some(temp_map)
+            temp_map
         });
 
         let value = Metric::Experiment(RecordedExperimentData {


### PR DESCRIPTION
* Lint error related to usage of __NonExhaustive pattern explicitly;
* Lint error related to usage of `and_then` instead of `map`;
* Overflow error on add, fixed by using `saturating_add` explicitly.