### PR TITLE
Use the same glean_parser version as used across the repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ python-docs: build-python ## Build the Python documentation
 .PHONY: docs rust-docs kotlin-docs swift-docs
 
 metrics-docs: python-setup ## Build the internal metrics documentation
-	$(GLEAN_PYENV)/bin/pip install glean_parser
+	$(GLEAN_PYENV)/bin/pip install glean_parser==1.28.5
 	$(GLEAN_PYENV)/bin/glean_parser translate --allow-reserved \
 		 -f markdown \
 		 -o ./docs/user/collected-metrics \

--- a/bin/update-glean-parser-version.sh
+++ b/bin/update-glean-parser-version.sh
@@ -69,3 +69,10 @@ run $SED -i.bak -E \
     -e "s/glean-parser = \"[0-9.]+\"/glean-parser = \"${NEW_VERSION}\"/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
+# update the version in the Makefile
+FILE=Makefile
+run $SED -i.bak -E \
+    -e "s/glean_parser==[0-9.]+/glean_parser==${NEW_VERSION}/" \
+    "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"


### PR DESCRIPTION
Previously it used whatever was the latest version.
This could lead to CI failures when we update glean_parser but don't
update inside this repository.

[doc only]

---

This either needs to land before #1213 and then that one gets an update, or land after and we rebase this one.
