### PR TITLE
Bug 1655116 - Suppress proguard warnings for `mozilla.telemetry.glean.testing.**`

### DIFF
--- a/glean-core/android/proguard-rules-consumer.pro
+++ b/glean-core/android/proguard-rules-consumer.pro
@@ -8,3 +8,9 @@
 
 # Glean specific rules
 -keep class mozilla.telemetry.** { *; }
+
+# The Glean SDK ships with classes used for tests as well. They are disabled
+# and not directly usable in production code: they throw if used there. They
+# can be used in tests just fine but, outside of tests, the test dependency
+# they use won't be there, hence the warning. It's safe to suppress these.
+-dontwarn mozilla.telemetry.glean.testing.**


### PR DESCRIPTION
The Glean SDK ships with classes used for tests as well. They are disabled and not directly usable in production code: they throw if used there. They can be used in tests just fine but, outside of tests, the test dependency they use won't be there, hence the warning. It's safe to suppress these.

See the [proguard docs](https://www.guardsquare.com/en/products/proguard/manual/usage) and [where was this discovered](https://github.com/mozilla-mobile/firefox-echo-show/pull/333).