### PR TITLE
Python: import setuptools first

### DIFF
--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -4,14 +4,16 @@
 
 """The setup script."""
 
+# setuptools must be imported first
+from setuptools import setup, Distribution, find_packages
+from setuptools.command.install import install
+
 from distutils.command.build import build as _build
 import os
 import shutil
 import subprocess
 import sys
 
-from setuptools import setup, Distribution, find_packages
-from setuptools.command.install import install
 import wheel.bdist_wheel
 
 


### PR DESCRIPTION
This is just to satisfy this new warning from recent versions of setuptools:

.venv3.9/lib/python3.9/site-packages/setuptools/distutils_patch.py:25: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.