### PR TITLE
Support installing Glean Python on musl-based platforms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,6 +767,20 @@ jobs:
           root: glean-core/python/
           paths: .venv3.9
 
+  Python 3_9 on Alpine tests:
+    docker:
+      - image: python:3.9-alpine
+    shell: /bin/sh -leo pipefail
+    environment:
+      - BASH_ENV: /etc/profile
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apk add curl git gcc musl-dev libffi-dev openssh-client make openssl-dev
+      - checkout
+      - test-python
+
   Python Windows x86_64 tests:
     docker:
       - image: circleci/python:3.8.5
@@ -1125,6 +1139,7 @@ workflows:
       - Python 3_8 tests
       - Python 3_8 tests minimum dependencies
       - Python 3_9 tests
+      - Python 3_9 on Alpine tests
       - Python Windows x86_64 tests
       - Python Windows i686 tests
 

--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 208 utf-8
+personal_ws-1.1 en 210 utf-8
 AAR
 AARs
 ABI
@@ -127,6 +127,7 @@ experimentId
 ffi
 func
 gfritzsche
+glibc
 glinter
 gradle
 grcov
@@ -158,6 +159,7 @@ megazord
 metric's
 mozilla
 mozregression
+musl
 mypy
 namespace
 ns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Rust
   * BUGFIX: Don't require mutable references in RLB traits ([#1417](https://github.com/mozilla/glean/pull/1417)).
+* Python
+  * Building the Python package from source now works on musl-based Linux distributions, such as Alpine Linux.
 
 # v33.9.1 (2020-12-17)
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(GLEAN_PYENV)/bin/python3:
 	python3 -m venv $(GLEAN_PYENV)
 	$(GLEAN_PYENV)/bin/pip install --upgrade pip
 	$(GLEAN_PYENV)/bin/pip install --use-feature=2020-resolver -r glean-core/python/requirements_dev.txt
-	bash -c "if [ \"$(GLEAN_PYDEPS)\" == \"min\" ]; then \
+	sh -c "if [ \"$(GLEAN_PYDEPS)\" == \"min\" ]; then \
 		$(GLEAN_PYENV)/bin/pip install requirements-builder; \
 		$(GLEAN_PYENV)/bin/requirements-builder --level=min glean-core/python/setup.py > min_requirements.txt; \
 		$(GLEAN_PYENV)/bin/pip install --use-feature=2020-resolver -r min_requirements.txt; \

--- a/docs/user/adding-glean-to-your-project.md
+++ b/docs/user/adding-glean-to-your-project.md
@@ -140,8 +140,8 @@ carthage update --platform iOS
 
 We recommend using a virtual environment for your work to isolate the dependencies for your project. There are many popular abstractions on top of virtual environments in the Python ecosystem which can help manage your project dependencies.
 
-The Glean SDK Python bindings currently have [prebuilt wheels on PyPI for Windows (i686 and x86_64), Linux (x86_64) and macOS (x86_64)](https://pypi.org/project/glean-sdk/#files).
-For other platforms, the `glean_sdk` package will be built from source on your machine.
+The Glean SDK Python bindings currently have [prebuilt wheels on PyPI for Windows (i686 and x86_64), Linux/glibc (x86_64) and macOS (x86_64)](https://pypi.org/project/glean-sdk/#files).
+For other platforms, including *BSD or Linux distributions that don't use glibc, such as Alpine Linux, the `glean_sdk` package will be built from source on your machine.
 This requires that Cargo and Rust are already installed.
 The easiest way to do this is through [rustup](https://rustup.rs/).
 


### PR DESCRIPTION
This adds the ability to install from a source Python package on musl-based platforms, such as Alpine Linux.  This still requires that a Rust compiler is installed (the usual `rustup` incantation should be sufficient).  This is a partial fix for #1410.

To test, in an Alpine Linux Docker image, such as `python:alpine-3.8`.  You can install the pip package from git from this branch:

```
# To build glean_sdk from a source package
apk add curl
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
export PATH=~/.cargo/bin:$PATH

# To build cffi from a source package
apk add gcc musl-dev libffi-dev

pip install git+git://github.com/mdboom/glean.rs.git@3e4ff4d36f5aa2535965b51444d79aecc666a96e#egg=glean_sdk
```

Cc: @marco-c