### PR TITLE
Bug 1671628 - Add traits to describe expected operations on Glean types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Standardize throttle backoff time throughout all bindings. ([#1240](https://github.com/mozilla/glean/pull/1240))
   * Update `glean_parser` to 1.29.0
     * Generated code now includes a comment next to each metric containing the name of the metric in its original `snake_case` form.
+  * Expose the description of the metric types in glean_core using traits.
 * Android
   * Update the JNA dependency from 5.2.0 to 5.6.0
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod metrics;
 pub mod ping;
 pub mod storage;
 mod system;
+pub mod traits;
 pub mod upload;
 mod util;
 

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -26,6 +26,10 @@ impl MetricType for BooleanMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl BooleanMetric {
     /// Creates a new boolean metric.
     pub fn new(meta: CommonMetricData) -> Self {

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -28,6 +28,10 @@ impl MetricType for CounterMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl CounterMetric {
     /// Creates a new counter metric.
     pub fn new(meta: CommonMetricData) -> Self {

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -41,6 +41,10 @@ impl MetricType for CustomDistributionMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl CustomDistributionMetric {
     /// Creates a new memory distribution metric.
     pub fn new(

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -40,6 +40,10 @@ impl MetricType for DatetimeMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl DatetimeMetric {
     /// Creates a new datetime metric.
     pub fn new(meta: CommonMetricData, time_unit: TimeUnit) -> Self {

--- a/glean-core/src/metrics/event.rs
+++ b/glean-core/src/metrics/event.rs
@@ -36,6 +36,10 @@ impl MetricType for EventMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl EventMetric {
     /// Creates a new event metric.
     pub fn new(meta: CommonMetricData, allowed_extra_keys: Vec<String>) -> Self {

--- a/glean-core/src/metrics/jwe.rs
+++ b/glean-core/src/metrics/jwe.rs
@@ -61,6 +61,10 @@ struct Jwe {
     auth_tag: String,
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl Jwe {
     /// Create a new JWE struct.
     fn new<S: Into<String>>(

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -51,6 +51,10 @@ impl MetricType for MemoryDistributionMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl MemoryDistributionMetric {
     /// Creates a new memory distribution metric.
     pub fn new(meta: CommonMetricData, memory_unit: MemoryUnit) -> Self {

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -38,11 +38,11 @@ use crate::Glean;
 
 pub use self::boolean::BooleanMetric;
 pub use self::counter::CounterMetric;
+pub use self::custom_distribution::CustomDistributionMetric;
 pub use self::datetime::DatetimeMetric;
 pub use self::event::EventMetric;
 pub(crate) use self::experiment::ExperimentMetric;
 pub use crate::histogram::HistogramType;
-pub use self::custom_distribution::CustomDistributionMetric;
 // Note: only expose RecordedExperimentData to tests in
 // the next line, so that glean-core\src\lib.rs won't fail to build.
 #[cfg(test)]

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -42,9 +42,9 @@ pub use self::datetime::DatetimeMetric;
 pub use self::event::EventMetric;
 pub(crate) use self::experiment::ExperimentMetric;
 pub use crate::histogram::HistogramType;
+pub use self::custom_distribution::CustomDistributionMetric;
 // Note: only expose RecordedExperimentData to tests in
 // the next line, so that glean-core\src\lib.rs won't fail to build.
-pub use self::custom_distribution::CustomDistributionMetric;
 #[cfg(test)]
 pub(crate) use self::experiment::RecordedExperimentData;
 pub use self::jwe::JweMetric;

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -21,6 +21,10 @@ pub struct PingType {
     pub reason_codes: Vec<String>,
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl PingType {
     /// Creates a new ping type for the given name, whether to include the client ID and whether to
     /// send this ping empty.

--- a/glean-core/src/metrics/quantity.rs
+++ b/glean-core/src/metrics/quantity.rs
@@ -27,6 +27,10 @@ impl MetricType for QuantityMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl QuantityMetric {
     /// Creates a new quantity metric.
     pub fn new(meta: CommonMetricData) -> Self {

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -30,6 +30,10 @@ impl MetricType for StringMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl StringMetric {
     /// Creates a new string metric.
     pub fn new(meta: CommonMetricData) -> Self {

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -33,6 +33,10 @@ impl MetricType for StringListMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl StringListMetric {
     /// Creates a new string list metric.
     pub fn new(meta: CommonMetricData) -> Self {

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -32,6 +32,10 @@ impl MetricType for TimespanMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl TimespanMetric {
     /// Creates a new timespan metric.
     pub fn new(meta: CommonMetricData, time_unit: TimeUnit) -> Self {

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -122,6 +122,10 @@ impl MetricType for TimingDistributionMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl TimingDistributionMetric {
     /// Creates a new timing distribution metric.
     pub fn new(meta: CommonMetricData, time_unit: TimeUnit) -> Self {

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -28,6 +28,10 @@ impl MetricType for UuidMetric {
     }
 }
 
+// IMPORTANT:
+//
+// When changing this implementation, make sure all the operations are
+// also declared in the related trait in `../traits/`.
 impl UuidMetric {
     /// Creates a new UUID metric
     pub fn new(meta: CommonMetricData) -> Self {

--- a/glean-core/src/traits/boolean.rs
+++ b/glean-core/src/traits/boolean.rs
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `BooleanMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Boolean {
+    /// Sets to the specified boolean value.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - the value to set.
+    fn set(&self, value: bool);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as a boolean.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<bool>;
+}

--- a/glean-core/src/traits/counter.rs
+++ b/glean-core/src/traits/counter.rs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `CounterMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Counter {
+    /// Increases the counter by `amount`.
+    ///
+    /// # Arguments
+    ///
+    /// * `amount` - The amount to increase by. Should be positive.
+    ///
+    /// ## Notes
+    ///
+    /// Logs an error if the `amount` is 0 or negative.
+    fn add(&self, amount: i32);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as an integer.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<i32>;
+}

--- a/glean-core/src/traits/custom_distribution.rs
+++ b/glean-core/src/traits/custom_distribution.rs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `CustomDistributionMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait CustomDistribution {
+    /// Accumulates the provided signed samples in the metric.
+    ///
+    /// This is required so that the platform-specific code can provide us with
+    /// 64 bit signed integers if no `u64` comparable type is available. This
+    /// will take care of filtering and reporting errors for any provided negative
+    /// sample.
+    ///
+    /// # Arguments
+    ///
+    /// - `samples` - The vector holding the samples to be recorded by the metric.
+    ///
+    /// ## Notes
+    ///
+    /// Discards any negative value in `samples` and report an `ErrorType::InvalidValue`
+    /// for each of them.
+    fn accumulate_samples_signed(&self, samples: Vec<i64>);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored histogram.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored histogram as a JSON String of the serialized value.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+}

--- a/glean-core/src/traits/datetime.rs
+++ b/glean-core/src/traits/datetime.rs
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![allow(clippy::too_many_arguments)]
+
+/// A description for the `DatetimeMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Datetime {
+    /// Sets the metric to a date/time including the timezone offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `year` - the year to set the metric to.
+    /// * `month` - the month to set the metric to (1-12).
+    /// * `day` - the day to set the metric to (1-based).
+    /// * `hour` - the hour to set the metric to.
+    /// * `minute` - the minute to set the metric to.
+    /// * `second` - the second to set the metric to.
+    /// * `nano` - the nanosecond fraction to the last whole second.
+    /// * `offset_seconds` - the timezone difference, in seconds, for the Eastern
+    ///   Hemisphere. Negative seconds mean Western Hemisphere.
+    fn set_with_details(
+        &self,
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+        nano: u32,
+        offset_seconds: i32,
+    );
+
+    /// Sets the metric to a date/time which including the timezone offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - Some date/time value, with offset, to set the metric to.
+    ///             If none, the current local time is used.
+    fn set(&self, value: Option<crate::metrics::Datetime>);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as a String.
+    ///
+    /// The precision of this value is truncated to the `time_unit` precision.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value_as_string(&self, storage_name: &str) -> Option<String>;
+}

--- a/glean-core/src/traits/event.rs
+++ b/glean-core/src/traits/event.rs
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::HashMap;
+
+use crate::event_database::RecordedEvent;
+
+/// A description for the `EventMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Event {
+    /// Records an event.
+    ///
+    /// # Arguments
+    ///
+    /// * `extra` - A HashMap of (key, value) pairs. The key is an index into
+    ///   the metric's `allowed_extra_keys` vector where the key's string is
+    ///   looked up. If any key index is out of range, an error is reported and
+    ///   no event is recorded.
+    fn record<M: Into<Option<HashMap<i32, String>>>>(&self, extra: M);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Tests whether there are currently stored events for this event metric.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_has_value(&self, store_name: &str) -> bool;
+
+    /// **Exported for test purposes.**
+    ///
+    /// Get the vector of currently stored events for this event metric.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, store_name: &str) -> Option<Vec<RecordedEvent>>;
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored events for this event metric as a JSON-encoded string.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value_as_json_string(&self, store_name: &str) -> String;
+}

--- a/glean-core/src/traits/jwe.rs
+++ b/glean-core/src/traits/jwe.rs
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `JweMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Jwe {
+    /// Sets to the specified JWE value.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - the [`compact representation`](https://tools.ietf.org/html/rfc7516#appendix-A.2.7) of a JWE value.
+    fn set_with_compact_representation<S: Into<String>>(&self, value: S);
+
+    /// Builds a JWE value from its elements and set to it.
+    ///
+    /// # Arguments
+    ///
+    /// * `header` - the JWE Protected Header element.
+    /// * `key` - the JWE Encrypted Key element.
+    /// * `init_vector` - the JWE Initialization Vector element.
+    /// * `cipher_text` - the JWE Ciphertext element.
+    /// * `auth_tag` - the JWE Authentication Tag element.
+    fn set<S: Into<String>>(&self, header: S, key: S, init_vector: S, cipher_text: S, auth_tag: S);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as a string.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<String>;
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored JWE as a JSON String of the serialized value.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+}

--- a/glean-core/src/traits/labeled.rs
+++ b/glean-core/src/traits/labeled.rs
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::metrics::MetricType;
+
+/// A description for the `LabeledMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Labeled<T>
+where
+    T: MetricType + Clone,
+{
+    /// Gets a specific metric for a given label.
+    ///
+    /// If a set of acceptable labels were specified in the `metrics.yaml` file,
+    /// and the given label is not in the set, it will be recorded under the special `OTHER_LABEL` label.
+    ///
+    /// If a set of acceptable labels was not specified in the `metrics.yaml` file,
+    /// only the first 16 unique labels will be used.
+    /// After that, any additional labels will be recorded under the special `OTHER_LABEL` label.
+    ///
+    /// Labels must be `snake_case` and less than 30 characters.
+    /// If an invalid label is used, the metric will be recorded in the special `OTHER_LABEL` label.
+    fn get(&self, label: &str) -> T;
+
+    /// Gets the template submetric.
+    ///
+    /// The template submetric is the actual metric that is cloned and modified
+    /// to record for a specific label.
+    fn get_submetric(&self) -> &T;
+}

--- a/glean-core/src/traits/memory_distribution.rs
+++ b/glean-core/src/traits/memory_distribution.rs
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::metrics::DistributionData;
+
+/// A description for the `MemoryDistributionMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait MemoryDistribution {
+    /// Accumulates the provided sample in the metric.
+    ///
+    /// # Arguments
+    ///
+    /// * `sample` - The sample to be recorded by the metric. The sample is assumed to be in the
+    ///   configured memory unit of the metric.
+    ///
+    /// ## Notes
+    ///
+    /// Values bigger than 1 Terabyte (2<sup>40</sup> bytes) are truncated
+    /// and an `ErrorType::InvalidValue` error is recorded.
+    fn accumulate(&self, sample: u64);
+
+    /// Accumulates the provided signed samples in the metric.
+    ///
+    /// This is required so that the platform-specific code can provide us with
+    /// 64 bit signed integers if no `u64` comparable type is available. This
+    /// will take care of filtering and reporting errors for any provided negative
+    /// sample.
+    ///
+    /// Please note that this assumes that the provided samples are already in the
+    /// "unit" declared by the instance of the implementing metric type (e.g. if the
+    /// implementing class is a [MemoryDistributionMetricType] and the instance this
+    /// method was called on is using [MemoryUnit.Kilobyte], then `samples` are assumed
+    /// to be in that unit).
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - The vector holding the samples to be recorded by the metric.
+    ///
+    /// ## Notes
+    ///
+    /// Discards any negative value in `samples` and report an `ErrorType::InvalidValue`
+    /// for each of them.
+    /// Values bigger than 1 Terabyte (2<sup>40</sup> bytes) are truncated
+    /// and an `ErrorType::InvalidValue` error is recorded.
+    fn accumulate_samples_signed(&self, samples: Vec<i64>);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as an integer.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<DistributionData>;
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently-stored histogram as a JSON String of the serialized value.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+}

--- a/glean-core/src/traits/mod.rs
+++ b/glean-core/src/traits/mod.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Important: consider this module unstable / experimental.
+//!
+//! The different metric types supported by the Glean SDK to handle data.
+
+mod boolean;
+mod counter;
+mod custom_distribution;
+mod datetime;
+mod event;
+mod jwe;
+mod labeled;
+mod memory_distribution;
+mod ping;
+mod quantity;
+mod string;
+mod string_list;
+mod timespan;
+mod timing_distribution;
+mod uuid;
+
+pub use crate::event_database::RecordedEvent;
+
+pub use self::boolean::Boolean;
+pub use self::counter::Counter;
+pub use self::custom_distribution::CustomDistribution;
+pub use self::datetime::Datetime;
+pub use self::event::Event;
+pub use self::jwe::Jwe;
+pub use self::labeled::Labeled;
+pub use self::memory_distribution::MemoryDistribution;
+pub use self::ping::Ping;
+pub use self::quantity::Quantity;
+pub use self::string::String;
+pub use self::string_list::StringList;
+pub use self::timespan::Timespan;
+pub use self::timing_distribution::TimingDistribution;
+pub use self::uuid::Uuid;
+pub use crate::histogram::HistogramType;

--- a/glean-core/src/traits/ping.rs
+++ b/glean-core/src/traits/ping.rs
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::error::Result;
+
+/// A description for the `PingType` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Ping {
+    /// Submits the ping for eventual uploading
+    ///
+    /// # Arguments
+    ///
+    /// * `reason` - the reason the ping was triggered. Included in the
+    ///   `ping_info.reason` part of the payload.
+    ///
+    /// # Returns
+    ///
+    /// See [`Glean#submit_ping`](../struct.Glean.html#method.submit_ping) for details.
+    fn submit(&self, reason: Option<&str>) -> Result<bool>;
+}

--- a/glean-core/src/traits/quantity.rs
+++ b/glean-core/src/traits/quantity.rs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `QuantityMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Quantity {
+    /// Sets the value. Must be non-negative.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The value. Must be non-negative.
+    ///
+    /// ## Notes
+    ///
+    /// Logs an error if the `value` is negative.
+    fn set(&self, value: i64);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as an integer.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<i64>;
+}

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `StringMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait String {
+    /// Sets to the specified value.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The string to set the metric to.
+    ///
+    /// ## Notes
+    ///
+    /// Truncates the value if it is longer than `MAX_STRING_LENGTH` bytes and logs an error.
+    fn set<S: Into<std::string::String>>(&self, value: S);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as a string.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<std::string::String>;
+}

--- a/glean-core/src/traits/string_list.rs
+++ b/glean-core/src/traits/string_list.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `StringListMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait StringList {
+    /// Adds a new string to the list.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The string to add.
+    ///
+    /// ## Notes
+    ///
+    /// Truncates the value if it is longer than `MAX_STRING_LENGTH` bytes and logs an error.
+    fn add<S: Into<String>>(&self, value: S);
+
+    /// Sets to a specific list of strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The list of string to set the metric to.
+    ///
+    /// ## Notes
+    ///
+    /// If passed an empty list, records an error and returns.
+    /// Truncates the list if it is longer than `MAX_LIST_LENGTH` and logs an error.
+    /// Truncates any value in the list if it is longer than `MAX_STRING_LENGTH` and logs an error.
+    fn set(&self, value: Vec<String>);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently-stored values.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<Vec<String>>;
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently-stored values as a JSON String of the format
+    /// ["string1", "string2", ...]
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+}

--- a/glean-core/src/traits/timespan.rs
+++ b/glean-core/src/traits/timespan.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::time::Duration;
+
+/// A description for the `TimespanMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Timespan {
+    /// Starts tracking time for the provided metric.
+    ///
+    /// This records an error if it's already tracking time (i.e. start was already
+    /// called with no corresponding `stop`): in that case the original
+    /// start time will be preserved.
+    fn set_start(&mut self, start_time: u64);
+
+    /// Stops tracking time for the provided metric. Sets the metric to the elapsed time.
+    ///
+    /// This will record an error if no `start` was called.
+    fn set_stop(&mut self, stop_time: u64);
+
+    /// Aborts a previous `start` call. No error is recorded if no `start` was called.
+    fn cancel(&mut self);
+
+    /// Explicitly sets the timespan value.
+    ///
+    /// This API should only be used if your library or application requires recording
+    /// times in a way that can not make use of `start`/`stop`/`cancel`.
+    ///
+    /// Care should be taken using this if the ping lifetime might contain more than one
+    /// timespan measurement. To be safe, `set_raw` should generally be followed by
+    /// sending a custom ping containing the timespan.
+    ///
+    /// # Arguments
+    ///
+    /// * `elapsed` - The elapsed time to record.
+    /// * `overwrite` - Whether or not to overwrite existing data.
+    fn set_raw(&self, elapsed: Duration, overwrite: bool);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as an integer.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<u64>;
+}

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::metrics::DistributionData;
+use crate::metrics::TimerId;
+
+/// A description for the `TimingDistributionMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait TimingDistribution {
+    /// Starts tracking time for the provided metric.
+    ///
+    /// This records an error if it’s already tracking time (i.e. start was already
+    /// called with no corresponding [stop]): in that case the original
+    /// start time will be preserved.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_time` - Timestamp in nanoseconds.
+    ///
+    /// # Returns
+    ///
+    /// A unique `TimerId` for the new timer.
+    fn set_start(&mut self, start_time: u64);
+
+    /// Stops tracking time for the provided metric and associated timer id.
+    ///
+    /// Adds a count to the corresponding bucket in the timing distribution.
+    /// This will record an error if no `start` was called.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The `TimerId` to associate with this timing. This allows
+    ///   for concurrent timing of events associated with different ids to the
+    ///   same timespan metric.
+    /// * `stop_time` - Timestamp in nanoseconds.
+    fn set_stop_and_accumulate(&mut self, id: TimerId, stop_time: u64);
+
+    /// Aborts a previous `set_start` call. No error is recorded if no `set_start`
+    /// was called.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The `TimerId` to associate with this timing. This allows
+    ///   for concurrent timing of events associated with different ids to the
+    ///   same timing distribution metric.
+    fn cancel(&mut self, id: TimerId);
+
+    /// Accumulates the provided signed samples in the metric.
+    ///
+    /// This is required so that the platform-specific code can provide us with
+    /// 64 bit signed integers if no `u64` comparable type is available. This
+    /// will take care of filtering and reporting errors for any provided negative
+    /// sample.
+    ///
+    /// Please note that this assumes that the provided samples are already in the
+    /// "unit" declared by the instance of the implementing metric type (e.g. if the
+    /// implementing class is a [TimingDistributionMetricType] and the instance this
+    /// method was called on is using [TimeUnit.Second], then `samples` are assumed
+    /// to be in that unit).
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - The vector holding the samples to be recorded by the metric.
+    ///
+    /// ## Notes
+    ///
+    /// Discards any negative value in `samples` and report an `ErrorType::InvalidValue`
+    /// for each of them. Reports an `ErrorType::InvalidOverflow` error for samples that
+    /// are longer than `MAX_SAMPLE_TIME`.
+    fn accumulate_samples_signed(&mut self, samples: Vec<i64>);
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as an integer.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<DistributionData>;
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently-stored histogram as a JSON String of the serialized value.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+}

--- a/glean-core/src/traits/uuid.rs
+++ b/glean-core/src/traits/uuid.rs
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A description for the `UuidMetric` type.
+///
+/// When changing this trait, make sure all the operations are
+/// implemented in the related type in `../metrics/`.
+pub trait Uuid {
+    /// Sets to the specified value.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The UUID to set the metric to.
+    fn set(&self, value: uuid::Uuid);
+
+    /// Generates a new random UUID and set the metric to it.
+    fn generate_and_set(&self) -> uuid::Uuid;
+
+    /// **Exported for test purposes.**
+    ///
+    /// Gets the currently stored value as a string.
+    ///
+    /// This doesn't clear the stored value.
+    fn test_get_value(&self, storage_name: &str) -> Option<String>;
+}


### PR DESCRIPTION
This exposes the description of the metric types in glean_core using Rust traits. All the traits live in the `traits` module.