### PR TITLE
Fix pypi-source-release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,8 +830,8 @@ jobs:
           name: Build Python extension
           command: |
             make python-setup
-            .venv3.8/bin/python3 setup.py sdist
-            .venv3.8/bin/python3 -m twine upload dist/*
+            glean-core/python/.venv3.8/bin/python3 setup.py sdist
+            glean-core/python/.venv3.8/bin/python3 -m twine upload dist/*
 
   pypi-linux-release:
     docker:


### PR DESCRIPTION
For the source release, we need to run the `setup.py` script from the top-level directory (but the venv is still under `glean-core/python`).  I think this is the correct solution in place of #1209.