### PR TITLE
Bug 1680789 - Properly shut down glean in tests (RLB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.7.0...main)
 
+* Rust
+  * Shut down Glean in tests before resetting to make sure they don't mistakenly init Glean twice in parallel.
+
 # v33.7.0 (2020-12-07)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.6.0...v33.7.0)

--- a/glean-core/rlb/src/common_test.rs
+++ b/glean-core/rlb/src/common_test.rs
@@ -52,6 +52,7 @@ pub(crate) fn new_glean(
         },
     };
 
+    crate::shutdown();
     crate::test_reset_glean(cfg, ClientInfoMetrics::unknown(), clear_stores);
     dir
 }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -310,6 +310,11 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
 /// This currently only attempts to shut down the
 /// internal dispatcher.
 pub fn shutdown() {
+    if !was_initialize_called() {
+        log::warn!("Shutdown called before Glean is initialized");
+        return;
+    }
+
     if let Err(e) = dispatcher::shutdown() {
         log::error!("Can't shutdown dispatcher thread: {:?}", e);
     }


### PR DESCRIPTION
FOG tests sometimes don't do anything other than initializing Glean. In these cases, nothing blocks on the dispatcher and tests might end up triggering init twice, in parallel, locking files on the disk or corrupting local data. This, in turn, makes FOG tests flaky and even RLB tests occasionally fail.