### PR TITLE
1678151: Record an error if UUID is invalid (affects only Python)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Rust
   * Introduce the UUID metric type in the RLB.
   * Introduce the Labeled metric type in the RLB [#1327](https://github.com/mozilla/glean/pull/1327).
+* Python
+  * BUGFIX: Setting a UUID metric to a value that is not in the expected UUID format will now record an error with the Glean error reporting system.
 
 # v33.4.0 (2020-11-17)
 

--- a/docs/user/metrics/uuid.md
+++ b/docs/user/metrics/uuid.md
@@ -171,7 +171,7 @@ assert_eq!(u, user::client_id.test_get_value(None).unwrap());
 
 ## Recorded errors
 
-* None.
+* `invalid_value`: if the value is set to a string that is not a UUID (only applies for dynamically-typed languages, such as Python).
 
 ## Reference
 

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -786,6 +786,10 @@ uint64_t glean_new_uuid_metric(FfiStr category,
                                Lifetime lifetime,
                                uint8_t disabled);
 
+int32_t glean_uuid_test_get_num_recorded_errors(uint64_t metric_id,
+                                                int32_t error_type,
+                                                FfiStr storage_name);
+
 void glean_uuid_set(uint64_t metric_id, FfiStr value);
 
 uint8_t glean_uuid_test_has_value(uint64_t metric_id, FfiStr storage_name);

--- a/glean-core/ffi/src/uuid.rs
+++ b/glean-core/ffi/src/uuid.rs
@@ -13,6 +13,7 @@ use crate::{
 
 define_metric!(UuidMetric => UUID_METRICS {
     new           -> glean_new_uuid_metric(),
+    test_get_num_recorded_errors -> glean_uuid_test_get_num_recorded_errors,
     destroy       -> glean_destroy_uuid_metric,
 });
 
@@ -21,14 +22,7 @@ pub extern "C" fn glean_uuid_set(metric_id: u64, value: FfiStr) {
     with_glean_value(|glean| {
         UUID_METRICS.call_with_log(metric_id, |metric| {
             let value = value.to_string_fallible()?;
-            if let Ok(uuid) = uuid::Uuid::parse_str(&value) {
-                metric.set(glean, uuid);
-            } else {
-                log::error!(
-                    "Unexpected `uuid` value coming from platform code '{}'",
-                    value
-                );
-            }
+            metric.set_from_str(glean, &value);
             Ok(())
         })
     })

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -786,6 +786,10 @@ uint64_t glean_new_uuid_metric(FfiStr category,
                                Lifetime lifetime,
                                uint8_t disabled);
 
+int32_t glean_uuid_test_get_num_recorded_errors(uint64_t metric_id,
+                                                int32_t error_type,
+                                                FfiStr storage_name);
+
 void glean_uuid_set(uint64_t metric_id, FfiStr value);
 
 uint8_t glean_uuid_test_has_value(uint64_t metric_id, FfiStr storage_name);

--- a/glean-core/python/tests/metrics/test_uuid.py
+++ b/glean-core/python/tests/metrics/test_uuid.py
@@ -8,6 +8,7 @@ import pytest
 
 from glean import metrics
 from glean.metrics import Lifetime
+from glean import testing
 
 
 def test_the_api_saves_to_its_storage_engine():
@@ -100,3 +101,19 @@ def test_invalid_uuid_must_not_crash():
 
     # Check that no value was stored.
     assert not uuid_metric.test_has_value()
+
+
+def test_invalid_uuid_string():
+    uuid_metric = metrics.UuidMetricType(
+        disabled=False,
+        category="telemetry",
+        lifetime=Lifetime.PING,
+        name="uuid_metric",
+        send_in_pings=["store1"],
+    )
+
+    uuid_metric.set("NOT-A-UUID!!!")
+    assert not uuid_metric.test_has_value()
+    assert (
+        uuid_metric.test_get_num_recorded_errors(testing.ErrorType.INVALID_VALUE) == 1
+    )

--- a/glean-core/rlb/src/private/uuid.rs
+++ b/glean-core/rlb/src/private/uuid.rs
@@ -83,7 +83,6 @@ impl glean_core::traits::Uuid for UuidMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    #[allow(dead_code)] // Remove after mozilla/glean#1328
     fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
         &self,
         error: ErrorType,


### PR DESCRIPTION
Even though for statically typed languages it is impossible to set the UUID to something invalid, there is still a hole for dynamically-typed languages, since we pass it over FFI as a string.

This solution is a little "deeper" than we might otherwise like, but it is currently impossible to record errors through the FFI, and even the `glean-ffi` itself can't record errors (since the API for it is all private).  But I think it's not terrible (the `glean-core` API isn't the real public RLB API anyway, so adding a new method there for this use doesn't seem that bad...)