### PR TITLE
Bug 1660210: Fix Python source package release

### DIFF
--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -11,5 +11,6 @@ pip
 pytest-localserver==0.5.0
 pytest-runner==5.2
 pytest==6.0.2
+setuptools-git==1.2
 twine==3.2.0
 wheel==0.34.2


### PR DESCRIPTION
The setuptools-git package is needed to include all files checked into git,
rather than the default Python heuristic that just (mainly) includes .py files.
This is why the released Python source package was only ~5kb rather than 1.5MB.