### PR TITLE
Bug 1657908: Use a better link checker in CI and fix links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -932,7 +932,7 @@ jobs:
       - run:
           name: Check internal documentation links
           command: |
-            link-checker
+            link-checker \
               build/docs/book \
               --disable-external true \
               --allow-hash-href true \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -921,25 +921,25 @@ jobs:
 
   docs-linkcheck:
     docker:
-      - image: circleci/python
+      - image: circleci/node
     steps:
       - checkout
       - run:
           name: Install linkchecker
-          command: sudo apt install linkchecker
+          command: npm install -g link-checker
       - attach_workspace:
           at: build/
       - run:
           name: Check internal documentation links
           command: |
-            linkchecker \
-              --ignore-url javadoc \
-              --ignore-url swift \
-              --ignore-url python \
-              --ignore-url docs/glean_core \
-              --ignore-url ErrorKind \
-              --ignore-url std.struct.Error \
-              build/docs
+            link-checker
+              build/docs/book \
+              --disable-external true \
+              --allow-hash-href true \
+              --url-ignore ".*/swift/.*" \
+              --url-ignore ".*/python/.*" \
+              --url-ignore ".*/javadoc/.*" \
+              --url-ignore ".*/docs/glean_.*"
 
   docs-spellcheck:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,7 +926,7 @@ jobs:
       - checkout
       - run:
           name: Install linkchecker
-          command: npm install -g link-checker
+          command: sudo npm install -g link-checker
       - attach_workspace:
           at: build/
       - run:

--- a/Makefile
+++ b/Makefile
@@ -149,16 +149,16 @@ python-docs: build-python ## Build the Python documentation
 
 .PHONY: docs rust-docs kotlin-docs swift-docs
 
-linkcheck: docs ## Run linkchecker on the generated docs
-	# Requires https://wummel.github.io/linkchecker/
-	linkchecker \
-		--ignore-url javadoc \
-		--ignore-url swift \
-		--ignore-url python \
-		--ignore-url docs/glean_core \
-		--ignore-url ErrorKind \
-		--ignore-url std.struct.Error \
-		build/docs
+linkcheck: docs ## Run link-checker on the generated docs
+	# Requires https://www.npmjs.com/package/link-checker
+	link-checker \
+		build/docs/book \
+    --disable-external true \
+    --allow-hash-href true \
+    --url-ignore ".*/swift/.*" \
+    --url-ignore ".*/python/.*" \
+    --url-ignore ".*/javadoc/.*" \
+    --url-ignore ".*/docs/glean_.*"
 .PHONY: linkcheck
 
 spellcheck: ## Spellcheck the docs

--- a/docs/dev/core/internal/payload.md
+++ b/docs/dev/core/internal/payload.md
@@ -1,6 +1,6 @@
 # Payload format
 
