### PR TITLE
Bug 1661036 - Check if upload is enabled before recording a metric [ALTERNATE]

### DIFF
--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::num::NonZeroU64;
 use std::path::Path;
 use std::str;
-use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
 
 use rkv::{Rkv, SingleStore, StoreOptions};
 
@@ -641,9 +641,10 @@ impl Database {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::tests::new_glean;
+    use crate::CommonMetricData;
     use std::collections::HashMap;
     use tempfile::tempdir;
-    use crate::tests::new_glean;
 
     #[test]
     fn test_panicks_if_fails_dir_creation() {

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -10,8 +10,8 @@ use std::io::BufReader;
 use std::io::Write;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -197,7 +197,11 @@ impl Glean {
 
         // Creating the data store creates the necessary path as well.
         // If that fails we bail out and don't initialize further.
-        let data_store = Some(Database::new(&cfg.data_path, cfg.delay_ping_lifetime_io, *&cfg.upload_enabled)?);
+        let data_store = Some(Database::new(
+            &cfg.data_path,
+            cfg.delay_ping_lifetime_io,
+            *&cfg.upload_enabled,
+        )?);
         let event_data_store = EventDatabase::new(&cfg.data_path, *&cfg.upload_enabled)?;
 
         // Create an upload manager with rate limiting of 10 pings every 60 seconds.
@@ -476,7 +480,6 @@ impl Glean {
             self.upload_enabled = true;
             // In order for `set` to fully work we also need to enable the metrics storage.
             self.storage().enable();
-
 
             // Store a "dummy" KNOWN_CLIENT_ID in the client_id metric. This will
             // make it easier to detect if pings were unintentionally sent after

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -200,9 +200,9 @@ impl Glean {
         let data_store = Some(Database::new(
             &cfg.data_path,
             cfg.delay_ping_lifetime_io,
-            *&cfg.upload_enabled,
+            cfg.upload_enabled,
         )?);
-        let event_data_store = EventDatabase::new(&cfg.data_path, *&cfg.upload_enabled)?;
+        let event_data_store = EventDatabase::new(&cfg.data_path, cfg.upload_enabled)?;
 
         // Create an upload manager with rate limiting of 10 pings every 60 seconds.
         let mut upload_manager =

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -75,6 +75,10 @@ impl CustomDistributionMetric {
     /// Discards any negative value in `samples` and report an `ErrorType::InvalidValue`
     /// for each of them.
     pub fn accumulate_samples_signed(&self, glean: &Glean, samples: Vec<i64>) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let mut num_negative_samples = 0;
 
         // Generic accumulation function to handle the different histogram types and count negative

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -72,6 +72,10 @@ impl DatetimeMetric {
         nano: u32,
         offset_seconds: i32,
     ) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let timezone_offset = FixedOffset::east_opt(offset_seconds);
         if timezone_offset.is_none() {
             let msg = format!("Invalid timezone offset {}. Not recording.", offset_seconds);

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -120,6 +120,10 @@ impl MemoryDistributionMetric {
     /// Values bigger than 1 Terabyte (2<sup>40</sup> bytes) are truncated
     /// and an `ErrorType::InvalidValue` error is recorded.
     pub fn accumulate_samples_signed(&self, glean: &Glean, samples: Vec<i64>) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let mut num_negative_samples = 0;
         let mut num_too_log_samples = 0;
 

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -242,6 +242,10 @@ impl TimingDistributionMetric {
     /// for each of them. Reports an `ErrorType::InvalidOverflow` error for samples that
     /// are longer than `MAX_SAMPLE_TIME`.
     pub fn accumulate_samples_signed(&mut self, glean: &Glean, samples: Vec<i64>) {
+        if !self.should_record(glean) {
+            return;
+        }
+
         let mut num_negative_samples = 0;
         let mut num_too_long_samples = 0;
         let max_sample_time = self.time_unit.as_nanos(MAX_SAMPLE_TIME);
@@ -273,6 +277,7 @@ impl TimingDistributionMetric {
                     hist.accumulate(sample);
                 }
             }
+
             Metric::TimingDistribution(hist)
         });
 


### PR DESCRIPTION
This is an alternative to #1172 

The main difference is that, instead of directly getting the `upload_enabled` state from the Glean object to decide whether to record or not on the databases, this solution propagates the `upload_enabled` state to the different Database objects.

The main advantage of this is that it would unblock us on not having to pass the Glean object around to record metrics, and instead just pass the database objects. See: [Bug 1589675](https://bugzilla.mozilla.org/show_bug.cgi?id=1589675)

