### PR TITLE
Bug 1661276 - Raise limit for max wait attempts

### DIFF
--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -32,7 +32,7 @@ mod result;
 const MAX_RECOVERABLE_FAILURES_PER_UPLOADING_WINDOW: u32 = 3;
 
 /// The maximum PingUploadTask::Wait allowed in a row.
-const MAX_WAIT_ATTEMPTS: u32 = 3;
+const MAX_WAIT_ATTEMPTS: u32 = 300;
 
 // The maximum size in bytes a ping body may have to be eligible for upload.
 const PING_BODY_MAX_SIZE: usize = 1024 * 1024; // 1 MB


### PR DESCRIPTION
This is just a quick fix so that intermittents stop for today.

A more sustainable approach for this would be having a way to turn limits off for tests. I am almost at EOD for today so, quick fix it is for now and tomorrow I work on the more involved fix.