### PR TITLE
Bug 1677807 - Document that invalid labels result in recordings going to the `__other__` label

### DIFF
--- a/docs/user/metrics/labeled_booleans.md
+++ b/docs/user/metrics/labeled_booleans.md
@@ -183,9 +183,9 @@ assert_eq!(
 
 ## Recorded Errors
 
-* `invalid_label`: If the label contains invalid characters.
+* `invalid_label`: If the label contains invalid characters. Data is still recorded to the special label `__other__`.
 
-* `invalid_label`: If the label exceeds the maximum number of allowed characters.
+* `invalid_label`: If the label exceeds the maximum number of allowed characters. Data is still recorded to the special label `__other__`.
 
 ## Reference
 

--- a/docs/user/metrics/labeled_counters.md
+++ b/docs/user/metrics/labeled_counters.md
@@ -179,9 +179,9 @@ assert_eq!(
 
 ## Recorded Errors
 
-* `invalid_label`: If the label contains invalid characters.
+* `invalid_label`: If the label contains invalid characters. Data is still recorded to the special label `__other__`.
 
-* `invalid_label`: If the label exceeds the maximum number of allowed characters.
+* `invalid_label`: If the label exceeds the maximum number of allowed characters. Data is still recorded to the special label `__other__`.
 
 ## Reference
 

--- a/docs/user/metrics/labeled_strings.md
+++ b/docs/user/metrics/labeled_strings.md
@@ -146,6 +146,8 @@ assert_eq!(
 
 * Labels must conform to the [label formatting regular expression](index.md#label-format).
 
+* Labels support lowercase alphanumeric characters; they additionally allow for dots (`.`), underscores (`_`) and/or hyphens (`-`).
+
 * Each label must have a maximum of 60 bytes, when encoded as UTF-8.
 
 * If the labels are specified in the `metrics.yaml`, using any label not listed in that file will be replaced with the special value `__other__`.
@@ -158,9 +160,9 @@ assert_eq!(
 
 ## Recorded Errors
 
-* `invalid_label`: If the label contains invalid characters.
+* `invalid_label`: If the label contains invalid characters. Data is still recorded to the special label `__other__`.
 
-* `invalid_label`: If the label exceeds the maximum number of allowed characters.
+* `invalid_label`: If the label exceeds the maximum number of allowed characters. Data is still recorded to the special label `__other__`.
 
 ## Reference
 


### PR DESCRIPTION
[doc only]