### PR TITLE
Bug 1656934 - Scan pending pings directories after dealing with upload status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Track the size of the database file at startup ([#1141](https://github.com/mozilla/glean/pull/1141)).
+  * BUGFIX: scan the pending pings directories **after** dealing with upload status on initialization. This is important, because in case upload is disabled we delete any outstanding non-deletion ping file, and if we scan the pending pings folder before doing that we may end up sending pings that should have been discarded. ([#1205](https://github.com/mozilla/glean/pull/1205))
 * iOS
   * Disabled code coverage in release builds ([#1195](https://github.com/mozilla/glean/issues/1195)).
 * Python

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -460,7 +460,7 @@ pub unsafe extern "C" fn glean_initialize_for_subprocess(cfg: *const FfiConfigur
         // 2. We're not holding on to it beyond this function
         //    and we copy out all data when needed.
         let glean_cfg = glean_core::Configuration::try_from(&*cfg)?;
-        let glean = Glean::new_for_subprocess(&glean_cfg)?;
+        let glean = Glean::new_for_subprocess(&glean_cfg, true)?;
         glean_core::setup_glean(glean)?;
         log::info!("Glean initialized for subprocess");
         Ok(true)


### PR DESCRIPTION
The bug that was causing that intermittent, was due to scanning the pings directories **before** running the `on_upload_disabled` function that deleted non-deletion request pings.

I fix that in this PR by moving the scanning to **after** function the `on_upload_disabled` function. 

As I mentioned in the bug, I was able to reproduce the intermittent reliably in a specific branch of mine, with the fix I don't get the errors anymore on that branch either.