### PR TITLE
Use one more e in "queueing" to make it consistent with Kotlin

### DIFF
--- a/glean-core/ios/Glean/Dispatchers.swift
+++ b/glean-core/ios/Glean/Dispatchers.swift
@@ -249,7 +249,7 @@ class Dispatchers {
     ///   * enabled: `Bool` whether or not to enable the queuing mode
     ///
     /// When enabled, tasks are queued until launched by calling `flushQueuedInitialTasks()`
-    func setTaskQueuing(enabled: Bool) {
+    func setTaskQueueing(enabled: Bool) {
         queueInitialTasks.value = enabled
     }
 }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -577,7 +577,7 @@ public class Glean {
 
         glean_destroy_glean()
         // Reset all state.
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
         self.initFinished = false
         self.initialized = false
     }

--- a/glean-core/ios/GleanTests/DispatchersTest.swift
+++ b/glean-core/ios/GleanTests/DispatchersTest.swift
@@ -10,7 +10,7 @@ class DispatchersTest: XCTestCase {
         var threadCanary = 0
 
         Dispatchers.shared.setTestingMode(enabled: true)
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         // Add 3 tasks to the queue, each one incrementing threadCanary to indicate the task has executed
         for _ in 0 ..< 3 {
@@ -56,7 +56,7 @@ class DispatchersTest: XCTestCase {
         var flushTasks = AtomicBoolean(false)
 
         Dispatchers.shared.setTestingMode(enabled: false)
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         // This background task will monitor the size of the cached initial
         // operations and attempt to flush it when it reaches 50 elements.
@@ -108,7 +108,7 @@ class DispatchersTest: XCTestCase {
         Dispatchers.shared.setTestingMode(enabled: false)
 
         // Set task queueing to true to ensure that we queue tasks when we launch them
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         // Add a task to the pre-init queue
         Dispatchers.shared.launchAPI {
@@ -130,7 +130,7 @@ class DispatchersTest: XCTestCase {
         Dispatchers.shared.setTestingMode(enabled: false)
 
         // Set up our test conditions for normal execution by setting queuing to false
-        Dispatchers.shared.setTaskQueuing(enabled: false)
+        Dispatchers.shared.setTaskQueueing(enabled: false)
 
         // Create a counter to use to determine if the task is actually cancelled
         var counter = 0
@@ -176,7 +176,7 @@ class DispatchersTest: XCTestCase {
         Dispatchers.shared.setTestingMode(enabled: false)
 
         // Set up our test conditions for normal execution by setting queuing to false
-        Dispatchers.shared.setTaskQueuing(enabled: false)
+        Dispatchers.shared.setTaskQueueing(enabled: false)
 
         // Create a counter to use to determine if the task is actually cancelled
         var counter = 0
@@ -221,7 +221,7 @@ class DispatchersTest: XCTestCase {
         Glean.shared.resetGlean(clearStores: true)
         Dispatchers.shared.preInitOperations.removeAll()
         Dispatchers.shared.setTestingMode(enabled: true)
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         for _ in 0 ..< (Dispatchers.Constants.maxQueueSize + 10) {
             Dispatchers.shared.launchAPI {

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -71,7 +71,7 @@ class GleanTests: XCTestCase {
     func testExperimentRecordingBeforeGleanInit() {
         // This test relies on Glean not being initialized and the task queueing to be on
         Glean.shared.testDestroyGleanHandle()
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         Glean.shared.setExperimentActive(
             experimentId: "experiment_set_preinit",
@@ -335,7 +335,7 @@ class GleanTests: XCTestCase {
         // real-world async behaviour of this.
         // We don't need to care about clearing it,
         // the test-unit hooks will call `resetGlean` anyway.
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
         Dispatchers.shared.setTestingMode(enabled: false)
 
         // We expect only a single ping later

--- a/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
@@ -256,7 +256,7 @@ class EventMetricTypeTests: XCTestCase {
         event.record(extra: [.someExtra: "run1"])
         XCTAssertEqual(1, try! event.testGetValue().count)
 
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
         event.record(extra: [.someExtra: "pre-init"])
 
         Glean.shared.resetGlean(clearStores: false)

--- a/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
+++ b/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
@@ -139,7 +139,7 @@ class MetricsPingSchedulerTests: XCTestCase {
     func testQueuedDataNotInOverdueMetricsPings() {
         // Reset Glean and do not start it right away
         Glean.shared.testDestroyGleanHandle()
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         // Set the last time the "metrics" ping was sent to now. This is required for us to not
         // send a metrics pings the first time we initialize Glean.
@@ -162,7 +162,7 @@ class MetricsPingSchedulerTests: XCTestCase {
 
         // Destroy Glean, it will retain the recorded metric.
         Glean.shared.testDestroyGleanHandle()
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         // Create data and attempt to record data before Glean is initialized.  This will
         // be queued in the dispatcher.
@@ -219,7 +219,7 @@ class MetricsPingSchedulerTests: XCTestCase {
     func testGleanPreservesLifetimeApplicationMetrics() {
         // Reset Glean and do not start it right away
         Glean.shared.testDestroyGleanHandle()
-        Dispatchers.shared.setTaskQueuing(enabled: true)
+        Dispatchers.shared.setTaskQueueing(enabled: true)
 
         // Set the last time the "metrics" ping was sent to now. This is required for us to not
         // send a metrics pings the first time we initialize Glean.


### PR DESCRIPTION
This unifies the naming across Kotlin and Swift.
I picked `queueing` because there were more occurences already.