### PR TITLE
Update crossbeam-channel to 0.5.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,22 +230,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -256,7 +246,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -267,21 +257,10 @@ checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -437,7 +416,7 @@ name = "glean"
 version = "33.9.1"
 dependencies = [
  "chrono",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "env_logger",
  "flate2",
  "glean-core",
@@ -669,12 +648,6 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -910,9 +883,9 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1487,7 +1487,7 @@ The following text applies to code linked from these dependencies:
 * [cfg-if 1.0.0]( https://github.com/alexcrichton/cfg-if )
 * [const-random 0.1.11]( https://github.com/tkaitchuck/constrandom )
 * [const-random-macro 0.1.11]( https://github.com/tkaitchuck/constrandom )
-* [crossbeam-channel 0.4.4]( https://github.com/crossbeam-rs/crossbeam )
+* [crossbeam-channel 0.5.0]( https://github.com/crossbeam-rs/crossbeam )
 * [crossbeam-utils 0.7.2]( https://github.com/crossbeam-rs/crossbeam )
 * [env_logger 0.7.1]( https://github.com/sebasmagri/env_logger/ )
 * [failure 0.1.8]( https://github.com/rust-lang-nursery/failure )

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -25,7 +25,7 @@ path = ".."
 version = "33.9.1"
 
 [dependencies]
-crossbeam-channel = "0.4.3"
+crossbeam-channel = "0.5"
 inherent = "0.1.4"
 log = "0.4.8"
 once_cell = "1.2.0"


### PR DESCRIPTION
The main motivation is to remove duplicate crossbeam versions in mozilla-central.