### PR TITLE
Bug 1661036 - Check if upload is enabled before recording a metric

### DIFF
--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -590,10 +590,10 @@ impl Database {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
-    use tempfile::tempdir;
     use crate::tests::new_glean;
     use crate::CommonMetricData;
+    use std::collections::HashMap;
+    use tempfile::tempdir;
 
     #[test]
     fn test_panicks_if_fails_dir_creation() {
@@ -1041,7 +1041,7 @@ mod test {
 
     #[test]
     fn doesnt_record_when_upload_is_disabled() {
-        let (mut glean, dir)= new_glean(None);
+        let (mut glean, dir) = new_glean(None);
 
         // Init the database in a temporary directory.
         let str_dir = dir.path().display().to_string();
@@ -1054,22 +1054,40 @@ mod test {
         // this should work since upload is enabled.
         let db = Database::new(&str_dir, true).unwrap();
         db.record(&glean, &test_data, &Metric::String("record".to_owned()));
-        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
-            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
-            match metric {
-                Metric::String(v) => assert_eq!("record", *v),
-                _ => panic!("Unexpected data found"),
-            }
-        });
+        db.iter_store_from(
+            Lifetime::Ping,
+            test_storage,
+            None,
+            &mut |metric_id: &[u8], metric: &Metric| {
+                assert_eq!(
+                    String::from_utf8_lossy(metric_id).into_owned(),
+                    test_metric_id
+                );
+                match metric {
+                    Metric::String(v) => assert_eq!("record", *v),
+                    _ => panic!("Unexpected data found"),
+                }
+            },
+        );
 
-        db.record_with(&glean, &test_data, |_| Metric::String("record_with".to_owned()));
-        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
-            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
-            match metric {
-                Metric::String(v) => assert_eq!("record_with", *v),
-                _ => panic!("Unexpected data found"),
-            }
+        db.record_with(&glean, &test_data, |_| {
+            Metric::String("record_with".to_owned())
         });
+        db.iter_store_from(
+            Lifetime::Ping,
+            test_storage,
+            None,
+            &mut |metric_id: &[u8], metric: &Metric| {
+                assert_eq!(
+                    String::from_utf8_lossy(metric_id).into_owned(),
+                    test_metric_id
+                );
+                match metric {
+                    Metric::String(v) => assert_eq!("record_with", *v),
+                    _ => panic!("Unexpected data found"),
+                }
+            },
+        );
 
         // Disable upload
         glean.set_upload_enabled(false);
@@ -1077,20 +1095,38 @@ mod test {
         // Attempt to record metric with the record and record_with functions,
         // this should work since upload is now **disabled**.
         db.record(&glean, &test_data, &Metric::String("record_nop".to_owned()));
-        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
-            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
-            match metric {
-                Metric::String(v) => assert_eq!("record_with", *v),
-                _ => panic!("Unexpected data found"),
-            }
+        db.iter_store_from(
+            Lifetime::Ping,
+            test_storage,
+            None,
+            &mut |metric_id: &[u8], metric: &Metric| {
+                assert_eq!(
+                    String::from_utf8_lossy(metric_id).into_owned(),
+                    test_metric_id
+                );
+                match metric {
+                    Metric::String(v) => assert_eq!("record_with", *v),
+                    _ => panic!("Unexpected data found"),
+                }
+            },
+        );
+        db.record_with(&glean, &test_data, |_| {
+            Metric::String("record_with_nop".to_owned())
         });
-        db.record_with(&glean, &test_data, |_| Metric::String("record_with_nop".to_owned()));
-        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
-            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
-            match metric {
-                Metric::String(v) => assert_eq!("record_with", *v),
-                _ => panic!("Unexpected data found"),
-            }
-        });
+        db.iter_store_from(
+            Lifetime::Ping,
+            test_storage,
+            None,
+            &mut |metric_id: &[u8], metric: &Metric| {
+                assert_eq!(
+                    String::from_utf8_lossy(metric_id).into_owned(),
+                    test_metric_id
+                );
+                match metric {
+                    Metric::String(v) => assert_eq!("record_with", *v),
+                    _ => panic!("Unexpected data found"),
+                }
+            },
+        );
     }
 }

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -263,7 +263,7 @@ impl Database {
     /// # Panics
     ///
     /// * This function will **not** panic on database errors.
-    pub fn write_with_store<F>(&self, store_name: Lifetime, mut transaction_fn: F) -> Result<()>
+    fn write_with_store<F>(&self, store_name: Lifetime, mut transaction_fn: F) -> Result<()>
     where
         F: FnMut(rkv::Writer, &SingleStore) -> Result<()>,
     {
@@ -274,6 +274,11 @@ impl Database {
 
     /// Records a metric in the underlying storage system.
     pub fn record(&self, glean: &Glean, data: &CommonMetricData, value: &Metric) {
+        // If upload is disabled we don't want to record.
+        if !glean.is_upload_enabled() {
+            return;
+        }
+
         let name = data.identifier(glean);
 
         for ping_name in data.storage_names() {
@@ -331,6 +336,11 @@ impl Database {
     where
         F: FnMut(Option<Metric>) -> Metric,
     {
+        // If upload is disabled we don't want to record.
+        if !glean.is_upload_enabled() {
+            return;
+        }
+
         let name = data.identifier(glean);
         for ping_name in data.storage_names() {
             if let Err(e) =
@@ -353,7 +363,7 @@ impl Database {
     /// # Panics
     ///
     /// This function will **not** panic on database errors.
-    pub fn record_per_lifetime_with<F>(
+    fn record_per_lifetime_with<F>(
         &self,
         lifetime: Lifetime,
         storage_name: &str,
@@ -582,6 +592,8 @@ mod test {
     use super::*;
     use std::collections::HashMap;
     use tempfile::tempdir;
+    use crate::tests::new_glean;
+    use crate::CommonMetricData;
 
     #[test]
     fn test_panicks_if_fails_dir_creation() {
@@ -1025,5 +1037,60 @@ mod test {
                 .unwrap_or(None)
                 .is_some());
         }
+    }
+
+    #[test]
+    fn doesnt_record_when_upload_is_disabled() {
+        let (mut glean, dir)= new_glean(None);
+
+        // Init the database in a temporary directory.
+        let str_dir = dir.path().display().to_string();
+
+        let test_storage = "test-storage";
+        let test_data = CommonMetricData::new("category", "name", test_storage);
+        let test_metric_id = test_data.identifier(&glean);
+
+        // Attempt to record metric with the record and record_with functions,
+        // this should work since upload is enabled.
+        let db = Database::new(&str_dir, true).unwrap();
+        db.record(&glean, &test_data, &Metric::String("record".to_owned()));
+        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
+            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
+            match metric {
+                Metric::String(v) => assert_eq!("record", *v),
+                _ => panic!("Unexpected data found"),
+            }
+        });
+
+        db.record_with(&glean, &test_data, |_| Metric::String("record_with".to_owned()));
+        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
+            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
+            match metric {
+                Metric::String(v) => assert_eq!("record_with", *v),
+                _ => panic!("Unexpected data found"),
+            }
+        });
+
+        // Disable upload
+        glean.set_upload_enabled(false);
+
+        // Attempt to record metric with the record and record_with functions,
+        // this should work since upload is now **disabled**.
+        db.record(&glean, &test_data, &Metric::String("record_nop".to_owned()));
+        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
+            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
+            match metric {
+                Metric::String(v) => assert_eq!("record_with", *v),
+                _ => panic!("Unexpected data found"),
+            }
+        });
+        db.record_with(&glean, &test_data, |_| Metric::String("record_with_nop".to_owned()));
+        db.iter_store_from(Lifetime::Ping, test_storage, None, &mut |metric_id: &[u8], metric: &Metric| {
+            assert_eq!(String::from_utf8_lossy(metric_id).into_owned(), test_metric_id);
+            match metric {
+                Metric::String(v) => assert_eq!("record_with", *v),
+                _ => panic!("Unexpected data found"),
+            }
+        });
     }
 }

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -481,8 +481,8 @@ mod test {
         db.record(&glean, &test_meta, 2, None);
         {
             let event_stores = db.event_stores.read().unwrap();
-            assert_eq!(&event_data, &event_stores.get(test_storage.clone()).unwrap()[0]);
-            assert_eq!(event_stores.get(test_storage.clone()).unwrap().len(), 1);
+            assert_eq!(&event_data, &event_stores.get(test_storage).unwrap()[0]);
+            assert_eq!(event_stores.get(test_storage).unwrap().len(), 1);
         }
 
         glean.set_upload_enabled(false);
@@ -491,7 +491,7 @@ mod test {
         db.record(&glean, &test_meta, 2, None);
         {
             let event_stores = db.event_stores.read().unwrap();
-            assert_eq!(event_stores.get(test_storage.clone()).unwrap().len(), 1);
+            assert_eq!(event_stores.get(test_storage).unwrap().len(), 1);
         }
     }
 }

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -187,6 +187,11 @@ impl EventDatabase {
         timestamp: u64,
         extra: Option<HashMap<String, String>>,
     ) {
+        // If upload is disabled we don't want to record.
+        if !glean.is_upload_enabled() {
+            return;
+        }
+
         // Create RecordedEvent object, and its JSON form for serialization
         // on disk.
         let event = RecordedEvent {
@@ -357,6 +362,8 @@ impl EventDatabase {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::tests::new_glean;
+    use crate::CommonMetricData;
 
     #[test]
     fn handle_truncated_events_on_disk() {
@@ -450,5 +457,41 @@ mod test {
             serde_json::from_str(&event_empty_json).unwrap()
         );
         assert_eq!(event_data, serde_json::from_str(&event_data_json).unwrap());
+    }
+
+    #[test]
+    fn doesnt_record_when_upload_is_disabled() {
+        let (mut glean, dir) = new_glean(None);
+        let db = EventDatabase::new(dir.path().to_str().unwrap()).unwrap();
+
+        let test_storage = "test-storage";
+        let test_category = "category";
+        let test_name = "name";
+        let test_timestamp = 2;
+        let test_meta = CommonMetricData::new(test_category, test_name, test_storage);
+        let event_data = RecordedEvent {
+            timestamp: test_timestamp,
+            category: test_category.to_string(),
+            name: test_name.to_string(),
+            extra: None,
+        };
+
+        // Upload is not yet disabled,
+        // so let's check that everything is getting recorded as expected.
+        db.record(&glean, &test_meta, 2, None);
+        {
+            let event_stores = db.event_stores.read().unwrap();
+            assert_eq!(&event_data, &event_stores.get(test_storage.clone()).unwrap()[0]);
+            assert_eq!(event_stores.get(test_storage.clone()).unwrap().len(), 1);
+        }
+
+        glean.set_upload_enabled(false);
+
+        // Now that upload is disabled, let's check nothing is recorded.
+        db.record(&glean, &test_meta, 2, None);
+        {
+            let event_stores = db.event_stores.read().unwrap();
+            assert_eq!(event_stores.get(test_storage.clone()).unwrap().len(), 1);
+        }
     }
 }

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -75,6 +75,10 @@ impl CustomDistributionMetric {
     /// Discards any negative value in `samples` and report an `ErrorType::InvalidValue`
     /// for each of them.
     pub fn accumulate_samples_signed(&self, glean: &Glean, samples: Vec<i64>) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let mut num_negative_samples = 0;
 
         // Generic accumulation function to handle the different histogram types and count negative

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -72,6 +72,10 @@ impl DatetimeMetric {
         nano: u32,
         offset_seconds: i32,
     ) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let timezone_offset = FixedOffset::east_opt(offset_seconds);
         if timezone_offset.is_none() {
             let msg = format!("Invalid timezone offset {}. Not recording.", offset_seconds);

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -120,6 +120,10 @@ impl MemoryDistributionMetric {
     /// Values bigger than 1 Terabyte (2<sup>40</sup> bytes) are truncated
     /// and an `ErrorType::InvalidValue` error is recorded.
     pub fn accumulate_samples_signed(&self, glean: &Glean, samples: Vec<i64>) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let mut num_negative_samples = 0;
         let mut num_too_log_samples = 0;
 

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -242,6 +242,10 @@ impl TimingDistributionMetric {
     /// for each of them. Reports an `ErrorType::InvalidOverflow` error for samples that
     /// are longer than `MAX_SAMPLE_TIME`.
     pub fn accumulate_samples_signed(&mut self, glean: &Glean, samples: Vec<i64>) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let mut num_negative_samples = 0;
         let mut num_too_long_samples = 0;
         let max_sample_time = self.time_unit.as_nanos(MAX_SAMPLE_TIME);
@@ -273,6 +277,7 @@ impl TimingDistributionMetric {
                     hist.accumulate(sample);
                 }
             }
+
             Metric::TimingDistribution(hist)
         });
 


### PR DESCRIPTION
I added this check to the metrics code that wasn't checking, to avoid running unnecessary code when the metric won't be recorded after all.

I also added checks to the `record_*` functions on the databases, just to be sure we are not recording when we don't want to. Note that I only check if upload is disabled on the databases.