### PR TITLE
Bug 1668820 - Always launch the ping uploader on a background thread

### DIFF
--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -158,7 +158,7 @@ public class Glean {
             // 1. Pings were submitted through Glean and it is ready to upload those pings;
             // 2. Upload is disabled, to upload a possible deletion-request ping.
             if pingSubmitted || !uploadEnabled {
-                HttpPingUploader(configuration: configuration).process()
+                HttpPingUploader.launch(configuration: configuration)
             }
 
             // Check for overdue metrics pings
@@ -270,9 +270,7 @@ public class Glean {
 
             if originalEnabled && !enabled {
                 // If uploading is disabled, we need to send the deletion-request ping
-                Dispatchers.shared.launchConcurrent {
-                    HttpPingUploader(configuration: self.configuration!).process()
-                }
+                HttpPingUploader.launch(configuration: self.configuration!)
             }
         }
     }
@@ -456,7 +454,7 @@ public class Glean {
 
         if submittedPing != 0 {
             if let config = self.configuration {
-                HttpPingUploader(configuration: config).process()
+                HttpPingUploader.launch(configuration: config)
             }
         }
     }

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -33,6 +33,15 @@ public class HttpPingUploader {
         self.config = configuration
     }
 
+    /// Launch a new ping uploader on the background thread.
+    ///
+    /// This function doesn't block.
+    static func launch(configuration: Configuration) {
+        Dispatchers.shared.launchConcurrent {
+            HttpPingUploader(configuration: configuration).process()
+        }
+    }
+
     /// Synchronously upload a ping to Mozilla servers.
     ///
     /// - parameters:


### PR DESCRIPTION
The uploader is always started after pings are already submitted (and assembled).
The ping uploader can potentially block as it uploads several pings and
even goes to sleep if told to wait (soon).
By putting it on a background thread we ensure this doesn't stop any
other work.

This was already manually done in one place, but not in the others.
This should be equivalent to Android's way of pushing this work to a
workmanager job.

Unfortunately this is near impossible to add a test for, as we would somehow need to instruct the uploader to block so that we can encounter the problems. Which we can't.
So we have to live with the existing tests (they pass) & integration tests (on CI).

---

This should unblock #1240 