### PR TITLE
Bug 1672958 - Introduce the RLB `net` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Rust
   * Add the `BooleanMetric` type.
   * Add the `dispatcher` module (copied over from [mozilla-central](https://hg.mozilla.org/mozilla-central/rev/fbe0ea62f4bb50bfc5879a56667945697b2c90e7)).
+  * Allow consumers to specify a custom uploader.
 * Android
   * Update the JNA dependency from 5.2.0 to 5.6.0
   * The `glean-gradle-plugin` now makes sure that only a single Miniconda installation will happen at the same time to avoid a race condition when multiple components within the same project are using Glean.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ version = "33.0.4"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
+ "flate2",
  "glean-core",
  "inherent",
  "jsonschema-valid",

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -36,3 +36,4 @@ env_logger = { version = "0.7.1", default-features = false, features = ["termcol
 tempfile = "3.1.0"
 jsonschema-valid = "0.4.0"
 serde_json = "1.0.44"
+flate2 = "1.0.19"

--- a/glean-core/rlb/examples/prototype.rs
+++ b/glean-core/rlb/examples/prototype.rs
@@ -49,6 +49,8 @@ fn main() -> Result<(), Error> {
         max_events: None,
         delay_ping_lifetime_io: false,
         channel: None,
+        server_endpoint: Some("invalid-test-host".into()),
+        uploader: None,
     };
 
     let client_info = ClientInfoMetrics {

--- a/glean-core/rlb/src/configuration.rs
+++ b/glean-core/rlb/src/configuration.rs
@@ -2,10 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::net::PingUploader;
+
+/// The default server pings are sent to.
+pub(crate) const DEFAULT_GLEAN_ENDPOINT: &str = "https://incoming.telemetry.mozilla.org";
+
 /// The Glean configuration.
 ///
 /// Optional values will be filled in with default values.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Configuration {
     /// Whether upload should be enabled.
     pub upload_enabled: bool,
@@ -19,4 +24,8 @@ pub struct Configuration {
     pub delay_ping_lifetime_io: bool,
     /// The release channel the application is on, if known.
     pub channel: Option<String>,
+    /// The server pings are sent to.
+    pub server_endpoint: Option<String>,
+    /// The instance of the uploader used to send pings.
+    pub uploader: Option<Box<dyn PingUploader + 'static>>,
 }

--- a/glean-core/rlb/src/dispatcher/global.rs
+++ b/glean-core/rlb/src/dispatcher/global.rs
@@ -81,6 +81,18 @@ pub fn try_shutdown() -> Result<(), DispatchError> {
     guard().shutdown()
 }
 
+/// TEST ONLY FUNCTION.
+/// Resets the Glean state and triggers init again.
+pub(crate) fn reset_dispatcher() {
+    // We don't care about shutdown errors, since they will
+    // definitely happen if this
+    let _ = try_shutdown();
+
+    // Now that the dispatcher is shut down, replace it.
+    let mut lock = GLOBAL_DISPATCHER.write().unwrap();
+    *lock = Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT));
+}
+
 #[cfg(test)]
 mod test {
     use std::sync::{Arc, Mutex};

--- a/glean-core/rlb/src/dispatcher/global.rs
+++ b/glean-core/rlb/src/dispatcher/global.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use once_cell::sync::{Lazy, OnceCell};
-use std::sync::RwLock;
+use once_cell::sync::Lazy;
+use std::{mem, sync::RwLock};
 
 use super::{DispatchError, DispatchGuard, Dispatcher};
 
@@ -11,13 +11,17 @@ const GLOBAL_DISPATCHER_LIMIT: usize = 100;
 static GLOBAL_DISPATCHER: Lazy<RwLock<Option<Dispatcher>>> =
     Lazy::new(|| RwLock::new(Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT))));
 
-fn guard() -> &'static DispatchGuard {
-    static GLOBAL_GUARD: OnceCell<DispatchGuard> = OnceCell::new();
-
-    GLOBAL_GUARD.get_or_init(|| {
-        let lock = GLOBAL_DISPATCHER.read().unwrap();
-        lock.as_ref().unwrap().guard()
-    })
+/// Get a dispatcher for the global queue.
+///
+/// A dispatcher is cheap to create, so we create one on every access instead of caching it.
+/// This avoids troubles for tests where the global dispatcher _can_ change.
+fn guard() -> DispatchGuard {
+    GLOBAL_DISPATCHER
+        .read()
+        .unwrap()
+        .as_ref()
+        .map(|dispatcher| dispatcher.guard())
+        .unwrap()
 }
 
 /// Launches a new task on the global dispatch queue.
@@ -44,16 +48,7 @@ pub fn launch(task: impl FnOnce() + Send + 'static) {
 
 /// Block until all tasks prior to this call are processed.
 pub fn block_on_queue() {
-    let guard = {
-        GLOBAL_DISPATCHER
-            .write()
-            .unwrap()
-            .as_ref()
-            .map(|dispatcher| dispatcher.guard())
-            .unwrap()
-    };
-
-    guard.block_on_queue();
+    guard().block_on_queue();
 }
 
 /// Starts processing queued tasks in the global dispatch queue.
@@ -61,15 +56,7 @@ pub fn block_on_queue() {
 /// This function blocks until queued tasks prior to this call are finished.
 /// Once the initial queue is empty the dispatcher will wait for new tasks to be launched.
 pub fn flush_init() -> Result<(), DispatchError> {
-    let mut guard = {
-        GLOBAL_DISPATCHER
-            .write()
-            .unwrap()
-            .as_ref()
-            .map(|dispatcher| dispatcher.guard())
-            .unwrap()
-    };
-    guard.flush_init()
+    guard().flush_init()
 }
 
 /// Shuts down the dispatch queue.
@@ -89,8 +76,15 @@ pub(crate) fn reset_dispatcher() {
     let _ = try_shutdown();
 
     // Now that the dispatcher is shut down, replace it.
+    // For that we
+    // 1. Create a new
+    // 2. Replace the global one
+    // 3. Wait for the old one to fully finish
+    // 4. Only then return (and thus release the lock)
     let mut lock = GLOBAL_DISPATCHER.write().unwrap();
-    *lock = Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT));
+    let new_dispatcher = Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT));
+    let old_dispatcher = mem::replace(&mut *lock, new_dispatcher);
+    old_dispatcher.map(|d| d.join());
 }
 
 #[cfg(test)]

