### PR TITLE
Bug 1679428 - Provide Glean debugging APIs for RLB consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Introduce the UUID metric type in the RLB.
   * Introduce the Labeled metric type in the RLB [#1327](https://github.com/mozilla/glean/pull/1327).
   * Introduce the `shutdown` API.
+  * Add Glean debugging APIs. 
 * Python
   * BUGFIX: Setting a UUID metric to a value that is not in the expected UUID format will now record an error with the Glean error reporting system.
 

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -414,11 +414,14 @@ pub fn register_ping_type(ping: &private::PingType) {
 /// Collects and submits a ping for eventual uploading.
 ///
 /// See `glean_core::Glean.submit_ping`.
-pub fn submit_ping(ping: &private::PingType, reason: Option<&str>) {
+pub(crate) fn submit_ping(ping: &private::PingType, reason: Option<&str>) {
     submit_ping_by_name(&ping.name, reason)
 }
 
 /// Collects and submits a ping for eventual uploading by name.
+/// 
+/// Note that this needs to be public in order for RLB consumers to
+/// use Glean debugging facilities.
 ///
 /// See `glean_core::Glean.submit_ping_by_name`.
 pub fn submit_ping_by_name(ping: &str, reason: Option<&str>) {

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -240,7 +240,7 @@ fn queued_recorded_metrics_correctly_record_during_init() {
 
     // Calling `new_glean` here will cause Glean to be initialized and should cause the queued
     // tasks recording metrics to execute
-    let _ = new_glean(None, false);
+    let _t = new_glean(None, false);
 
     // Verify that the callback was executed by testing for the correct value
     assert!(metric.test_get_value(None).is_some(), "Value must exist");
@@ -352,6 +352,65 @@ fn test_sending_of_startup_baseline_ping_with_application_lifetime_metric() {
 #[ignore] // TODO: To be done in bug 1673672.
 fn test_dirty_flag_is_reset_to_false() {
     todo!()
+}
+
+#[test]
+fn setting_debug_view_tag_before_initialization_should_not_crash() {
+    let _lock = lock_test();
+
+    destroy_glean(true);
+    assert!(!was_initialize_called());
+
+    // Define a fake uploader that reports back the submission headers
+    // using a crossbeam channel.
+    let (s, r) = crossbeam_channel::bounded::<Vec<(String, String)>>(1);
+
+    #[derive(Debug)]
+    pub struct FakeUploader {
+        sender: crossbeam_channel::Sender<Vec<(String, String)>>,
+    };
+    impl net::PingUploader for FakeUploader {
+        fn upload(
+            &self,
+            _url: String,
+            _body: Vec<u8>,
+            headers: Vec<(String, String)>,
+        ) -> net::UploadResult {
+            self.sender.send(headers).unwrap();
+            net::UploadResult::HttpStatus(200)
+        }
+    }
+
+    // Attempt to set a debug view tag before Glean is initialized.
+    set_debug_view_tag("valid-tag");
+
+    // Create a custom configuration to use a fake uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+
+    let cfg = Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        channel: Some("testing".into()),
+        server_endpoint: Some("invalid-test-host".into()),
+        uploader: Some(Box::new(FakeUploader { sender: s })),
+    };
+
+    let _t = new_glean(Some(cfg), true);
+    crate::dispatcher::block_on_queue();
+
+    // Submit a baseline ping.
+    submit_ping_by_name("baseline", Some("background"));
+
+    // Wait for the ping to arrive.
+    let headers = r.recv().unwrap();
+    assert_eq!(
+        headers.iter().find(|&kv| kv.0 == "X-Debug-ID").unwrap().1,
+        "valid-tag"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This makes sure RLB consumers can directly enable logging, set debug tags or source tags by calling Glean APIs in addition to setting environment variables (e.g. this is needed for FOG's `about:glean`)