### PR TITLE
Bug 1656934 - Upload manager: ignore files if metadata can't be read

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
@@ -14,7 +14,6 @@ import mozilla.telemetry.glean.resetGlean
 import java.io.File
 import mozilla.telemetry.glean.testing.GleanTestRule
 import mozilla.telemetry.glean.triggerWorkManager
-import mozilla.telemetry.glean.waitForEnqueuedWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertFalse
@@ -134,7 +133,6 @@ class DeletionPingTest {
             serverEndpoint = "http://" + server.hostName + ":" + server.port
         ), clearStores = true, uploadEnabled = false)
         triggerWorkManager(context)
-        waitForEnqueuedWorker(context, PingUploadWorker.PING_WORKER_TAG)
 
         var request = server.takeRequest(20L, TimeUnit.SECONDS)
         var docType = request.path.split("/")[3]


### PR DESCRIPTION
There's a rare case where this races against a parallel deletion of all pending ping files.
This could therefore fail, in which case we don't care about the result and can ignore the ping, it's already been deleted.