### PR TITLE
Don't require swiftformat to run anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,13 +123,10 @@ fmt: rustfmt
 rustfmt: ## Format all Rust code
 	cargo fmt --all
 
-swiftfmt: ## Format all Swift code
-	swiftformat glean-core/ios samples/ios --swiftversion 5 --verbose
-
 pythonfmt: python-setup ## Run black to format Python code
 	$(GLEAN_PYENV)/bin/python3 -m black glean-core/python/glean glean-core/python/tests
 
-.PHONY: fmt rustfmt swiftfmt
+.PHONY: fmt rustfmt
 
 # Docs
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,7 +69,6 @@ Before submitting a PR:
 - For changes to Swift code
   - `make test-swift` (or running tests in Xcode) runs without emitting any warnings or errors.
   - `make swiftlint` runs without emitting any warnings or errors.
-  - `make swiftfmt` runs without emitting any warnings or producing changes.
 - Your patch should include new tests that cover your changes. It is your and your reviewer's responsibility to ensure your patch includes adequate tests.
 
 When submitting a PR:


### PR DESCRIPTION
This was previously already removed from CI,
but we missed to remove the make task and documentation.

[doc only]