### PR TITLE
Bug 1670184 - Upgrade to rkv 0.15.0 and make the backend selectable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,9 +322,9 @@ jobs:
       - run:
           name: FFI header consistency check
           command: |
-            CBINDGEN_VERSION=v0.14.3
+            CBINDGEN_VERSION=v0.15.0
             CBINDGEN=cbindgen
-            CBINDGEN_SHA256=d1975ef0c0abbca2f53d62dc1a3fd5136a192b6108479866e602b9238d908b44
+            CBINDGEN_SHA256=46ad9fef860f18a6b5f307d2acae58833f347857a6ce42d8baf40d0e34805b4d
             curl -sfSL --retry 5 -O "https://github.com/eqrion/cbindgen/releases/download/${CBINDGEN_VERSION}/${CBINDGEN}"
             echo "${CBINDGEN_SHA256} *${CBINDGEN}" | shasum -a 256 -c -
             mv cbindgen /usr/local/cargo/bin/cbindgen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
  "iso8601 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rkv 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rkv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,6 +408,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "idna"
@@ -624,6 +629,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "paste-impl 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "rkv"
-version = "0.10.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -779,9 +801,12 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "id-arena 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-rkv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1127,6 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum half 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 "checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+"checksum id-arena 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum iri-string 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "402e5c3bd66bbe43ac90915097caa0347fc2666ecb8a0047154f4494ed577995"
 "checksum iso8601 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cee08a007a59a8adfc96f69738ddf59e374888dfd84b49c4b916543067644d58"
@@ -1154,6 +1180,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum oorandom 11.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
 "checksum ordered-float 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
 "checksum oslog 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e9092ca1e653fbd9057bc5d7c3c5559ce62648465d2293dcc87e000413adbc7f"
+"checksum paste 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+"checksum paste-impl 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 "checksum plotters 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
@@ -1173,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 "checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 "checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-"checksum rkv 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "30a3dbc1f4971372545ed4175f23ef206c81e5874cd574d153646e7ee78f6793"
+"checksum rkv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e97d1b6321740ce36d77d67d22ff84ac8a996cf69dbd0727b8bcae52f1c98aaa"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -27,7 +27,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.44"
-rkv = "0.10.3"
+rkv = "0.15.0"
 bincode = "1.3.1"
 log = "0.4.8"
 uuid = { version = "0.8.1", features = ["v4"] }
