### PR TITLE
[ci full] Bug 1666859: Fix missing Rust binaries from package

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -224,6 +224,9 @@ afterEvaluate {
 
         tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
 
+        // Don't merge the jni lib folders until after the Rust libraries have been built
+        tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
+
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
     }


### PR DESCRIPTION
I discovered this by comparing the output of a working `publishToMavenLocal` build against a broken one.  The differences were minor, but in the broken one the `mergeReleaseJniLibFolders` task was running *before* the Rust binaries were built with cargo, but *after* in the working build.

Adding this dependency seems to re-order things correctly (perhaps at the loss of a little parallelism).