### PR TITLE
Bug 1664501 - Add better docs for special pings [doc only]

### DIFF
--- a/docs/dev/core/internal/reserved-ping-names.md
+++ b/docs/dev/core/internal/reserved-ping-names.md
@@ -4,7 +4,7 @@ The Glean SDK reserves all ping names in `send_in_pings` starting with `glean_`.
 
 This currently includes, but is not limited to:
 
-* `glean_client_info`
-* `glean_internal_info`
+* `glean_client_info`: metrics sent with this ping are added to every ping in its `client_info` section;
+* `glean_internal_info`: metrics sent with this ping are added to every ping in its `ping_info` section.
 
 Additionally, only Glean may specify `all-pings`.  This special value has no effect in the client, but indicates to the backend infrastructure that a metric may appear in any ping.

--- a/glean-core/android/metrics.yaml
+++ b/glean-core/android/metrics.yaml
@@ -2,9 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# This file defines the metrics that are recorded by the Glean SDK. They are
-# automatically converted to Kotlin code at build time using the `glean_parser`
-# PyPI package.
+# This file defines the metrics that are recorded by the Glean SDK.
+# Their code APIs is automatically generated, at build time using,
+# the `glean_parser` PyPI package.
+
+# Metrics in this file may make use of SDK reserved ping names. See
+# https://mozilla.github.io/glean/book/dev/core/internal/reserved-ping-names.html
+# for additional information.
 
 ---
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0

--- a/glean-core/android/metrics.yaml
+++ b/glean-core/android/metrics.yaml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # This file defines the metrics that are recorded by the Glean SDK.
-# Their code APIs is automatically generated, at build time using,
+# APIs to use these metrics are automatically generated at build time using
 # the `glean_parser` PyPI package.
 
 # Metrics in this file may make use of SDK reserved ping names. See

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -2,9 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# This file defines the metrics that are recorded by the Glean SDK. They are
-# automatically converted to Kotlin code at build time using the `glean_parser`
-# PyPI package.
+# This file defines the metrics that are recorded by the Glean SDK.
+# Their code APIs is automatically generated, at build time using,
+# the `glean_parser` PyPI package.
+
+# Metrics in this file may make use of SDK reserved ping names. See
+# https://mozilla.github.io/glean/book/dev/core/internal/reserved-ping-names.html
+# for additional information.
 
 ---
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # This file defines the metrics that are recorded by the Glean SDK.
-# Their code APIs is automatically generated, at build time using,
+# APIs to use these pings are automatically generated at build time using
 # the `glean_parser` PyPI package.
 
 # Metrics in this file may make use of SDK reserved ping names. See

--- a/glean-core/pings.yaml
+++ b/glean-core/pings.yaml
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# This file defines the built-in pings that are recorded by the Glean SDK. They
-# are automatically converted to Kotlin code at build time using the
-# `glean_parser` PyPI package.
+# This file defines the pings that are recorded by the Glean SDK.
+# Their code APIs is automatically generated, at build time using,
+# the `glean_parser` PyPI package.
 
 ---
 $schema: moz://mozilla.org/schemas/glean/pings/1-0-0


### PR DESCRIPTION
This adds better internal documentation and references with respect to special ping names inside SDK-owned registry files.