### PR TITLE
Improve spellchecker output in CI

### DIFF
--- a/bin/spellcheck.sh
+++ b/bin/spellcheck.sh
@@ -85,7 +85,7 @@ elif [[ "$mode" == "list" ]]; then
                 # FIXME: Find more correct way to get line number
                 # (ideally from aspell). Now it can make some false positives,
                 # because it is just a grep
-                grep --with-filename --line-number --color=always "$error" "$fname"
+                grep --with-filename --line-number -o --color=always "$error" "$fname"
             done
             retval=1
         fi


### PR DESCRIPTION
The spellchecking CI *does* highlight the misspelled word using colorizing when
run locally, but this is somehow broken when displayed in the CircleCI log
viewer online.

There doesn't appear to be a way to put custom delimiters around the misspelled
word, but it is possible to *only* display the misspelled word without the
context from the rest of the line.  This is probably more helpful to understand
which words the spellchecker doesn't like.

Running the spellchecker locally through `make spellcheck` doesn't change --
that will still use the interactive version of aspell.