### PR TITLE
Xcode 12 support (currently Beta5)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,7 @@ jobs:
 
   Check Swift formatting:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       - checkout
       - run:
@@ -484,7 +484,7 @@ jobs:
 
   iOS build and test:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       - checkout
       - run:
@@ -608,7 +608,7 @@ jobs:
 
   iOS integration test:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       - checkout
       - skip-if-doc-only
@@ -674,7 +674,7 @@ jobs:
 
   Carthage release:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       - checkout
       - attach_workspace:
@@ -850,7 +850,7 @@ jobs:
 
   pypi-macos-release:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       - install-rustup
       - setup-rust-toolchain


### PR DESCRIPTION
On Firefox iOS we are now supporting xcode 12 on main and need release for this version.

xref to a-s lib https://github.com/mozilla/application-services/pull/3532