### PR TITLE
Rust UUID test APIs must correctly block on the dispatcher

### DIFF
--- a/glean-core/rlb/src/private/uuid.rs
+++ b/glean-core/rlb/src/private/uuid.rs
@@ -88,6 +88,8 @@ impl glean_core::traits::Uuid for UuidMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
+        dispatcher::block_on_queue();
+
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)


### PR DESCRIPTION
This slipped through review.