### PR TITLE
iOS: Disable code coverage 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * General
   * Track the size of the database file at startup ([#1141](https://github.com/mozilla/glean/pull/1141)).
+* iOS
+  * Disabled code coverage in release builds ([#1195](https://github.com/mozilla/glean/issues/1195)).
 
 # v32.3.0 (2020-08-27)
 

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -719,6 +719,7 @@
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -773,6 +774,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF51C3B9224BF19F0014CBAF /* debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
@@ -807,6 +809,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF51C3BA224BF19F0014CBAF /* release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;


### PR DESCRIPTION
This avoids linker errors due to missing errors such as as "___llvm_profile_runtime".
We only use code coverage in development for our manual checks, but we
should not put that in released binary frameworks.