### PR TITLE
Bug 1672722 - Ignore return value of a launch that may fail or it might not.

### DIFF
--- a/glean-core/rlb/src/dispatcher/mod.rs
+++ b/glean-core/rlb/src/dispatcher/mod.rs
@@ -414,12 +414,12 @@ mod test {
         dispatcher.guard().shutdown().unwrap();
         {
             let result = Arc::clone(&result);
-            dispatcher
-                .guard()
-                .launch(move || {
-                    result.lock().unwrap().push(0);
-                })
-                .unwrap();
+            // This might fail because the shutdown is quick enough,
+            // or it might succeed and still send the task.
+            // In any case that task should not be executed.
+            let _ = dispatcher.guard().launch(move || {
+                result.lock().unwrap().push(0);
+            });
         }
 
         dispatcher.join().unwrap();


### PR DESCRIPTION
Just before the launch we send a shutdown command.
If processing is faster on the main thread it might still be able to
send the following command.
But it also might not.

In any case a task that is sent after a shutdown command should not be executed.
And that's what we test for.

Note: the *global* dispatcher API does not return a `Result`, so users
shouldn't even need to deal with this.