### PR TITLE
Increase rate limiter to 15 pings per minute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v32.0.0...main)
 
 * General
+  * The upload rate limiter has been changed from 10 pings per minute to 15 pings per minute.
   * Move logic to limit the number of retries on ping uploading "recoverable failures" to glean-core. ([#1120](https://github.com/mozilla/glean/pull/1120))
     * The functionality to limit the number of retries in these cases was introduced to the Glean SDK in `v31.1.0`. The work done now was to move that logic to the glean-core in order to avoid code duplication throughout the language bindings.
   * Update `glean_parser` to `v1.28.3`

--- a/docs/dev/core/internal/upload.md
+++ b/docs/dev/core/internal/upload.md
@@ -90,7 +90,7 @@ sequenceDiagram
 
 Glean core will take care of file management, cleanup, rescheduling and rate limiting[^1].
 
-[^1]: Rate limiting is achieved by limiting the amount of times a language binding is allowed to get a `Task::Upload(PingRequest)` from `get_upload_task` in a given time interval. Currently, the default limit is for a maximum of 10 upload tasks every 60 seconds and there are no exposed methods that allow changing this default (follow [Bug 1647630](https://bugzilla.mozilla.org/show_bug.cgi?id=1647630) for updates). If the caller has reached the maximum tasks for the current interval, they will get a `Task::Wait` regardless if there are other `Task::Upload(PingRequest)`s queued.
+[^1]: Rate limiting is achieved by limiting the amount of times a language binding is allowed to get a `Task::Upload(PingRequest)` from `get_upload_task` in a given time interval. Currently, the default limit is for a maximum of 15 upload tasks every 60 seconds and there are no exposed methods that allow changing this default (follow [Bug 1647630](https://bugzilla.mozilla.org/show_bug.cgi?id=1647630) for updates). If the caller has reached the maximum tasks for the current interval, they will get a `Task::Wait` regardless if there are other `Task::Upload(PingRequest)`s queued.
 
 ## Available APIs
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -202,7 +202,7 @@ impl Glean {
         let mut upload_manager =
             PingUploadManager::new(&cfg.data_path, &cfg.language_binding_name, false);
         upload_manager.set_rate_limiter(
-            /* seconds per interval */ 60, /* max tasks per interval */ 10,
+            /* seconds per interval */ 60, /* max tasks per interval */ 15,
         );
 
         Ok(Self {


### PR DESCRIPTION
This will be introduced as an experiment in a patch release and shipped to Fenix quickly to see if this is the issue with not getting all migration pings.

(A successful migration sends 11 pings, so stopping with 10 does seem to point at the rate limiter, but this experiment will help us confirm.)