### PR TITLE
Document that timespan doesn't overwrite and records `InvalidState`

### DIFF
--- a/docs/user/metrics/timespan.md
+++ b/docs/user/metrics/timespan.md
@@ -357,6 +357,7 @@ The raw API is not supported in Rust. See [bug 1680225](https://bugzilla.mozilla
     * If starting a timer while a previous timer is running.
     * If stopping a timer while it is not running.
     * If trying to set a raw timespan while a timer is running.
+    * If trying to record a timespan again while a previous value is still stored.
 
 ## Reference
 

--- a/glean-core/ffi/src/timespan.rs
+++ b/glean-core/ffi/src/timespan.rs
@@ -44,7 +44,7 @@ pub extern "C" fn glean_timespan_set_raw_nanos(metric_id: u64, elapsed_nanos: u6
     let elapsed = Duration::from_nanos(elapsed_nanos);
     with_glean_value(|glean| {
         TIMESPAN_METRICS.call_infallible(metric_id, |metric| {
-            metric.set_raw(glean, elapsed, false);
+            metric.set_raw(glean, elapsed);
         })
     })
 }

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -108,7 +108,7 @@ impl TimespanMetric {
             }
         };
         let duration = Duration::from_nanos(duration);
-        self.set_raw(glean, duration, false);
+        self.set_raw(glean, duration);
     }
 
     /// Aborts a previous [`set_start`](TimespanMetric::set_start) call. No
@@ -132,8 +132,7 @@ impl TimespanMetric {
     /// # Arguments
     ///
     /// * `elapsed` - The elapsed time to record.
-    /// * `overwrite` - Whether or not to overwrite existing data.
-    pub fn set_raw(&self, glean: &Glean, elapsed: Duration, overwrite: bool) {
+    pub fn set_raw(&self, glean: &Glean, elapsed: Duration) {
         if !self.should_record(glean) {
             return;
         }
@@ -151,19 +150,15 @@ impl TimespanMetric {
 
         let mut report_value_exists: bool = false;
         glean.storage().record_with(glean, &self.meta, |old_value| {
-            if overwrite {
-                Metric::Timespan(elapsed, self.time_unit)
-            } else {
-                match old_value {
-                    Some(old @ Metric::Timespan(..)) => {
-                        // If some value already exists, report an error.
-                        // We do this out of the storage since recording an
-                        // error accesses the storage as well.
-                        report_value_exists = true;
-                        old
-                    }
-                    _ => Metric::Timespan(elapsed, self.time_unit),
+            match old_value {
+                Some(old @ Metric::Timespan(..)) => {
+                    // If some value already exists, report an error.
+                    // We do this out of the storage since recording an
+                    // error accesses the storage as well.
+                    report_value_exists = true;
+                    old
                 }
+                _ => Metric::Timespan(elapsed, self.time_unit),
             }
         });
 

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -247,7 +247,7 @@ fn set_raw_time() {
     );
 
     let time = Duration::from_secs(1);
-    metric.set_raw(&glean, time, false);
+    metric.set_raw(&glean, time);
 
     let time_in_ns = time.as_nanos() as u64;
     assert_eq!(Some(time_in_ns), metric.test_get_value(&glean, "store1"));
@@ -272,7 +272,7 @@ fn set_raw_time_does_nothing_when_timer_running() {
     let time = Duration::from_secs(42);
 
     metric.set_start(&glean, 0);
-    metric.set_raw(&glean, time, false);
+    metric.set_raw(&glean, time);
     metric.set_stop(&glean, 60);
 
     // We expect the start/stop value, not the raw value.


### PR DESCRIPTION
In [bug 1562859](https://bugzilla.mozilla.org/show_bug.cgi?id=1562859) we changed how this work: a timespan never overwrites a previous value, not even with `set_raw_nanos`.
We didn't document the error it records though.
We also didn't remove the unused parameter.

This tackles both.