### PR TITLE
Bug 1662584 - Submitting a ping with upload disabled no longer errors

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -635,7 +635,7 @@ open class GleanInternalAPI internal constructor () {
         }
 
         if (!internalGetUploadEnabled()) {
-            Log.e(LOG_TAG, "Glean disabled: not submitting any pings.")
+            Log.i(LOG_TAG, "Glean disabled: not submitting any pings.")
             return
         }
 

--- a/glean-core/csharp/Glean/Glean.cs
+++ b/glean-core/csharp/Glean/Glean.cs
@@ -591,7 +591,7 @@ namespace Mozilla.Glean
 
             if (!GetUploadEnabled())
             {
-                Log.Error("Glean disabled: not submitting any pings.");
+                Log.Information("Glean disabled: not submitting any pings.");
                 return;
             }
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -445,7 +445,7 @@ public class Glean {
         }
 
         if !self.internalGetUploadEnabled() {
-            self.logger.error("Glean disabled: not submitting any pings")
+            self.logger.info("Glean disabled: not submitting any pings")
             return
         }
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -548,7 +548,7 @@ class Glean:
             return
 
         if not cls._get_upload_enabled():
-            log.error("Glean disabled: not submitting any pings.")
+            log.info("Glean disabled: not submitting any pings.")
             return
 
         sent_ping = _ffi.lib.glean_submit_ping_by_name(

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -584,7 +584,7 @@ impl Glean {
     /// If collecting or writing the ping to disk failed.
     pub fn submit_ping(&self, ping: &PingType, reason: Option<&str>) -> Result<bool> {
         if !self.is_upload_enabled() {
-            log::error!("Glean disabled: not submitting any pings.");
+            log::info!("Glean disabled: not submitting any pings.");
             return Ok(false);
         }
 


### PR DESCRIPTION
The error message is now just an info message, so that it doesn't clutter users logs.