### PR TITLE
Bug 1679949 - Hacky bug fix: Lower sleep time to one second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v33.5.0...main)
 
 * Python
-  * BUGFIX: Network slowness or errors will no longer block the main dispatcher thread, leaving work undone on shutdown.
+  * BUGFIX: Network slowness or errors will no longer block the main dispatcher thread, leaving work undone on shutdown ([#1350](https://github.com/mozilla/glean/pull/1350)).
+  * BUGFIX: Lower sleep time on upload waits to avoid being stuck when the main process ends ([#1349](https://github.com/mozilla/glean/pull/1349)).
 
 # v33.5.0 (2020-12-01)
 
@@ -14,7 +15,7 @@
   * Introduce the Labeled metric type in the RLB [#1327](https://github.com/mozilla/glean/pull/1327).
   * Introduce the Quantity metric type in the RLB.
   * Introduce the `shutdown` API.
-  * Add Glean debugging APIs. 
+  * Add Glean debugging APIs.
 * Python
   * BUGFIX: Setting a UUID metric to a value that is not in the expected UUID format will now record an error with the Glean error reporting system.
 

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -154,7 +154,7 @@ def _process(
                 incoming_task, upload_result.to_ffi()
             )
         elif tag == UploadTaskTag.WAIT:
-            time.sleep(throttle_backoff_time_s)
+            time.sleep(1)
         elif tag == UploadTaskTag.DONE:
             return True
 


### PR DESCRIPTION
Partial revert of 2261845761251d91b6968f29846dc3aabbc0cc45

The default-increased sleep time causes issues for short-lived
applications, such as tests (burnham) or command-line tools (if they are
_really_ quick):

Glean initializes asynchronously, so by the time the first ping is
submitted it is not yet done with initialization and scanning the
pending pings directory and therefore asking the uploader to sleep for a
moment and return when the scan finished.
However right now it has no mechanism to communicate a short wait, so
consumers default to the throttle backoff time (which is 60s).

So if a fast client:
1. Calls `Glean.initialize`
2. Records some data and submits a ping
3. Stops

the uploader will start, get told to wait, sleep for 60s.
Meanwhile Glean-py's shutdown routine asks the upload process to come to
an end within 30s or kills it, which is subsequently does (a sleeping
process will not notice).

By dropping back to a 1s sleep we avoid that situation for now.
A proper fix will allow glean-core to communicate the sleep time correctly.

The downside is that for long-lived Python processes, once we get
throttled it will quickly ask glean-core for tasks again 3 times in a
row, then gets told it's done.
Pending pings will then not be picked up until a new ping is submitted
again (or the process is restarted completely).
That's an acceptable risk given that we don't really have long-running
clients right now.