### PR TITLE
Expose the core's `ErrorType` in the RLB

### DIFF
--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -45,7 +45,9 @@ use std::sync::Mutex;
 pub use configuration::Configuration;
 use configuration::DEFAULT_GLEAN_ENDPOINT;
 pub use core_metrics::ClientInfoMetrics;
-pub use glean_core::{global_glean, setup_glean, CommonMetricData, Error, Glean, Lifetime, Result};
+pub use glean_core::{
+    global_glean, setup_glean, CommonMetricData, Error, ErrorType, Glean, Lifetime, Result,
+};
 use private::RecordedExperimentData;
 
 mod configuration;


### PR DESCRIPTION
The `ErrorType` is required for consumers to use the testing APIs to count the number of reported errors.