### PR TITLE
Fix broken tree

### DIFF
--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -163,6 +163,7 @@ impl DatetimeMetric {
             glean.storage(),
             storage_name,
             &self.meta.identifier(glean),
+            self.meta.lifetime,
         ) {
             Some(Metric::Datetime(d, tu)) => {
                 // The string version of the test function truncates using string


### PR DESCRIPTION
This adds the missing parameter to the snapshot function,
it was missing due to a wrong rebase.