### PR TITLE
Bug 1673850 - Allow ping registration before RLB init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Introduce the String List metric type in the RLB. [#1380](https://github.com/mozilla/glean/pull/1380).
   * Introduce the `Datetime` metric type in the RLB [#1384](https://github.com/mozilla/glean/pull/1384).
   * Introduce the `CustomDistribution` and `TimingDistribution` metric type in the RLB [#1394](https://github.com/mozilla/glean/pull/1394).
-  * Support ping registration before Glean initializes.
+  * Support ping registration before Glean initializes [#1393](https://github.com/mozilla/glean/pull/1393).
 
 # v33.8.0 (2020-12-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Introduce the String List metric type in the RLB. [#1380](https://github.com/mozilla/glean/pull/1380).
   * Introduce the `Datetime` metric type in the RLB [#1384](https://github.com/mozilla/glean/pull/1384).
   * Introduce the `CustomDistribution` and `TimingDistribution` metric type in the RLB [#1394](https://github.com/mozilla/glean/pull/1394).
+  * Support ping registration before Glean initializes.
 
 # v33.8.0 (2020-12-10)
 

--- a/docs/user/pings/custom.md
+++ b/docs/user/pings/custom.md
@@ -220,6 +220,16 @@ Pings.search.Submit(
 
 </div>
 
+<div data-lang="Rust" class="tab">
+
+```Rust
+use glean::Pings;
+
+Pings::search.submit(Pings::searchReasonCodes::performed);
+```
+
+</div>
+
 {{#include ../../tab_footer.md}}
 
 If none of the metrics for the ping contain data the ping is not sent (unless `send_if_empty` is set to true in the definition file)

--- a/docs/user/pings/custom.md
+++ b/docs/user/pings/custom.md
@@ -225,7 +225,7 @@ Pings.search.Submit(
 ```Rust
 use glean::Pings;
 
-Pings::search.submit(Pings::searchReasonCodes::performed);
+pings::search.submit(pings::SearchReasonCodes::Performed);
 ```
 
 </div>

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -4,7 +4,6 @@
 
 use crate::private::PingType;
 use crate::private::{BooleanMetric, CounterMetric};
-use once_cell::sync::Lazy;
 use std::path::PathBuf;
 
 use super::*;
@@ -512,11 +511,7 @@ fn registering_pings_before_init_must_work() {
     }
 
     // Create a custom ping and attempt its registration.
-    #[allow(non_upper_case_globals)]
-    pub static SamplePing: Lazy<PingType> =
-        Lazy::new(|| PingType::new("pre-register", true, true, vec![]));
-
-    register_ping_type(&SamplePing);
+    let sample_ping = PingType::new("pre-register", true, true, vec![]);
 
     // Create a custom configuration to use a fake uploader.
     let dir = tempfile::tempdir().unwrap();
@@ -537,7 +532,7 @@ fn registering_pings_before_init_must_work() {
     crate::block_on_dispatcher();
 
     // Submit a baseline ping.
-    SamplePing.submit(None);
+    sample_ping.submit(None);
 
     // Wait for the ping to arrive.
     let url = r.recv().unwrap();


### PR DESCRIPTION
This is needed so that products using Glean (and tests) could register pings at an arbitrary time, even if the Glean init is deferred a bit.