### PR TITLE
Bug 1672990 - Make the ping name optional in the RLB testing APIs

### DIFF
--- a/docs/user/metrics/boolean.md
+++ b/docs/user/metrics/boolean.md
@@ -137,9 +137,9 @@ There are test APIs available too:
 use glean_metrics;
 
 // Was anything recorded?
-assert!(flags::a11y_enabled.test_get_value().is_some());
+assert!(flags::a11y_enabled.test_get_value(None).is_some());
 // Does it have the expected value?
-assert!(flags::a11y_enabled.test_get_value().unwrap());
+assert!(flags::a11y_enabled.test_get_value(None).unwrap());
 ```
 
 </div>

--- a/glean-core/src/traits/boolean.rs
+++ b/glean-core/src/traits/boolean.rs
@@ -19,5 +19,10 @@ pub trait Boolean {
     /// Gets the currently stored value as a boolean.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<bool>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<bool>;
 }

--- a/glean-core/src/traits/counter.rs
+++ b/glean-core/src/traits/counter.rs
@@ -23,5 +23,10 @@ pub trait Counter {
     /// Gets the currently stored value as an integer.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<i32>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i32>;
 }

--- a/glean-core/src/traits/custom_distribution.rs
+++ b/glean-core/src/traits/custom_distribution.rs
@@ -29,12 +29,28 @@ pub trait CustomDistribution {
     /// Gets the currently stored histogram.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str);
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<crate::metrics::DistributionData>;
 
     /// **Exported for test purposes.**
     ///
     /// Gets the currently stored histogram as a JSON String of the serialized value.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value_as_json_string<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<String>;
 }

--- a/glean-core/src/traits/datetime.rs
+++ b/glean-core/src/traits/datetime.rs
@@ -44,10 +44,35 @@ pub trait Datetime {
 
     /// **Exported for test purposes.**
     ///
+    /// Gets the currently stored value as a Datetime.
+    ///
+    /// The precision of this value is truncated to the `time_unit` precision.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<crate::metrics::Datetime>;
+
+    /// **Exported for test purposes.**
+    ///
     /// Gets the currently stored value as a String.
     ///
     /// The precision of this value is truncated to the `time_unit` precision.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value_as_string(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value_as_string<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<String>;
 }

--- a/glean-core/src/traits/event.rs
+++ b/glean-core/src/traits/event.rs
@@ -23,22 +23,31 @@ pub trait Event {
 
     /// **Exported for test purposes.**
     ///
-    /// Tests whether there are currently stored events for this event metric.
-    ///
-    /// This doesn't clear the stored value.
-    fn test_has_value(&self, store_name: &str) -> bool;
-
-    /// **Exported for test purposes.**
-    ///
     /// Get the vector of currently stored events for this event metric.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, store_name: &str) -> Option<Vec<RecordedEvent>>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<Vec<RecordedEvent>>;
 
     /// **Exported for test purposes.**
     ///
     /// Gets the currently stored events for this event metric as a JSON-encoded string.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value_as_json_string(&self, store_name: &str) -> String;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value_as_json_string<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<String>;
 }

--- a/glean-core/src/traits/jwe.rs
+++ b/glean-core/src/traits/jwe.rs
@@ -30,12 +30,25 @@ pub trait Jwe {
     /// Gets the currently stored value as a string.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<String>;
 
     /// **Exported for test purposes.**
     ///
     /// Gets the currently stored JWE as a JSON String of the serialized value.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value_as_json_string<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<String>;
 }

--- a/glean-core/src/traits/memory_distribution.rs
+++ b/glean-core/src/traits/memory_distribution.rs
@@ -52,12 +52,28 @@ pub trait MemoryDistribution {
     /// Gets the currently stored value as an integer.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<DistributionData>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<DistributionData>;
 
     /// **Exported for test purposes.**
     ///
     /// Gets the currently-stored histogram as a JSON String of the serialized value.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value_as_json_string<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<String>;
 }

--- a/glean-core/src/traits/quantity.rs
+++ b/glean-core/src/traits/quantity.rs
@@ -23,5 +23,10 @@ pub trait Quantity {
     /// Gets the currently stored value as an integer.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<i64>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i64>;
 }

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -23,5 +23,13 @@ pub trait String {
     /// Gets the currently stored value as a string.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<std::string::String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<std::string::String>;
 }

--- a/glean-core/src/traits/string_list.rs
+++ b/glean-core/src/traits/string_list.rs
@@ -36,7 +36,12 @@ pub trait StringList {
     /// Gets the currently-stored values.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<Vec<String>>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<Vec<String>>;
 
     /// **Exported for test purposes.**
     ///
@@ -44,5 +49,13 @@ pub trait StringList {
     /// ["string1", "string2", ...]
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value_as_json_string<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<String>;
 }

--- a/glean-core/src/traits/timespan.rs
+++ b/glean-core/src/traits/timespan.rs
@@ -44,5 +44,10 @@ pub trait Timespan {
     /// Gets the currently stored value as an integer.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<u64>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<u64>;
 }

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -77,12 +77,28 @@ pub trait TimingDistribution {
     /// Gets the currently stored value as an integer.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<DistributionData>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<DistributionData>;
 
     /// **Exported for test purposes.**
     ///
     /// Gets the currently-stored histogram as a JSON String of the serialized value.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value_as_json_string(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value_as_json_string<'a, S: Into<Option<&'a str>>>(
+        &self,
+        ping_name: S,
+    ) -> Option<String>;
 }

--- a/glean-core/src/traits/uuid.rs
+++ b/glean-core/src/traits/uuid.rs
@@ -22,5 +22,10 @@ pub trait Uuid {
     /// Gets the currently stored value as a string.
     ///
     /// This doesn't clear the stored value.
-    fn test_get_value(&self, storage_name: &str) -> Option<String>;
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - represents the optional name of the ping to retrieve the
+    ///   metric for. Defaults to the first value in `send_in_pings`.
+    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<String>;
 }


### PR DESCRIPTION
This also fixes the already existing `BooleanMetric` and updates the related docs.