### PR TITLE
Bug 1634064 - Implement the 'X-Source-Tags' header

### DIFF
--- a/docs/user/debugging/android.md
+++ b/docs/user/debugging/android.md
@@ -22,6 +22,7 @@ In the above:
 | `logPings` | boolean (`--ez`)  | If set to `true`, pings are dumped to logcat; defaults to `false` |
 | `sendPing` | string (`--es`)  | Sends the ping with the given name immediately |
 | `debugViewTag` | string (`--es`)  | Tags all outgoing pings as debug pings to make them available for real-time validation, on the [Glean Debug View](./debug-ping-view.md). The value must match the pattern `[a-zA-Z0-9-]{1,20}`. **Important**: in older versions of the Glean SDK, this was named `tagPings` |
+| `sourceTags` | string array (`--esa`)  | Tags outgoing pings with a maximum of 5 comma-separated tags. The tags must match the pattern `[a-zA-Z0-9-]{1,20}`. The `automation` tag is meant for tagging pings generated on automation: such pings will be specially handled on the pipeline (i.e. discarded from [non-live views](https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html#table-layout-and-naming)). Tags starting with `glean` are reserved for future use. Subsequent calls of this overwrite any previously stored tag |
 
 All [the options](https://developer.android.com/studio/command-line/adb#am) provided to start the activity are passed over to the main activity for the application to process.
 This is useful if SDK users wants to debug telemetry while providing additional options to the product to enable specific behaviors.  

--- a/docs/user/debugging/android.md
+++ b/docs/user/debugging/android.md
@@ -21,7 +21,7 @@ In the above:
 |---|----|-----------|
 | `logPings` | boolean (`--ez`)  | If set to `true`, pings are dumped to logcat; defaults to `false` |
 | `sendPing` | string (`--es`)  | Sends the ping with the given name immediately |
-| `tagPings` | string (`--es`)  | Tags all outgoing pings as debug pings to make them available for real-time validation, on the [Glean Debug View](./debug-ping-view.md). The value must match the pattern `[a-zA-Z0-9-]{1,20}` |
+| `debugViewTag` | string (`--es`)  | Tags all outgoing pings as debug pings to make them available for real-time validation, on the [Glean Debug View](./debug-ping-view.md). The value must match the pattern `[a-zA-Z0-9-]{1,20}`. **Important**: in older versions of the Glean SDK, this was named `tagPings` |
 
 All [the options](https://developer.android.com/studio/command-line/adb#am) provided to start the activity are passed over to the main activity for the application to process.
 This is useful if SDK users wants to debug telemetry while providing additional options to the product to enable specific behaviors.  
@@ -34,7 +34,7 @@ For example, to direct a release build of the Glean sample application to (1) du
 adb shell am start -n org.mozilla.samples.gleancore/mozilla.telemetry.glean.debug.GleanDebugActivity \
   --ez logPings true \
   --es sendPing metrics \
-  --es tagPings test-metrics-ping
+  --es debugViewTag test-metrics-ping
 ```
 
 The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been sent. You can use the `sendPing` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day.
@@ -54,7 +54,7 @@ persist until the application is closed or manually reset.
 > adb shell am start -n org.mozilla.samples.gleancore/mozilla.components.service.glean.debug.GleanDebugActivity \
 >   --ez logPings true \
 >   --es sendPing metrics \
->   --es tagPings test-metrics-ping
+>   --es debugViewTag test-metrics-ping
 > ```
 
 ### Glean Log messages

--- a/docs/user/debugging/index.md
+++ b/docs/user/debugging/index.md
@@ -13,7 +13,7 @@
 There are 3 available commands that you can use with the Glean SDK debug tools
 
 - `logPings`: This is either true or false and will cause pings that are submitted to also be echoed to the device's log.
-- `tagPings`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters.
+- `debugViewTag`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters.
 - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
 
 Different platforms have different ways to send these commands.
@@ -24,7 +24,7 @@ Some of the debugging features described above may also be enabled using environ
 
 - `logPings`: May be set by the `GLEAN_LOG_PINGS` environment variable. The accepted values are
 `true` or `false`. Any other value will be ignored.
-- `tagPings`: May be set by the `GLEAN_DEBUG_VIEW_TAG` environment variable. Any valid HTTP header value maybe set here
+- `debugViewTag`: May be set by the `GLEAN_DEBUG_VIEW_TAG` environment variable. Any valid HTTP header value maybe set here
 (e.g. any value that matches the regex `[a-zA-Z0-9-]{1,20}`). Invalid values will be ignored.
 
 These variables must be set at runtime, not at compile time. They will be checked upon Glean initialization.

--- a/docs/user/debugging/index.md
+++ b/docs/user/debugging/index.md
@@ -10,11 +10,12 @@
 
 ### Available commands and query format
 
-There are 3 available commands that you can use with the Glean SDK debug tools
+There are 4 available commands that you can use with the Glean SDK debug tools
 
 - `logPings`: This is either true or false and will cause pings that are submitted to also be echoed to the device's log.
 - `debugViewTag`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters.
 - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
+- `sourceTags`: Tags outgoing pings with a maximum of 5, comma-separated, tags.
 
 Different platforms have different ways to send these commands.
 
@@ -25,6 +26,8 @@ Some of the debugging features described above may also be enabled using environ
 - `logPings`: May be set by the `GLEAN_LOG_PINGS` environment variable. The accepted values are
 `true` or `false`. Any other value will be ignored.
 - `debugViewTag`: May be set by the `GLEAN_DEBUG_VIEW_TAG` environment variable. Any valid HTTP header value maybe set here
+(e.g. any value that matches the regex `[a-zA-Z0-9-]{1,20}`). Invalid values will be ignored.
+- `sourceTags`: May be set by the `GLEAN_SOURCE_TAGS` environment variable. A comma-separated list of valid HTTP header values may be set here
 (e.g. any value that matches the regex `[a-zA-Z0-9-]{1,20}`). Invalid values will be ignored.
 
 These variables must be set at runtime, not at compile time. They will be checked upon Glean initialization.

--- a/docs/user/debugging/ios.md
+++ b/docs/user/debugging/ios.md
@@ -17,7 +17,7 @@ For debugging and validation purposes on iOS, Glean makes use of a custom URL sc
 There are 3 available commands that you can use with the Glean SDK debug tools
 
 - `logPings`: This is either true or false and will cause pings that are submitted to also be echoed to the device's log
-- `tagPings`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters.
+- `debugViewTag`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters. **Important**: in older versions of the Glean SDK, this was named `tagPings`.
 - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
 
 The structure of the custom URL uses the following format:
@@ -90,7 +90,7 @@ Perhaps the simplest way to invoke the Glean SDK debug functionality is to open 
 Using the glean-sample-app as an example: to activate ping logging, tag the pings to go to the Glean Debug View, and force the `events` ping to be sent, enter the following URL in a web browser on the iOS device:
 
 ```shell
-glean-sample-app://glean?logPings=true&tagPings=My-ping-tag&sendPing=events
+glean-sample-app://glean?logPings=true&debugViewTag=My-ping-tag&sendPing=events
 ```
 
 This should cause iOS to prompt you with a dialog asking if you want to open the URL in the Glean Sample App, and if you select "Okay" then it will launch (or resume if it's already running) the application with the indicated commands and parameters and immediately force the collection and submission of the events ping.
@@ -104,7 +104,7 @@ It is also possible to encode the URL into a 2D barcode or QR code and launch th
 This method is useful for testing via the Simulator, which typically requires a Mac with Xcode installed, including the Xcode command line tools.  In order to perform the same command as above with using the browser to input the URL, you can use the following command in the command line terminal of the Mac:
 
 ```shell
-xcrun simctl openurl booted "glean-sample-app://glean?logPings=true&tagPings=My-ping-tag&sendPing=events"
+xcrun simctl openurl booted "glean-sample-app://glean?logPings=true&debugViewTag=My-ping-tag&sendPing=events"
 ```
 
 This will launch the simulator and again prompt the user with a dialog box asking if you want to open the URL in the Glean Sample App (or whichever app you are instrumenting and testing).

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -104,6 +104,8 @@ A pre-defined set of headers is additionally sent along with the submitted ping:
 | `Date` | e.g. `Mon, 23 Jan 2019 10:10:10 GMT+00:00` | Submission date/time in GMT/UTC+0 offset |
 | `X-Client-Type` | `Glean` | Custom header to support handling of Glean pings in the legacy pipeline |
 | `X-Client-Version` | e.g. `0.40.0` | The Glean SDK version, sent as a custom header to support handling of Glean pings in the legacy pipeline |
+| `X-Debug-ID` | *Optional*, e.g. `test-tag` | Debug header attached to Glean pings when using the [debug tools](../../user/debugging/index.md) |
+| `X-Source-Tags` | *Optional*, e.g. `automation, perf` | A list of tags to associate with the ping, useful for clustering pings at analysis time, for example to tell data generated from CI from other data. |
 
 
 ## Defining foreground and background state

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
@@ -38,6 +38,8 @@ class GleanDebugActivity : Activity() {
          * The value must match the pattern `[a-zA-Z0-9-]{1,20}`.
          */
         const val TAG_DEBUG_VIEW_EXTRA_KEY = "debugViewTag"
+        const val LEGACY_TAG_PINGS = "tagPings"
+
         /**
          * Tags all outgoing pings as debug pings to make them available for real-time validation.
          * The value must match the pattern `[a-zA-Z0-9-]{1,20}`.
@@ -74,8 +76,10 @@ class GleanDebugActivity : Activity() {
         }
 
         // Make sure that at least one of the supported commands was used.
-        val supportedCommands =
-            listOf(SEND_PING_EXTRA_KEY, LOG_PINGS_EXTRA_KEY, TAG_DEBUG_VIEW_EXTRA_KEY, SOURCE_TAGS_KEY)
+        val supportedCommands = listOf(
+            SEND_PING_EXTRA_KEY, LOG_PINGS_EXTRA_KEY,
+            TAG_DEBUG_VIEW_EXTRA_KEY, SOURCE_TAGS_KEY, LEGACY_TAG_PINGS
+        )
 
         // Enable debugging options and start the application.
         intent.extras?.let {
@@ -92,6 +96,13 @@ class GleanDebugActivity : Activity() {
             // Set the debug view tag, if the tag is invalid it won't be set
             debugViewTag?.let {
                 Glean.setDebugViewTag(debugViewTag)
+            } ?: run {
+                // If the 'debugViewTag' was not used, try to look for the legacy
+                // way of setting debug view tags. We should leave this block of
+                // code around at most until December 2020.
+                intent.getStringExtra(LEGACY_TAG_PINGS)?.let { legacyTag ->
+                    Glean.setDebugViewTag(legacyTag)
+                }
             }
 
             val logPings: Boolean? = intent.getBooleanExtra(LOG_PINGS_EXTRA_KEY, false)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
@@ -38,6 +38,11 @@ class GleanDebugActivity : Activity() {
          * The value must match the pattern `[a-zA-Z0-9-]{1,20}`.
          */
         const val TAG_DEBUG_VIEW_EXTRA_KEY = "debugViewTag"
+        /**
+         * Tags all outgoing pings as debug pings to make them available for real-time validation.
+         * The value must match the pattern `[a-zA-Z0-9-]{1,20}`.
+         */
+        const val SOURCE_TAGS_KEY = "sourceTags"
     }
 
     // IMPORTANT: These activities are unsecured, and may be triggered by
@@ -49,6 +54,7 @@ class GleanDebugActivity : Activity() {
     /**
      * On creation of the debug activity, launch the requested command.
      */
+    @Suppress("ComplexMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -69,7 +75,7 @@ class GleanDebugActivity : Activity() {
 
         // Make sure that at least one of the supported commands was used.
         val supportedCommands =
-            listOf(SEND_PING_EXTRA_KEY, LOG_PINGS_EXTRA_KEY, TAG_DEBUG_VIEW_EXTRA_KEY)
+            listOf(SEND_PING_EXTRA_KEY, LOG_PINGS_EXTRA_KEY, TAG_DEBUG_VIEW_EXTRA_KEY, SOURCE_TAGS_KEY)
 
         // Enable debugging options and start the application.
         intent.extras?.let {
@@ -93,8 +99,14 @@ class GleanDebugActivity : Activity() {
                 Glean.setLogPings(logPings)
             }
 
-            intent.getStringExtra(SEND_PING_EXTRA_KEY)?.let {
-                Glean.submitPingByName(it)
+            intent.getStringArrayExtra(SOURCE_TAGS_KEY)?.let { tags ->
+                Glean.setSourceTags(tags.toSet())
+            }
+
+            // Important: this should be applied as the last one, so that
+            // any other option will affect the ping submission as well.
+            intent.getStringExtra(SEND_PING_EXTRA_KEY)?.let { name ->
+                Glean.submitPingByName(name)
             }
         }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
@@ -37,7 +37,7 @@ class GleanDebugActivity : Activity() {
          * Tags all outgoing pings as debug pings to make them available for real-time validation.
          * The value must match the pattern `[a-zA-Z0-9-]{1,20}`.
          */
-        const val TAG_DEBUG_VIEW_EXTRA_KEY = "tagPings"
+        const val TAG_DEBUG_VIEW_EXTRA_KEY = "debugViewTag"
     }
 
     // IMPORTANT: These activities are unsecured, and may be triggered by

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -564,6 +564,8 @@ internal interface LibGleanFFI : Library {
 
     fun glean_set_log_pings(value: Byte)
 
+    fun glean_set_source_tags(raw_tags: StringArray, raw_tags_count: Int): Byte
+
     // Misc
 
     fun glean_str_free(ptr: Pointer)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -140,7 +140,7 @@ class GleanDebugActivityTest {
     }
 
     @Test
-    fun `tagPings filters ID's that don't match the pattern`() {
+    fun `debugViewTag filters ID's that don't match the pattern`() {
         val server = getMockWebServer()
 
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -189,7 +189,7 @@ class GleanDebugActivityTest {
     }
 
     @Test
-    fun `pings are correctly tagged using tagPings`() {
+    fun `pings are correctly tagged using debugViewTag`() {
         val pingTag = "test-debug-ID"
 
         // Use the test client in the Glean configuration

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -690,6 +690,8 @@ void glean_set_experiment_inactive(FfiStr experiment_id);
 
 void glean_set_log_pings(uint8_t value);
 
+uint8_t glean_set_source_tags(RawStringArray raw_tags, int32_t tags_count);
+
 void glean_set_upload_enabled(uint8_t flag);
 
 /**

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -441,4 +441,12 @@ pub extern "C" fn glean_set_log_pings(value: u8) {
     with_glean_mut(|glean| Ok(glean.set_log_pings(value != 0)));
 }
 
+#[no_mangle]
+pub extern "C" fn glean_set_source_tags(raw_tags: RawStringArray, tags_count: i32) -> u8 {
+    with_glean_mut(|glean| {
+        let tags = from_raw_string_array(raw_tags, tags_count)?;
+        Ok(glean.set_source_tags(tags))
+    })
+}
+
 define_string_destructor!(glean_str_free);

--- a/glean-core/ios/Glean/Debug/GleanDebugTools.swift
+++ b/glean-core/ios/Glean/Debug/GleanDebugTools.swift
@@ -22,7 +22,7 @@ class GleanDebugUtility {
     /// There are 3 available commands that you can use with the Glean SDK debug tools
     ///
     /// - `logPings`: If "true", will cause pings that are submitted successfully to also be echoed to the device's log
-    /// - `tagPings`:  This command expects a string to tag the pings with and redirects them to the Glean Debug View
+    /// - `debugViewTag`:  This command expects a string to tag the pings with and redirects them to the Debug View
     /// - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
     ///
     /// The structure of the custom URL uses the following format:
@@ -100,10 +100,10 @@ class GleanDebugUtility {
             }
 
             switch param.name {
-            case "tagPings":
+            case "debugViewTag":
                 if pingTagName != nil {
                     logger.error(
-                        "Multiple `tagPings` commands not allowed, aborting Glean debug tools")
+                        "Multiple `debugViewTag` commands not allowed, aborting Glean debug tools")
                     return nil
                 }
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -491,7 +491,8 @@ public class Glean {
     ///
     /// There are 3 available commands that you can use with the Glean SDK debug tools
     ///
-    /// - `tagPings`:  This command expects a string to tag the pings with and redirects them to the Glean Debug View
+    /// - `logPings`: If "true", will cause pings that are submitted successfully to also be echoed to the device's log
+    /// - `debugViewTag`:  This command expects a string to tag the pings with and redirects them to the Debug View
     /// - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
     ///
     /// The structure of the custom URL uses the following format:

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -690,6 +690,8 @@ void glean_set_experiment_inactive(FfiStr experiment_id);
 
 void glean_set_log_pings(uint8_t value);
 
+uint8_t glean_set_source_tags(RawStringArray raw_tags, int32_t tags_count);
+
 void glean_set_upload_enabled(uint8_t flag);
 
 /**

--- a/glean-core/src/debug.rs
+++ b/glean-core/src/debug.rs
@@ -70,7 +70,7 @@ impl DebugOptions {
 /// A representation of a debug option,
 /// where the value can be set programmatically or come from an environment variable.
 #[derive(Debug)]
-pub struct DebugOption<T, E = fn(String) -> Option<T>, F = fn(&T) -> bool> {
+pub struct DebugOption<T, E = fn(String) -> Option<T>, V = fn(&T) -> bool> {
     /// The name of the environment variable related to this debug option.
     env: String,
     /// The actual value of this option.
@@ -80,18 +80,18 @@ pub struct DebugOption<T, E = fn(String) -> Option<T>, F = fn(&T) -> bool> {
     extraction: E,
     /// Optional function to validate the value parsed from the environment
     /// or passed to the `set` function.
-    validation: Option<F>,
+    validation: Option<V>,
 }
 
-impl<T, E, F> DebugOption<T, E, F>
+impl<T, E, V> DebugOption<T, E, V>
 where
     T: Clone,
     E: Fn(String) -> Option<T>,
-    F: Fn(&T) -> bool,
+    V: Fn(&T) -> bool,
 {
     /// Create a new debug option,
     /// tries to get the initial value of the option from the environment.
-    pub fn new(env: &str, extraction: E, validation: Option<F>) -> Self {
+    pub fn new(env: &str, extraction: E, validation: Option<V>) -> Self {
         let mut option = Self {
             env: env.into(),
             value: None,
@@ -177,6 +177,7 @@ fn tokenize_string(value: String) -> Option<Vec<String>> {
 ///
 /// The regex crate isn't used here because it adds to the binary size,
 /// and the Glean SDK doesn't use regular expressions anywhere else.
+#[allow(clippy::ptr_arg)]
 fn validate_tag(value: &String) -> bool {
     if value.is_empty() {
         log::error!("A tag must have at least one character.");
@@ -210,6 +211,7 @@ fn validate_tag(value: &String) -> bool {
 ///
 /// This builds upon the existing `validate_tag` function, since all the
 /// tags should respect the same rules to make the pipeline happy.
+#[allow(clippy::ptr_arg)]
 fn validate_source_tags(tags: &Vec<String>) -> bool {
     if tags.is_empty() {
         return false;
@@ -246,6 +248,7 @@ mod test {
 
     #[test]
     fn debug_option_is_correctly_validated_when_necessary() {
+        #[allow(clippy::ptr_arg)]
         fn validate(value: &String) -> bool {
             value == "test"
         }

--- a/glean-core/src/debug.rs
+++ b/glean-core/src/debug.rs
@@ -18,10 +18,6 @@
 //!         allowing these tagged pings to be sent to the ["Ping Debug Viewer"](https://mozilla.github.io/glean/book/dev/core/internal/debug-pings.html).
 //!         This may be set by calling glean.set_debug_view_tag(value: &str)
 //!         or by setting the environment variable GLEAN_DEBUG_VIEW_TAG=<some tag>;
-//! * **Source tagging** - Adding the X-Source-Tags header to every ping request,
-//!         allowing pings to be tagged with custom labels.
-//!         This may be set by calling glean.set_source_tags(value: Vec<String>)
-//!         or by setting the environment variable GLEAN_SOURCE_TAGS=<some, tags>;
 //!
 //! Bindings may implement other debugging features, e.g. sending pings on demand.
 
@@ -29,8 +25,6 @@ use std::env;
 
 const GLEAN_LOG_PINGS: &str = "GLEAN_LOG_PINGS";
 const GLEAN_DEBUG_VIEW_TAG: &str = "GLEAN_DEBUG_VIEW_TAG";
-const GLEAN_SOURCE_TAGS: &str = "GLEAN_SOURCE_TAGS";
-const GLEAN_MAX_SOURCE_TAGS: usize = 5;
 
 /// A representation of all of Glean's debug options.
 #[derive(Debug)]
@@ -39,21 +33,13 @@ pub struct DebugOptions {
     pub log_pings: DebugOption<bool>,
     /// Option to add the X-Debug-ID header to every ping request.
     pub debug_view_tag: DebugOption<String>,
-    /// Option to add the X-Source-Tags header to ping requests. This will allow the data
-    /// consumers to classify data depending on the applied tags.
-    pub sourge_tags: DebugOption<Vec<String>>,
 }
 
 impl DebugOptions {
     pub fn new() -> Self {
         Self {
             log_pings: DebugOption::new(GLEAN_LOG_PINGS, get_bool_from_str, None),
-            debug_view_tag: DebugOption::new(GLEAN_DEBUG_VIEW_TAG, Some, Some(validate_tag)),
-            sourge_tags: DebugOption::new(
-                GLEAN_SOURCE_TAGS,
-                tokenize_string,
-                Some(validate_source_tags),
-            ),
+            debug_view_tag: DebugOption::new(GLEAN_DEBUG_VIEW_TAG, Some, Some(validate_debug_view_tag)),
         }
     }
 }
@@ -152,32 +138,16 @@ fn get_bool_from_str(value: String) -> Option<bool> {
     std::str::FromStr::from_str(&value).ok()
 }
 
-fn tokenize_string(value: String) -> Option<Vec<String>> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    Some(
-        trimmed
-            .split(',')
-            .map(|s| s.trim().to_string())
-            // Filter out tags starting with "glean". They are reserved.
-            .filter(|s| !s.starts_with("glean"))
-            .collect(),
-    )
-}
-
-/// A tag is the value used in both the `X-Debug-ID` and `X-Source-Tags` headers
-/// of tagged ping requests, thus is it must be a valid header value.
+/// The debug view tag is the value for the `X-Debug-ID` header of tagged ping requests,
+/// thus is it must be a valid header value.
 ///
 /// In other words, it must match the regex: "[a-zA-Z0-9-]{1,20}"
 ///
 /// The regex crate isn't used here because it adds to the binary size,
 /// and the Glean SDK doesn't use regular expressions anywhere else.
-fn validate_tag(value: String) -> bool {
+fn validate_debug_view_tag(value: String) -> bool {
     if value.is_empty() {
-        log::error!("A tag must have at least one character.");
+        log::error!("Debug view tag must have at least one character.");
         return false;
     }
 
@@ -192,42 +162,16 @@ fn validate_tag(value: String) -> bool {
             Some('-') | Some('a'..='z') | Some('A'..='Z') | Some('0'..='9') => (),
             // An invalid character
             Some(c) => {
-                log::error!("Invalid character '{}' in the tag.", c);
+                log::error!("Invalid character '{}' in debug view tag.", c);
                 return false;
             }
         }
         count += 1;
         if count == 20 {
-            log::error!("A tag cannot exceed 20 characters.");
+            log::error!("Debug view tag cannot exceed 20 characters");
             return false;
         }
     }
-}
-
-/// Validate the list of source tags.
-///
-/// This builds upon the existing `validate_tag` function, since all the
-/// tags should respect the same rules to make the pipeline happy.
-fn validate_source_tags(tags: Vec<String>) -> bool {
-    if tags.is_empty() {
-        return false;
-    }
-
-    if tags.len() > GLEAN_MAX_SOURCE_TAGS {
-        log::error!(
-            "A list of tags cannot contain more than {} elements.",
-            GLEAN_MAX_SOURCE_TAGS
-        );
-        return false;
-    }
-
-    for tag in tags {
-        if !validate_tag(tag) {
-            return false;
-        }
-    }
-
-    true
 }
 
 #[cfg(test)]
@@ -264,50 +208,15 @@ mod test {
     }
 
     #[test]
-    fn tokenize_string_splits_correctly() {
-        // Valid list is properly tokenized and spaces are trimmed.
-        assert_eq!(
-            Some(vec!["test1".to_string(), "test2".to_string()]),
-            tokenize_string("    test1,        test2  ".to_string())
+    fn validates_debug_view_tag_correctly() {
+        assert!(validate_debug_view_tag("valid-value".to_string()));
+        assert!(validate_debug_view_tag("-also-valid-value".to_string()));
+        assert!(!validate_debug_view_tag("invalid_value".to_string()));
+        assert!(!validate_debug_view_tag("invalid value".to_string()));
+        assert!(!validate_debug_view_tag("!nv@lid-val*e".to_string()));
+        assert!(
+            !validate_debug_view_tag("invalid-value-because-way-too-long".to_string())
         );
-
-        // Empty strings return no item.
-        assert_eq!(None, tokenize_string("".to_string()));
-
-        // Entries starting with 'glean' are filtered out.
-        assert_eq!(
-            Some(vec!["test2".to_string()]),
-            tokenize_string("glean-test1, test2".to_string())
-        );
-    }
-
-    #[test]
-    fn validates_tag_correctly() {
-        assert!(validate_tag("valid-value".to_string()));
-        assert!(validate_tag("-also-valid-value".to_string()));
-        assert!(!validate_tag("invalid_value".to_string()));
-        assert!(!validate_tag("invalid value".to_string()));
-        assert!(!validate_tag("!nv@lid-val*e".to_string()));
-        assert!(!validate_tag(
-            "invalid-value-because-way-too-long".to_string()
-        ));
-        assert!(!validate_tag("".to_string()));
-    }
-
-    #[test]
-    fn validates_source_tags_correctly() {
-        // Empty tags.
-        assert!(!validate_source_tags(vec!["".to_string()]));
-        // Too many tags.
-        assert!(!validate_source_tags(vec![
-            "1".to_string(),
-            "2".to_string(),
-            "3".to_string(),
-            "4".to_string(),
-            "5".to_string(),
-            "6".to_string()
-        ]));
-        // Invalid tags.
-        assert!(!validate_source_tags(vec!["!nv@lid-val*e".to_string()]));
+        assert!(!validate_debug_view_tag("".to_string()));
     }
 }

--- a/glean-core/src/debug.rs
+++ b/glean-core/src/debug.rs
@@ -18,6 +18,10 @@
 //!         allowing these tagged pings to be sent to the ["Ping Debug Viewer"](https://mozilla.github.io/glean/book/dev/core/internal/debug-pings.html).
 //!         This may be set by calling glean.set_debug_view_tag(value: &str)
 //!         or by setting the environment variable GLEAN_DEBUG_VIEW_TAG=<some tag>;
+//! * **Source tagging** - Adding the X-Source-Tags header to every ping request,
+//!         allowing pings to be tagged with custom labels.
+//!         This may be set by calling glean.set_source_tags(value: Vec<String>)
+//!         or by setting the environment variable GLEAN_SOURCE_TAGS=<some, tags>;
 //!
 //! Bindings may implement other debugging features, e.g. sending pings on demand.
 
@@ -25,6 +29,8 @@ use std::env;
 
 const GLEAN_LOG_PINGS: &str = "GLEAN_LOG_PINGS";
 const GLEAN_DEBUG_VIEW_TAG: &str = "GLEAN_DEBUG_VIEW_TAG";
+const GLEAN_SOURCE_TAGS: &str = "GLEAN_SOURCE_TAGS";
+const GLEAN_MAX_SOURCE_TAGS: usize = 5;
 
 /// A representation of all of Glean's debug options.
 #[derive(Debug)]
@@ -33,13 +39,21 @@ pub struct DebugOptions {
     pub log_pings: DebugOption<bool>,
     /// Option to add the X-Debug-ID header to every ping request.
     pub debug_view_tag: DebugOption<String>,
+    /// Option to add the X-Source-Tags header to ping requests. This will allow the data
+    /// consumers to classify data depending on the applied tags.
+    pub sourge_tags: DebugOption<Vec<String>>,
 }
 
 impl DebugOptions {
     pub fn new() -> Self {
         Self {
-            log_pings: DebugOption::new(GLEAN_LOG_PINGS, None),
-            debug_view_tag: DebugOption::new(GLEAN_DEBUG_VIEW_TAG, Some(validate_debug_view_tag)),
+            log_pings: DebugOption::new(GLEAN_LOG_PINGS, get_bool_from_str, None),
+            debug_view_tag: DebugOption::new(GLEAN_DEBUG_VIEW_TAG, Some, Some(validate_tag)),
+            sourge_tags: DebugOption::new(
+                GLEAN_SOURCE_TAGS,
+                tokenize_string,
+                Some(validate_source_tags),
+            ),
         }
     }
 }
@@ -47,27 +61,32 @@ impl DebugOptions {
 /// A representation of a debug option,
 /// where the value can be set programmatically or come from an environment variable.
 #[derive(Debug)]
-pub struct DebugOption<T, F = fn(T) -> Option<T>> {
+pub struct DebugOption<T, E = fn(String) -> Option<T>, F = fn(T) -> bool> {
     /// The name of the environment variable related to this debug option.
     env: String,
     /// The actual value of this option.
     value: Option<T>,
-    /// Optional function to validade the value parsed from the environment
+    /// Function to extract the data of type `T` from a `String`, used when
+    /// extracting data from the environment.
+    extraction: E,
+    /// Optional function to validate the value parsed from the environment
     /// or passed to the `set` function.
     validation: Option<F>,
 }
 
-impl<T, F> DebugOption<T, F>
+impl<T, E, F> DebugOption<T, E, F>
 where
-    T: std::str::FromStr,
-    F: Fn(T) -> Option<T>,
+    T: Clone,
+    E: Fn(String) -> Option<T>,
+    F: Fn(T) -> bool,
 {
     /// Create a new debug option,
     /// tries to get the initial value of the option from the environment.
-    pub fn new(env: &str, validation: Option<F>) -> Self {
+    pub fn new(env: &str, extraction: E, validation: Option<F>) -> Self {
         let mut option = Self {
             env: env.into(),
             value: None,
+            extraction,
             validation,
         };
 
@@ -75,21 +94,22 @@ where
         option
     }
 
-    fn validate(&self, value: T) -> Option<T> {
+    fn validate(&self, value: T) -> bool {
         if let Some(f) = self.validation.as_ref() {
             f(value)
         } else {
-            Some(value)
+            true
         }
     }
 
     fn set_from_env(&mut self) {
+        let extract = &self.extraction;
         match env::var(&self.env) {
-            Ok(env_value) => match T::from_str(&env_value) {
-                Ok(v) => {
+            Ok(env_value) => match extract(env_value.clone()) {
+                Some(v) => {
                     self.set(v);
                 }
-                Err(_) => {
+                None => {
                     log::error!(
                         "Unable to parse debug option {}={} into {}. Ignoring.",
                         self.env,
@@ -112,10 +132,10 @@ where
     ///
     /// Validates the value in case a validation function is available.
     pub fn set(&mut self, value: T) -> bool {
-        let validated = self.validate(value);
-        if validated.is_some() {
+        let validated = self.validate(value.clone());
+        if validated {
             log::info!("Setting the debug option {}.", self.env);
-            self.value = validated;
+            self.value = Some(value);
             return true;
         }
         log::info!("Invalid value for debug option {}.", self.env);
@@ -128,17 +148,37 @@ where
     }
 }
 
-/// The debug view tag is the value for the `X-Debug-ID` header of tagged ping requests,
-/// thus is it must be a valid header value.
+fn get_bool_from_str(value: String) -> Option<bool> {
+    std::str::FromStr::from_str(&value).ok()
+}
+
+fn tokenize_string(value: String) -> Option<Vec<String>> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(
+        trimmed
+            .split(',')
+            .map(|s| s.trim().to_string())
+            // Filter out tags starting with "glean". They are reserved.
+            .filter(|s| !s.starts_with("glean"))
+            .collect(),
+    )
+}
+
+/// A tag is the value used in both the `X-Debug-ID` and `X-Source-Tags` headers
+/// of tagged ping requests, thus is it must be a valid header value.
 ///
 /// In other words, it must match the regex: "[a-zA-Z0-9-]{1,20}"
 ///
 /// The regex crate isn't used here because it adds to the binary size,
 /// and the Glean SDK doesn't use regular expressions anywhere else.
-pub fn validate_debug_view_tag(value: String) -> Option<String> {
+fn validate_tag(value: String) -> bool {
     if value.is_empty() {
-        log::error!("Debug view tag must have at least one character.");
-        return None;
+        log::error!("A tag must have at least one character.");
+        return false;
     }
 
     let mut iter = value.chars();
@@ -147,21 +187,47 @@ pub fn validate_debug_view_tag(value: String) -> Option<String> {
     loop {
         match iter.next() {
             // We are done, so the whole expression is valid.
-            None => return Some(value),
+            None => return true,
             // Valid characters.
             Some('-') | Some('a'..='z') | Some('A'..='Z') | Some('0'..='9') => (),
             // An invalid character
             Some(c) => {
-                log::error!("Invalid character '{}' in debug view tag.", c);
-                return None;
+                log::error!("Invalid character '{}' in the tag.", c);
+                return false;
             }
         }
         count += 1;
         if count == 20 {
-            log::error!("Debug view tag cannot exceed 20 characters");
-            return None;
+            log::error!("A tag cannot exceed 20 characters.");
+            return false;
         }
     }
+}
+
+/// Validate the list of source tags.
+///
+/// This builds upon the existing `validate_tag` function, since all the
+/// tags should respect the same rules to make the pipeline happy.
+fn validate_source_tags(tags: Vec<String>) -> bool {
+    if tags.is_empty() {
+        return false;
+    }
+
+    if tags.len() > GLEAN_MAX_SOURCE_TAGS {
+        log::error!(
+            "A list of tags cannot contain more than {} elements.",
+            GLEAN_MAX_SOURCE_TAGS
+        );
+        return false;
+    }
+
+    for tag in tags {
+        if !validate_tag(tag) {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(test)]
@@ -172,23 +238,20 @@ mod test {
     #[test]
     fn debug_option_is_correctly_loaded_from_env() {
         env::set_var("GLEAN_TEST_1", "test");
-        let option: DebugOption<String> = DebugOption::new("GLEAN_TEST_1", None);
+        let option: DebugOption<String> = DebugOption::new("GLEAN_TEST_1", Some, None);
         assert_eq!(option.get().unwrap(), "test");
     }
 
     #[test]
     fn debug_option_is_correctly_validated_when_necessary() {
-        fn validate(value: String) -> Option<String> {
-            if value == "test" {
-                Some(value)
-            } else {
-                None
-            }
+        fn validate(value: String) -> bool {
+            value == "test"
         }
 
         // Invalid values from the env are not set
         env::set_var("GLEAN_TEST_2", "invalid");
-        let mut option: DebugOption<String> = DebugOption::new("GLEAN_TEST_2", Some(validate));
+        let mut option: DebugOption<String> =
+            DebugOption::new("GLEAN_TEST_2", Some, Some(validate));
         assert!(option.get().is_none());
 
         // Valid values are set using the `set` function
@@ -201,15 +264,50 @@ mod test {
     }
 
     #[test]
-    fn validates_debug_view_tag_correctly() {
-        assert!(validate_debug_view_tag("valid-value".to_string()).is_some());
-        assert!(validate_debug_view_tag("-also-valid-value".to_string()).is_some());
-        assert!(validate_debug_view_tag("invalid_value".to_string()).is_none());
-        assert!(validate_debug_view_tag("invalid value".to_string()).is_none());
-        assert!(validate_debug_view_tag("!nv@lid-val*e".to_string()).is_none());
-        assert!(
-            validate_debug_view_tag("invalid-value-because-way-too-long".to_string()).is_none()
+    fn tokenize_string_splits_correctly() {
+        // Valid list is properly tokenized and spaces are trimmed.
+        assert_eq!(
+            Some(vec!["test1".to_string(), "test2".to_string()]),
+            tokenize_string("    test1,        test2  ".to_string())
         );
-        assert!(validate_debug_view_tag("".to_string()).is_none());
+
+        // Empty strings return no item.
+        assert_eq!(None, tokenize_string("".to_string()));
+
+        // Entries starting with 'glean' are filtered out.
+        assert_eq!(
+            Some(vec!["test2".to_string()]),
+            tokenize_string("glean-test1, test2".to_string())
+        );
+    }
+
+    #[test]
+    fn validates_tag_correctly() {
+        assert!(validate_tag("valid-value".to_string()));
+        assert!(validate_tag("-also-valid-value".to_string()));
+        assert!(!validate_tag("invalid_value".to_string()));
+        assert!(!validate_tag("invalid value".to_string()));
+        assert!(!validate_tag("!nv@lid-val*e".to_string()));
+        assert!(!validate_tag(
+            "invalid-value-because-way-too-long".to_string()
+        ));
+        assert!(!validate_tag("".to_string()));
+    }
+
+    #[test]
+    fn validates_source_tags_correctly() {
+        // Empty tags.
+        assert!(!validate_source_tags(vec!["".to_string()]));
+        // Too many tags.
+        assert!(!validate_source_tags(vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string(),
+            "6".to_string()
+        ]));
+        // Invalid tags.
+        assert!(!validate_source_tags(vec!["!nv@lid-val*e".to_string()]));
     }
 }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -732,6 +732,27 @@ impl Glean {
         self.debug.debug_view_tag.get()
     }
 
+    /// Set source tags.
+    ///
+    /// This will return `false` in case `value` contains invalid tags.
+    ///
+    /// Ping tags will show in the destination datasets, after ingestion.
+    ///
+    /// ## Arguments
+    ///
+    /// * `value` - A vector of at most 5 valid HTTP header values. Individual tags must match the regex: "[a-zA-Z0-9-]{1,20}".
+    pub fn set_source_tags(&mut self, value: Vec<String>) -> bool {
+        self.debug.source_tags.set(value)
+    }
+
+    /// Return the value for the source tags or `None` if it hasn't been set.
+    ///
+    /// The source_tags may be set from an environment variable (GLEAN_SOURCE_TAGS)
+    /// or through the `set_source_tags` function.
+    pub(crate) fn source_tags(&self) -> Option<&Vec<String>> {
+        self.debug.source_tags.get()
+    }
+
     /// Set the log pings debug option.
     ///
     /// This will return `false` in case we are unable to set the option.

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -181,11 +181,32 @@ impl PingMaker {
     /// }
     /// ```
     fn get_metadata(&self, glean: &Glean) -> Option<JsonValue> {
+        let mut headers_map = json!({});
+
         if let Some(debug_view_tag) = glean.debug_view_tag() {
+            headers_map
+                .as_object_mut()
+                .unwrap() // safe unwrap, we created the object above
+                .insert(
+                    "X-Debug-ID".to_string(),
+                    JsonValue::String(debug_view_tag.to_string()),
+                );
+        }
+
+        if let Some(source_tags) = glean.source_tags() {
+            headers_map
+                .as_object_mut()
+                .unwrap() // safe unwrap, we created the object above
+                .insert(
+                    "X-Source-Tags".to_string(),
+                    JsonValue::String(source_tags.join(",")),
+                );
+        }
+
+        // safe unwrap, we created the object above
+        if !headers_map.as_object().unwrap().is_empty() {
             Some(json!({
-                "headers": {
-                    "X-Debug-ID": debug_view_tag,
-                },
+                "headers": headers_map,
             }))
         } else {
             None


### PR DESCRIPTION
This implements the new ping tagging system in the Glean SDK. It adds a CLI option for `adb`, all the glean-core implementation and environment variable support.

Please note that I had to refactor the debug options module a bit in order to allow using non-`String` option types.