### PR TITLE
Bug 1672984 - Recoverable network error is noisily logged at error level

### DIFF
--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -630,7 +630,7 @@ impl PingUploadManager {
             }
 
             RecoverableFailure | HttpStatus(_) => {
-                log::error!(
+                log::info!(
                     "Recoverable upload failure while attempting to send ping {}, will retry. Error was {:?}",
                     document_id,
                     status


### PR DESCRIPTION
Reduce Sentry noise for Fx-iOS by reducing the logging level of the recoverable network errors in the upload module.