### PR TITLE
Add missing `div` for Java API in Quantity docs

### DIFF
--- a/docs/user/metrics/quantity.md
+++ b/docs/user/metrics/quantity.md
@@ -48,6 +48,8 @@ assertEquals(1, Display.width.testGetNumRecordedErrors(ErrorType.InvalidValue))
 
 </div>
 
+<div data-lang="Java" class="tab">
+
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.Display;
 


### PR DESCRIPTION
This is causing rendering breakage on the page:

![image](https://user-images.githubusercontent.com/38294/99812340-575d3a80-2b14-11eb-95f9-d17715f8f122.png)