@@ -41,3 +41,7 @@ env_logger = { version = "0.7.1", default-features = false, features = ["termcol
 tempfile = "3.1.0"
 iso8601 = "0.4"
 ctor = "0.1.12"
+
+[features]
+# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
+rkv-safe-mode = []

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -17,13 +17,6 @@
 #include <stdlib.h>
 
 /**
- * A HTTP response code.
- *
- * The actual response code is encoded in the lower bits.
- */
-#define UPLOAD_RESULT_HTTP_STATUS 32768
-
-/**
  * A recoverable error.
  */
 #define UPLOAD_RESULT_RECOVERABLE 1
@@ -32,6 +25,13 @@
  * An unrecoverable error.
  */
 #define UPLOAD_RESULT_UNRECOVERABLE 2
+
+/**
+ * A HTTP response code.
+ *
+ * The actual response code is encoded in the lower bits.
+ */
+#define UPLOAD_RESULT_HTTP_STATUS 32768
 
 /**
  * The supported metrics' lifetimes.
@@ -161,9 +161,20 @@ typedef int32_t TimeUnit;
  */
 typedef const char *FfiStr;
 
-typedef const int64_t *RawInt64Array;
-
-typedef const int32_t *RawIntArray;
+/**
+ * Configuration over FFI.
+ *
+ * **CAUTION**: This must match _exactly_ the definition on the Kotlin side.
+ * If this side is changed, the Kotlin side need to be changed, too.
+ */
+typedef struct {
+  FfiStr data_dir;
+  FfiStr package_name;
+  FfiStr language_binding_name;
+  uint8_t upload_enabled;
+  const int32_t *max_events;
+  uint8_t delay_ping_lifetime_io;
+} FfiConfiguration;
 
 typedef const char *const *RawStringArray;
 
@@ -291,110 +302,14 @@ typedef union {
   FfiPingUploadTask_Upload_Body upload;
 } FfiPingUploadTask;
 
-/**
- * Configuration over FFI.
- *
- * **CAUTION**: This must match _exactly_ the definition on the Kotlin side.
- * If this side is changed, the Kotlin side need to be changed, too.
- */
-typedef struct {
-  FfiStr data_dir;
-  FfiStr package_name;
-  FfiStr language_binding_name;
-  uint8_t upload_enabled;
-  const int32_t *max_events;
-  uint8_t delay_ping_lifetime_io;
-} FfiConfiguration;
+typedef const int64_t *RawInt64Array;
+
+typedef const int32_t *RawIntArray;
 
 /**
  * Identifier for a running timer.
  */
 typedef uint64_t TimerId;
-
-void glean_boolean_set(uint64_t metric_id, uint8_t value);
-
-uint8_t glean_boolean_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_boolean_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_clear_application_lifetime_metrics(void);
-
-void glean_counter_add(uint64_t metric_id, int32_t amount);
-
-int32_t glean_counter_test_get_num_recorded_errors(uint64_t metric_id,
-                                                   int32_t error_type,
-                                                   FfiStr storage_name);
-
-int32_t glean_counter_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_counter_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_custom_distribution_accumulate_samples(uint64_t metric_id,
-                                                  RawInt64Array raw_samples,
-                                                  int32_t num_samples);
-
-int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t metric_id,
-                                                               int32_t error_type,
-                                                               FfiStr storage_name);
-
-char *glean_custom_distribution_test_get_value_as_json_string(uint64_t metric_id,
-                                                              FfiStr storage_name);
-
-uint8_t glean_custom_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_datetime_set(uint64_t metric_id,
-                        int32_t year,
-                        uint32_t month,
-                        uint32_t day,
-                        uint32_t hour,
-                        uint32_t minute,
-                        uint32_t second,
-                        int64_t nano,
-                        int32_t offset_seconds);
-
-int32_t glean_datetime_test_get_num_recorded_errors(uint64_t metric_id,
-                                                    int32_t error_type,
-                                                    FfiStr storage_name);
-
-char *glean_datetime_test_get_value_as_string(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_datetime_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_destroy_boolean_metric(uint64_t v);
-
-void glean_destroy_counter_metric(uint64_t v);
-
-void glean_destroy_custom_distribution_metric(uint64_t v);
-
-void glean_destroy_datetime_metric(uint64_t v);
-
-void glean_destroy_event_metric(uint64_t v);
-
-void glean_destroy_glean(void);
-
-void glean_destroy_jwe_metric(uint64_t v);
-
-void glean_destroy_labeled_boolean_metric(uint64_t v);
-
-void glean_destroy_labeled_counter_metric(uint64_t v);
-
-void glean_destroy_labeled_string_metric(uint64_t v);
-
-void glean_destroy_memory_distribution_metric(uint64_t v);
-
-void glean_destroy_ping_type(uint64_t v);
-
-void glean_destroy_quantity_metric(uint64_t v);
-
-void glean_destroy_string_list_metric(uint64_t v);
-
-void glean_destroy_string_metric(uint64_t v);
-
-void glean_destroy_timespan_metric(uint64_t v);
-
-void glean_destroy_timing_distribution_metric(uint64_t v);
-
-void glean_destroy_uuid_metric(uint64_t v);
 
 /**
  * Initialize the logging system based on the target platform. This ensures
@@ -416,26 +331,6 @@ void glean_enable_logging(void);
  */
 void glean_enable_logging_to_fd(uint64_t fd);
 
-void glean_event_record(uint64_t metric_id,
-                        uint64_t timestamp,
-                        RawIntArray extra_keys,
-                        RawStringArray extra_values,
-                        int32_t extra_len);
-
-int32_t glean_event_test_get_num_recorded_errors(uint64_t metric_id,
-                                                 int32_t error_type,
-                                                 FfiStr storage_name);
-
-char *glean_event_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_event_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-char *glean_experiment_test_get_data(FfiStr experiment_id);
-
-uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
-
-void glean_get_upload_task(FfiPingUploadTask *result);
-
 /**
  * # Safety
  *
@@ -443,226 +338,41 @@ void glean_get_upload_task(FfiPingUploadTask *result);
  */
 uint8_t glean_initialize(const FfiConfiguration *cfg);
 
-/**
- * # Safety
- *
- * A valid and non-null configuration object is required for this function.
- */
-uint8_t glean_initialize_for_subprocess(const FfiConfiguration *cfg);
-
-uint8_t glean_is_dirty_flag_set(void);
-
-uint8_t glean_is_first_run(void);
+uint8_t glean_on_ready_to_submit_pings(void);
 
 uint8_t glean_is_upload_enabled(void);
 
-void glean_jwe_set(uint64_t metric_id,
-                   FfiStr header,
-                   FfiStr key,
-                   FfiStr init_vector,
-                   FfiStr cipher_text,
-                   FfiStr auth_tag);
+void glean_set_upload_enabled(uint8_t flag);
 
-void glean_jwe_set_with_compact_representation(uint64_t metric_id, FfiStr value);
-
-int32_t glean_jwe_test_get_num_recorded_errors(uint64_t metric_id,
-                                               int32_t error_type,
-                                               FfiStr storage_name);
-
-char *glean_jwe_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-char *glean_jwe_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_jwe_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-/**
- * Create a new instance of the sub-metric of this labeled metric.
- */
-uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
-
-int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t metric_id,
-                                                           int32_t error_type,
-                                                           FfiStr storage_name);
-
-/**
- * Create a new instance of the sub-metric of this labeled metric.
- */
-uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
-
-int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t metric_id,
-                                                           int32_t error_type,
-                                                           FfiStr storage_name);
-
-/**
- * Create a new instance of the sub-metric of this labeled metric.
- */
-uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
-
-int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t metric_id,
-                                                          int32_t error_type,
-                                                          FfiStr storage_name);
-
-void glean_memory_distribution_accumulate(uint64_t metric_id, uint64_t sample);
-
-void glean_memory_distribution_accumulate_samples(uint64_t metric_id,
-                                                  RawInt64Array raw_samples,
-                                                  int32_t num_samples);
-
-int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t metric_id,
-                                                               int32_t error_type,
-                                                               FfiStr storage_name);
-
-char *glean_memory_distribution_test_get_value_as_json_string(uint64_t metric_id,
-                                                              FfiStr storage_name);
-
-uint8_t glean_memory_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-uint64_t glean_new_boolean_metric(FfiStr category,
-                                  FfiStr name,
-                                  RawStringArray send_in_pings,
-                                  int32_t send_in_pings_len,
-                                  Lifetime lifetime,
-                                  uint8_t disabled);
-
-uint64_t glean_new_counter_metric(FfiStr category,
-                                  FfiStr name,
-                                  RawStringArray send_in_pings,
-                                  int32_t send_in_pings_len,
-                                  Lifetime lifetime,
-                                  uint8_t disabled);
-
-uint64_t glean_new_custom_distribution_metric(FfiStr category,
-                                              FfiStr name,
-                                              RawStringArray send_in_pings,
-                                              int32_t send_in_pings_len,
-                                              Lifetime lifetime,
-                                              uint8_t disabled,
-                                              uint64_t range_min,
-                                              uint64_t range_max,
-                                              uint64_t bucket_count,
-                                              int32_t histogram_type);
-
-uint64_t glean_new_datetime_metric(FfiStr category,
-                                   FfiStr name,
-                                   RawStringArray send_in_pings,
-                                   int32_t send_in_pings_len,
-                                   Lifetime lifetime,
-                                   uint8_t disabled,
-                                   TimeUnit time_unit);
-
-uint64_t glean_new_event_metric(FfiStr category,
-                                FfiStr name,
-                                RawStringArray send_in_pings,
-                                int32_t send_in_pings_len,
-                                int32_t lifetime,
-                                uint8_t disabled,
-                                RawStringArray extra_keys,
-                                int32_t extra_keys_len);
-
-uint64_t glean_new_jwe_metric(FfiStr category,
-                              FfiStr name,
-                              RawStringArray send_in_pings,
-                              int32_t send_in_pings_len,
-                              Lifetime lifetime,
-                              uint8_t disabled);
-
-/**
- * Create a new labeled metric.
- */
-uint64_t glean_new_labeled_boolean_metric(FfiStr category,
-                                          FfiStr name,
-                                          RawStringArray send_in_pings,
-                                          int32_t send_in_pings_len,
-                                          int32_t lifetime,
-                                          uint8_t disabled,
-                                          RawStringArray labels,
-                                          int32_t label_count);
-
-/**
- * Create a new labeled metric.
- */
-uint64_t glean_new_labeled_counter_metric(FfiStr category,
-                                          FfiStr name,
-                                          RawStringArray send_in_pings,
-                                          int32_t send_in_pings_len,
-                                          int32_t lifetime,
-                                          uint8_t disabled,
-                                          RawStringArray labels,
-                                          int32_t label_count);
-
-/**
- * Create a new labeled metric.
- */
-uint64_t glean_new_labeled_string_metric(FfiStr category,
-                                         FfiStr name,
-                                         RawStringArray send_in_pings,
-                                         int32_t send_in_pings_len,
-                                         int32_t lifetime,
-                                         uint8_t disabled,
-                                         RawStringArray labels,
-                                         int32_t label_count);
-
-uint64_t glean_new_memory_distribution_metric(FfiStr category,
-                                              FfiStr name,
-                                              RawStringArray send_in_pings,
-                                              int32_t send_in_pings_len,
-                                              Lifetime lifetime,
-                                              uint8_t disabled,
-                                              MemoryUnit memory_unit);
-
-uint64_t glean_new_ping_type(FfiStr ping_name,
-                             uint8_t include_client_id,
-                             uint8_t send_if_empty,
-                             RawStringArray reason_codes,
-                             int32_t reason_codes_len);
-
-uint64_t glean_new_quantity_metric(FfiStr category,
-                                   FfiStr name,
-                                   RawStringArray send_in_pings,
-                                   int32_t send_in_pings_len,
-                                   Lifetime lifetime,
-                                   uint8_t disabled);
-
-uint64_t glean_new_string_list_metric(FfiStr category,
-                                      FfiStr name,
-                                      RawStringArray send_in_pings,
-                                      int32_t send_in_pings_len,
-                                      Lifetime lifetime,
-                                      uint8_t disabled);
-
-uint64_t glean_new_string_metric(FfiStr category,
-                                 FfiStr name,
-                                 RawStringArray send_in_pings,
-                                 int32_t send_in_pings_len,
-                                 Lifetime lifetime,
-                                 uint8_t disabled);
-
-uint64_t glean_new_timespan_metric(FfiStr category,
-                                   FfiStr name,
-                                   RawStringArray send_in_pings,
-                                   int32_t send_in_pings_len,
-                                   Lifetime lifetime,
-                                   uint8_t disabled,
-                                   int32_t time_unit);
-
-uint64_t glean_new_timing_distribution_metric(FfiStr category,
-                                              FfiStr name,
-                                              RawStringArray send_in_pings,
-                                              int32_t send_in_pings_len,
-                                              Lifetime lifetime,
-                                              uint8_t disabled,
-                                              TimeUnit time_unit);
-
-uint64_t glean_new_uuid_metric(FfiStr category,
-                               FfiStr name,
-                               RawStringArray send_in_pings,
-                               int32_t send_in_pings_len,
-                               Lifetime lifetime,
-                               uint8_t disabled);
-
-uint8_t glean_on_ready_to_submit_pings(void);
+uint8_t glean_submit_ping_by_name(FfiStr ping_name, FfiStr reason);
 
 char *glean_ping_collect(uint64_t ping_type_handle, FfiStr reason);
+
+void glean_set_experiment_active(FfiStr experiment_id,
+                                 FfiStr branch,
+                                 RawStringArray extra_keys,
+                                 RawStringArray extra_values,
+                                 int32_t extra_len);
+
+void glean_set_experiment_inactive(FfiStr experiment_id);
+
+uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
+
+char *glean_experiment_test_get_data(FfiStr experiment_id);
+
+void glean_clear_application_lifetime_metrics(void);
+
+void glean_set_dirty_flag(uint8_t flag);
+
+uint8_t glean_is_dirty_flag_set(void);
+
+void glean_test_clear_all_stores(void);
+
+void glean_destroy_glean(void);
+
+uint8_t glean_is_first_run(void);
+
+void glean_get_upload_task(FfiPingUploadTask *result);
 
 /**
  * Process and free a `FfiPingUploadTask`.
@@ -678,35 +388,18 @@ char *glean_ping_collect(uint64_t ping_type_handle, FfiStr reason);
  */
 void glean_process_ping_upload_response(FfiPingUploadTask *task, uint32_t status);
 
