### PR TITLE
[doc only] Bug 1635377: Document metrics and events sections

### DIFF
--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -22,7 +22,7 @@ Every ping has the following keys at the top-level:
 - The [`client_info` section](#the-client_info-section) contains information that identifies the client.
   It is included in most pings (including all built-in pings), but may be excluded from pings where we don't want to connect client information with the other metrics in the ping.
 
-- The `metrics` section contains the submitted values for all metric types (except for events).
+- The `metrics` section contains the submitted values for all metric types except for [events](../metrics/event.md).
   It has keys for each of the metric types, under which is data for each metric.
 
 - The `events` section contains the events recorded in the ping.

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -15,12 +15,19 @@ There is also a [high-level overview](ping-schedules-and-timings.html) of how th
 
 ## Ping sections
 
-There are two standard metadata sections that are added to most pings, in addition to their core metrics and events content (which are described in [Adding new metrics](../adding-new-metrics.md)).
+Every ping has the following keys at the top-level:
 
 - The [`ping_info` section](#the-ping_info-section) contains core metadata that is included in **every** ping.
-  
+
 - The [`client_info` section](#the-client_info-section) contains information that identifies the client.
   It is included in most pings (including all built-in pings), but may be excluded from pings where we don't want to connect client information with the other metrics in the ping.
+
+- The `metrics` section contains the submitted values for all metric types (except for events).
+  It has keys for each of the metric types, under which is data for each metric.
+
+- The `events` section contains the events recorded in the ping.
+
+See the [payload documentation](../../dev/core/payload.md) documentation for more details for each metric type in the `metrics` and `events` section.
 
 ### The `ping_info` section
 The following fields are included in the `ping_info` section, for every ping.
@@ -35,6 +42,22 @@ Optional fields are marked accordingly.
 | `reason` | String | *Optional*. The reason the ping was submitted. The specific set of values and their meanings are defined for each metric type in the `reasons` field in the `pings.yaml` file. |
 
 All the metrics surviving application restarts (e.g. `seq`, ...) are removed once the application using the Glean SDK is uninstalled.
+
+#### The `experiments` object
+
+This object (included in the [`ping_info` section](#the-ping_info-section)) contains experiments keyed by the experiment `id`. Each listed experiment contains the `branch` the client is enrolled in and may contain a string to string map with additional data in the `extra` key. Both the `id` and `branch` are truncated to 30 characters.
+See [Using the Experiments API](../experiments-api.md) on how to record experiments data.
+
+```json
+{
+  "<id>": {
+    "branch": "branch-id",
+    "extra": {
+      "some-key": "a-value"
+    }
+  }
+}
+```
 
 ### The `client_info` section
 The following fields are included in the `client_info` section.
@@ -59,22 +82,6 @@ Optional fields are marked accordingly.
 All the metrics surviving application restarts (e.g. `client_id`, ...) are removed once the application using the Glean SDK is uninstalled.
 
 [`Build.MODEL`]: https://developer.android.com/reference/android/os/Build.html#MODEL
-
-### The `experiments` object
-
-This object (included in the [`ping_info` section](#the-ping_info-section)) contains experiments keyed by the experiment `id`. Each listed experiment contains the `branch` the client is enrolled in and may contain a string to string map with additional data in the `extra` key. Both the `id` and `branch` are truncated to 30 characters.
-See [Using the Experiments API](../experiments-api.md) on how to record experiments data.
-
-```json
-{
-  "<id>": {
-    "branch": "branch-id",
-    "extra": {
-      "some-key": "a-value"
-    }
-  }
-}
-```
 
 ## Ping submission
 

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -27,7 +27,7 @@ Every ping has the following keys at the top-level:
 
 - The `events` section contains the events recorded in the ping.
 
-See the [payload documentation](../../dev/core/payload.md) documentation for more details for each metric type in the `metrics` and `events` section.
+See the [payload documentation](../../dev/core/internal/payload.md) documentation for more details for each metric type in the `metrics` and `events` section.
 
 ### The `ping_info` section
 The following fields are included in the `ping_info` section, for every ping.

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -45,7 +45,7 @@ All the metrics surviving application restarts (e.g. `seq`, ...) are removed onc
 
 #### The `experiments` object
 
-This object (included in the [`ping_info` section](#the-ping_info-section)) contains experiments keyed by the experiment `id`. Each listed experiment contains the `branch` the client is enrolled in and may contain a string to string map with additional data in the `extra` key. Both the `id` and `branch` are truncated to 30 characters.
+This object (included in the [`ping_info` section](#the-ping_info-section)) contains experiment annotations keyed by the experiment `id`. Each annotation contains the experiment `branch` the client is enrolled in and may contain a string to string map with additional data in the `extra` key. Both the `id` and `branch` are truncated to 30 characters.
 See [Using the Experiments API](../experiments-api.md) on how to record experiments data.
 
 ```json


### PR DESCRIPTION
Also reorganizes document to describe experiments as a subsection of ping_info