### PR TITLE
Don't update homebrew to install swiftlint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,13 +468,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update brew
-          command: |
-            # we want the latest versions of the tools
-            brew update
-      - run:
           name: Install lint tools
           command: |
+            export HOMEBREW_NO_AUTO_UPDATE=1
             brew install swiftlint
       - run:
           name: Run swiftlint


### PR DESCRIPTION
It is super slow and at the moment causes quite some failures due to
timeouts or other network problems.
The image should get us a suitable version of swiftlint already without
requiring an update.

[doc only]