-void glean_quantity_set(uint64_t metric_id, int64_t value);
-
-int32_t glean_quantity_test_get_num_recorded_errors(uint64_t metric_id,
-                                                    int32_t error_type,
-                                                    FfiStr storage_name);
-
-int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_register_ping_type(uint64_t ping_type_handle);
+/**
+ * # Safety
+ *
+ * A valid and non-null configuration object is required for this function.
+ */
+uint8_t glean_initialize_for_subprocess(const FfiConfiguration *cfg);
 
 uint8_t glean_set_debug_view_tag(FfiStr tag);
-
-void glean_set_dirty_flag(uint8_t flag);
-
-void glean_set_experiment_active(FfiStr experiment_id,
-                                 FfiStr branch,
-                                 RawStringArray extra_keys,
-                                 RawStringArray extra_values,
-                                 int32_t extra_len);
-
-void glean_set_experiment_inactive(FfiStr experiment_id);
 
 void glean_set_log_pings(uint8_t value);
 
 uint8_t glean_set_source_tags(RawStringArray raw_tags, int32_t tags_count);
-
-void glean_set_upload_enabled(uint8_t flag);
 
 /**
  * Public destructor for strings managed by the other side of the FFI.
@@ -721,55 +414,351 @@ void glean_set_upload_enabled(uint8_t flag);
  */
 void glean_str_free(char *s);
 
-void glean_string_list_add(uint64_t metric_id, FfiStr value);
+void glean_destroy_boolean_metric(uint64_t v);
 
-void glean_string_list_set(uint64_t metric_id, RawStringArray values, int32_t values_len);
+uint64_t glean_new_boolean_metric(FfiStr category,
+                                  FfiStr name,
+                                  RawStringArray send_in_pings,
+                                  int32_t send_in_pings_len,
+                                  Lifetime lifetime,
+                                  uint8_t disabled);
 
-int32_t glean_string_list_test_get_num_recorded_errors(uint64_t metric_id,
-                                                       int32_t error_type,
-                                                       FfiStr storage_name);
+void glean_boolean_set(uint64_t metric_id, uint8_t value);
 
-char *glean_string_list_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_boolean_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_string_list_test_has_value(uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_boolean_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_string_set(uint64_t metric_id, FfiStr value);
+void glean_destroy_counter_metric(uint64_t v);
+
+uint64_t glean_new_counter_metric(FfiStr category,
+                                  FfiStr name,
+                                  RawStringArray send_in_pings,
+                                  int32_t send_in_pings_len,
+                                  Lifetime lifetime,
+                                  uint8_t disabled);
+
+int32_t glean_counter_test_get_num_recorded_errors(uint64_t metric_id,
+                                                   int32_t error_type,
+                                                   FfiStr storage_name);
+
+void glean_counter_add(uint64_t metric_id, int32_t amount);
+
+uint8_t glean_counter_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+int32_t glean_counter_test_get_value(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_custom_distribution_metric(uint64_t v);
+
+uint64_t glean_new_custom_distribution_metric(FfiStr category,
+                                              FfiStr name,
+                                              RawStringArray send_in_pings,
+                                              int32_t send_in_pings_len,
+                                              Lifetime lifetime,
+                                              uint8_t disabled,
+                                              uint64_t range_min,
+                                              uint64_t range_max,
+                                              uint64_t bucket_count,
+                                              int32_t histogram_type);
+
+int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
+
+void glean_custom_distribution_accumulate_samples(uint64_t metric_id,
+                                                  RawInt64Array raw_samples,
+                                                  int32_t num_samples);
+
+uint8_t glean_custom_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_custom_distribution_test_get_value_as_json_string(uint64_t metric_id,
+                                                              FfiStr storage_name);
+
+void glean_destroy_datetime_metric(uint64_t v);
+
+uint64_t glean_new_datetime_metric(FfiStr category,
+                                   FfiStr name,
+                                   RawStringArray send_in_pings,
+                                   int32_t send_in_pings_len,
+                                   Lifetime lifetime,
+                                   uint8_t disabled,
+                                   TimeUnit time_unit);
+
+int32_t glean_datetime_test_get_num_recorded_errors(uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
+
+void glean_datetime_set(uint64_t metric_id,
+                        int32_t year,
+                        uint32_t month,
+                        uint32_t day,
+                        uint32_t hour,
+                        uint32_t minute,
+                        uint32_t second,
+                        int64_t nano,
+                        int32_t offset_seconds);
+
+uint8_t glean_datetime_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_datetime_test_get_value_as_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_event_metric(uint64_t v);
+
+int32_t glean_event_test_get_num_recorded_errors(uint64_t metric_id,
+                                                 int32_t error_type,
+                                                 FfiStr storage_name);
+
+uint64_t glean_new_event_metric(FfiStr category,
+                                FfiStr name,
+                                RawStringArray send_in_pings,
+                                int32_t send_in_pings_len,
+                                int32_t lifetime,
+                                uint8_t disabled,
+                                RawStringArray extra_keys,
+                                int32_t extra_keys_len);
+
+void glean_event_record(uint64_t metric_id,
+                        uint64_t timestamp,
+                        RawIntArray extra_keys,
+                        RawStringArray extra_values,
+                        int32_t extra_len);
+
+uint8_t glean_event_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_event_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_jwe_metric(uint64_t v);
+
+uint64_t glean_new_jwe_metric(FfiStr category,
+                              FfiStr name,
+                              RawStringArray send_in_pings,
+                              int32_t send_in_pings_len,
+                              Lifetime lifetime,
+                              uint8_t disabled);
+
+int32_t glean_jwe_test_get_num_recorded_errors(uint64_t metric_id,
+                                               int32_t error_type,
+                                               FfiStr storage_name);
+
+void glean_jwe_set_with_compact_representation(uint64_t metric_id, FfiStr value);
+
+void glean_jwe_set(uint64_t metric_id,
+                   FfiStr header,
+                   FfiStr key,
+                   FfiStr init_vector,
+                   FfiStr cipher_text,
+                   FfiStr auth_tag);
+
+uint8_t glean_jwe_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_jwe_test_get_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_jwe_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_labeled_counter_metric(uint64_t v);
+
+/**
+ * Create a new labeled metric.
+ */
+uint64_t glean_new_labeled_counter_metric(FfiStr category,
+                                          FfiStr name,
+                                          RawStringArray send_in_pings,
+                                          int32_t send_in_pings_len,
+                                          int32_t lifetime,
+                                          uint8_t disabled,
+                                          RawStringArray labels,
+                                          int32_t label_count);
+
+/**
+ * Create a new instance of the sub-metric of this labeled metric.
+ */
+uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
+
+int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t metric_id,
+                                                           int32_t error_type,
+                                                           FfiStr storage_name);
+
+void glean_destroy_labeled_boolean_metric(uint64_t v);
+
+/**
+ * Create a new labeled metric.
+ */
+uint64_t glean_new_labeled_boolean_metric(FfiStr category,
+                                          FfiStr name,
+                                          RawStringArray send_in_pings,
+                                          int32_t send_in_pings_len,
+                                          int32_t lifetime,
+                                          uint8_t disabled,
+                                          RawStringArray labels,
+                                          int32_t label_count);
+
+/**
+ * Create a new instance of the sub-metric of this labeled metric.
+ */
+uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
+
+int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t metric_id,
+                                                           int32_t error_type,
+                                                           FfiStr storage_name);
+
+void glean_destroy_labeled_string_metric(uint64_t v);
+
+/**
+ * Create a new labeled metric.
+ */
+uint64_t glean_new_labeled_string_metric(FfiStr category,
+                                         FfiStr name,
+                                         RawStringArray send_in_pings,
+                                         int32_t send_in_pings_len,
+                                         int32_t lifetime,
+                                         uint8_t disabled,
+                                         RawStringArray labels,
+                                         int32_t label_count);
+
+/**
+ * Create a new instance of the sub-metric of this labeled metric.
+ */
+uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
+
+int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t metric_id,
+                                                          int32_t error_type,
+                                                          FfiStr storage_name);
+
+void glean_destroy_memory_distribution_metric(uint64_t v);
+
+uint64_t glean_new_memory_distribution_metric(FfiStr category,
+                                              FfiStr name,
+                                              RawStringArray send_in_pings,
+                                              int32_t send_in_pings_len,
+                                              Lifetime lifetime,
+                                              uint8_t disabled,
+                                              MemoryUnit memory_unit);
+
+int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
+
+void glean_memory_distribution_accumulate(uint64_t metric_id, uint64_t sample);
+
+void glean_memory_distribution_accumulate_samples(uint64_t metric_id,
+                                                  RawInt64Array raw_samples,
+                                                  int32_t num_samples);
+
+uint8_t glean_memory_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_memory_distribution_test_get_value_as_json_string(uint64_t metric_id,
+                                                              FfiStr storage_name);
+
+void glean_destroy_ping_type(uint64_t v);
+
+uint64_t glean_new_ping_type(FfiStr ping_name,
+                             uint8_t include_client_id,
+                             uint8_t send_if_empty,
+                             RawStringArray reason_codes,
+                             int32_t reason_codes_len);
+
+uint8_t glean_test_has_ping_type(FfiStr ping_name);
+
+void glean_register_ping_type(uint64_t ping_type_handle);
+
+void glean_destroy_quantity_metric(uint64_t v);
+
+uint64_t glean_new_quantity_metric(FfiStr category,
+                                   FfiStr name,
+                                   RawStringArray send_in_pings,
+                                   int32_t send_in_pings_len,
+                                   Lifetime lifetime,
+                                   uint8_t disabled);
+
+int32_t glean_quantity_test_get_num_recorded_errors(uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
+
+void glean_quantity_set(uint64_t metric_id, int64_t value);
+
+uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_string_metric(uint64_t v);
+
+uint64_t glean_new_string_metric(FfiStr category,
+                                 FfiStr name,
+                                 RawStringArray send_in_pings,
+                                 int32_t send_in_pings_len,
+                                 Lifetime lifetime,
+                                 uint8_t disabled);
 
 int32_t glean_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                   int32_t error_type,
                                                   FfiStr storage_name);
 
