### PR TITLE
Don't run Miniconda install in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Android
   * Update the JNA dependency from 5.2.0 to 5.6.0
+  * The `glean-gradle-plugin` now makes sure that only a single Miniconda installation will happen at the same time to avoid a race condition when multiple components within the same project are using Glean.
 
 # v33.0.4 (2020-09-28)
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -12,6 +12,8 @@ import org.gradle.api.internal.artifacts.ArtifactAttributes
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.TaskProvider
 
+import java.util.concurrent.Semaphore
+
 // The suppression "GrPackage" is needed below since Android Studio wants this file to have
 // a package name, but adding one causes the build to fail with:
 //    "'.../GleanGradlePlugin.groovy' should not contain a package statement"
@@ -40,6 +42,8 @@ class GleanPlugin implements Plugin<Project> {
     private String MINICONDA_VERSION = "4.5.11"
 
     private String TASK_NAME_PREFIX = "gleanGenerateMetrics"
+
+    private Semaphore bootstrapMinicondaSemaphore = new Semaphore(1)
 
     /* This script runs a given Python module as a "main" module, like
      * `python -m module`. However, it first checks that the installed
@@ -411,6 +415,15 @@ except:
             project.tasks.whenTaskAdded { task ->
                 if (task.name.startsWith('Bootstrap_CONDA')) {
                     task.dependsOn(createBuildDir)
+
+                    // The Bootstrap_CONDA* tasks all install miniconda to the
+                    // same place, so they can't run at the same time. This
+                    // holds a semaphore while running the task to make sure
+                    // only one of these classes of tasks runs at the same time. 
+                    // Solution proposed in this Gradle bug:
+                    // https://github.com/gradle/gradle/issues/7047#issuecomment-430139316
+                    task.doFirst { bootstrapMinicondaSemaphore.acquire() }
+                    task.doLast { bootstrapMinicondaSemaphore.release() }
                 }
             }
             project.preBuild.dependsOn(createBuildDir)


### PR DESCRIPTION
This should address the intermittent build failures in android-components [described here](https://github.com/gradle/gradle/issues/7047#issuecomment-430139316).

We will need to make a Glean release and ship it to android-components to fix the build failures there.  I was unable to confirm the existing build failure in a-c, but I did confirm that this patch seems to do no harm there.

Cc @pocmo