### PR TITLE
Have each tab constrain its height based on its own content [doc only]

### DIFF
--- a/docs/glean.css
+++ b/docs/glean.css
@@ -40,6 +40,10 @@
     padding: 6px 12px;
 }
 
+.tab.active {
+    display: block;
+}
+
 /* The footer with the "Open on GitHub" link */
 footer#open-on-gh {
   font-size: 0.8em;

--- a/docs/glean.css
+++ b/docs/glean.css
@@ -33,7 +33,8 @@
 
 /* The container for each individual language */
 .tab {
-    visibility: hidden;
+    display: none;
+    width: 100%;
     border: 1px solid #ccc;
     border-top: none;
     padding: 6px 12px;

--- a/docs/tabs.js
+++ b/docs/tabs.js
@@ -27,17 +27,17 @@ function onClickTab(event) {
  * :param language: The language to switch to.
  */
 function switchTab(container, language) {
-    const previouslyActiveTab = container.querySelector(".tabcontents.active");
-    previouslyActiveTab && previouslyActiveTab.classList.remove(".tabcontents active");
-    let tab = container.querySelector(`.tabcontents [data-value="${language}"]`);
+    const previouslyActiveTab = container.querySelector(".tabcontents .active");
+    previouslyActiveTab && previouslyActiveTab.classList.remove("active");
+    let tab = container.querySelector(`.tabcontents [data-lang="${language}"]`);
     if (!tab) {
         tab = container.querySelector(".tabcontents .tab");
     }
     tab.classList.add("active");
 
-    const previouslyActiveButton = container.querySelector(".tabbar.active");
-    previouslyActiveButton && previouslyActiveButton.classList.remove(".tabbar active");
-    let button = container.querySelector(`.tabbar [data-value="${language}"]`);
+    const previouslyActiveButton = container.querySelector(".tabbar .active");
+    previouslyActiveButton && previouslyActiveButton.classList.remove("active");
+    let button = container.querySelector(`.tabbar [data-lang="${language}"]`);
     if (!button) {
         button = container.querySelector(".tabbar button");
     }

--- a/docs/tabs.js
+++ b/docs/tabs.js
@@ -16,7 +16,16 @@ function onClickTab(event) {
     let target = event.currentTarget;
     let language = target.dataset.lang;
 
+    const initialTargetOffset = target.offsetTop;
+    const initialScrollPosition = window.scrollY;
     switchAllTabs(language);
+
+    // Keep initial perceived scroll position after resizing
+    // that may happen due to activation of multiple tabs in the same page.
+    const finalTargetOffset = target.offsetTop;
+    window.scrollTo({
+        top: initialScrollPosition + (finalTargetOffset - initialTargetOffset)
+    });
 }
 
 /**
@@ -30,18 +39,12 @@ function switchTab(container, language) {
     const previouslyActiveTab = container.querySelector(".tabcontents .active");
     previouslyActiveTab && previouslyActiveTab.classList.remove("active");
     let tab = container.querySelector(`.tabcontents [data-lang="${language}"]`);
-    if (!tab) {
-        tab = container.querySelector(".tabcontents .tab");
-    }
-    tab.classList.add("active");
+    tab && tab.classList.add("active");
 
     const previouslyActiveButton = container.querySelector(".tabbar .active");
     previouslyActiveButton && previouslyActiveButton.classList.remove("active");
     let button = container.querySelector(`.tabbar [data-lang="${language}"]`);
-    if (!button) {
-        button = container.querySelector(".tabbar button");
-    }
-    button.classList.add("active");
+    button && button.classList.add("active");
 }
 
 /**
@@ -50,7 +53,7 @@ function switchTab(container, language) {
  * :param language: The language to switch to.
  */
 function switchAllTabs(language) {
-    let containers = document.getElementsByClassName("tabs");
+    const containers = document.getElementsByClassName("tabs");
     for (let i = 0; i < containers.length; ++i) {
         switchTab(containers[i], language);
     }

--- a/docs/tabs.js
+++ b/docs/tabs.js
@@ -27,24 +27,21 @@ function onClickTab(event) {
  * :param language: The language to switch to.
  */
 function switchTab(container, language) {
-    let tab_contents_container = container.children[1];
-    for (i = 0; i < tab_contents_container.children.length; ++i) {
-        let tab = tab_contents_container.children[i];
-        if (tab.dataset.lang === language) {
-            tab.style.display = "block";
-        } else {
-            tab.style.display = "none";
-        }
+    const previouslyActiveTab = container.querySelector(".tabcontents.active");
+    previouslyActiveTab && previouslyActiveTab.classList.remove(".tabcontents active");
+    let tab = container.querySelector(`.tabcontents [data-value="${language}"]`);
+    if (!tab) {
+        tab = container.querySelector(".tabcontents .tab");
     }
+    tab.classList.add("active");
 
-    let tab_container = container.children[0];
-    for (i = 0; i < tab_container.children.length; ++i) {
-        let button = tab_container.children[i];
-        button.className = button.className.replace(" active", "");
-        if (button.dataset.lang === language) {
-            button.className += " active";
-        }
+    const previouslyActiveButton = container.querySelector(".tabbar.active");
+    previouslyActiveButton && previouslyActiveButton.classList.remove(".tabbar active");
+    let button = container.querySelector(`.tabbar [data-value="${language}"]`);
+    if (!button) {
+        button = container.querySelector(".tabbar button");
     }
+    button.classList.add("active");
 }
 
 /**

--- a/docs/tabs.js
+++ b/docs/tabs.js
@@ -31,9 +31,9 @@ function switchTab(container, language) {
     for (i = 0; i < tab_contents_container.children.length; ++i) {
         let tab = tab_contents_container.children[i];
         if (tab.dataset.lang === language) {
-            tab.style.visibility = "visible";
+            tab.style.display = "block";
         } else {
-            tab.style.visibility = "hidden";
+            tab.style.display = "none";
         }
     }
 
@@ -83,15 +83,6 @@ function openTabs() {
             button.onclick = onClickTab;
             button.innerText = tabcontent.dataset.lang;
             tabs.appendChild(button);
-        }
-
-        // Set up the spacing and layout based on the number of active tabs
-        let numTabs = tabcontents.children.length;
-        tabcontents.style.width = `${numTabs * 100}%`;
-        for (let j = 0; j < numTabs; ++j) {
-            let tab = tabcontents.children[j];
-            tab.style.transform = `translateX(-${j * 100}%)`;
-            tab.style.width = `calc(${100 / numTabs}% - 26px)`;
         }
     }
 


### PR DESCRIPTION
Before, the tabs would all be the same height as the longest tab,
which would result in a lot of unnecessary white space at the bottom of
a tab, if a tab with very little content was sibling
to a tab with a lot of content.

See this problem, for example, by selecting the C# tab in this page: https://mozilla.github.io/glean/book/user/general-api.html

[UPDATE]

Found another bug on the tabs, where no tab would be selected in case the "Kotlin" (the default) tab was not present. I fixed it in 335e921. You can see this bug on the "Paralelism" section of the same link I posted above. If this behaviour was intentional, we can just delete that commit :)