### PR TITLE
Bug 1653046: Don't send NULLs over FFI where not expected

### DIFF
--- a/glean-core/python/glean/_ffi.py
+++ b/glean-core/python/glean/_ffi.py
@@ -71,9 +71,17 @@ def make_config(
     return cfg
 
 
-def ffi_encode_string(value: Optional[str]) -> Optional[bytes]:
+def ffi_encode_string(value: str) -> bytes:
     """
     Convert a Python string to a UTF-8 encoded char* for sending over FFI.
+    """
+    return value.encode("utf-8")
+
+
+def ffi_encode_string_or_none(value: Optional[str]) -> Optional[bytes]:
+    """
+    Convert a Python string (or None) to a UTF-8 encoded char* (or NULL) for
+    sending over FFI.
     """
     if value is None:
         return ffi.NULL

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -471,7 +471,9 @@ class Glean:
             reason (str, optional): The reason code to record in the ping.
         """
         return _ffi.ffi_decode_string(
-            _ffi.lib.glean_ping_collect(ping._handle, _ffi.ffi_encode_string(reason))
+            _ffi.lib.glean_ping_collect(
+                ping._handle, _ffi.ffi_encode_string_or_none(reason)
+            )
         )
 
     @classmethod
@@ -514,7 +516,7 @@ class Glean:
             return
 
         sent_ping = _ffi.lib.glean_submit_ping_by_name(
-            _ffi.ffi_encode_string(ping_name), _ffi.ffi_encode_string(reason),
+            _ffi.ffi_encode_string(ping_name), _ffi.ffi_encode_string_or_none(reason),
         )
 
         if sent_ping:

--- a/glean-core/python/tests/metrics/test_string.py
+++ b/glean-core/python/tests/metrics/test_string.py
@@ -76,3 +76,17 @@ def test_setting_a_long_string_records_an_error():
     assert 1 == string_metric.test_get_num_recorded_errors(
         testing.ErrorType.INVALID_VALUE
     )
+
+
+def test_setting_a_string_as_none():
+    string_metric = metrics.StringMetricType(
+        disabled=False,
+        category="telemetry",
+        lifetime=Lifetime.APPLICATION,
+        name="string_metric",
+        send_in_pings=["store1", "store2"],
+    )
+
+    string_metric.set(None)
+
+    assert not string_metric.test_has_value()


### PR DESCRIPTION
This is just resolving a part of 1653046 and making the FFI calls type safe.
Full-on type safety in Python is a much broader problem that affects many
call sites so deferring for now.