### PR TITLE
Bug 1679949: Don't block on running ping uploading process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.5.0...main)
 
+* Python
+  * BUGFIX: Network slowness or errors will no longer block the main dispatcher thread, leaving work undone on shutdown.
+
 # v33.5.0 (2020-12-01)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.4.0...v33.5.0)

--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -89,10 +89,6 @@ class ProcessDispatcher:
             cls._last_process = None
 
     @classmethod
-    def _is_last_process_running(cls) -> bool:
-        return cls._last_process is not None and cls._last_process.poll() is None
-
-    @classmethod
     def dispatch(cls, func, args) -> Union[_SyncWorkWrapper, subprocess.Popen]:
         from . import Glean
 
@@ -100,7 +96,7 @@ class ProcessDispatcher:
             # We only want one of these processes running at a time, so if
             # there's already one running, just bail out. It will pick up any
             # newly-written pings as it processes the directory.
-            if cls._is_last_process_running():
+            if cls._last_process is not None and cls._last_process.poll() is None:
                 return cls._last_process
 
             # This sends the data over as a commandline argument, which has a

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -145,23 +145,31 @@ def test_ping_upload_worker_single_process(safe_httpserver):
     pings_dir = Glean._data_dir / "pending_pings"
     pings_dir.mkdir()
 
-    for _ in range(10):
+    for _ in range(5):
         with (pings_dir / str(uuid.uuid4())).open("wb") as fd:
             fd.write(b"/data/path/\n")
             fd.write(b"{}\n")
 
-    # Fire off two PingUploadWorker processing tasks at the same time. If
-    # working correctly, p1 should finish entirely before p2 starts.
-    # If these actually run in parallel, one or the other will try to send
-    # deleted queued ping files and fail.
+    # Fire off the the first PingUploaderWorker process to handle the existing
+    # pings. Then, in parallel, write more pings and fire off "new"
+    # PingUploadWorker processes (some of which will be no-ops and just keeping
+    # the existing worker running).
     p1 = PingUploadWorker._process()
-    p2 = PingUploadWorker._process()
+
+    processes = []
+    for _ in range(5):
+        with (pings_dir / str(uuid.uuid4())).open("wb") as fd:
+            fd.write(b"/data/path/\n")
+            fd.write(b"{}\n")
+
+        processes.append(PingUploadWorker._process())
 
     p1.wait()
     assert p1.returncode == 0
 
-    p2.wait()
-    assert p2.returncode == 0
+    for p in processes:
+        p.wait()
+        assert p.returncode == 0
 
     assert 10 == len(safe_httpserver.requests)
 

--- a/glean-core/python/tests/test_network.py
+++ b/glean-core/python/tests/test_network.py
@@ -150,7 +150,7 @@ def test_ping_upload_worker_single_process(safe_httpserver):
             fd.write(b"/data/path/\n")
             fd.write(b"{}\n")
 
-    # Fire off the the first PingUploaderWorker process to handle the existing
+    # Fire off the first PingUploaderWorker process to handle the existing
     # pings. Then, in parallel, write more pings and fire off "new"
     # PingUploadWorker processes (some of which will be no-ops and just keeping
     # the existing worker running).


### PR DESCRIPTION
We only want to run one ping uploading subprocess at a time -- for one, it might
delete ping files, and we can't have contention for that. This is currently
handled by waiting on an existing uploading subprocess before firing off a new
one. However, this can cause the main dispatcher thread to block, causing work
to go uncompleted and subsequent pings to go unsent, on shutdown of the main process.

Instead, this just does nothing if an uploading subprocess is already running,
since the existing uploader will also pick up any new pings added to the
outgoing directory and send them.