### PR TITLE
Fix YAML formatting

### DIFF
--- a/docs/user/collected-metrics/metrics.md
+++ b/docs/user/collected-metrics/metrics.md
@@ -19,12 +19,12 @@ These metrics are sent in every ping.
 
 The following metrics are added to the ping:
 
-| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefix/Data_Collection) |
-| --- | --- | --- | --- | --- | --- |
-| glean.error.invalid_label |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set with an invalid label. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |1 |
-| glean.error.invalid_overflow |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set a value that overflew. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1591912#c3)||never |1 |
-| glean.error.invalid_state |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a timing metric was used incorrectly. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |1 |
-| glean.error.invalid_value |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set to an invalid value. The labels are the `category.name` identifier of the metric. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |1 |
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| glean.error.invalid_label |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set with an invalid label. The labels are the `category.name` identifier of the metric.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |1 |
+| glean.error.invalid_overflow |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set a value that overflew. The labels are the `category.name` identifier of the metric.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1591912#c3)||never |1 |
+| glean.error.invalid_state |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a timing metric was used incorrectly. The labels are the `category.name` identifier of the metric.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |1 |
+| glean.error.invalid_value |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of times a metric was set to an invalid value. The labels are the `category.name` identifier of the metric.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5)||never |1 |
 
 ## baseline
 
@@ -64,14 +64,15 @@ This ping includes the [client id](https://mozilla.github.io/glean/book/user/pin
 
 The following metrics are added to the ping:
 
-| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefix/Data_Collection) |
-| --- | --- | --- | --- | --- | --- |
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
 | glean.baseline.duration |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The duration of the last foreground session.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3)||never |1, 2 |
 
 ## deletion-request
 
-This ping is submitted when a user opts out of sending technical and interaction data to Mozilla. This ping is intended to communicate to the Data Pipeline that the user wishes to have their reported Telemetry data deleted. As such it attempts to send itself at the moment the user opts out of data collection.
+This is a built-in ping that is assembled out of the box by the Glean SDK.
 
+See the Glean SDK documentation for the [`deletion-request` ping](https://mozilla.github.io/glean/book/user/pings/deletion-request.html).
 
 This ping is sent if empty.
 
@@ -125,10 +126,10 @@ This ping includes the [client id](https://mozilla.github.io/glean/book/user/pin
 
 The following metrics are added to the ping:
 
-| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefix/Data_Collection) |
-| --- | --- | --- | --- | --- | --- |
-| glean.error.preinit_tasks_overflow |[counter](https://mozilla.github.io/glean/book/user/metrics/counter.html) |The number of tasks queued in the pre-initialization buffer. Only sent if the buffer overflows. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1609482#c3)||never |1 |
-| glean.upload.ping_upload_failure |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of ping upload failures, by type of failure. This includes failures for all ping types, though the counts appear in the next successfully sent `metrics` ping. |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1589124#c1)|<ul><li>status_code_4xx</li><li>status_code_5xx</li><li>status_code_unknown</li><li>unrecoverable</li><li>recoverable</li></ul>|never |1 |
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| glean.error.preinit_tasks_overflow |[counter](https://mozilla.github.io/glean/book/user/metrics/counter.html) |The number of tasks queued in the pre-initialization buffer. Only sent if the buffer overflows.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1609482#c3)||never |1 |
+| glean.upload.ping_upload_failure |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counts the number of ping upload failures, by type of failure. This includes failures for all ping types, though the counts appear in the next successfully sent `metrics` ping.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1589124#c1)|<ul><li>status_code_4xx</li><li>status_code_5xx</li><li>status_code_unknown</li><li>unrecoverable</li><li>recoverable</li></ul>|never |1 |
 
 
 Data categories are [defined here](https://wiki.mozilla.org/Firefox/Data_Collection).

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -91,7 +91,7 @@ glean.internal.metrics:
     lifetime: application
     send_in_pings:
       - glean_client_info
-    description: >
+    description: |
       The model of the device the application is running on.
       On Android, this is Build.MODEL, the user-visible marketing name,
       like "Pixel 2 XL".
@@ -257,7 +257,7 @@ glean.internal.metrics:
 glean.error:
   invalid_value:
     type: labeled_counter
-    description:
+    description: |
       Counts the number of times a metric was set to an invalid value.
       The labels are the `category.name` identifier of the metric.
     bugs:
@@ -276,7 +276,7 @@ glean.error:
 
   invalid_label:
     type: labeled_counter
-    description:
+    description: |
       Counts the number of times a metric was set with an invalid label.
       The labels are the `category.name` identifier of the metric.
     bugs:
@@ -295,7 +295,7 @@ glean.error:
 
   invalid_state:
     type: labeled_counter
-    description:
+    description: |
       Counts the number of times a timing metric was used incorrectly.
       The labels are the `category.name` identifier of the metric.
     bugs:
@@ -314,8 +314,8 @@ glean.error:
 
   invalid_overflow:
     type: labeled_counter
-    description:
-      Counts the number of times a metric was set a value that overflew.
+    description: |
+      Counts the number of times a metric was set a value that overflowed.
       The labels are the `category.name` identifier of the metric.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1591912
@@ -333,7 +333,7 @@ glean.error:
 
   preinit_tasks_overflow:
     type: counter
-    description:
+    description: |
       The number of tasks queued in the pre-initialization buffer.
       Only sent if the buffer overflows.
     unit:
@@ -353,7 +353,7 @@ glean.error:
 glean.upload:
   ping_upload_failure:
     type: labeled_counter
-    description:
+    description: |
       Counts the number of ping upload failures, by type of failure.
       This includes failures for all ping types,
       though the counts appear in the next successfully sent `metrics` ping.

--- a/glean-core/pings.yaml
+++ b/glean-core/pings.yaml
@@ -10,7 +10,7 @@
 $schema: moz://mozilla.org/schemas/glean/pings/1-0-0
 
 baseline:
-  description: >
+  description: |
     This ping is intended to provide metrics that are managed by the library
     itself, and not explicitly set by the application or included in the
     application's `metrics.yaml` file.
@@ -42,7 +42,7 @@ baseline:
       *Note*: this ping will not contain the `glean.baseline.duration` metric.
 
 metrics:
-  description: >
+  description: |
     The `metrics` ping is intended for all of the metrics that are explicitly
     set by the application or are included in the application's `metrics.yaml`
     file (except events).
@@ -78,7 +78,7 @@ metrics:
       day at 4am.
 
 events:
-  description: >
+  description: |
     The events ping's purpose is to transport all of the event metric
     information. The `events` ping is automatically sent when the application is
     moved to the background.
@@ -100,7 +100,7 @@ events:
       The maximum number of events was reached (default 500 events).
 
 deletion-request:
-  description: >
+  description: |
     This ping is submitted when a user opts out of
     sending technical and interaction data to Mozilla.
     This ping is intended to communicate to the Data Pipeline


### PR DESCRIPTION
This fixes the YAML formatting so it uses the `|` rather than `>` mode for multi-line strings. These preserve the newlines as-is, rather than converting all newlines to spaces, which is compatible with markdown paragraph formatting etc. (not that we have any right now.

Also changed `overflew` (which is admittedly cool) to `overflowed`.