### PR TITLE
Update identifier in string metric `set` docstring

### DIFF
--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -49,7 +49,7 @@ impl StringMetric {
     ///
     /// ## Notes
     ///
-    /// Truncates the value if it is longer than `MAX_STRING_LENGTH` bytes and logs an error.
+    /// Truncates the value if it is longer than `MAX_LENGTH_VALUE` bytes and logs an error.
     pub fn set<S: Into<String>>(&self, glean: &Glean, value: S) {
         if !self.should_record(glean) {
             return;

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -17,7 +17,7 @@ pub trait String {
     ///
     /// ## Notes
     ///
-    /// Truncates the value if it is longer than `MAX_STRING_LENGTH` bytes and logs an error.
+    /// Truncates the value if it is longer than `MAX_LENGTH_VALUE` bytes and logs an error.
     fn set<S: Into<std::string::String>>(&self, value: S);
 
     /// **Exported for test purposes.**


### PR DESCRIPTION
[doc only]

Randomly found this bug while reading through code.