### PR TITLE
Bug 1657852 - Transform ping dir size to kB before accumulating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.0.4...main)
 
+* General
+  * BUGFIX: Transform ping directory size from bytes to kilobytes before accumulating to `glean.upload.pending_pings_directory_size` ([#1236](https://github.com/mozilla/glean/pull/1236)).
+
 # v33.0.4 (2020-09-28)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.0.3...v33.0.4)

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -399,7 +399,7 @@ impl PingUploadManager {
             cached_pings.pending_pings.reverse();
             self.upload_metrics
                 .pending_pings_directory_size
-                .accumulate(glean, pending_pings_directory_size as u64);
+                .accumulate(glean, pending_pings_directory_size as u64 / 1024);
 
             // Enqueue the remaining pending pings and
             // enqueue all deletion-request pings.


### PR DESCRIPTION
Found this bug during vlidation of these metrics. 

See: https://sql.telemetry.mozilla.org/queries/75022/source?p_date=2020-09-16--2020-09-28#187737