### PR TITLE
Bug 1655613 - Work around a crash on Android 8 buggy devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
     * This kinds of failures yield a "recoverable error", which means the ping gets re-enqueued. That can cause infinite loops on the ping upload worker. For python we were incorrectly only limiting the number of retries for I/O errors, another type of "recoverable error".
   * `kebab-case` ping names are now converted to `snake_case` so they are available on the object returned by `load_pings`.
   * For performance reasons, the `glinter` is no longer run as part of `glean.load_metrics()`. We recommend running `glinter` as part of your project's continuous integration instead.
+* Android
+  * Fix a startup crash on some Android 8 (SDK=25) devices, due to a [bug in the Java compiler](https://issuetracker.google.com/issues/110848122#comment17).
 
 # v32.0.0 (2020-08-03)
 


### PR DESCRIPTION
This works around a bug in the Java compiler on some Android 8/8.1 devices (SDK=25). See [here](https://issuetracker.google.com/issues/110848122#comment17) for more details. On buggy devices, an `AssertionError` is raised because the timezone name `enum` switch is compiled into racy code. Since we only use the timezone name in our logs, we can safely swap that out.

We don't need this defensive programming in `DateUtis.kt` as we're not using timezone names there.