### PR TITLE
Bug 1654811 - Add "fake" legacy telemetry ID to deletion-request integration tests

### DIFF
--- a/glean-core/ios/Glean/Scheduler/PingUploadOperation.swift
+++ b/glean-core/ios/Glean/Scheduler/PingUploadOperation.swift
@@ -56,7 +56,7 @@ class PingUploadOperation: GleanOperation {
     }
 
     /// Handles cancelling the underlying data task
-    override public func cancel() {
+    public override func cancel() {
         uploadTask?.cancel()
         super.cancel()
     }

--- a/samples/android/app/metrics.yaml
+++ b/samples/android/app/metrics.yaml
@@ -134,3 +134,18 @@ custom:
     notification_emails:
       - CHANGE-ME@test-only.com
     expires: 2100-01-01
+
+legacy_ids:
+  client_id:
+    type: uuid
+    description: |
+      Testing deletion request payload
+    send_in_pings:
+      - deletion-request
+    bugs:
+      - https://bugzilla.mozilla.org/1654811
+    data_reviews:
+      - N/A
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/DeletionRequestPingTest.kt
@@ -22,6 +22,7 @@ import org.mozilla.samples.gleancore.MainActivity
 import androidx.test.uiautomator.UiDevice
 import mozilla.telemetry.glean.testing.GleanTestLocalServer
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 class DeletionRequestPingTest {
@@ -60,6 +61,11 @@ class DeletionRequestPingTest {
         var clientInfo = deletionPing.getJSONObject("client_info")
         val clientId = clientInfo.getString("client_id")
         assertNotEquals(clientId, "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0")
+
+        val metrics = deletionPing.getJSONObject("metrics")
+        val uuids = metrics.getJSONObject("uuid")
+        val legacyId = uuids.getString("legacy_ids.client_id")
+        assertEquals("01234567-89ab-cdef-0123-456789abcdef", legacyId)
 
         // Try re-enabling and waiting for next baseline ping
         onView(withId(R.id.uploadSwitch)).perform(click())

--- a/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -12,7 +12,7 @@ import org.mozilla.samples.gleancore.GleanMetrics.Test
 import org.mozilla.samples.gleancore.GleanMetrics.Custom
 import org.mozilla.samples.gleancore.GleanMetrics.LegacyIds
 import org.mozilla.samples.gleancore.GleanMetrics.Pings
-import java.util.*
+import java.util.UUID
 
 private const val TAG = "Glean"
 

--- a/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -10,7 +10,9 @@ import mozilla.telemetry.glean.Glean
 import org.mozilla.samples.gleancore.GleanMetrics.Basic
 import org.mozilla.samples.gleancore.GleanMetrics.Test
 import org.mozilla.samples.gleancore.GleanMetrics.Custom
+import org.mozilla.samples.gleancore.GleanMetrics.LegacyIds
 import org.mozilla.samples.gleancore.GleanMetrics.Pings
+import java.util.*
 
 private const val TAG = "Glean"
 
@@ -21,6 +23,9 @@ class GleanApplication : Application() {
 
         // Register the sample application's custom pings.
         Glean.registerPings(Pings)
+
+        // Set a "fake" legacy client id for the purpose of testing the deletion-request ping payload
+        LegacyIds.clientId.set(UUID.fromString("01234567-89ab-cdef-0123-456789abcdef"))
 
         // Initialize the Glean library. Ideally, this is the first thing that
         // must be done right after enabling logging.

--- a/samples/ios/app/glean-sample-app/AppDelegate.swift
+++ b/samples/ios/app/glean-sample-app/AppDelegate.swift
@@ -19,6 +19,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         glean.registerPings(Pings.shared)
 
+        // Set a "fake" legacy client id for the purpose of testing the deletion-request ping payload
+        if let fakeLegacyId = UUID.init(uuidString: "01234567-89ab-cdef-0123-456789abcdef") {
+            GleanMetrics.LegacyIds.clientId.set(fakeLegacyId)
+        }
+
         let mockServerIndex = ProcessInfo.processInfo.arguments.firstIndex(of: "USE_MOCK_SERVER")
         if let idx = mockServerIndex {
             let portIdx = idx + 1

--- a/samples/ios/app/glean-sample-app/AppDelegate.swift
+++ b/samples/ios/app/glean-sample-app/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         glean.registerPings(Pings.shared)
 
         // Set a "fake" legacy client id for the purpose of testing the deletion-request ping payload
-        if let fakeLegacyId = UUID.init(uuidString: "01234567-89ab-cdef-0123-456789abcdef") {
+        if let fakeLegacyId = UUID(uuidString: "01234567-89ab-cdef-0123-456789abcdef") {
             GleanMetrics.LegacyIds.clientId.set(fakeLegacyId)
         }
 

--- a/samples/ios/app/glean-sample-appUITests/DeletionRequestPingTest.swift
+++ b/samples/ios/app/glean-sample-appUITests/DeletionRequestPingTest.swift
@@ -53,6 +53,12 @@ class DeletionRequestPingTest: XCTestCase {
         let clientId = clientInfo["client_id"] as! String
         XCTAssertNotEqual(clientId, "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0")
 
+        // Test deletion-request legacy id payload
+        let metrics = lastPingJson!["metrics"] as! [String: Any]
+        let uuids = metrics["uuid"] as! [String: Any]
+        let legacyId = uuids["legacy_ids.client_id"] as! String
+        XCTAssertEqual("01234567-89ab-cdef-0123-456789abcdef", legacyId)
+
         server.stop()
 
         // Try re-enabling and waiting for next baseline ping

--- a/samples/ios/app/metrics.yaml
+++ b/samples/ios/app/metrics.yaml
@@ -134,3 +134,18 @@ custom:
     notification_emails:
       - CHANGE-ME@test-only.com
     expires: 2100-01-01
+
+legacy_ids:
+  client_id:
+    type: uuid
+    description: |
+      Testing deletion request payload
+    send_in_pings:
+      - deletion-request
+    bugs:
+      - https://bugzilla.mozilla.org/1654811
+    data_reviews:
+      - N/A
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01


### PR DESCRIPTION
This adds a fake legacy telemetry id to test out the payload of the deletion-request ping to ensure that we can indeed send other ids in it.
