### PR TITLE
Drop `duplicate ping` log message to `debug` level

### DIFF
--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -677,7 +677,7 @@ impl Glean {
     /// Register a new [`PingType`](metrics/struct.PingType.html).
     pub fn register_ping_type(&mut self, ping: &PingType) {
         if self.ping_registry.contains_key(&ping.name) {
-            log::error!("Duplicate ping named '{}'", ping.name)
+            log::debug!("Duplicate ping named '{}'", ping.name)
         }
 
         self.ping_registry.insert(ping.name.clone(), ping.clone());


### PR DESCRIPTION
This is not really an error and due to re-sets of the Glean object
during tests leads to some noise in the log.
It will still be visible in our CI (because that runs at log level debug),
but reduces noise in consumer's tests.