### PR TITLE
Bug 1677150: Panic before blocking

### DIFF
--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -320,6 +320,17 @@ pub fn shutdown() {
     }
 }
 
+/// Block on the dispatcher emptying.
+///
+/// This will panic if called before Glean is initialized.
+fn block_on_dispatcher() {
+    assert!(
+        was_initialize_called(),
+        "initialize was never called. Can't block on the dispatcher queue."
+    );
+    dispatcher::block_on_queue()
+}
+
 /// Checks if [`initialize`] was ever called.
 ///
 /// # Returns
@@ -510,7 +521,7 @@ pub fn set_experiment_inactive(experiment_id: String) {
 /// Checks if an experiment is currently active.
 #[allow(dead_code)]
 pub(crate) fn test_is_experiment_active(experiment_id: String) -> bool {
-    dispatcher::block_on_queue();
+    block_on_dispatcher();
     with_glean(|glean| glean.test_is_experiment_active(experiment_id.to_owned()))
 }
 
@@ -519,7 +530,7 @@ pub(crate) fn test_is_experiment_active(experiment_id: String) -> bool {
 /// the id isn't found.
 #[allow(dead_code)]
 pub(crate) fn test_get_experiment_data(experiment_id: String) -> RecordedExperimentData {
-    dispatcher::block_on_queue();
+    block_on_dispatcher();
     with_glean(|glean| {
         let json_data = glean
             .test_get_experiment_data_as_json(experiment_id.to_owned())

--- a/glean-core/rlb/src/private/boolean.rs
+++ b/glean-core/rlb/src/private/boolean.rs
@@ -37,7 +37,7 @@ impl glean_core::traits::Boolean for BooleanMetric {
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<bool> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = match ping_name.into() {
             Some(name) => name,

--- a/glean-core/rlb/src/private/counter.rs
+++ b/glean-core/rlb/src/private/counter.rs
@@ -38,7 +38,7 @@ impl glean_core::traits::Counter for CounterMetric {
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i32> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -52,7 +52,7 @@ impl glean_core::traits::Counter for CounterMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())

--- a/glean-core/rlb/src/private/datetime.rs
+++ b/glean-core/rlb/src/private/datetime.rs
@@ -41,7 +41,7 @@ impl glean_core::traits::Datetime for DatetimeMetric {
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<Datetime> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -55,7 +55,7 @@ impl glean_core::traits::Datetime for DatetimeMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())

--- a/glean-core/rlb/src/private/event.rs
+++ b/glean-core/rlb/src/private/event.rs
@@ -63,7 +63,7 @@ impl<K: traits::ExtraKeys> traits::Event for EventMetric<K> {
         &self,
         ping_name: S,
     ) -> Option<Vec<RecordedEvent>> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -77,7 +77,7 @@ impl<K: traits::ExtraKeys> traits::Event for EventMetric<K> {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(

--- a/glean-core/rlb/src/private/labeled.rs
+++ b/glean-core/rlb/src/private/labeled.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 use glean_core::metrics::MetricType;
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 /// Sealed traits protect against downstream implementations.
 ///
 /// We wrap it in a private module that is inaccessible outside of this module.
@@ -134,7 +132,7 @@ where
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(

--- a/glean-core/rlb/src/private/memory_distribution.rs
+++ b/glean-core/rlb/src/private/memory_distribution.rs
@@ -43,7 +43,7 @@ impl glean_core::traits::MemoryDistribution for MemoryDistributionMetric {
         &self,
         ping_name: S,
     ) -> Option<DistributionData> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -57,7 +57,7 @@ impl glean_core::traits::MemoryDistribution for MemoryDistributionMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())

--- a/glean-core/rlb/src/private/quantity.rs
+++ b/glean-core/rlb/src/private/quantity.rs
@@ -38,7 +38,7 @@ impl glean_core::traits::Quantity for QuantityMetric {
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i64> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -53,7 +53,7 @@ impl glean_core::traits::Quantity for QuantityMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())

--- a/glean-core/rlb/src/private/string.rs
+++ b/glean-core/rlb/src/private/string.rs
@@ -42,7 +42,7 @@ impl glean_core::traits::String for StringMetric {
         &self,
         ping_name: S,
     ) -> Option<std::string::String> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -56,7 +56,7 @@ impl glean_core::traits::String for StringMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())

--- a/glean-core/rlb/src/private/string_list.rs
+++ b/glean-core/rlb/src/private/string_list.rs
@@ -44,7 +44,7 @@ impl glean_core::traits::StringList for StringListMetric {
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<Vec<String>> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -58,7 +58,7 @@ impl glean_core::traits::StringList for StringListMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())

--- a/glean-core/rlb/src/private/timespan.rs
+++ b/glean-core/rlb/src/private/timespan.rs
@@ -73,7 +73,7 @@ impl glean_core::traits::Timespan for TimespanMetric {
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<u64> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean(|glean| {
             // Note: The order of operations is important here to avoid potential deadlocks because
@@ -99,7 +99,7 @@ impl glean_core::traits::Timespan for TimespanMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let metric = self
             .0

--- a/glean-core/rlb/src/private/uuid.rs
+++ b/glean-core/rlb/src/private/uuid.rs
@@ -45,7 +45,7 @@ impl glean_core::traits::Uuid for UuidMetric {
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<uuid::Uuid> {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         let queried_ping_name = ping_name
             .into()
@@ -59,7 +59,7 @@ impl glean_core::traits::Uuid for UuidMetric {
         error: ErrorType,
         ping_name: S,
     ) -> i32 {
-        dispatcher::block_on_queue();
+        crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())


### PR DESCRIPTION
This ensures a test case like the following doesn't hang, but explodes:

1. create a metric
2. check what it contains
3. init glean