-char *glean_string_test_get_value(uint64_t metric_id, FfiStr storage_name);
+void glean_string_set(uint64_t metric_id, FfiStr value);
 
 uint8_t glean_string_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_submit_ping_by_name(FfiStr ping_name, FfiStr reason);
+char *glean_string_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_test_clear_all_stores(void);
+void glean_destroy_string_list_metric(uint64_t v);
 
-uint8_t glean_test_has_ping_type(FfiStr ping_name);
+uint64_t glean_new_string_list_metric(FfiStr category,
+                                      FfiStr name,
+                                      RawStringArray send_in_pings,
+                                      int32_t send_in_pings_len,
+                                      Lifetime lifetime,
+                                      uint8_t disabled);
 
-void glean_timespan_cancel(uint64_t metric_id);
+int32_t glean_string_list_test_get_num_recorded_errors(uint64_t metric_id,
+                                                       int32_t error_type,
+                                                       FfiStr storage_name);
 
-void glean_timespan_set_raw_nanos(uint64_t metric_id, uint64_t elapsed_nanos);
+void glean_string_list_add(uint64_t metric_id, FfiStr value);
 
-void glean_timespan_set_start(uint64_t metric_id, uint64_t start_time);
+void glean_string_list_set(uint64_t metric_id, RawStringArray values, int32_t values_len);
 
-void glean_timespan_set_stop(uint64_t metric_id, uint64_t stop_time);
+uint8_t glean_string_list_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_string_list_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_timespan_metric(uint64_t v);
+
+uint64_t glean_new_timespan_metric(FfiStr category,
+                                   FfiStr name,
+                                   RawStringArray send_in_pings,
+                                   int32_t send_in_pings_len,
+                                   Lifetime lifetime,
+                                   uint8_t disabled,
+                                   int32_t time_unit);
 
 int32_t glean_timespan_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-uint64_t glean_timespan_test_get_value(uint64_t metric_id, FfiStr storage_name);
+void glean_timespan_set_start(uint64_t metric_id, uint64_t start_time);
+
+void glean_timespan_set_stop(uint64_t metric_id, uint64_t stop_time);
+
+void glean_timespan_cancel(uint64_t metric_id);
+
+void glean_timespan_set_raw_nanos(uint64_t metric_id, uint64_t elapsed_nanos);
 
 uint8_t glean_timespan_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_timing_distribution_accumulate_samples(uint64_t metric_id,
-                                                  RawInt64Array raw_samples,
-                                                  int32_t num_samples);
+uint64_t glean_timespan_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
+void glean_destroy_timing_distribution_metric(uint64_t v);
+
+uint64_t glean_new_timing_distribution_metric(FfiStr category,
+                                              FfiStr name,
+                                              RawStringArray send_in_pings,
+                                              int32_t send_in_pings_len,
+                                              Lifetime lifetime,
+                                              uint8_t disabled,
+                                              TimeUnit time_unit);
+
+int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 TimerId glean_timing_distribution_set_start(uint64_t metric_id, uint64_t start_time);
 
@@ -777,17 +766,28 @@ void glean_timing_distribution_set_stop_and_accumulate(uint64_t metric_id,
                                                        TimerId timer_id,
                                                        uint64_t stop_time);
 
-int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t metric_id,
-                                                               int32_t error_type,
-                                                               FfiStr storage_name);
+void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
+
+void glean_timing_distribution_accumulate_samples(uint64_t metric_id,
+                                                  RawInt64Array raw_samples,
+                                                  int32_t num_samples);
+
+uint8_t glean_timing_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 char *glean_timing_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_timing_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
+void glean_destroy_uuid_metric(uint64_t v);
+
+uint64_t glean_new_uuid_metric(FfiStr category,
+                               FfiStr name,
+                               RawStringArray send_in_pings,
+                               int32_t send_in_pings_len,
+                               Lifetime lifetime,
+                               uint8_t disabled);
 
 void glean_uuid_set(uint64_t metric_id, FfiStr value);
 
-char *glean_uuid_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
 uint8_t glean_uuid_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_uuid_test_get_value(uint64_t metric_id, FfiStr storage_name);

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -17,13 +17,6 @@
 #include <stdlib.h>
 
 /**
- * A HTTP response code.
- *
- * The actual response code is encoded in the lower bits.
- */
-#define UPLOAD_RESULT_HTTP_STATUS 32768
-
-/**
  * A recoverable error.
  */
 #define UPLOAD_RESULT_RECOVERABLE 1
@@ -32,6 +25,13 @@
  * An unrecoverable error.
  */
 #define UPLOAD_RESULT_UNRECOVERABLE 2
+
+/**
+ * A HTTP response code.
+ *
+ * The actual response code is encoded in the lower bits.
+ */
+#define UPLOAD_RESULT_HTTP_STATUS 32768
 
 /**
  * The supported metrics' lifetimes.
@@ -161,9 +161,20 @@ typedef int32_t TimeUnit;
  */
 typedef const char *FfiStr;
 
-typedef const int64_t *RawInt64Array;
-
-typedef const int32_t *RawIntArray;
+/**
+ * Configuration over FFI.
+ *
+ * **CAUTION**: This must match _exactly_ the definition on the Kotlin side.
+ * If this side is changed, the Kotlin side need to be changed, too.
+ */
+typedef struct {
+  FfiStr data_dir;
+  FfiStr package_name;
+  FfiStr language_binding_name;
+  uint8_t upload_enabled;
+  const int32_t *max_events;
+  uint8_t delay_ping_lifetime_io;
+} FfiConfiguration;
 
 typedef const char *const *RawStringArray;
 
@@ -291,110 +302,14 @@ typedef union {
   FfiPingUploadTask_Upload_Body upload;
 } FfiPingUploadTask;
 
-/**
- * Configuration over FFI.
- *
- * **CAUTION**: This must match _exactly_ the definition on the Kotlin side.
- * If this side is changed, the Kotlin side need to be changed, too.
- */
-typedef struct {
-  FfiStr data_dir;
-  FfiStr package_name;
-  FfiStr language_binding_name;
-  uint8_t upload_enabled;
-  const int32_t *max_events;
-  uint8_t delay_ping_lifetime_io;
-} FfiConfiguration;
+typedef const int64_t *RawInt64Array;
+
+typedef const int32_t *RawIntArray;
 
 /**
  * Identifier for a running timer.
  */
 typedef uint64_t TimerId;