-The main sections of a Glean ping are described in [Ping Sections](../../../user/pings/index.md#Ping-sections).
+The main sections of a Glean ping are described in [Ping Sections](../../../user/pings/index.md#ping-sections).
 This **Payload format** chapter describes details of the ping payload that are relevant for decoding Glean pings in the pipeline.
 This is less relevant for end users of the Glean SDK.
 
@@ -205,7 +205,7 @@ Also see [the JSON schema for events](https://github.com/mozilla-services/mozill
 To avoid losing events when the application is killed by the operating system, events are queued on disk as they are recorded.
 When the application starts up again, there is no good way to determine if the device has rebooted since the last run and therefore any timestamps recorded in the new run could not be guaranteed to be consistent with those recorded in the previous run.
 To get around this, on application startup, any queued events are immediately collected into pings and then cleared.
-These "startup-triggered pings" are likely to have a very short duration, as recorded in `ping_info.start_time` and `ping_info.end_time` (see [the `ping_info` section](../../../user/pings/index.md#The-ping_info-section)).
+These "startup-triggered pings" are likely to have a very short duration, as recorded in `ping_info.start_time` and `ping_info.end_time` (see [the `ping_info` section](../../../user/pings/index.md#the-ping_info-section)).
 The maximum timestamp of the events in these pings are quite likely to exceed the duration of the ping, but this is to be expected.
 
 ### Custom Distribution

--- a/docs/dev/core/internal/upload.md
+++ b/docs/dev/core/internal/upload.md
@@ -90,7 +90,7 @@ sequenceDiagram
 
 Glean core will take care of file management, cleanup, rescheduling and rate limiting[^1].
 
-> [^1] Rate limiting is achieved by limiting the amount of times a language binding is allowed to get a `Task::Upload(PingRequest)` from `get_upload_task` in a given time interval. Currently, the default limit is for a maximum of 10 upload tasks every 60 seconds and there are no exposed methods that allow changing this default (follow [Bug 1647630](https://bugzilla.mozilla.org/show_bug.cgi?id=1647630) for updates). If the caller has reached the maximum tasks for the current interval, they will get a `Task::Wait` regardless if there are other `Task::Upload(PingRequest)`s queued.
+[^1]: Rate limiting is achieved by limiting the amount of times a language binding is allowed to get a `Task::Upload(PingRequest)` from `get_upload_task` in a given time interval. Currently, the default limit is for a maximum of 10 upload tasks every 60 seconds and there are no exposed methods that allow changing this default (follow [Bug 1647630](https://bugzilla.mozilla.org/show_bug.cgi?id=1647630) for updates). If the caller has reached the maximum tasks for the current interval, they will get a `Task::Wait` regardless if there are other `Task::Upload(PingRequest)`s queued.
 
 ## Available APIs
 

--- a/docs/user/adding-glean-to-your-project.md
+++ b/docs/user/adding-glean-to-your-project.md
@@ -145,7 +145,7 @@ All metrics that your project collects must be defined in a `metrics.yaml` file.
 To learn more, see [adding new metrics](adding-new-metrics.md).
 See the [metric parameters](metric-parameters.md) documentation which provides reference information about the contents of that file.
 
-> **Important**: as stated [before](adding-glean-to-your-project.md#before-using-glean), any new data collection requires documentation and data-review.
+> **Important**: as stated [before](adding-glean-to-your-project.md#glean-integration-checklist), any new data collection requires documentation and data-review.
 > This is also required for any new metric automatically collected by the Glean SDK.
 
 {{#include ../tab_header.md}}
@@ -356,7 +356,7 @@ This is using the Python 3 interpreter found in `PATH` under the hood. The `GLEA
 
 Please refer to the [custom pings documentation](pings/custom.md).
 
-> **Important**: as stated [before](adding-glean-to-your-project.md#before-using-glean), any new data collection requires documentation and data-review.
+> **Important**: as stated [before](adding-glean-to-your-project.md#glean-integration-checklist), any new data collection requires documentation and data-review.
 > This is also required for any new metric automatically collected by the Glean SDK.
 
 ### Parallelism

--- a/docs/user/adding-new-metrics.md
+++ b/docs/user/adding-new-metrics.md
@@ -3,7 +3,7 @@
 When adding a new metric, the workflow is:
 
 * Consider the question you are trying to answer with this data, and choose the [metric type](metrics/index.md) and parameters to use.
-* Add a new entry to [`metrics.yaml`](#The-metricsyaml-file).
+* Add a new entry to [`metrics.yaml`](#adding-the-metric-to-the-metricsyaml-file).
 * Add code to your project to record into the metric by calling the Glean SDK.
 
 > **Important**: Any new data collection requires documentation and [data-review](https://wiki.mozilla.org/Firefox/Data_Collection). This is also required for any new metric automatically collected by the Glean SDK.
@@ -26,7 +26,7 @@ If you need to store multiple string values in a metric, use a [string list metr
 
 <!-- If you have a related set of metrics that you want to record strings for, and you don't know the things the strings relate to at build time, use a [labeled string metric](metrics/labeled_strings.html). -->
 
-For all of the metric types in this section that measure single values, it is especially important to consider how the lifetime of the value relates to the ping it is being sent in. Since these metrics don't perform any aggregation on the client side, when a ping containing the metric is submitted, it will contain only the "last known" value for the metric, potentially resulting in **data loss**.  There is further discussion of [metric lifetimes](#When-should-Glean-automatically-reset-the-measurement) below.
+For all of the metric types in this section that measure single values, it is especially important to consider how the lifetime of the value relates to the ping it is being sent in. Since these metrics don't perform any aggregation on the client side, when a ping containing the metric is submitted, it will contain only the "last known" value for the metric, potentially resulting in **data loss**.  There is further discussion of [metric lifetimes](#when-should-the-glean-sdk-automatically-clear-the-measurement) below.
 
 ### Are you counting things?
 

--- a/docs/user/metrics/index.md
+++ b/docs/user/metrics/index.md
@@ -1,6 +1,6 @@
 # Metrics
 
-> **Not sure which metric type to use?** These docs contain a [series of questions](../adding-new-metrics.html#Choosing-a-metric-type) that can help. Reference information about each metric type is linked below.
+> **Not sure which metric type to use?** These docs contain a [series of questions](../adding-new-metrics.html#choosing-a-metric-type) that can help. Reference information about each metric type is linked below.
 
 There are different metrics to choose from, depending on what you want to achieve:
 

--- a/docs/user/pings/baseline.md
+++ b/docs/user/pings/baseline.md
@@ -8,9 +8,9 @@ This ping is intended to provide metrics that are managed by the Glean SDK itsel
 
 ## Scheduling
 
-The `baseline` ping is automatically submitted with a `reason: foreground` when the application is moved to the [foreground](index.md#defining-background-state).  These baseline pings do not contain `duration`.
+The `baseline` ping is automatically submitted with a `reason: foreground` when the application is moved to the [foreground](index.md#defining-foreground-and-background-state).  These baseline pings do not contain `duration`.
 
-The `baseline` ping is automatically submitted with a `reason: background` when the application is moved to the [background](index.md#defining-background-state).
+The `baseline` ping is automatically submitted with a `reason: background` when the application is moved to the [background](index.md#defining-foreground-and-background-state).
 Occasionally, the `baseline` ping may fail to send when going to background (e.g. the process is killed quickly).  In that case, it will be submitted at startup with a `reason: dirty_startup`, if the previous session was not cleanly closed. This only happens from the second start onward.
 
 See also the [ping schedules and timing overview](ping-schedules-and-timings.html).

--- a/docs/user/pings/custom.md
+++ b/docs/user/pings/custom.md
@@ -17,11 +17,11 @@ Each ping has the following parameters:
 
 - `description` (required): A textual description describing the purpose of the ping. It may contain [markdown syntax](https://www.markdownguide.org/basic-syntax/).
 - `include_client_id` (required): A boolean indicating whether to include the
-  `client_id` in the [`client_info` section](index.md#The-client_info-section)).
+  `client_id` in the [`client_info` section](index.md#the-client_info-section)).
 - `send_if_empty` (optional, default: false): A boolean indicating if the ping is sent if it contains no metric data.
 - `reasons` (optional, default: `{}`): The reasons that this ping may be sent. The keys are the reason codes, and the values are a textual description of each reason. The ping payload will (optionally) contain one of these reasons in the `ping_info.reason` field.
 
-In addition to these parameters, pings also support the parameters related to data review and expiration defined in [common metric parameters](../adding-new-metrics.md#common-metric-parameters): `description`, `notification_emails`, `bugs`, and `data_reviews`.
+In addition to these parameters, pings also support the parameters related to data review and expiration defined in [common metric parameters](../metric-parameters.md): `description`, `notification_emails`, `bugs`, and `data_reviews`.
 
 For example, to define a custom ping called `search` specifically for search information:
 

--- a/docs/user/pings/events.md
+++ b/docs/user/pings/events.md
@@ -8,7 +8,7 @@ If the application crashes, an `events` ping is generated next time the applicat
 
 The `events` ping is collected under the following circumstances:
 
-1. Normally, it is collected when the application goes into the [background](index.md#defining-background-state), if there are any recorded events to send.
+1. Normally, it is collected when the application goes into the [background](index.md#defining-foreground-and-background-state), if there are any recorded events to send.
 
 2. When the queue of events exceeds `Glean.configuration.maxEvents` (default 500).
 

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -17,9 +17,9 @@ There is also a [high-level overview](ping-schedules-and-timings.html) of how th
 
 There are two standard metadata sections that are added to most pings, in addition to their core metrics and events content (which are described in [Adding new metrics](../adding-new-metrics.md)).
 
-- The [`ping_info` section](#The-ping_info-section) contains core metadata that is included in **every** ping.
+- The [`ping_info` section](#the-ping_info-section) contains core metadata that is included in **every** ping.
   
-- The [`client_info` section](#The-client_info-section) contains information that identifies the client.
+- The [`client_info` section](#the-client_info-section) contains information that identifies the client.
   It is included in most pings (including all built-in pings), but may be excluded from pings where we don't want to connect client information with the other metrics in the ping.
 
 ### The `ping_info` section
@@ -62,7 +62,7 @@ All the metrics surviving application restarts (e.g. `client_id`, ...) are remov
 
 ### The `experiments` object
 
-This object (included in the [`ping_info` section](#The-ping_info-section)) contains experiments keyed by the experiment `id`. Each listed experiment contains the `branch` the client is enrolled in and may contain a string to string map with additional data in the `extra` key. Both the `id` and `branch` are truncated to 30 characters.
+This object (included in the [`ping_info` section](#the-ping_info-section)) contains experiments keyed by the experiment `id`. Each listed experiment contains the `branch` the client is enrolled in and may contain a string to string map with additional data in the `extra` key. Both the `id` and `branch` are truncated to 30 characters.
 See [Using the Experiments API](../experiments-api.md) on how to record experiments data.
 
 ```json


### PR DESCRIPTION
The Python-based linkchecker had buggy checking of anchors within pages,
which has caused a number of our internal doc links to break.

This replaces it with a different link checking tool, and then corrects
all of the errors it found.