### PR TITLE
Implement ping tagging for iOS

### DIFF
--- a/docs/user/debugging/ios.md
+++ b/docs/user/debugging/ios.md
@@ -14,7 +14,7 @@ For debugging and validation purposes on iOS, Glean makes use of a custom URL sc
 
 ### Available commands and query format
 
-There are 3 available commands that you can use with the Glean SDK debug tools
+There are 4 available commands that you can use with the Glean SDK debug tools
 
 - `logPings`: This is either true or false and will cause pings that are submitted to also be echoed to the device's log
 - `debugViewTag`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters. **Important**: in older versions of the Glean SDK, this was named `tagPings`.

--- a/docs/user/debugging/ios.md
+++ b/docs/user/debugging/ios.md
@@ -18,6 +18,7 @@ There are 3 available commands that you can use with the Glean SDK debug tools
 
 - `logPings`: This is either true or false and will cause pings that are submitted to also be echoed to the device's log
 - `debugViewTag`: This command will tag outgoing pings with the provided value, in order to identify them in the Glean Debug View. Tags need to be string with upper and lower case letters, numbers and dashes, with a max length of 20 characters. **Important**: in older versions of the Glean SDK, this was named `tagPings`.
+- `sourceTags`: This command tags outgoing pings with a maximum of 5 comma-separated tags. The tags must match the pattern `[a-zA-Z0-9-]{1,20}`. The `automation` tag is meant for tagging pings generated on automation: such pings will be specially handled on the pipeline (i.e. discarded from [non-live views](https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html#table-layout-and-naming)). Tags starting with `glean` are reserved for future use.
 - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
 
 The structure of the custom URL uses the following format:
@@ -37,6 +38,7 @@ There are a few things to consider when creating the custom URL:
 - Not all commands are required to be encoded in the URL, you can mix and match the commands that you need.
 - Multiple instances of commands are not allowed in the same URL and, if present, will cause the entire URL to be ignored.
 - The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPings` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
+- Enabling debugging features through custom URLs overrides any debugging features set through environment variables.
 
 ### Instrumenting the application for Glean debug functionality
 

--- a/glean-core/ios/Glean/Debug/GleanDebugTools.swift
+++ b/glean-core/ios/Glean/Debug/GleanDebugTools.swift
@@ -19,7 +19,7 @@ class GleanDebugUtility {
     /// - parameters:
     ///     * url: A `URL` object containing the Glean debug commands as query parameters
     ///
-    /// There are 3 available commands that you can use with the Glean SDK debug tools
+    /// There are 4 available commands that you can use with the Glean SDK debug tools
     ///
     /// - `logPings`: If "true", will cause pings that are submitted successfully to also be echoed to the device's log.
     /// - `debugViewTag`:  This command expects a string to tag the pings with and redirects them to the Debug View.

--- a/glean-core/ios/Glean/Debug/GleanDebugTools.swift
+++ b/glean-core/ios/Glean/Debug/GleanDebugTools.swift
@@ -21,8 +21,12 @@ class GleanDebugUtility {
     ///
     /// There are 3 available commands that you can use with the Glean SDK debug tools
     ///
-    /// - `logPings`: If "true", will cause pings that are submitted successfully to also be echoed to the device's log
-    /// - `debugViewTag`:  This command expects a string to tag the pings with and redirects them to the Debug View
+    /// - `logPings`: If "true", will cause pings that are submitted successfully to also be echoed to the device's log.
+    /// - `debugViewTag`:  This command expects a string to tag the pings with and redirects them to the Debug View.
+    ///     The string must match the pattern `[a-zA-Z0-9-]{1,20}`.
+    /// - `sourceTags`: This command tags all outgoing pings to make them available for real-time validation.
+    ///     Tags are represented by a comma separated list. Each tag must match the pattern `[a-zA-Z0-9-]{1,20}`.
+    ///     Up to 5 tags are allowed.
     /// - `sendPing`: This command expects a string name of a ping to force immediate collection and submission of.
     ///
     /// The structure of the custom URL uses the following format:
@@ -53,11 +57,20 @@ class GleanDebugUtility {
         }
 
         if let parsedCommands = processCustomUrlQuery(urlQueryItems: params) {
-            if let tag = parsedCommands.pingTag {
-                if Glean.shared.setDebugViewTag(tag) {
-                    logger.debug("Pings tagged with: \(tag)")
+            if let debugTag = parsedCommands.debugViewTag {
+                if Glean.shared.setDebugViewTag(debugTag) {
+                    logger.debug("Pings tagged with debug tag: \(debugTag)")
                 } else {
-                    logger.error("Invalid ping tag name, aborting Glean debug tools")
+                    logger.error("Invalid ping debug tag name, aborting Glean debug tools")
+                    return
+                }
+            }
+
+            if let sourceTags = parsedCommands.sourceTags {
+                if Glean.shared.setSourceTags(sourceTags) {
+                    logger.debug("Pings tagged with source tags: \(sourceTags)")
+                } else {
+                    logger.error("Invalid ping source tags value, aborting Glean debug tools")
                     return
                 }
             }
@@ -76,11 +89,13 @@ class GleanDebugUtility {
 
     /// A simple struct to represent the commands parsed from the custom URL
     private struct ParsedQueryCommands {
-        let pingTag: String?
+        let debugViewTag: String?
+        let sourceTags: [String]?
         let logPings: Bool?
         let pingNameToSend: String?
     }
 
+    // swiftlint:disable cyclomatic_complexity
     /// Helper function to process parameters passed as a query to the custom URL processed by `handleCustomUrl`
     ///
     /// - parameters:
@@ -89,7 +104,8 @@ class GleanDebugUtility {
     /// - returns: A tuple containing the values of the parameters `pingTag`, `logPings`, `pingNamesToSend` or nil
     ///     when invalid or duplicated commands are detected.
     private static func processCustomUrlQuery(urlQueryItems: [URLQueryItem]) -> ParsedQueryCommands? {
-        var pingTagName: String?
+        var debugViewTag: String?
+        var sourceTags: [String]?
         var willLogPings: Bool?
         var pingToSend: String?
 
@@ -101,13 +117,21 @@ class GleanDebugUtility {
 
             switch param.name {
             case "debugViewTag":
-                if pingTagName != nil {
+                if debugViewTag != nil {
                     logger.error(
                         "Multiple `debugViewTag` commands not allowed, aborting Glean debug tools")
                     return nil
                 }
 
-                pingTagName = param.value
+                debugViewTag = param.value
+            case "sourceTags":
+                if sourceTags != nil {
+                    logger.error(
+                        "Multiple `sourceTags` commands not allowed, aborting Glean debug tools")
+                    return nil
+                }
+
+                sourceTags = param.value?.components(separatedBy: ",")
             case "logPings":
                 if willLogPings != nil {
                     logger.error("Multiple `logPings` commands not allowed, aborting Glean debug tools")
@@ -132,9 +156,12 @@ class GleanDebugUtility {
         }
 
         return ParsedQueryCommands(
-            pingTag: pingTagName,
+            debugViewTag: debugViewTag,
+            sourceTags: sourceTags,
             logPings: willLogPings,
             pingNameToSend: pingToSend
         )
     }
+
+    // swiftlint:enable cyclomatic_complexity
 }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -122,12 +122,12 @@ public class Glean {
                 _ = self.setDebugViewTag(debugViewTag)
             }
 
-            if let sourceTags = self.sourceTags {
-                _ = self.setSourceTags(sourceTags)
-            }
-
             if self.logPings {
                 self.setLogPings(self.logPings)
+            }
+
+            if let sourceTags = self.sourceTags {
+                _ = self.setSourceTags(sourceTags)
             }
 
             // If any pings were registered before initializing, do so now

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -32,6 +32,7 @@ public class Glean {
     var initFinished: Bool = false
 
     private var debugViewTag: String?
+    private var sourceTags: [String]?
     var logPings: Bool = false
     var configuration: Configuration?
     private var observer: GleanLifecycleObserver?
@@ -119,6 +120,10 @@ public class Glean {
 
             if let debugViewTag = self.debugViewTag {
                 _ = self.setDebugViewTag(debugViewTag)
+            }
+
+            if let sourceTags = self.sourceTags {
+                _ = self.setSourceTags(sourceTags)
             }
 
             if self.logPings {
@@ -501,6 +506,18 @@ public class Glean {
             glean_set_log_pings(value.toByte())
         } else {
             logPings = value
+        }
+    }
+
+    func setSourceTags(_ value: [String]) -> Bool {
+        if self.isInitialized() {
+            let len = value.count
+            return withArrayOfCStrings(value) { value in
+                glean_set_source_tags(value, Int32(len)).toBool()
+            }
+        } else {
+            sourceTags = value
+            return true
         }
     }
 


### PR DESCRIPTION
Tested locally and it works.

Not sure if I should have added tests anywhere for this changes. I followed the `debugViewTag` implementation which also doesn't have explicit tests.