--- a/glean-core/rlb/src/dispatcher/mod.rs
+++ b/glean-core/rlb/src/dispatcher/mod.rs
@@ -115,7 +115,10 @@ impl DispatchGuard {
         self.send(task)
     }
 
-    pub fn shutdown(&self) -> Result<(), DispatchError> {
+    pub fn shutdown(&mut self) -> Result<(), DispatchError> {
+        // Need to flush in order for the thread to actually process anything,
+        // including the shutdown command.
+        self.flush_init().ok();
         self.send(Command::Shutdown)
     }
 

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -435,7 +435,7 @@ pub(crate) fn submit_ping_by_name_sync(ping: &str, reason: Option<&str>) {
         glean.submit_ping_by_name(&ping, reason.as_deref()).ok()
     });
 
-    if submitted_ping.unwrap() {
+    if let Some(true) = submitted_ping {
         let uploader = get_upload_manager().lock().unwrap();
         uploader.trigger_upload();
     }
@@ -443,6 +443,7 @@ pub(crate) fn submit_ping_by_name_sync(ping: &str, reason: Option<&str>) {
 
 /// TEST ONLY FUNCTION.
 /// Resets the Glean state and triggers init again.
+#[cfg(test)]
 #[allow(dead_code)]
 pub(crate) fn reset_glean(cfg: Configuration, client_info: ClientInfoMetrics, clear_stores: bool) {
     // Destroy the existing glean instance from glean-core.

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -25,6 +25,8 @@
 //!     max_events: None,
 //!     delay_ping_lifetime_io: false,
 //!     channel: None,
+//!     server_endpoint: None,
+//!     uploader: None,
 //! };
 //! glean::initialize(cfg, ClientInfoMetrics::unknown());
 //!
@@ -39,6 +41,7 @@ use once_cell::sync::OnceCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
+use configuration::DEFAULT_GLEAN_ENDPOINT;
 pub use configuration::Configuration;
 pub use core_metrics::ClientInfoMetrics;
 pub use glean_core::{global_glean, setup_glean, CommonMetricData, Error, Glean, Lifetime, Result};
@@ -47,6 +50,7 @@ mod configuration;
 mod core_metrics;
 pub mod dispatcher;
 mod glean_metrics;
+mod net;
 pub mod private;
 mod system;
 
@@ -92,9 +96,31 @@ fn setup_state(state: RustBindingsState) {
     }
 }
 
+/// An instance of the upload manager.
+///
+/// Requires a Mutex, because in tests we can actual reset this.
+static UPLOAD_MANAGER: OnceCell<Mutex<net::UploadManager>> = OnceCell::new();
+
+/// Get a reference to the global upload manager.
+///
+/// Panics if no global state object was set.
+fn get_upload_manager() -> &'static Mutex<net::UploadManager> {
+    UPLOAD_MANAGER.get().unwrap()
+}
+
+/// Set or replace the global Glean object.
+fn setup_upload_manager(upload_manager: net::UploadManager) {
+    if UPLOAD_MANAGER.get().is_none() {
+        UPLOAD_MANAGER.set(Mutex::new(upload_manager));
+    } else {
+        let mut lock = UPLOAD_MANAGER.get().unwrap().lock().unwrap();
+        *lock = upload_manager;
+    }
+}
+
 fn with_glean<F, R>(f: F) -> R
 where
-    F: Fn(&Glean) -> R,
+    F: FnOnce(&Glean) -> R,
 {
     let glean = global_glean().expect("Global Glean object not initialized");
     let lock = glean.lock().unwrap();
@@ -103,7 +129,7 @@ where
 
 fn with_glean_mut<F, R>(f: F) -> R
 where
-    F: Fn(&mut Glean) -> R,
+    F: FnOnce(&mut Glean) -> R,
 {
     let glean = global_glean().expect("Global Glean object not initialized");
     let mut lock = glean.lock().unwrap();
@@ -156,6 +182,15 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
             client_info,
         });
 
+        // Initialize the ping uploader.
+        setup_upload_manager(
+            net::UploadManager::new(
+                cfg.server_endpoint.unwrap_or(DEFAULT_GLEAN_ENDPOINT.to_string()),
+                cfg.uploader
+                    .unwrap_or_else(|| Box::new(net::HttpUploader) as Box<dyn net::PingUploader>)
+            )
+        );
+
         let upload_enabled = cfg.upload_enabled;
 
         with_glean_mut(|glean| {
@@ -196,7 +231,8 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
             // 1. Pings were submitted through Glean and it is ready to upload those pings;
             // 2. Upload is disabled, to upload a possible deletion-request ping.
             if pings_submitted || !upload_enabled {
-                // TODO: bug 1672958.
+                let uploader = get_upload_manager().lock().unwrap();
+                uploader.trigger_upload();
             }
 
             // Set up information and scheduling for Glean owned pings. Ideally, the "metrics"
@@ -208,7 +244,7 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
             // force-closed. If that's the case, submit a 'baseline' ping with the
             // reason "dirty_startup". We only do that from the second run.
             if !is_first_run && dirty_flag {
-                // TODO: bug 1672958 - submit_ping_by_name_sync("baseline", "dirty_startup");
+                // TODO: bug 1672956 - submit_ping_by_name_sync("baseline", "dirty_startup");
             }
 
             // From the second time we run, after all startup pings are generated,
@@ -300,19 +336,30 @@ pub fn set_upload_enabled(enabled: bool) {
                 initialize_core_metrics(&glean, &state.client_info, state.channel.clone());
             }
 
-            // TODO: trigger upload for the deletion-ping. Will happen in bug 1672952.
+            if old_enabled && !enabled {
+                // If uploading is disabled, we need to send the deletion-request ping:
+                // note that glean-core takes care of generating it.
+                let uploader = get_upload_manager().lock().unwrap();
+                uploader.trigger_upload();
+            }
         });
     });
 }
 
 /// Register a new [`PingType`](metrics/struct.PingType.html).
 pub fn register_ping_type(ping: &private::PingType) {
-    let ping = ping.clone();
-    dispatcher::launch(move || {
-        with_glean_mut(|glean| {
-            glean.register_ping_type(&ping.ping_type);
+    // If this happens after Glean.initialize is called (and returns),
+    // we dispatch ping registration on the thread pool.
+    // Registering a ping should not block the application.
+    // Submission itself is also dispatched, so it will always come after the registration.
+    if was_initialize_called() {
+        let ping = ping.clone();
+        dispatcher::launch(move || {
+            with_glean_mut(|glean| {
+                glean.register_ping_type(&ping.ping_type);
+            })
         })
-    })
+    }
 }
 
 /// Collects and submits a ping for eventual uploading.
@@ -329,8 +376,49 @@ pub fn submit_ping_by_name(ping: &str, reason: Option<&str>) {
     let ping = ping.to_string();
     let reason = reason.map(|s| s.to_string());
     dispatcher::launch(move || {
-        with_glean(|glean| glean.submit_ping_by_name(&ping, reason.as_deref()).ok());
+        submit_ping_by_name_sync(&ping, reason.as_deref());
     })
+}
+
+/// Collect and submit a ping (by its name) for eventual upload, synchronously.
+/// 
+/// The ping will be looked up in the known instances of `private::PingType`. If the
+/// ping isn't known, an error is logged and the ping isn't queued for uploading.
+/// 
+/// The ping content is assembled as soon as possible, but upload is not
+/// guaranteed to happen immediately, as that depends on the upload
+/// policies.
+/// 
+/// If the ping currently contains no content, it will not be assembled and
+/// queued for sending, unless explicitly specified otherwise in the registry
+/// file.
+///
+/// ## Arguments
+///
+/// * `ping_name` - the name of the ping to submit.
+/// * `reason` - the reason the ping is being submitted.
+pub(crate) fn submit_ping_by_name_sync(ping: &str, reason: Option<&str>) {
+    if !was_initialize_called() {
+        log::error!("Glean must be initialized before submitting pings.");
+        return;
+    }
+
+    let submitted_ping = with_glean(|glean| {
+        if !glean.is_upload_enabled() {
+            log::info!("Glean disabled: not submitting any pings.");
+            // This won't actually return from `submit_ping_by_name`, but
+            // returning `false` here skips spinning up the uploader below,
+            // which is basically the same.
+            return Some(false);
+        }
+
+        glean.submit_ping_by_name(&ping, reason.as_deref()).ok()
+    });
+
+    if submitted_ping.unwrap() {
+        let uploader = get_upload_manager().lock().unwrap();
+        uploader.trigger_upload();
+    }
 }
 
 #[cfg(test)]

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -48,9 +48,9 @@ pub use glean_core::{global_glean, setup_glean, CommonMetricData, Error, Glean, 
 
 mod configuration;
 mod core_metrics;
-pub mod dispatcher;
+mod dispatcher;
 mod glean_metrics;
-mod net;
+pub mod net;
 pub mod private;
 mod system;
 

--- a/glean-core/rlb/src/net/http_uploader.rs
+++ b/glean-core/rlb/src/net/http_uploader.rs
@@ -4,7 +4,7 @@
 
 use crate::net::{PingUploader, UploadResult};
 
-/// A description of a component used to upload pings.
+/// A simple mechanism to upload pings over HTTPS.
 #[derive(Debug)]
 pub struct HttpUploader;
 

--- a/glean-core/rlb/src/net/http_uploader.rs
+++ b/glean-core/rlb/src/net/http_uploader.rs
@@ -18,7 +18,7 @@ impl PingUploader for HttpUploader {
     /// * `headers` - a vector of tuples containing the headers to send with
     ///   the request, i.e. (Name, Value).
     fn upload(&self, url: String, _body: Vec<u8>, _headers: Vec<(String, String)>) -> UploadResult {
-        log::debug!("TODO bug xxx: submitting to {:?}", url);
+        log::debug!("TODO bug 1675468: submitting to {:?}", url);
         UploadResult::HttpStatus(200)
     }
 }

--- a/glean-core/rlb/src/net/http_uploader.rs
+++ b/glean-core/rlb/src/net/http_uploader.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::net::{PingUploader, UploadResult};
+
+/// A description of a component used to upload pings.
+#[derive(Debug)]
+pub struct HttpUploader;
+
+impl PingUploader for HttpUploader {
+    /// Uploads a ping to a server.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - the URL path to upload the data to.
+    /// * `body` - the serialized text data to send.
+    /// * `headers` - a vector of tuples containing the headers to send with
+    ///   the request, i.e. (Name, Value).
+    fn upload(&self, url: String, _body: Vec<u8>, _headers: Vec<(String, String)>) -> UploadResult {
+        log::debug!("TODO bug xxx: submitting to {:?}", url);
+        UploadResult::HttpStatus(200)
+    }
+}

--- a/glean-core/rlb/src/net/mod.rs
+++ b/glean-core/rlb/src/net/mod.rs
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A module responsible for the Glean upload logic.
+//!
+//! This doesn't perform the actual upload but rather handles
+//! retries, upload limitations and error tracking.
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::thread;
+use std::time::Duration;
+
+use crate::with_glean;
+use glean_core::upload::PingUploadTask;
+pub use glean_core::upload::{PingRequest, UploadResult};
+
+pub use http_uploader::*;
+
+mod http_uploader;
+
+/// The number of milliseconds to make the uploader thread, when told to,
+/// by glean-core.
+const THROTTLE_BACKOFF_TIME_MS: u64 = 60_000;
+
+/// A description of a component used to upload pings.
+pub trait PingUploader: std::fmt::Debug + Send + Sync {
+    /// Uploads a ping to a server.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - the URL path to upload the data to.
+    /// * `body` - the serialized text data to send.
+    /// * `headers` - a vector of tuples containing the headers to send with
+    ///   the request, i.e. (Name, Value).
+    fn upload(&self, url: String, body: Vec<u8>, headers: Vec<(String, String)>) -> UploadResult;
+}
+
+/// The logic for uploading pings: this leaves the actual upload mechanism as
+/// a detail of the user-provided object implementing `PingUploader`.
+pub(crate) struct UploadManager {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    server_endpoint: String,
+    uploader: Box<dyn PingUploader + 'static>,
+    thread_running: AtomicBool,
+}
+
+impl UploadManager {
+    /// Create a new instance of the upload manager.
+    ///
+    /// # Arguments
+    ///
+    /// * `server_endpoint` -  the server pings are sent to.
+    /// * `new_uploader` - the instance of the uploader used to send pings.
+    pub(crate) fn new(
+        server_endpoint: String,
+        new_uploader: Box<dyn PingUploader + 'static>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                server_endpoint,
+                uploader: new_uploader,
+                thread_running: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Signals Glean to upload pings at the next best opportunity.
+    pub(crate) fn trigger_upload(&self) {
+        if self.inner.thread_running.load(Ordering::SeqCst) {
+            log::debug!("The upload task is already running.");
+            return;
+        }
+
+        let inner = Arc::clone(&self.inner);
+
+        thread::spawn(move || {
+            // Mark the uploader as running.
+            inner.thread_running.store(true, Ordering::SeqCst);
+
+            loop {
+                let incoming_task = with_glean(|glean| glean.get_upload_task());
+
+                match incoming_task {
+                    PingUploadTask::Upload(request) => {
+                        let doc_id = request.document_id.clone();
+                        let upload_url = format!("{}{}", inner.server_endpoint, request.path);
+                        let headers: Vec<(String, String)> = request.headers.into_iter().collect();
+                        let result = inner.uploader.upload(upload_url, request.body, headers);
+                        // Process the upload response.
+                        with_glean(|glean| glean.process_ping_upload_response(&doc_id, result));
+                    }
+                    PingUploadTask::Wait => {
+                        thread::sleep(Duration::from_millis(THROTTLE_BACKOFF_TIME_MS));
+                    }
+                    PingUploadTask::Done => {
+                        // Nothing to do here, break out of the loop and clear the
+                        // running flag.
+                        inner.thread_running.store(false, Ordering::SeqCst);
+                        return;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/glean-core/rlb/src/net/mod.rs
+++ b/glean-core/rlb/src/net/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! A module responsible for the Glean upload logic.
+//! Handling the Glean upload logic.
 //!
 //! This doesn't perform the actual upload but rather handles
 //! retries, upload limitations and error tracking.
@@ -22,9 +22,8 @@ pub use http_uploader::*;
 
 mod http_uploader;
 
-/// The number of milliseconds to make the uploader thread, when told to,
-/// by glean-core.
-const THROTTLE_BACKOFF_TIME_MS: u64 = 60_000;
+/// The duration the uploader thread should sleep, when told to by glean-core.
+const THROTTLE_BACKOFF_TIME: Duration = Duration::from_secs(60);
 
 /// A description of a component used to upload pings.
 pub trait PingUploader: std::fmt::Debug + Send + Sync {
@@ -97,7 +96,7 @@ impl UploadManager {
                         with_glean(|glean| glean.process_ping_upload_response(&doc_id, result));
                     }
                     PingUploadTask::Wait => {
-                        thread::sleep(Duration::from_millis(THROTTLE_BACKOFF_TIME_MS));
+                        thread::sleep(THROTTLE_BACKOFF_TIME);
                     }
                     PingUploadTask::Done => {
                         // Nothing to do here, break out of the loop and clear the

--- a/glean-core/rlb/src/private/ping.rs
+++ b/glean-core/rlb/src/private/ping.rs
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/// Stores information about a ping.
-///
-/// This is required so that given metric data queued on disk we can send
-/// pings with the correct settings, e.g. whether it has a client_id.
+/// A Glean ping.
 #[derive(Clone, Debug)]
 pub struct PingType {
     pub(crate) name: String,
@@ -15,7 +12,7 @@ pub struct PingType {
 impl PingType {
     /// Creates a new ping type.
     ///
-    /// # Arguments
+    /// ## Arguments
     ///
     /// * `name` - The name of the ping.
     /// * `include_client_id` - Whether to include the client ID in the assembled ping when.
@@ -34,10 +31,30 @@ impl PingType {
             send_if_empty,
             reason_codes,
         );
-        Self { name, ping_type }
+
+        let me = Self { name, ping_type };
+        crate::register_ping_type(&me);
+        me
     }
 
-    /// Submits the ping.
+    /// Collect and submit the ping for eventual upload.
+    ///
+    /// This will collect all stored data to be included in the ping.
+    /// Data with lifetime `ping` will then be reset.
+    ///
+    /// If the ping is configured with `send_if_empty = false`
+    /// and the ping currently contains no content,
+    /// it will not be queued for upload.
+    /// If the ping is configured with `send_if_empty = true`
+    /// it will be queued for upload even if otherwise empty.
+    ///
+    /// Pings always contain the `ping_info` and `client_info` sections.
+    /// See [ping sections](https://mozilla.github.io/glean/book/user/pings/index.html#ping-sections)
+    /// for details.
+    ///
+    /// ## Parameters
+    /// * `reason` - The reason the ping is being submitted.
+    ///              Must be one of the configured `reason_codes`.
     pub fn submit(&self, reason: Option<&str>) {
         crate::submit_ping(self, reason)
     }

--- a/glean-core/rlb/src/private/ping.rs
+++ b/glean-core/rlb/src/private/ping.rs
@@ -12,7 +12,7 @@ pub struct PingType {
 impl PingType {
     /// Creates a new ping type.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `name` - The name of the ping.
     /// * `include_client_id` - Whether to include the client ID in the assembled ping when.
@@ -52,7 +52,8 @@ impl PingType {
     /// See [ping sections](https://mozilla.github.io/glean/book/user/pings/index.html#ping-sections)
     /// for details.
     ///
-    /// ## Parameters
+    /// # Arguments
+    ///
     /// * `reason` - The reason the ping is being submitted.
     ///              Must be one of the configured `reason_codes`.
     pub fn submit(&self, reason: Option<&str>) {

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -34,11 +34,11 @@ fn new_glean(configuration: Option<Configuration>) -> tempfile::TempDir {
             delay_ping_lifetime_io: false,
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
-            uploader: None
-        }
+            uploader: None,
+        },
     };
 
-    initialize(cfg, ClientInfoMetrics::unknown());
+    crate::reset_glean(cfg, ClientInfoMetrics::unknown(), true);
     dir
 }
 
@@ -53,11 +53,15 @@ fn send_a_ping() {
     // using a crossbeam channel.
     #[derive(Debug)]
     pub struct FakeUploader {
-        sender: crossbeam_channel::Sender<String>
+        sender: crossbeam_channel::Sender<String>,
     };
     impl net::PingUploader for FakeUploader {
-        fn upload(&self, url: String, _body: Vec<u8>, _headers: Vec<(String, String)>) -> net::UploadResult 
-        {
+        fn upload(
+            &self,
+            url: String,
+            _body: Vec<u8>,
+            _headers: Vec<(String, String)>,
+        ) -> net::UploadResult {
             self.sender.send(url).unwrap();
             net::UploadResult::HttpStatus(200)
         }
@@ -75,7 +79,7 @@ fn send_a_ping() {
         delay_ping_lifetime_io: false,
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
-        uploader: Some(Box::new(FakeUploader{sender: s}))
+        uploader: Some(Box::new(FakeUploader { sender: s })),
     };
 
     let _t = new_glean(Some(cfg));
@@ -85,7 +89,7 @@ fn send_a_ping() {
     const PING_NAME: &str = "test-ping";
     let custom_ping = private::PingType::new(PING_NAME, true, true, vec![]);
     custom_ping.submit(None);
-    
+
     // Wait for the ping to arrive.
     let url = r.recv().unwrap();
     assert_eq!(url.contains(PING_NAME), true);
@@ -157,13 +161,15 @@ fn initialize_must_not_crash_if_data_dir_is_messed_up() {
         delay_ping_lifetime_io: false,
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
-        uploader: None
+        uploader: None,
     };
 
-    initialize(cfg, ClientInfoMetrics::unknown());
-
-    // TODO: is this test working? is it waiting for init to finish?
-    dispatcher::block_on_queue();
+    reset_glean(cfg, ClientInfoMetrics::unknown(), false);
+    // Glean init is async and, for this test, it bails out early due to
+    // an error: we can do nothing but wait. Tests in other bindings use
+    // the dispatcher's test mode, which runs tasks sequentially on the main
+    // thread, so no sleep is required. Bug 1675215 might fix this, as well.
+    std::thread::sleep(std::time::Duration::from_secs(3));
 }
 
 #[test]
@@ -174,30 +180,53 @@ fn queued_recorded_metrics_correctly_record_during_init() {
 
 #[test]
 fn initializing_twice_is_a_noop() {
+    let _lock = GLOBAL_LOCK.lock().unwrap();
+    env_logger::try_init().ok();
+
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
 
-    initialize(Configuration {
-        data_path: tmpname.clone().into(),
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-        channel: Some("testing".into()),
-        server_endpoint: Some("invalid-test-host".into()),
-        uploader: None
-    }, ClientInfoMetrics::unknown());
+    reset_glean(
+        Configuration {
+            data_path: tmpname.clone(),
+            application_id: GLOBAL_APPLICATION_ID.into(),
+            upload_enabled: true,
+            max_events: None,
+            delay_ping_lifetime_io: false,
+            channel: Some("testing".into()),
+            server_endpoint: Some("invalid-test-host".into()),
+            uploader: None,
+        },
+        ClientInfoMetrics::unknown(),
+        true,
+    );
 
-    initialize(Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-        channel: Some("testing".into()),
-        server_endpoint: Some("invalid-test-host".into()),
-        uploader: None
-    }, ClientInfoMetrics::unknown());
+    // Glean init is async and we need to wait for it to complete. There
+    // is nothing we can do but wait. Tests in other bindings use
+    // the dispatcher's test mode, which runs tasks sequentially on the main
+    // thread, so no sleep is required. Bug 1675215 might fix this, as well.
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    reset_glean(
+        Configuration {
+            data_path: tmpname,
+            application_id: GLOBAL_APPLICATION_ID.into(),
+            upload_enabled: true,
+            max_events: None,
+            delay_ping_lifetime_io: false,
+            channel: Some("testing".into()),
+            server_endpoint: Some("invalid-test-host".into()),
+            uploader: None,
+        },
+        ClientInfoMetrics::unknown(),
+        false,
+    );
+
+    // Glean init is async and, for this test, it bails out early due to
+    // being initialized: we can do nothing but wait. Tests in other bindings use
+    // the dispatcher's test mode, which runs tasks sequentially on the main
+    // thread, so no sleep is required. Bug 1675215 might fix this, as well.
+    std::thread::sleep(std::time::Duration::from_secs(3));
 }
 
 #[test]

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -67,7 +67,7 @@ fn send_a_ping() {
         }
     }
 
-    // Createa  custom configuration to use a fake uploader.
+    // Create a custom configuration to use a fake uploader.
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
 
@@ -165,10 +165,13 @@ fn initialize_must_not_crash_if_data_dir_is_messed_up() {
     };
 
     reset_glean(cfg, ClientInfoMetrics::unknown(), false);
+    // TODO(bug 1675215): ensure initialize runs through dispatcher.
     // Glean init is async and, for this test, it bails out early due to
-    // an error: we can do nothing but wait. Tests in other bindings use
-    // the dispatcher's test mode, which runs tasks sequentially on the main
-    // thread, so no sleep is required. Bug 1675215 might fix this, as well.
+    // an caused by not being able to create the data dir: we can do nothing
+    // but wait. Tests in other bindings use the dispatcher's test mode, which
+    // runs tasks sequentially on the main thread, so no sleep is required,
+    // because we're guaranteed that, once we reach this point, the full
+    // init potentially ran.
     std::thread::sleep(std::time::Duration::from_secs(3));
 }
 
@@ -201,11 +204,7 @@ fn initializing_twice_is_a_noop() {
         true,
     );
 
-    // Glean init is async and we need to wait for it to complete. There
-    // is nothing we can do but wait. Tests in other bindings use
-    // the dispatcher's test mode, which runs tasks sequentially on the main
-    // thread, so no sleep is required. Bug 1675215 might fix this, as well.
-    std::thread::sleep(std::time::Duration::from_secs(3));
+    dispatcher::block_on_queue();
 
     reset_glean(
         Configuration {
@@ -222,6 +221,7 @@ fn initializing_twice_is_a_noop() {
         false,
     );
 
+    // TODO(bug 1675215): ensure initialize runs through dispatcher.
     // Glean init is async and, for this test, it bails out early due to
     // being initialized: we can do nothing but wait. Tests in other bindings use
     // the dispatcher's test mode, which runs tasks sequentially on the main

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -32,6 +32,8 @@ fn new_glean() -> tempfile::TempDir {
         max_events: None,
         delay_ping_lifetime_io: false,
         channel: None,
+        server_endpoint: Some("invalid-test-host".into()),
+        uploader: None,
     };
 
     let client_info = ClientInfoMetrics {

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -54,7 +54,7 @@ fn validate_against_schema() {
 
     let (s, r) = crossbeam_channel::bounded::<Vec<u8>>(1);
 
-    // Define a fake uploader that reports back the submission URL
+    // Define a fake uploader that reports back the submitted payload
     // using a crossbeam channel.
     #[derive(Debug)]
     pub struct ValidatingUploader {

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -2,14 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::io::Read;
 
+use flate2::read::GzDecoder;
 use jsonschema_valid::{self, schemas::Draft};
 use serde_json::Value;
 
-use glean::{private::PingType, ClientInfoMetrics, Configuration};
+use glean::{ClientInfoMetrics, Configuration};
 
 const SCHEMA_JSON: &str = include_str!("../../../glean.1.schema.json");
 
@@ -21,19 +20,22 @@ const GLOBAL_APPLICATION_ID: &str = "org.mozilla.glean.test.app";
 
 // Create a new instance of Glean with a temporary directory.
 // We need to keep the `TempDir` alive, so that it's not deleted before we stop using it.
-fn new_glean() -> tempfile::TempDir {
+fn new_glean(configuration: Option<Configuration>) -> tempfile::TempDir {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
 
-    let cfg = Configuration {
-        data_path: tmpname,
-        application_id: GLOBAL_APPLICATION_ID.into(),
-        upload_enabled: true,
-        max_events: None,
-        delay_ping_lifetime_io: false,
-        channel: None,
-        server_endpoint: Some("invalid-test-host".into()),
-        uploader: None,
+    let cfg = match configuration {
+        Some(c) => c,
+        None => Configuration {
+            data_path: tmpname,
+            application_id: GLOBAL_APPLICATION_ID.into(),
+            upload_enabled: true,
+            max_events: None,
+            delay_ping_lifetime_io: false,
+            channel: Some("testing".into()),
+            server_endpoint: Some("invalid-test-host".into()),
+            uploader: None,
+        },
     };
 
     let client_info = ClientInfoMetrics {
@@ -50,39 +52,63 @@ fn new_glean() -> tempfile::TempDir {
 fn validate_against_schema() {
     let schema = load_schema();
 
-    let dir = new_glean();
+    let (s, r) = crossbeam_channel::bounded::<Vec<u8>>(1);
 
-    // Register and submit a ping for testing
-    let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
-    glean::register_ping_type(&ping_type);
-    ping_type.submit(None);
-    glean::dispatcher::block_on_queue();
+    // Define a fake uploader that reports back the submission URL
+    // using a crossbeam channel.
+    #[derive(Debug)]
+    pub struct ValidatingUploader {
+        sender: crossbeam_channel::Sender<Vec<u8>>,
+    };
+    impl glean::net::PingUploader for ValidatingUploader {
+        fn upload(
+            &self,
+            _url: String,
+            body: Vec<u8>,
+            _headers: Vec<(String, String)>,
+        ) -> glean::net::UploadResult {
+            self.sender.send(body).unwrap();
+            glean::net::UploadResult::HttpStatus(200)
+        }
+    }
 
-    // Read the ping from disk.
-    // We know where it should be placed.
-    let pings_dir = dir.path().join("pending_pings");
-    let pending_pings: Vec<PathBuf> = pings_dir
-        .read_dir()
-        .unwrap()
-        .filter_map(|entry| entry.ok())
-        .filter_map(|entry| match entry.file_type() {
-            Ok(f) if f.is_file() => Some(entry.path()),
-            _ => None,
-        })
-        .collect();
+    // Create a custom configuration to use a validating uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
 
-    // There should only be one: our custom ping.
-    assert_eq!(1, pending_pings.len());
+    let cfg = Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        channel: Some("testing".into()),
+        server_endpoint: Some("invalid-test-host".into()),
+        uploader: Some(Box::new(ValidatingUploader { sender: s })),
+    };
+    let _ = new_glean(Some(cfg));
 
-    // 1. line: the URL
-    // 2. line: the JSON body
-    let file = File::open(&pending_pings[0]).unwrap();
-    let mut lines = BufReader::new(file).lines();
-    let _url = lines.next().unwrap().unwrap();
-    let body = lines.next().unwrap().unwrap();
+    // Define a new ping and submit it.
+    const PING_NAME: &str = "test-ping";
+    let custom_ping = glean::private::PingType::new(PING_NAME, true, true, vec![]);
+    custom_ping.submit(None);
+
+    // Wait for the ping to arrive.
+    let raw_body = r.recv().unwrap();
+
+    // Decode the gzipped body.
+    let mut gzip_decoder = GzDecoder::new(&raw_body[..]);
+    let mut s = String::with_capacity(raw_body.len());
+
+    let data = gzip_decoder
+        .read_to_string(&mut s)
+        .ok()
+        .map(|_| &s[..])
+        .or_else(|| std::str::from_utf8(&raw_body).ok())
+        .and_then(|payload| serde_json::from_str(payload).ok())
+        .unwrap();
 
     // Now validate against the vendored schema
-    let data = serde_json::from_str(&body).unwrap();
     let cfg = jsonschema_valid::Config::from_schema(&schema, Some(Draft::Draft6)).unwrap();
     let validation = cfg.validate(&data);
     match validation {


### PR DESCRIPTION
This introduces the 'net' module for the RLB, fixes the ping submission functions and allows RLB consumers to
specify uploader implementations.

Thanks @badboy for the help on the flaky tests.