### PR TITLE
Fix clippy for Rust Beta 1.49.0

### DIFF
--- a/glean-core/ffi/src/byte_buffer.rs
+++ b/glean-core/ffi/src/byte_buffer.rs
@@ -145,7 +145,7 @@ impl Default for ByteBuffer {
     #[inline]
     fn default() -> Self {
         Self {
-            len: 0 as i32,
+            len: 0,
             data: std::ptr::null_mut(),
         }
     }


### PR DESCRIPTION
The error is from [here](https://firefox-ci-tc.services.mozilla.com/tasks/LGW47wKWS0CgcRG2HMqSHQ/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FLGW47wKWS0CgcRG2HMqSHQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L1051-1057).