### PR TITLE
Python: Use new pip-resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ python-setup: $(GLEAN_PYENV)/bin/python3 ## Setup a Python virtual environment
 $(GLEAN_PYENV)/bin/python3:
 	python3 -m venv $(GLEAN_PYENV)
 	$(GLEAN_PYENV)/bin/pip install --upgrade pip
-	$(GLEAN_PYENV)/bin/pip install -r glean-core/python/requirements_dev.txt
+	$(GLEAN_PYENV)/bin/pip install --use-feature=2020-resolver -r glean-core/python/requirements_dev.txt
 	bash -c "if [ \"$(GLEAN_PYDEPS)\" == \"min\" ]; then \
 		$(GLEAN_PYENV)/bin/pip install requirements-builder; \
 		$(GLEAN_PYENV)/bin/requirements-builder --level=min glean-core/python/setup.py > min_requirements.txt; \
-		$(GLEAN_PYENV)/bin/pip install -r min_requirements.txt; \
+		$(GLEAN_PYENV)/bin/pip install --use-feature=2020-resolver -r min_requirements.txt; \
 	fi"
 
 # All builds


### PR DESCRIPTION
The new pip resolver (which should soon be the default) is stricter about global consistency of versions.

This should error out of there is an inconsistency between versions of
libraries, and avoid dependabot creating errors that lead to the fix in #1184

For context: "The new dependency resolver is significantly stricter and more consistent when it receives incompatible instructions, and reduces support for certain kinds of constraints files, so some workarounds and workflows may break." [ref](https://discuss.python.org/t/announcement-pip-20-2-release/4863)