### PR TITLE
Change to lockfile-only strategy for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: lockfile-only
 
   # glean-python
   - package-ecosystem: "pip"


### PR DESCRIPTION
From the docs at https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy: 

    Only create pull requests to update lockfiles updates. Ignore any new versions that would require package manifest changes.


---


Followup after #1295 