### PR TITLE
Bug 1657292 - Ping registration off main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v32.2.0...main)
 
+* Android
+  * Handle ping registration off the main thread. This removes a potential blocking call ([#1132](https://github.com/mozilla/glean/pull/1132)).
+* iOS
+  * Handle ping registration off the main thread. This removes a potential blocking call ([#1132](https://github.com/mozilla/glean/pull/1132)).
+
 # v32.2.0 (2020-08-25)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v32.1.1...v32.2.0)

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -29,7 +29,7 @@ public class Glean {
     // Set when `initialize()` returns.
     // This allows to detect calls that happen before `Glean.shared.initialize()` was called.
     // Note: The initialization might still be in progress, as it runs in a separate thread.
-    var initFinished: Bool = false
+    var initFinished = AtomicBoolean(false)
 
     private var debugViewTag: String?
     private var sourceTags: [String]?
@@ -188,7 +188,7 @@ public class Glean {
             self.observer = GleanLifecycleObserver()
         }
 
-        self.initFinished = true
+        self.initFinished.value = true
     }
 
     // swiftlint:enable function_body_length cyclomatic_complexity
@@ -228,7 +228,7 @@ public class Glean {
     /// - parameters:
     ///     * enabled: When true, enable metric collection.
     public func setUploadEnabled(_ enabled: Bool) {
-        if !self.initFinished {
+        if !self.initFinished.value {
             let msg = """
             Changing upload enabled before Glean is initialized is not supported.
             Pass the correct state into `Glean.initialize()`.
@@ -595,7 +595,7 @@ public class Glean {
         glean_destroy_glean()
         // Reset all state.
         Dispatchers.shared.setTaskQueueing(enabled: true)
-        self.initFinished = false
+        self.initFinished.value = false
         self.initialized = false
     }
 


### PR DESCRIPTION
~~I don't like the second commit that disables the metrics ping by setting the last sent date, awkardly.
Not sure why that is necessary, at a minimum we should have a nicer way to deal with it.~~

Otherwise this seems to work in our tests.
We would need to take this to a test drive in Fenix to figure out if that fixes the startup delay for them.