-
-void glean_boolean_set(uint64_t metric_id, uint8_t value);
-
-uint8_t glean_boolean_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_boolean_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_clear_application_lifetime_metrics(void);
-
-void glean_counter_add(uint64_t metric_id, int32_t amount);
-
-int32_t glean_counter_test_get_num_recorded_errors(uint64_t metric_id,
-                                                   int32_t error_type,
-                                                   FfiStr storage_name);
-
-int32_t glean_counter_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_counter_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_custom_distribution_accumulate_samples(uint64_t metric_id,
-                                                  RawInt64Array raw_samples,
-                                                  int32_t num_samples);
-
-int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t metric_id,
-                                                               int32_t error_type,
-                                                               FfiStr storage_name);
-
-char *glean_custom_distribution_test_get_value_as_json_string(uint64_t metric_id,
-                                                              FfiStr storage_name);
-
-uint8_t glean_custom_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_datetime_set(uint64_t metric_id,
-                        int32_t year,
-                        uint32_t month,
-                        uint32_t day,
-                        uint32_t hour,
-                        uint32_t minute,
-                        uint32_t second,
-                        int64_t nano,
-                        int32_t offset_seconds);
-
-int32_t glean_datetime_test_get_num_recorded_errors(uint64_t metric_id,
-                                                    int32_t error_type,
-                                                    FfiStr storage_name);
-
-char *glean_datetime_test_get_value_as_string(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_datetime_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_destroy_boolean_metric(uint64_t v);
-
-void glean_destroy_counter_metric(uint64_t v);
-
-void glean_destroy_custom_distribution_metric(uint64_t v);
-
-void glean_destroy_datetime_metric(uint64_t v);
-
-void glean_destroy_event_metric(uint64_t v);
-
-void glean_destroy_glean(void);
-
-void glean_destroy_jwe_metric(uint64_t v);
-
-void glean_destroy_labeled_boolean_metric(uint64_t v);
-
-void glean_destroy_labeled_counter_metric(uint64_t v);
-
-void glean_destroy_labeled_string_metric(uint64_t v);
-
-void glean_destroy_memory_distribution_metric(uint64_t v);
-
-void glean_destroy_ping_type(uint64_t v);
-
-void glean_destroy_quantity_metric(uint64_t v);
-
-void glean_destroy_string_list_metric(uint64_t v);
-
-void glean_destroy_string_metric(uint64_t v);
-
-void glean_destroy_timespan_metric(uint64_t v);
-
-void glean_destroy_timing_distribution_metric(uint64_t v);
-
-void glean_destroy_uuid_metric(uint64_t v);
 
 /**
  * Initialize the logging system based on the target platform. This ensures
@@ -416,26 +331,6 @@ void glean_enable_logging(void);
  */
 void glean_enable_logging_to_fd(uint64_t fd);
 
-void glean_event_record(uint64_t metric_id,
-                        uint64_t timestamp,
-                        RawIntArray extra_keys,
-                        RawStringArray extra_values,
-                        int32_t extra_len);
-
-int32_t glean_event_test_get_num_recorded_errors(uint64_t metric_id,
-                                                 int32_t error_type,
-                                                 FfiStr storage_name);
-
-char *glean_event_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_event_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-char *glean_experiment_test_get_data(FfiStr experiment_id);
-
-uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
-
-void glean_get_upload_task(FfiPingUploadTask *result);
-
 /**
  * # Safety
  *
@@ -443,226 +338,41 @@ void glean_get_upload_task(FfiPingUploadTask *result);
  */
 uint8_t glean_initialize(const FfiConfiguration *cfg);
 
-/**
- * # Safety
- *
- * A valid and non-null configuration object is required for this function.
- */
-uint8_t glean_initialize_for_subprocess(const FfiConfiguration *cfg);
-
-uint8_t glean_is_dirty_flag_set(void);
-
-uint8_t glean_is_first_run(void);
+uint8_t glean_on_ready_to_submit_pings(void);
 
 uint8_t glean_is_upload_enabled(void);
 
-void glean_jwe_set(uint64_t metric_id,
-                   FfiStr header,
-                   FfiStr key,
-                   FfiStr init_vector,
-                   FfiStr cipher_text,
-                   FfiStr auth_tag);
+void glean_set_upload_enabled(uint8_t flag);
 
-void glean_jwe_set_with_compact_representation(uint64_t metric_id, FfiStr value);
-
-int32_t glean_jwe_test_get_num_recorded_errors(uint64_t metric_id,
-                                               int32_t error_type,
-                                               FfiStr storage_name);
-
-char *glean_jwe_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-char *glean_jwe_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_jwe_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-/**
- * Create a new instance of the sub-metric of this labeled metric.
- */
-uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
-
-int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t metric_id,
-                                                           int32_t error_type,
-                                                           FfiStr storage_name);
-
-/**
- * Create a new instance of the sub-metric of this labeled metric.
- */
-uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
-
-int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t metric_id,
-                                                           int32_t error_type,
-                                                           FfiStr storage_name);
-
-/**
- * Create a new instance of the sub-metric of this labeled metric.
- */
-uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
-
-int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t metric_id,
-                                                          int32_t error_type,
-                                                          FfiStr storage_name);
-
-void glean_memory_distribution_accumulate(uint64_t metric_id, uint64_t sample);
-
-void glean_memory_distribution_accumulate_samples(uint64_t metric_id,
-                                                  RawInt64Array raw_samples,
-                                                  int32_t num_samples);
-
-int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t metric_id,
-                                                               int32_t error_type,
-                                                               FfiStr storage_name);
-
-char *glean_memory_distribution_test_get_value_as_json_string(uint64_t metric_id,
-                                                              FfiStr storage_name);
-
-uint8_t glean_memory_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-uint64_t glean_new_boolean_metric(FfiStr category,
-                                  FfiStr name,
-                                  RawStringArray send_in_pings,
-                                  int32_t send_in_pings_len,
-                                  Lifetime lifetime,
-                                  uint8_t disabled);
-
-uint64_t glean_new_counter_metric(FfiStr category,
-                                  FfiStr name,
-                                  RawStringArray send_in_pings,
-                                  int32_t send_in_pings_len,
-                                  Lifetime lifetime,
-                                  uint8_t disabled);
-
-uint64_t glean_new_custom_distribution_metric(FfiStr category,
-                                              FfiStr name,
-                                              RawStringArray send_in_pings,
-                                              int32_t send_in_pings_len,
-                                              Lifetime lifetime,
-                                              uint8_t disabled,
-                                              uint64_t range_min,
-                                              uint64_t range_max,
-                                              uint64_t bucket_count,
-                                              int32_t histogram_type);
-
-uint64_t glean_new_datetime_metric(FfiStr category,
-                                   FfiStr name,
-                                   RawStringArray send_in_pings,
-                                   int32_t send_in_pings_len,
-                                   Lifetime lifetime,
-                                   uint8_t disabled,
-                                   TimeUnit time_unit);
-
-uint64_t glean_new_event_metric(FfiStr category,
-                                FfiStr name,
-                                RawStringArray send_in_pings,
-                                int32_t send_in_pings_len,
-                                int32_t lifetime,
-                                uint8_t disabled,
-                                RawStringArray extra_keys,
-                                int32_t extra_keys_len);
-
-uint64_t glean_new_jwe_metric(FfiStr category,
-                              FfiStr name,
-                              RawStringArray send_in_pings,
-                              int32_t send_in_pings_len,
-                              Lifetime lifetime,
-                              uint8_t disabled);
-
-/**
- * Create a new labeled metric.
- */
-uint64_t glean_new_labeled_boolean_metric(FfiStr category,
-                                          FfiStr name,
-                                          RawStringArray send_in_pings,
-                                          int32_t send_in_pings_len,
-                                          int32_t lifetime,
-                                          uint8_t disabled,
-                                          RawStringArray labels,
-                                          int32_t label_count);
-
-/**
- * Create a new labeled metric.
- */
-uint64_t glean_new_labeled_counter_metric(FfiStr category,
-                                          FfiStr name,
-                                          RawStringArray send_in_pings,
-                                          int32_t send_in_pings_len,
-                                          int32_t lifetime,
-                                          uint8_t disabled,
-                                          RawStringArray labels,
-                                          int32_t label_count);
-
-/**
- * Create a new labeled metric.
- */
-uint64_t glean_new_labeled_string_metric(FfiStr category,
-                                         FfiStr name,
-                                         RawStringArray send_in_pings,
-                                         int32_t send_in_pings_len,
-                                         int32_t lifetime,
-                                         uint8_t disabled,
-                                         RawStringArray labels,
-                                         int32_t label_count);
-
-uint64_t glean_new_memory_distribution_metric(FfiStr category,
-                                              FfiStr name,
-                                              RawStringArray send_in_pings,
-                                              int32_t send_in_pings_len,
-                                              Lifetime lifetime,
-                                              uint8_t disabled,
-                                              MemoryUnit memory_unit);
-
-uint64_t glean_new_ping_type(FfiStr ping_name,
-                             uint8_t include_client_id,
-                             uint8_t send_if_empty,
-                             RawStringArray reason_codes,
-                             int32_t reason_codes_len);
-
-uint64_t glean_new_quantity_metric(FfiStr category,
-                                   FfiStr name,
-                                   RawStringArray send_in_pings,
-                                   int32_t send_in_pings_len,
-                                   Lifetime lifetime,
-                                   uint8_t disabled);
-
-uint64_t glean_new_string_list_metric(FfiStr category,
-                                      FfiStr name,
-                                      RawStringArray send_in_pings,
-                                      int32_t send_in_pings_len,
-                                      Lifetime lifetime,
-                                      uint8_t disabled);
-
-uint64_t glean_new_string_metric(FfiStr category,
-                                 FfiStr name,
-                                 RawStringArray send_in_pings,
-                                 int32_t send_in_pings_len,
-                                 Lifetime lifetime,
-                                 uint8_t disabled);
-
-uint64_t glean_new_timespan_metric(FfiStr category,
-                                   FfiStr name,
-                                   RawStringArray send_in_pings,
-                                   int32_t send_in_pings_len,
-                                   Lifetime lifetime,
-                                   uint8_t disabled,
-                                   int32_t time_unit);
-
-uint64_t glean_new_timing_distribution_metric(FfiStr category,
-                                              FfiStr name,
-                                              RawStringArray send_in_pings,
-                                              int32_t send_in_pings_len,
-                                              Lifetime lifetime,
-                                              uint8_t disabled,
-                                              TimeUnit time_unit);
-
-uint64_t glean_new_uuid_metric(FfiStr category,
-                               FfiStr name,
-                               RawStringArray send_in_pings,
-                               int32_t send_in_pings_len,
-                               Lifetime lifetime,
-                               uint8_t disabled);
-
-uint8_t glean_on_ready_to_submit_pings(void);
+uint8_t glean_submit_ping_by_name(FfiStr ping_name, FfiStr reason);
 
 char *glean_ping_collect(uint64_t ping_type_handle, FfiStr reason);
