### PR TITLE
Bug 1659548 - CI: Downgrade Android image to use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,7 +390,8 @@ jobs:
 
   Lint Android with ktlint and detekt:
     docker:
-      - image: circleci/android:api-28-ndk
+      # FIXME(bug 1659706): Use `circleci/android:api-28-ndk` again
+      - image: circleci/android@sha256:467c03465c664de6c915cfd94f4a8fc91cd16d87f704e8323704b2576330bf6e
     steps:
       - checkout
       - run: ./gradlew --no-daemon lint
@@ -399,7 +400,8 @@ jobs:
 
   Android tests:
     docker:
-      - image: circleci/android:api-28-ndk
+      # FIXME(bug 1659706): Use `circleci/android:api-28-ndk` again
+      - image: circleci/android@sha256:467c03465c664de6c915cfd94f4a8fc91cd16d87f704e8323704b2576330bf6e
     steps:
       - android-setup
       - skip-if-doc-only
@@ -445,7 +447,8 @@ jobs:
 
   Generate Kotlin documentation:
     docker:
-      - image: circleci/android:api-28-ndk
+      # FIXME(bug 1659706): Use `circleci/android:api-28-ndk` again
+      - image: circleci/android@sha256:467c03465c664de6c915cfd94f4a8fc91cd16d87f704e8323704b2576330bf6e
     steps:
       - android-setup
       - run:


### PR DESCRIPTION
CircleCI recently upgraded that image from OpenJDK 8 to OpenJDK 11.
We pin to the old version for now.

---

Followup filed: https://bugzilla.mozilla.org/show_bug.cgi?id=1659706