### PR TITLE
Bug 1634064 - Propagate `GleanDebugActivity` intent options to the main intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v31.4.0...main)
 
+* General
+  * Enable propagating options to the main product Activity when using the `GleanDebugActivity`.
+
 # v31.4.0 (2020-07-16)
+
+[Full changelog](https://github.com/mozilla/glean/compare/v31.3.0...v31.4.0)
 
 * General
   * Enable debugging features through environment variables. ([#1058](https://github.com/mozilla/glean/pull/1058))
-
-[Full changelog](https://github.com/mozilla/glean/compare/v31.3.0...v31.4.0)
 
 # v31.3.0 (2020-07-10)
 

--- a/docs/user/debugging/android.md
+++ b/docs/user/debugging/android.md
@@ -23,6 +23,9 @@ In the above:
 | `sendPing` | string (`--es`)  | Sends the ping with the given name immediately |
 | `tagPings` | string (`--es`)  | Tags all outgoing pings as debug pings to make them available for real-time validation, on the [Glean Debug View](./debug-ping-view.md). The value must match the pattern `[a-zA-Z0-9-]{1,20}` |
 
+All [the options](https://developer.android.com/studio/command-line/adb#am) provided to start the activity are passed over to the main activity for the application to process.
+This is useful if SDK users wants to debug telemetry while providing additional options to the product to enable specific behaviors.  
+
 > **Note:** Due to limitations on Android logcat message size, pings larger than 4KB are broken into multiple log messages when using `logPings`.
 
 For example, to direct a release build of the Glean sample application to (1) dump pings to logcat, (2) tag the ping with the `test-metrics-ping` tag, and (3) send the "metrics" ping immediately, the following command can be used:

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -75,19 +75,22 @@ class GleanDebugActivityTest {
     }
 
     @Test
-    fun `the main activity is correctly started`() {
+    fun `the main activity is correctly started and intent args are propagated`() {
         // Build the intent that will call our debug activity, with no extra.
         val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
             GleanDebugActivity::class.java)
         // Add at least an option, otherwise the activity will be removed.
         intent.putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
+        intent.putExtra("TestOptionFromCLI", "TestValue")
         // Start the activity through our intent.
         val scenario = launch<GleanDebugActivity>(intent)
 
         // Check that our main activity was launched.
         scenario.onActivity { activity ->
-            assertEquals(testPackageName,
-                shadowOf(activity).peekNextStartedActivityForResult().intent.`package`!!)
+            val startedIntent = shadowOf(activity).peekNextStartedActivityForResult().intent
+            assertEquals(testPackageName, startedIntent.`package`!!)
+            // Make sure that the extra intent option was propagated to this intent.
+            assertEquals("TestValue", startedIntent.getStringExtra("TestOptionFromCLI"))
         }
     }
 


### PR DESCRIPTION
Products might want to debug a product and launch it using different options. Without this change, such options are discarded by Glean.

**How to test this**

1. `adb shell am set-debug-app -w org.mozilla.samples.gleancore`
2. adb shell am start -d "https://www.example.com" -n org.mozilla.samples.gleancore/mozilla.telemetry.glean.debug.GleanDebugActivity --es tagPings mytest --es otherOption other-value
3. Place a breakpoint [in the MainActivity](https://searchfox.org/glean/rev/7ad095554c6baa2b92f9ab005a1dcaf157e61723/samples/android/app/src/main/java/org/mozilla/samples/glean/MainActivity.kt#19) and inspect `intent.data` (should be `"https://www.example.com"`) and `intent.getStringExtra(otherOption)` (should be `other-value`)

More context on why this is needed can be [read on the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1634064#c14).