+
+void glean_set_experiment_active(FfiStr experiment_id,
+                                 FfiStr branch,
+                                 RawStringArray extra_keys,
+                                 RawStringArray extra_values,
+                                 int32_t extra_len);
+
+void glean_set_experiment_inactive(FfiStr experiment_id);
+
+uint8_t glean_experiment_test_is_active(FfiStr experiment_id);
+
+char *glean_experiment_test_get_data(FfiStr experiment_id);
+
+void glean_clear_application_lifetime_metrics(void);
+
+void glean_set_dirty_flag(uint8_t flag);
+
+uint8_t glean_is_dirty_flag_set(void);
+
+void glean_test_clear_all_stores(void);
+
+void glean_destroy_glean(void);
+
+uint8_t glean_is_first_run(void);
+
+void glean_get_upload_task(FfiPingUploadTask *result);
 
 /**
  * Process and free a `FfiPingUploadTask`.
@@ -678,35 +388,18 @@ char *glean_ping_collect(uint64_t ping_type_handle, FfiStr reason);
  */
 void glean_process_ping_upload_response(FfiPingUploadTask *task, uint32_t status);
 
-void glean_quantity_set(uint64_t metric_id, int64_t value);
-
-int32_t glean_quantity_test_get_num_recorded_errors(uint64_t metric_id,
-                                                    int32_t error_type,
-                                                    FfiStr storage_name);
-
-int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
-uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
-
-void glean_register_ping_type(uint64_t ping_type_handle);
+/**
+ * # Safety
+ *
+ * A valid and non-null configuration object is required for this function.
+ */
+uint8_t glean_initialize_for_subprocess(const FfiConfiguration *cfg);
 
 uint8_t glean_set_debug_view_tag(FfiStr tag);
-
-void glean_set_dirty_flag(uint8_t flag);
-
-void glean_set_experiment_active(FfiStr experiment_id,
-                                 FfiStr branch,
-                                 RawStringArray extra_keys,
-                                 RawStringArray extra_values,
-                                 int32_t extra_len);
-
-void glean_set_experiment_inactive(FfiStr experiment_id);
 
 void glean_set_log_pings(uint8_t value);
 
 uint8_t glean_set_source_tags(RawStringArray raw_tags, int32_t tags_count);
-
-void glean_set_upload_enabled(uint8_t flag);
 
 /**
  * Public destructor for strings managed by the other side of the FFI.
@@ -721,55 +414,351 @@ void glean_set_upload_enabled(uint8_t flag);
  */
 void glean_str_free(char *s);
 
-void glean_string_list_add(uint64_t metric_id, FfiStr value);
+void glean_destroy_boolean_metric(uint64_t v);
 
-void glean_string_list_set(uint64_t metric_id, RawStringArray values, int32_t values_len);
+uint64_t glean_new_boolean_metric(FfiStr category,
+                                  FfiStr name,
+                                  RawStringArray send_in_pings,
+                                  int32_t send_in_pings_len,
+                                  Lifetime lifetime,
+                                  uint8_t disabled);
 
-int32_t glean_string_list_test_get_num_recorded_errors(uint64_t metric_id,
-                                                       int32_t error_type,
-                                                       FfiStr storage_name);
+void glean_boolean_set(uint64_t metric_id, uint8_t value);
 
