### PR TITLE
Bug 1680474- Join on the dispatcher thread after shutting it down

### DIFF
--- a/glean-core/rlb/src/dispatcher/mod.rs
+++ b/glean-core/rlb/src/dispatcher/mod.rs
@@ -274,7 +274,7 @@ impl Dispatcher {
 
     /// Waits for the worker thread to finish and finishes the dispatch queue.
     ///
-    /// You need to call `try_shutdown` to initiate a shutdown of the queue.
+    /// You need to call `shutdown` to initiate a shutdown of the queue.
     fn join(mut self) -> Result<(), DispatchError> {
         if let Some(worker) = self.worker.take() {
             worker.join().map_err(|_| DispatchError::WorkerPanic)?;

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -332,7 +332,7 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
 /// This currently only attempts to shut down the
 /// internal dispatcher.
 pub fn shutdown() {
-    if let Err(e) = dispatcher::try_shutdown() {
+    if let Err(e) = dispatcher::shutdown() {
         log::error!("Can't shutdown dispatcher thread: {:?}", e);
     }
 }


### PR DESCRIPTION
This makes sure tools (e.g. TSAN) properly account for the thread being shut down and do not flag this as a pending
thread error.