### PR TITLE
Add library-loading configuration hooks for megazording.

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -40,6 +40,7 @@ android {
         // TODO: 1551691 Get the version from git tag...? Also, we need to select a
         // version that won't conflict with legacy glean-ac versions.
         buildConfigField("String", "LIBRARY_VERSION", "\"0.1\"")
+        buildConfigField("String", "JNA_LIBRARY_NAME", "\"glean_ffi\"")
         // Carefully escape the string here so it will support `\` in
         // Windows paths correctly.
         buildConfigField("String", "GLEAN_PING_SCHEMA_PATH", JsonOutput.toJson(GLEAN_PING_SCHEMA_PATH.path))

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -529,7 +529,7 @@ class EventMetricTypeTest {
         // but we can try to receive one and that causes an exception if there is none.
         try {
             val request = server.takeRequest(20L, TimeUnit.SECONDS)
-            val docType = request.path.split("/")[3]
+            val docType = request!!.path.split("/")[3]
             assertTrue("Didn't expect a ping, still got one with document type $docType", false)
         } catch (e: NullPointerException) {
             assertTrue("No ping received.", true)
@@ -540,7 +540,7 @@ class EventMetricTypeTest {
         ping.submit()
         try {
             val request = server.takeRequest(20L, TimeUnit.SECONDS)
-            val docType = request.path.split("/")[3]
+            val docType = request!!.path.split("/")[3]
             assertTrue("Didn't expect a ping, still got one with document type $docType", false)
         } catch (e: NullPointerException) {
             assertTrue("No ping received.", true)

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -48,7 +48,7 @@ pub use glean_core::{global_glean, setup_glean, CommonMetricData, Error, Glean, 
 
 mod configuration;
 mod core_metrics;
-mod dispatcher;
+pub mod dispatcher;
 mod glean_metrics;
 pub mod net;
 pub mod private;


### PR DESCRIPTION
The application-services team is experimenting with including Glean
as part of their "megazord" library, a collection of Rust components
that are all compiled together into a single unit. See the PR for
more details:

  https://github.com/mozilla/application-services/pull/3669

This commit adds some library-loading configuration hooks so that Glean
can choose between loading either the standalone `libglean_ffi.so` or
the combined appservices megazord, based on build-time config.

I'm pushing this as a PR as well for early visibility. Feedback most welcome
of course, but this will stay squarely in "draft" until the work on the appservices
side has been reviewed.