### PR TITLE
Upgrade to newer manylinux image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -852,20 +852,13 @@ jobs:
   pypi-linux-release:
     docker:
       # The official docker image for building manylinux2010 wheels
-      - image: quay.io/pypa/manylinux2010_x86_64
+      - image: quay.io/pypa/manylinux2014_x86_64
     steps:
-      # manylinux2010 doesn't have ssh installed.
+      # manylinux2014 doesn't have ssh installed.
       - run:
           name: Install missing tools
           command: yum install -y openssh-clients
-      # The curl in the manylinux2010 docker image doesn't support `--proto`.
-      - run:
-          name: Installing rustup
-          command: curl -sSf https://sh.rustup.rs | sh -s -- -y
-      - run:
-          name: Setup custom environment variables
-          command: |
-              echo "export PATH=$HOME/.cargo/bin:$PATH" >> $BASH_ENV
+      - install-rustup
       - setup-rust-toolchain
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.6.0...main)
 
+* Python
+  * Python Linux wheels no longer work on Linux distributions released before 2014 (they now use the manylinux2014 ABI)
+
 # v33.6.0 (2020-12-02)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.5.0...v33.6.0)


### PR DESCRIPTION
manylinux10 is based on CentOS 6, which as of 2020-12-02 09:00 is dead.

From http://mirror.centos.org/centos/6/readme:

> The whole CentOS 6 is *dead* and *shouldn't* be used anywhere at *all*

We rely on installing an SSH client (probably to checkout the repository),
so CentOS 6 is no good for us.

manylinux2014 is CentOS 7.8, which is also unmaintained, but at least
continues to work for now.

[doc only]