### PR TITLE
Python: Fix wheel dependency so it matches auditwheel

### DIFF
--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -12,4 +12,4 @@ pytest-runner==4.4
 pytest==6.0.1
 toml==0.10.1
 twine==3.2.0
-wheel==0.35.1
+wheel==0.34.2


### PR DESCRIPTION
dependabot put us in an unsupported state: auditwheel 3.2.0 requires exactly wheel 0.34.2