### PR TITLE
Bug 1656879 - Move MAX_WAIT_ATTEMPTS logic to the core

### DIFF
--- a/glean-core/csharp/Glean/Net/BaseUploader.cs
+++ b/glean-core/csharp/Glean/Net/BaseUploader.cs
@@ -19,9 +19,6 @@ namespace Mozilla.Glean.Net
     /// </summary>
     internal class BaseUploader
     {
-        // How many times to attempt waiting when told to by glean-core's upload API.
-        private const int MAX_WAIT_ATTEMPTS = 3;
-
         private readonly IPingUploader uploader;
 
         /// <summary>
@@ -129,17 +126,8 @@ namespace Mozilla.Glean.Net
                         }
                         break;
                     case UploadTaskTag.Wait:
-                        {
-                            if (waitAttempts < MAX_WAIT_ATTEMPTS)
-                            {
-                                waitAttempts += 1;
-                            }
-                            else
-                            {
-                                Thread.Sleep(100);
-                                return;
-                            }
-                        } break;
+                        Thread.Sleep(100);
+                        break;
                     case UploadTaskTag.Done:
                         // Nothing to do here, break out of the loop.
                         return;

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -110,8 +110,6 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
             log.error("Couldn't initialize Glean in subprocess")
             sys.exit(1)
 
-    wait_attempts = 0
-
     # Limits are enforced by glean-core to avoid an inifinite loop here.
     # Whenever a limit is reached, this binding will receive `UploadTaskTag.DONE` and step out.
     while True:

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -22,10 +22,6 @@ from .._process_dispatcher import ProcessDispatcher
 log = logging.getLogger(__name__)
 
 
-# How many times to attempt waiting when told to by glean-core's upload API.
-MAX_WAIT_ATTEMPTS = 3
-
-
 class PingUploadWorker:
     @classmethod
     def process(cls):
@@ -147,12 +143,7 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
                 incoming_task, upload_result.to_ffi()
             )
         elif tag == UploadTaskTag.WAIT:
-            # Try not to be stuck waiting forever.
-            if wait_attempts < MAX_WAIT_ATTEMPTS:
-                wait_attempts += 1
-                time.sleep(1)
-            else:
-                return False
+            time.sleep(1)
         elif tag == UploadTaskTag.DONE:
             return True
 

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -34,6 +34,11 @@ impl PingPayloadsByDirectory {
         self.deletion_request_pings
             .extend(other.deletion_request_pings);
     }
+
+    // Get the sum of the number of deletion request and regular pending pings.
+    pub fn len(&self) -> usize {
+        self.pending_pings.len() + self.deletion_request_pings.len()
+    }
 }
 
 /// Gets the file name from a path as a &str.

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -132,7 +132,7 @@ pub enum PingUploadTask {
     ///
     /// There are three possibilities for this scenario:
     /// * Pending pings queue is empty, no more pings to request;
-    /// * Requester has gotten more than three `PingUploadTask::Wait` responses in a row;
+    /// * Requester has gotten more than MAX_WAIT_ATTEMPTS (3, by default) `PingUploadTask::Wait` responses in a row;
     /// * Requester has reported more than MAX_RECOVERABLE_FAILURES_PER_UPLOADING_WINDOW
     ///   recoverable upload failures on the same uploading window[1]
     ///   and should stop requesting at this moment.

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -435,10 +435,10 @@ impl PingUploadManager {
     }
 
     fn get_upload_task_internal(&self, glean: &Glean, log_ping: bool) -> PingUploadTask {
-        // Helper function to return to decide whether to return PingUploadTask::Wait or PingUploadTask::Done.
+        // Helper to decide whether to return PingUploadTask::Wait or PingUploadTask::Done.
         //
         // We want to limit the amount of PingUploadTask::Wait returned in a row,
-        // in case we reach MAX_WAIT_ATTEMPTS we want to actually return PingUploadTask::Done
+        // in case we reach MAX_WAIT_ATTEMPTS we want to actually return PingUploadTask::Done.
         let wait_or_done = || {
             self.wait_attempt_count.fetch_add(1, Ordering::SeqCst);
             if self.wait_attempt_count() > MAX_WAIT_ATTEMPTS {
@@ -1289,17 +1289,12 @@ mod test {
     }
 
     #[test]
-    fn maximum_wait_attemps_in_enforced() {
+    fn maximum_wait_attemps_is_enforced() {
         let (glean, _) = new_glean(None);
 
         // Create a new upload_manager
         let dir = tempfile::tempdir().unwrap();
-        let mut upload_manager = PingUploadManager::new(dir.path(), "Testing", false);
-
-        // Wait for processing of pending pings directory to finish.
-        while upload_manager.get_upload_task(&glean, false) == PingUploadTask::Wait {
-            thread::sleep(Duration::from_millis(10));
-        }
+        let mut upload_manager = PingUploadManager::new(dir.path(), "Testing", true);
 
         // Add a rate limiter to the upload mangager with max of 1 ping 5secs.
         //

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -702,10 +702,7 @@ mod test {
 
         // Try and get the next request.
         // Verify request was not returned
-        assert_eq!(
-            glean.get_upload_task(),
-            PingUploadTask::Done
-        );
+        assert_eq!(glean.get_upload_task(), PingUploadTask::Done);
     }
 
     #[test]
@@ -762,7 +759,8 @@ mod test {
 
         // Create a new upload manager so that we have access to its functions directly,
         // make it synchronous so we don't have to manually wait for the scanning to finish.
-        let mut upload_manager = PingUploadManager::new(dir.path(), "Testing", /* sync */ true);
+        let mut upload_manager =
+            PingUploadManager::new(dir.path(), "Testing", /* sync */ true);
 
         // Add a rate limiter to the upload mangager with max of 10 pings every 3 seconds.
         let secs_per_interval = 3;
@@ -1264,7 +1262,8 @@ mod test {
 
         // Create a new upload manager so that we have access to its functions directly,
         // make it synchronous so we don't have to manually wait for the scanning to finish.
-        let mut upload_manager = PingUploadManager::new(dir.path(), "Testing", /* sync */ true);
+        let mut upload_manager =
+            PingUploadManager::new(dir.path(), "Testing", /* sync */ true);
 
         // Add a rate limiter to the upload mangager with max of 1 ping 5secs.
         //


### PR DESCRIPTION
While working on this I realized that Python and C# don't have the exponential backoff like Android does.

Not necessary at the moment obviously, but I guess it's time to at least file a bug about adding a duration to the `PingUploadTask::Wait`, so that we can implement the exponential backoff on the Rust side. That way this behaviour can be consistent across all bindings.