-char *glean_string_list_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_boolean_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_string_list_test_has_value(uint64_t metric_id, FfiStr storage_name);
+uint8_t glean_boolean_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_string_set(uint64_t metric_id, FfiStr value);
+void glean_destroy_counter_metric(uint64_t v);
+
+uint64_t glean_new_counter_metric(FfiStr category,
+                                  FfiStr name,
+                                  RawStringArray send_in_pings,
+                                  int32_t send_in_pings_len,
+                                  Lifetime lifetime,
+                                  uint8_t disabled);
+
+int32_t glean_counter_test_get_num_recorded_errors(uint64_t metric_id,
+                                                   int32_t error_type,
+                                                   FfiStr storage_name);
+
+void glean_counter_add(uint64_t metric_id, int32_t amount);
+
+uint8_t glean_counter_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+int32_t glean_counter_test_get_value(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_custom_distribution_metric(uint64_t v);
+
+uint64_t glean_new_custom_distribution_metric(FfiStr category,
+                                              FfiStr name,
+                                              RawStringArray send_in_pings,
+                                              int32_t send_in_pings_len,
+                                              Lifetime lifetime,
+                                              uint8_t disabled,
+                                              uint64_t range_min,
+                                              uint64_t range_max,
+                                              uint64_t bucket_count,
+                                              int32_t histogram_type);
+
+int32_t glean_custom_distribution_test_get_num_recorded_errors(uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
+
+void glean_custom_distribution_accumulate_samples(uint64_t metric_id,
+                                                  RawInt64Array raw_samples,
+                                                  int32_t num_samples);
+
+uint8_t glean_custom_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_custom_distribution_test_get_value_as_json_string(uint64_t metric_id,
+                                                              FfiStr storage_name);
+
+void glean_destroy_datetime_metric(uint64_t v);
+
+uint64_t glean_new_datetime_metric(FfiStr category,
+                                   FfiStr name,
+                                   RawStringArray send_in_pings,
+                                   int32_t send_in_pings_len,
+                                   Lifetime lifetime,
+                                   uint8_t disabled,
+                                   TimeUnit time_unit);
+
+int32_t glean_datetime_test_get_num_recorded_errors(uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
+
+void glean_datetime_set(uint64_t metric_id,
+                        int32_t year,
+                        uint32_t month,
+                        uint32_t day,
+                        uint32_t hour,
+                        uint32_t minute,
+                        uint32_t second,
+                        int64_t nano,
+                        int32_t offset_seconds);
+
+uint8_t glean_datetime_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_datetime_test_get_value_as_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_event_metric(uint64_t v);
+
+int32_t glean_event_test_get_num_recorded_errors(uint64_t metric_id,
+                                                 int32_t error_type,
+                                                 FfiStr storage_name);
+
+uint64_t glean_new_event_metric(FfiStr category,
+                                FfiStr name,
+                                RawStringArray send_in_pings,
+                                int32_t send_in_pings_len,
+                                int32_t lifetime,
+                                uint8_t disabled,
+                                RawStringArray extra_keys,
+                                int32_t extra_keys_len);
+
+void glean_event_record(uint64_t metric_id,
+                        uint64_t timestamp,
+                        RawIntArray extra_keys,
+                        RawStringArray extra_values,
+                        int32_t extra_len);
+
+uint8_t glean_event_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_event_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_jwe_metric(uint64_t v);
+
+uint64_t glean_new_jwe_metric(FfiStr category,
+                              FfiStr name,
+                              RawStringArray send_in_pings,
+                              int32_t send_in_pings_len,
+                              Lifetime lifetime,
+                              uint8_t disabled);
+
+int32_t glean_jwe_test_get_num_recorded_errors(uint64_t metric_id,
+                                               int32_t error_type,
+                                               FfiStr storage_name);
+
+void glean_jwe_set_with_compact_representation(uint64_t metric_id, FfiStr value);
+
+void glean_jwe_set(uint64_t metric_id,
+                   FfiStr header,
+                   FfiStr key,
+                   FfiStr init_vector,
+                   FfiStr cipher_text,
+                   FfiStr auth_tag);
+
+uint8_t glean_jwe_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_jwe_test_get_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_jwe_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_labeled_counter_metric(uint64_t v);
+
+/**
+ * Create a new labeled metric.
+ */
+uint64_t glean_new_labeled_counter_metric(FfiStr category,
+                                          FfiStr name,
+                                          RawStringArray send_in_pings,
+                                          int32_t send_in_pings_len,
+                                          int32_t lifetime,
+                                          uint8_t disabled,
+                                          RawStringArray labels,
+                                          int32_t label_count);
+
+/**
+ * Create a new instance of the sub-metric of this labeled metric.
+ */
+uint64_t glean_labeled_counter_metric_get(uint64_t handle, FfiStr label);
+
+int32_t glean_labeled_counter_test_get_num_recorded_errors(uint64_t metric_id,
+                                                           int32_t error_type,
+                                                           FfiStr storage_name);
+
+void glean_destroy_labeled_boolean_metric(uint64_t v);
+
+/**
+ * Create a new labeled metric.
+ */
+uint64_t glean_new_labeled_boolean_metric(FfiStr category,
+                                          FfiStr name,
+                                          RawStringArray send_in_pings,
+                                          int32_t send_in_pings_len,
+                                          int32_t lifetime,
+                                          uint8_t disabled,
+                                          RawStringArray labels,
+                                          int32_t label_count);
+
+/**
+ * Create a new instance of the sub-metric of this labeled metric.
+ */
+uint64_t glean_labeled_boolean_metric_get(uint64_t handle, FfiStr label);
+
+int32_t glean_labeled_boolean_test_get_num_recorded_errors(uint64_t metric_id,
+                                                           int32_t error_type,
+                                                           FfiStr storage_name);
+
+void glean_destroy_labeled_string_metric(uint64_t v);
+
+/**
+ * Create a new labeled metric.
+ */
+uint64_t glean_new_labeled_string_metric(FfiStr category,
+                                         FfiStr name,
+                                         RawStringArray send_in_pings,
+                                         int32_t send_in_pings_len,
+                                         int32_t lifetime,
+                                         uint8_t disabled,
+                                         RawStringArray labels,
+                                         int32_t label_count);
+
+/**
+ * Create a new instance of the sub-metric of this labeled metric.
+ */
+uint64_t glean_labeled_string_metric_get(uint64_t handle, FfiStr label);
+
+int32_t glean_labeled_string_test_get_num_recorded_errors(uint64_t metric_id,
+                                                          int32_t error_type,
+                                                          FfiStr storage_name);
+
+void glean_destroy_memory_distribution_metric(uint64_t v);
+
+uint64_t glean_new_memory_distribution_metric(FfiStr category,
+                                              FfiStr name,
+                                              RawStringArray send_in_pings,
+                                              int32_t send_in_pings_len,
+                                              Lifetime lifetime,
+                                              uint8_t disabled,
+                                              MemoryUnit memory_unit);
+
+int32_t glean_memory_distribution_test_get_num_recorded_errors(uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
+
+void glean_memory_distribution_accumulate(uint64_t metric_id, uint64_t sample);
+
+void glean_memory_distribution_accumulate_samples(uint64_t metric_id,
+                                                  RawInt64Array raw_samples,
+                                                  int32_t num_samples);
+
+uint8_t glean_memory_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_memory_distribution_test_get_value_as_json_string(uint64_t metric_id,
+                                                              FfiStr storage_name);
+
+void glean_destroy_ping_type(uint64_t v);
+
+uint64_t glean_new_ping_type(FfiStr ping_name,
+                             uint8_t include_client_id,
+                             uint8_t send_if_empty,
+                             RawStringArray reason_codes,
+                             int32_t reason_codes_len);
+
+uint8_t glean_test_has_ping_type(FfiStr ping_name);
+
+void glean_register_ping_type(uint64_t ping_type_handle);
+
+void glean_destroy_quantity_metric(uint64_t v);
+
+uint64_t glean_new_quantity_metric(FfiStr category,
+                                   FfiStr name,
+                                   RawStringArray send_in_pings,
+                                   int32_t send_in_pings_len,
+                                   Lifetime lifetime,
+                                   uint8_t disabled);
+
+int32_t glean_quantity_test_get_num_recorded_errors(uint64_t metric_id,
+                                                    int32_t error_type,
+                                                    FfiStr storage_name);
+
+void glean_quantity_set(uint64_t metric_id, int64_t value);
+
+uint8_t glean_quantity_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+int64_t glean_quantity_test_get_value(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_string_metric(uint64_t v);
+
+uint64_t glean_new_string_metric(FfiStr category,
+                                 FfiStr name,
+                                 RawStringArray send_in_pings,
+                                 int32_t send_in_pings_len,
+                                 Lifetime lifetime,
+                                 uint8_t disabled);
 
 int32_t glean_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                   int32_t error_type,
                                                   FfiStr storage_name);
 
-char *glean_string_test_get_value(uint64_t metric_id, FfiStr storage_name);
+void glean_string_set(uint64_t metric_id, FfiStr value);
 
 uint8_t glean_string_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-uint8_t glean_submit_ping_by_name(FfiStr ping_name, FfiStr reason);
+char *glean_string_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_test_clear_all_stores(void);
+void glean_destroy_string_list_metric(uint64_t v);
 
-uint8_t glean_test_has_ping_type(FfiStr ping_name);
+uint64_t glean_new_string_list_metric(FfiStr category,
+                                      FfiStr name,
+                                      RawStringArray send_in_pings,
+                                      int32_t send_in_pings_len,
+                                      Lifetime lifetime,
+                                      uint8_t disabled);
 
-void glean_timespan_cancel(uint64_t metric_id);
+int32_t glean_string_list_test_get_num_recorded_errors(uint64_t metric_id,
+                                                       int32_t error_type,
+                                                       FfiStr storage_name);
 
-void glean_timespan_set_raw_nanos(uint64_t metric_id, uint64_t elapsed_nanos);
+void glean_string_list_add(uint64_t metric_id, FfiStr value);
 
-void glean_timespan_set_start(uint64_t metric_id, uint64_t start_time);
+void glean_string_list_set(uint64_t metric_id, RawStringArray values, int32_t values_len);
 
-void glean_timespan_set_stop(uint64_t metric_id, uint64_t stop_time);
+uint8_t glean_string_list_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_string_list_test_get_value_as_json_string(uint64_t metric_id, FfiStr storage_name);
+
+void glean_destroy_timespan_metric(uint64_t v);
+
+uint64_t glean_new_timespan_metric(FfiStr category,
+                                   FfiStr name,
+                                   RawStringArray send_in_pings,
+                                   int32_t send_in_pings_len,
+                                   Lifetime lifetime,
+                                   uint8_t disabled,
+                                   int32_t time_unit);
 
 int32_t glean_timespan_test_get_num_recorded_errors(uint64_t metric_id,
                                                     int32_t error_type,
                                                     FfiStr storage_name);
 
-uint64_t glean_timespan_test_get_value(uint64_t metric_id, FfiStr storage_name);
+void glean_timespan_set_start(uint64_t metric_id, uint64_t start_time);
+
+void glean_timespan_set_stop(uint64_t metric_id, uint64_t stop_time);
+
+void glean_timespan_cancel(uint64_t metric_id);
+
+void glean_timespan_set_raw_nanos(uint64_t metric_id, uint64_t elapsed_nanos);
 
 uint8_t glean_timespan_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_timing_distribution_accumulate_samples(uint64_t metric_id,
-                                                  RawInt64Array raw_samples,
-                                                  int32_t num_samples);
+uint64_t glean_timespan_test_get_value(uint64_t metric_id, FfiStr storage_name);
 
-void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
+void glean_destroy_timing_distribution_metric(uint64_t v);
+
+uint64_t glean_new_timing_distribution_metric(FfiStr category,
+                                              FfiStr name,
+                                              RawStringArray send_in_pings,
+                                              int32_t send_in_pings_len,
+                                              Lifetime lifetime,
+                                              uint8_t disabled,
+                                              TimeUnit time_unit);
+
+int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t metric_id,
+                                                               int32_t error_type,
+                                                               FfiStr storage_name);
 
 TimerId glean_timing_distribution_set_start(uint64_t metric_id, uint64_t start_time);
 
@@ -777,17 +766,28 @@ void glean_timing_distribution_set_stop_and_accumulate(uint64_t metric_id,
                                                        TimerId timer_id,
                                                        uint64_t stop_time);
 
-int32_t glean_timing_distribution_test_get_num_recorded_errors(uint64_t metric_id,
-                                                               int32_t error_type,
-                                                               FfiStr storage_name);
+void glean_timing_distribution_cancel(uint64_t metric_id, TimerId timer_id);
+
+void glean_timing_distribution_accumulate_samples(uint64_t metric_id,
+                                                  RawInt64Array raw_samples,
+                                                  int32_t num_samples);
+
+uint8_t glean_timing_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
 
 char *glean_timing_distribution_test_get_value_as_json_string(uint64_t metric_id,
                                                               FfiStr storage_name);
 
-uint8_t glean_timing_distribution_test_has_value(uint64_t metric_id, FfiStr storage_name);
+void glean_destroy_uuid_metric(uint64_t v);
+
+uint64_t glean_new_uuid_metric(FfiStr category,
+                               FfiStr name,
+                               RawStringArray send_in_pings,
+                               int32_t send_in_pings_len,
+                               Lifetime lifetime,
+                               uint8_t disabled);
 
 void glean_uuid_set(uint64_t metric_id, FfiStr value);
 
-char *glean_uuid_test_get_value(uint64_t metric_id, FfiStr storage_name);
-
 uint8_t glean_uuid_test_has_value(uint64_t metric_id, FfiStr storage_name);
+
+char *glean_uuid_test_get_value(uint64_t metric_id, FfiStr storage_name);

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -17,8 +17,11 @@ use rkv::StoreOptions;
 mod backend {
     use std::path::Path;
 
+    /// cbindgen:ignore
     pub type Rkv = rkv::Rkv<rkv::backend::LmdbEnvironment>;
+    /// cbindgen:ignore
     pub type SingleStore = rkv::SingleStore<rkv::backend::LmdbDatabase>;
+    /// cbindgen:ignore
     pub type Writer<'t> = rkv::Writer<rkv::backend::LmdbRwTransaction<'t>>;
 
     pub fn rkv_new(path: &Path) -> Result<Rkv, rkv::StoreError> {
@@ -31,8 +34,11 @@ mod backend {
 mod backend {
     use std::path::Path;
 
+    /// cbindgen:ignore
     pub type Rkv = rkv::Rkv<rkv::backend::SafeModeEnvironment>;
+    /// cbindgen:ignore
     pub type SingleStore = rkv::SingleStore<rkv::backend::SafeModeDatabase>;
+    /// cbindgen:ignore
     pub type Writer<'t> = rkv::Writer<rkv::backend::SafeModeRwTransaction<'t>>;
 
     pub fn rkv_new(path: &Path) -> Result<Rkv, rkv::StoreError> {

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -10,13 +10,42 @@ use std::path::Path;
 use std::str;
 use std::sync::RwLock;
 
-use rkv::{Rkv, SingleStore, StoreOptions};
+use rkv::StoreOptions;
+
+// Select the LMDB-powered storage backend when the feature is not activated.
+#[cfg(not(feature = "rkv-safe-mode"))]
+mod backend {
+    use std::path::Path;
+
+    pub type Rkv = rkv::Rkv<rkv::backend::LmdbEnvironment>;
+    pub type SingleStore = rkv::SingleStore<rkv::backend::LmdbDatabase>;
+    pub type Writer<'t> = rkv::Writer<rkv::backend::LmdbRwTransaction<'t>>;
+
+    pub fn rkv_new(path: &Path) -> Result<Rkv, rkv::StoreError> {
+        Rkv::new::<rkv::backend::Lmdb>(path)
+    }
+}
+
+// Select the "safe mode" storage backend when the feature is activated.
+#[cfg(feature = "rkv-safe-mode")]
+mod backend {
+    use std::path::Path;
+
+    pub type Rkv = rkv::Rkv<rkv::backend::SafeModeEnvironment>;
+    pub type SingleStore = rkv::SingleStore<rkv::backend::SafeModeDatabase>;
+    pub type Writer<'t> = rkv::Writer<rkv::backend::SafeModeRwTransaction<'t>>;
+
+    pub fn rkv_new(path: &Path) -> Result<Rkv, rkv::StoreError> {
+        Rkv::new::<rkv::backend::SafeMode>(path)
+    }
+}
 
 use crate::metrics::Metric;
 use crate::CommonMetricData;
 use crate::Glean;
 use crate::Lifetime;
 use crate::Result;
+use backend::*;
 
 pub struct Database {
     /// Handle to the database environment.
@@ -81,7 +110,13 @@ impl Database {
         let path = Path::new(data_path).join("db");
         log::debug!("Database path: {:?}", path.display());
 
+        // FIXME(bug 1670634): This is probably more knowledge
+        // than we should have about the database internals.
+        // We could instead iterate over the directory and sum up the file sizes.
+        #[cfg(not(feature = "rkv-safe-mode"))]
         let file_size = file_size(&path.join("data.mdb"));
+        #[cfg(feature = "rkv-safe-mode")]
+        let file_size = file_size(&path.join("data.safe.bin"));
 
         let rkv = Self::open_rkv(&path)?;
         let user_store = rkv.open_single(Lifetime::User.as_str(), StoreOptions::create())?;
@@ -125,7 +160,7 @@ impl Database {
     fn open_rkv(path: &Path) -> Result<Rkv> {
         fs::create_dir_all(&path)?;
 
-        let rkv = Rkv::new(&path)?;
+        let rkv = rkv_new(&path)?;
         log::info!("Database initialized");
         Ok(rkv)
     }
@@ -168,7 +203,7 @@ impl Database {
                     Ok(metric_id) => metric_id.to_string(),
                     _ => continue,
                 };
-                let metric: Metric = match value.expect("Value missing in iteration") {
+                let metric: Metric = match value {
                     rkv::Value::Blob(blob) => unwrap_or!(bincode::deserialize(blob), continue),
                     _ => continue,
                 };
@@ -241,7 +276,7 @@ impl Database {
             }
 
             let metric_id = &metric_id[len..];
-            let metric: Metric = match value.expect("Value missing in iteration") {
+            let metric: Metric = match value {
                 rkv::Value::Blob(blob) => unwrap_or!(bincode::deserialize(blob), continue),
                 _ => continue,
             };
@@ -297,7 +332,7 @@ impl Database {
     /// * This function will **not** panic on database errors.
     fn write_with_store<F>(&self, store_name: Lifetime, mut transaction_fn: F) -> Result<()>
     where
-        F: FnMut(rkv::Writer, &SingleStore) -> Result<()>,
+        F: FnMut(Writer, &SingleStore) -> Result<()>,
     {
         let writer = self.rkv.write().unwrap();
         let store = self.get_store(store_name);

--- a/glean-core/src/error.rs
+++ b/glean-core/src/error.rs
@@ -9,7 +9,7 @@ use std::result;
 
 use ffi_support::{handle_map::HandleError, ExternError};
 
-use rkv::error::StoreError;
+use rkv::StoreError;
 
 /// A specialized [`Result`] type for this crate's operations.
 ///


### PR DESCRIPTION
The default is still Rkv's LMDB storage backend and we don't have any
intention to change that at the moment.