### PR TITLE
Bug 1653995: Provide more info to diagnose intermittent

### DIFF
--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -747,6 +747,7 @@ def test_presubmit_makes_a_valid_ping(tmpdir, ping_schema_url, monkeypatch):
         url_path = fd.readline()
         serialized_ping = fd.readline()
 
+    print(url_path)
     assert ping_name == url_path.split("/")[3]
 
     assert 0 == validate_ping.validate_ping(


### PR DESCRIPTION
This just adds code to print out the URL read from the file so we can hopefully better diagnose the error.  This only adds a print to a test, and even that will only be shown if the test fails, so low risk to just include this.