### PR TITLE
Bug 1676712: Reduce throttle backoff time to 1s and fixes it for python and swift

### DIFF
--- a/glean-core/csharp/Glean/Net/BaseUploader.cs
+++ b/glean-core/csharp/Glean/Net/BaseUploader.cs
@@ -19,7 +19,7 @@ namespace Mozilla.Glean.Net
     /// </summary>
     internal class BaseUploader
     {
-        internal const int THROTTLED_BACKOFF_MS = 60_000;
+        internal const int THROTTLED_BACKOFF_S = 1;
         private readonly IPingUploader uploader;
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Mozilla.Glean.Net
                         }
                         break;
                     case UploadTaskTag.Wait:
-                        Thread.Sleep(THROTTLED_BACKOFF_MS);
+                        Thread.Sleep(THROTTLED_BACKOFF_S * 1000);
                         break;
                     case UploadTaskTag.Done:
                         // Nothing to do here, break out of the loop.

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -13,7 +13,7 @@ public class HttpPingUploader {
         // Since ping file names are UUIDs, this matches UUIDs for filtering purposes
         static let logTag = "glean/HttpPingUploader"
         static let connectionTimeout = 10000
-        static let throttleBackoffMs: UInt32 = 60_000
+        static let throttleBackoffS: UInt32 = 1
 
         // For this error, the ping will be retried later
         static let recoverableErrorStatusCode: UInt16 = 500
@@ -118,7 +118,7 @@ public class HttpPingUploader {
                     glean_process_ping_upload_response(&incomingTask, result.toFfi())
                 }
             case .wait:
-                sleep(Constants.throttleBackoffMs)
+                sleep(Constants.throttleBackoffS)
                 continue
             case .done:
                 return

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -230,9 +230,6 @@ class Glean:
         The temporary directory will be destroyed when Glean is initialized
         again or at process shutdown.
         """
-        # Lower throttle backoff time for testing
-        PingUploadWorker._throttle_backoff_time = 1
-
         actual_data_dir = Path(tempfile.TemporaryDirectory().name)
         cls.initialize(
             application_id,

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -23,7 +23,8 @@ log = logging.getLogger(__name__)
 
 
 class PingUploadWorker:
-    _throttle_backoff_time = 60_000
+    # In seconds
+    _throttle_backoff_time = 1.0
 
     @classmethod
     def process(cls):


### PR DESCRIPTION
Fixes regression introduced by PR #1240 :
Python and Swift "sleep" functions are expecting "seconds" and not ms.