### PR TITLE
Get to zero rustdoc warnings

### DIFF
--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -197,9 +197,6 @@ typedef const char *const *RawStringArray;
  * is because in the future, we may allow it's use for passing data into Rust code.
  * ByteBuffer assuming ownership of the data would make this a problem.
  *
- * Note that calling `destroy` manually is not typically needed or recommended,
- * and instead you should use [`define_bytebuffer_destructor!`].
- *
  * ## Layout/fields
  *
  * This struct's field are not `pub` (mostly so that we can soundly implement `Send`, but also so
@@ -226,10 +223,6 @@ typedef const char *const *RawStringArray;
  * The bytes array is allocated on the heap and must be freed on it as well. Critically, if there
  * are multiple rust packages using being used in the same application, it *must be freed on the
  * same heap that allocated it*, or you will corrupt both heaps.
- *
- * Typically, this object is managed on the other side of the FFI (on the "FFI consumer"), which
- * means you must expose a function to release the resources of `data` which can be done easily
- * using the [`define_bytebuffer_destructor!`] macro provided by this crate.
  */
 typedef struct {
   int32_t len;

--- a/glean-core/ffi/src/byte_buffer.rs
+++ b/glean-core/ffi/src/byte_buffer.rs
@@ -27,9 +27,6 @@
 /// is because in the future, we may allow it's use for passing data into Rust code.
 /// ByteBuffer assuming ownership of the data would make this a problem.
 ///
-/// Note that calling `destroy` manually is not typically needed or recommended,
-/// and instead you should use [`define_bytebuffer_destructor!`].
-///
 /// ## Layout/fields
 ///
 /// This struct's field are not `pub` (mostly so that we can soundly implement `Send`, but also so
@@ -56,10 +53,6 @@
 /// The bytes array is allocated on the heap and must be freed on it as well. Critically, if there
 /// are multiple rust packages using being used in the same application, it *must be freed on the
 /// same heap that allocated it*, or you will corrupt both heaps.
-///
-/// Typically, this object is managed on the other side of the FFI (on the "FFI consumer"), which
-/// means you must expose a function to release the resources of `data` which can be done easily
-/// using the [`define_bytebuffer_destructor!`] macro provided by this crate.
 #[repr(C)]
 pub struct ByteBuffer {
     len: i32,
@@ -122,9 +115,6 @@ impl ByteBuffer {
     }
 
     /// Reclaim memory stored in this ByteBuffer.
-    ///
-    /// You typically should not call this manually, and instead expose a
-    /// function that does so via [`define_bytebuffer_destructor!`].
     ///
     /// ## Caveats
     ///

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#![deny(broken_intra_doc_links)]
+
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::os::raw::c_char;

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -197,9 +197,6 @@ typedef const char *const *RawStringArray;
  * is because in the future, we may allow it's use for passing data into Rust code.
  * ByteBuffer assuming ownership of the data would make this a problem.
  *
- * Note that calling `destroy` manually is not typically needed or recommended,
- * and instead you should use [`define_bytebuffer_destructor!`].
- *
  * ## Layout/fields
  *
  * This struct's field are not `pub` (mostly so that we can soundly implement `Send`, but also so
@@ -226,10 +223,6 @@ typedef const char *const *RawStringArray;
  * The bytes array is allocated on the heap and must be freed on it as well. Critically, if there
  * are multiple rust packages using being used in the same application, it *must be freed on the
  * same heap that allocated it*, or you will corrupt both heaps.
- *
- * Typically, this object is managed on the other side of the FFI (on the "FFI consumer"), which
- * means you must expose a function to release the resources of `data` which can be done easily
- * using the [`define_bytebuffer_destructor!`] macro provided by this crate.
  */
 typedef struct {
   int32_t len;

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#![deny(broken_intra_doc_links)]
 #![deny(missing_docs)]
 
 //! Glean is a modern approach for recording and sending Telemetry data.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#![deny(broken_intra_doc_links)]
 #![deny(missing_docs)]
 
 //! Glean is a modern approach for recording and sending Telemetry data.

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -110,7 +110,7 @@ impl MemoryDistributionMetric {
     /// Please note that this assumes that the provided samples are already in the
     /// "unit" declared by the instance of the implementing metric type (e.g. if the
     /// implementing class is a [MemoryDistributionMetric] and the instance this
-    /// method was called on is using [MemoryUnit.Kilobyte], then `samples` are assumed
+    /// method was called on is using [MemoryUnit::Kilobyte], then `samples` are assumed
     /// to be in that unit).
     ///
     /// # Arguments

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -109,7 +109,7 @@ impl MemoryDistributionMetric {
     ///
     /// Please note that this assumes that the provided samples are already in the
     /// "unit" declared by the instance of the implementing metric type (e.g. if the
-    /// implementing class is a [MemoryDistributionMetricType] and the instance this
+    /// implementing class is a [MemoryDistributionMetric] and the instance this
     /// method was called on is using [MemoryUnit.Kilobyte], then `samples` are assumed
     /// to be in that unit).
     ///

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -107,11 +107,10 @@ impl MemoryDistributionMetric {
     /// will take care of filtering and reporting errors for any provided negative
     /// sample.
     ///
-    /// Please note that this assumes that the provided samples are already in the
-    /// "unit" declared by the instance of the implementing metric type (e.g. if the
-    /// implementing class is a [MemoryDistributionMetric] and the instance this
-    /// method was called on is using [MemoryUnit::Kilobyte], then `samples` are assumed
-    /// to be in that unit).
+    /// Please note that this assumes that the provided samples are already in
+    /// the "unit" declared by the instance of the metric type (e.g. if the the
+    /// instance this method was called on is using [MemoryUnit::Kilobyte], then
+    /// `samples` are assumed to be in that unit).
     ///
     /// # Arguments
     ///

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -138,9 +138,10 @@ impl TimingDistributionMetric {
 
     /// Starts tracking time for the provided metric.
     ///
-    /// This records an error if it’s already tracking time (i.e. start was already
-    /// called with no corresponding [stop]): in that case the original
-    /// start time will be preserved.
+    /// This records an error if it’s already tracking time (i.e.
+    /// [TimingDistributionMetric::set_start] was already called with no
+    /// corresponding [TimingDistributionMetric::set_stop_and_accumulate]): in
+    /// that case the original start time will be preserved.
     ///
     /// # Arguments
     ///
@@ -232,7 +233,7 @@ impl TimingDistributionMetric {
     ///
     /// Please note that this assumes that the provided samples are already in the
     /// "unit" declared by the instance of the implementing metric type (e.g. if the
-    /// implementing class is a [TimingDistributionMetricType] and the instance this
+    /// implementing class is a [TimingDistributionMetric] and the instance this
     /// method was called on is using [TimeUnit.Second], then `samples` are assumed
     /// to be in that unit).
     ///

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -139,8 +139,8 @@ impl TimingDistributionMetric {
     /// Starts tracking time for the provided metric.
     ///
     /// This records an error if it’s already tracking time (i.e.
-    /// [TimingDistributionMetric::set_start] was already called with no
-    /// corresponding [TimingDistributionMetric::set_stop_and_accumulate]): in
+    /// [`set_start`](TimingDistributionMetric::set_start) was already called with no
+    /// corresponding [`set_stop_and_accumulate`](TimingDistributionMetric::set_stop_and_accumulate)): in
     /// that case the original start time will be preserved.
     ///
     /// # Arguments
@@ -234,7 +234,7 @@ impl TimingDistributionMetric {
     /// Please note that this assumes that the provided samples are already in the
     /// "unit" declared by the instance of the implementing metric type (e.g. if the
     /// implementing class is a [TimingDistributionMetric] and the instance this
-    /// method was called on is using [TimeUnit.Second], then `samples` are assumed
+    /// method was called on is using [TimeUnit::Second], then `samples` are assumed
     /// to be in that unit).
     ///
     /// # Arguments

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -231,11 +231,10 @@ impl TimingDistributionMetric {
     /// will take care of filtering and reporting errors for any provided negative
     /// sample.
     ///
-    /// Please note that this assumes that the provided samples are already in the
-    /// "unit" declared by the instance of the implementing metric type (e.g. if the
-    /// implementing class is a [TimingDistributionMetric] and the instance this
-    /// method was called on is using [TimeUnit::Second], then `samples` are assumed
-    /// to be in that unit).
+    /// Please note that this assumes that the provided samples are already in
+    /// the "unit" declared by the instance of the metric type (e.g. if the
+    /// instance this method was called on is using [TimeUnit::Second], then
+    /// `samples` are assumed to be in that unit).
     ///
     /// # Arguments
     ///

--- a/glean-core/src/traits/memory_distribution.rs
+++ b/glean-core/src/traits/memory_distribution.rs
@@ -32,7 +32,7 @@ pub trait MemoryDistribution {
     /// Please note that this assumes that the provided samples are already in
     /// the "unit" declared by the instance of the implementing metric type
     /// (e.g. if the implementing class is a [MemoryDistribution] and the
-    /// instance this method was called on is using [MemoryUnit.Kilobyte], then
+    /// instance this method was called on is using [MemoryUnit::Kilobyte], then
     /// `samples` are assumed to be in that unit).
     ///
     /// # Arguments

--- a/glean-core/src/traits/memory_distribution.rs
+++ b/glean-core/src/traits/memory_distribution.rs
@@ -29,11 +29,11 @@ pub trait MemoryDistribution {
     /// will take care of filtering and reporting errors for any provided negative
     /// sample.
     ///
-    /// Please note that this assumes that the provided samples are already in the
-    /// "unit" declared by the instance of the implementing metric type (e.g. if the
-    /// implementing class is a [MemoryDistributionMetricType] and the instance this
-    /// method was called on is using [MemoryUnit.Kilobyte], then `samples` are assumed
-    /// to be in that unit).
+    /// Please note that this assumes that the provided samples are already in
+    /// the "unit" declared by the instance of the implementing metric type
+    /// (e.g. if the implementing class is a [MemoryDistribution] and the
+    /// instance this method was called on is using [MemoryUnit.Kilobyte], then
+    /// `samples` are assumed to be in that unit).
     ///
     /// # Arguments
     ///

--- a/glean-core/src/traits/memory_distribution.rs
+++ b/glean-core/src/traits/memory_distribution.rs
@@ -32,8 +32,8 @@ pub trait MemoryDistribution {
     /// Please note that this assumes that the provided samples are already in
     /// the "unit" declared by the instance of the implementing metric type
     /// (e.g. if the implementing class is a [MemoryDistribution] and the
-    /// instance this method was called on is using [MemoryUnit::Kilobyte], then
-    /// `samples` are assumed to be in that unit).
+    /// instance this method was called on is using kilobyte, then `samples` are
+    /// assumed to be in that unit).
     ///
     /// # Arguments
     ///

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -59,8 +59,8 @@ pub trait TimingDistribution {
     /// Please note that this assumes that the provided samples are already in
     /// the "unit" declared by the instance of the implementing metric type
     /// (e.g. if the implementing class is a [TimingDistribution] and the
-    /// instance this method was called on is using [TimeUnit::Second], then
-    /// `samples` are assumed to be in that unit).
+    /// instance this method was called on is using second, then `samples` are
+    /// assumed to be in that unit).
     ///
     /// # Arguments
     ///

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -12,9 +12,10 @@ use crate::metrics::TimerId;
 pub trait TimingDistribution {
     /// Starts tracking time for the provided metric.
     ///
-    /// This records an error if it’s already tracking time (i.e. start was already
-    /// called with no corresponding [stop]): in that case the original
-    /// start time will be preserved.
+    /// This records an error if it’s already tracking time (i.e.
+    /// [TimingDistribution::set_start] was already called with no corresponding
+    /// [TimingDistribution::set_stop_and_accumulate]): in that case the
+    /// original start time will be preserved.
     ///
     /// # Arguments
     ///
@@ -55,11 +56,11 @@ pub trait TimingDistribution {
     /// will take care of filtering and reporting errors for any provided negative
     /// sample.
     ///
-    /// Please note that this assumes that the provided samples are already in the
-    /// "unit" declared by the instance of the implementing metric type (e.g. if the
-    /// implementing class is a [TimingDistributionMetricType] and the instance this
-    /// method was called on is using [TimeUnit.Second], then `samples` are assumed
-    /// to be in that unit).
+    /// Please note that this assumes that the provided samples are already in
+    /// the "unit" declared by the instance of the implementing metric type
+    /// (e.g. if the implementing class is a [TimingDistribution] and the
+    /// instance this method was called on is using [TimeUnit.Second], then
+    /// `samples` are assumed to be in that unit).
     ///
     /// # Arguments
     ///

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -13,8 +13,8 @@ pub trait TimingDistribution {
     /// Starts tracking time for the provided metric.
     ///
     /// This records an error if it’s already tracking time (i.e.
-    /// [TimingDistribution::set_start] was already called with no corresponding
-    /// [TimingDistribution::set_stop_and_accumulate]): in that case the
+    /// [`set_start`](TimingDistribution::set_start) was already called with no corresponding
+    /// [`set_stop_and_accumulate`](TimingDistribution::set_stop_and_accumulate)): in that case the
     /// original start time will be preserved.
     ///
     /// # Arguments
@@ -59,7 +59,7 @@ pub trait TimingDistribution {
     /// Please note that this assumes that the provided samples are already in
     /// the "unit" declared by the instance of the implementing metric type
     /// (e.g. if the implementing class is a [TimingDistribution] and the
-    /// instance this method was called on is using [TimeUnit.Second], then
+    /// instance this method was called on is using [TimeUnit::Second], then
     /// `samples` are assumed to be in that unit).
     ///
     /// # Arguments

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -123,11 +123,12 @@ pub enum PingUploadTask {
     /// * Pending pings queue is empty, no more pings to request;
     /// * Requester has gotten more than MAX_WAIT_ATTEMPTS (3, by default) `PingUploadTask::Wait` responses in a row;
     /// * Requester has reported more than MAX_RECOVERABLE_FAILURES_PER_UPLOADING_WINDOW
-    ///   recoverable upload failures on the same uploading window[1]
+    ///   recoverable upload failures on the same uploading window (see below)
     ///   and should stop requesting at this moment.
     ///
-    /// [1]: An "uploading window" starts when a requester gets a new `PingUploadTask::Upload(PingRequest)`
-    ///      response and finishes when they finally get a `PingUploadTask::Done` or `PingUploadTask::Wait` response.
+    /// An "uploading window" starts when a requester gets a new
+    /// `PingUploadTask::Upload(PingRequest)` response and finishes when they
+    /// finally get a `PingUploadTask::Done` or `PingUploadTask::Wait` response.
     Done,
 }
 


### PR DESCRIPTION
This fixes a number of warnings emitted during the rustdoc build, and also turns those warnings into errors to prevent them from reappearing.  (There's also probably a lot that could be done to improve the intra-doc linking, but that's work for another PR...)