### PR TITLE
Bug 1679426 - Allow RLB consumers to shut down Glean.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Rust
   * Introduce the UUID metric type in the RLB.
   * Introduce the Labeled metric type in the RLB [#1327](https://github.com/mozilla/glean/pull/1327).
+  * Introduce the `shutdown` API.
 * Python
   * BUGFIX: Setting a UUID metric to a value that is not in the expected UUID format will now record an error with the Glean error reporting system.
 

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -292,6 +292,16 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
     INITIALIZE_CALLED.store(true, Ordering::SeqCst);
 }
 
+/// Shuts down Glean.
+///
+/// This currently only attempts to shut down the
+/// internal dispatcher.
+pub fn shutdown() {
+    if let Err(e) = dispatcher::try_shutdown() {
+        log::error!("Can't shutdown dispatcher thread: {:?}", e);
+    }
+}
+
 /// Checks if `glean::initialize` was ever called.
 ///
 /// # Returns


### PR DESCRIPTION
This exclusively shuts down the dispatcher. Any additional complex behaviour should be discussed in bug 1647348 and probably addressed for all the platforms.