### PR TITLE
Bug 1655100 - Capture device logs to diagnose intermittent iOS integration test failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -526,6 +526,10 @@ jobs:
             - target
           key: v1-cargo-cache-{{arch}}-{{checksum "buildtype.txt"}}-{{checksum "Cargo.lock"}}
       - run:
+          name: Configure device logging
+          command: |
+            xcrun simctl spawn booted log config --mode "level:debug" --subsystem org.mozilla.glean-sample-app
+      - run:
           name: Run iOS tests
           command: |
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[doc only\]'; then
@@ -542,6 +546,14 @@ jobs:
       - store_artifacts:
           path: raw_xcodetest.log
           destination: raw_xcodetest.log
+      - run:
+          name: Collect device logs
+          command: |
+            xcrun simctl spawn booted log collect --output $(pwd)/ios-tests.logarchive
+            zip -r $(pwd)/device_logs.zip $(pwd)/ios-tests.logarchive
+      - store_artifacts:
+          path: device_logs.zip
+          destination: device_logs.zip
       - persist_to_workspace:
           root: build/
           paths: docs/swift

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -633,12 +633,24 @@ jobs:
           path: raw_sample_xcodebuild.log
           destination: raw_sample_xcodebuild.log
       - run:
+          name: Configure device logging
+          command: |
+            xcrun simctl spawn booted log config --mode "level:debug" --subsystem org.mozilla.glean-sample-app
+      - run:
           name: Run sample app tests
           command: |
             bash bin/run-ios-sample-app-test.sh
       - store_artifacts:
           path: raw_sample_xcodetest.log
           destination: raw_sample_xcodetest.log
+      - run:
+          name: Collect device logs
+          command: |
+            xcrun simctl spawn booted log collect --output $(pwd)/ios-integration-test.logarchive
+            zip ~/project/device_logs.zip ~/project/ios-integration-test.logarchive
+      - store_artifacts:
+          path: device_logs.zip
+          destination: device_logs.zip
 
   Carthage release:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,7 +647,7 @@ jobs:
           name: Collect device logs
           command: |
             xcrun simctl spawn booted log collect --output $(pwd)/ios-integration-test.logarchive
-            zip ~/project/device_logs.zip ~/project/ios-integration-test.logarchive
+            zip -r $(pwd)/device_logs.zip $(pwd)/ios-integration-test.logarchive
       - store_artifacts:
           path: device_logs.zip
           destination: device_logs.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   * A `measure` context manager for conveniently measuring runtimes has been added to `TimespanMetricType` and `TimingDistributionMetricType`.
 * Android
   * Fix a startup crash on some Android 8 (SDK=25) devices, due to a [bug in the Java compiler](https://issuetracker.google.com/issues/110848122#comment17).
+* iOS
+  * Changed logging to use [`OSLog`](https://developer.apple.com/documentation/os/logging) rather than a mix of `NSLog` and `print`. ([#1133](https://github.com/mozilla/glean/pull/1133))
 
 # v32.0.0 (2020-08-03)
 

--- a/glean-core/ios/Glean/Utils/Logger.swift
+++ b/glean-core/ios/Glean/Utils/Logger.swift
@@ -2,28 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/// This is a simple Logger class to unify and simplify log messaging
-/// across the application
-class Logger {
-    // This holds the log tag for reuse by the instance
-    private let tag: String
+import Foundation
+import os.log
 
-    // Represents the different supported log levels and the raw value
-    // that is used as a start character for the log message in order
-    // to be consistent with the Android log output.
-    enum LogLevel: String {
-        case debug = "D"
-        case info = "I"
-        case warn = "W"
-        case error = "E"
-    }
+class Logger {
+    private let log: OSLog
 
     /// Creates a new logger instance with the specified tag value
     ///
     /// - parameters:
     ///     * tag: `String` value used to tag log messages
     init(tag: String) {
-        self.tag = tag
+        self.log = OSLog(
+            subsystem: Bundle.main.bundleIdentifier!,
+            category: tag
+        )
     }
 
     /// Output a debug log message
@@ -31,7 +24,7 @@ class Logger {
     /// - parameters:
     ///     * message: The message to log
     func debug(_ message: String) {
-        log(message: message, level: .debug)
+        log(message, type: .debug)
     }
 
     /// Output an info log message
@@ -39,15 +32,7 @@ class Logger {
     /// - parameters:
     ///     * message: The message to log
     func info(_ message: String) {
-        log(message: message, level: .info)
-    }
-
-    /// Output a warning log message
-    ///
-    /// - parameters:
-    ///     * message: The message to log
-    func warn(_ message: String) {
-        log(message: message, level: .warn)
+        log(message, type: .info)
     }
 
     /// Output an error log message
@@ -55,25 +40,15 @@ class Logger {
     /// - parameters:
     ///     * message: The message to log
     func error(_ message: String) {
-        log(message: message, level: .error)
+        log(message, type: .error)
     }
 
-    /// Private function that formats and outputs the log message based on the level
+    /// Private function that calls os_log with the proper parameters
     ///
     /// - parameters:
     ///     * message: The message to log
     ///     * level: The `LogLevel` at which to output the message
-    private func log(message: String, level: LogLevel) {
-        let formattedMessage = "\(level.rawValue)/\(tag): \(message)"
-
-        // Since logging via `NSLog` has overhead, we only want to output via `NSLog`
-        // for critical messages such as errors.  Everything else can be outputted
-        // using `print()` so that it does not impact the log on release builds.
-        switch level {
-        case .error:
-            NSLog(formattedMessage)
-        default:
-            print(formattedMessage)
-        }
+    private func log(_ message: String, type: OSLogType) {
+        os_log("%@", log: self.log, type: type, message)
     }
 }


### PR DESCRIPTION
This adds a 100ms delay after launching the app to the `testDeletionRequestPing` test in order to prevent a race condition that is happening when the test is triggering `setUploadEnabled(false)` very quickly after app launch, which is intermittently causing the deletion-request ping to not be sent.