### PR TITLE
Bug 1598291 - Publish the Rust crates from CI on every release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,6 +396,33 @@ jobs:
             - docs/docs
             - docs/index.html
 
+  Publish Rust crates:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run:
+          name: Publish Cargo Package
+          command: |
+            # Login to crates.io so the following commands work
+            cargo login -- "$CRATES_IO_TOKEN"
+
+            # Publish all crates from CI.
+            # The token is set in CircleCI settings.
+            # Need some sleep inbetween to ensure crates.io is updated.
+
+            pushd glean-core
+            cargo publish --verbose
+
+            sleep 30
+            pushd ffi
+            cargo publish --verbose
+            popd
+
+            sleep 30
+            pushd rlb
+            cargo publish --verbose
+
   ###########################################################################
   # Android / Kotlin / Java
 
@@ -1214,4 +1241,6 @@ workflows:
       - Carthage release:
           requires:
             - iOS build and test
+          filters: *release-filters
+      - Publish Rust crates:
           filters: *release-filters

--- a/docs/dev/cut-a-new-release.md
+++ b/docs/dev/cut-a-new-release.md
@@ -81,20 +81,11 @@ When CI has finished and is green for your specific release branch, you are read
 5. Wait for the CI build to complete for the tag.
     * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla/glean).
     * You can find the TaskCluster task on the corresponding commit. See [How to find TaskCluster tasks](ci.md#how-to-find-taskcluster-tasks) for details.
-6. Release the Rust crates:
-    ```
-    cd glean-core
-    cargo publish --verbose
-    cd ffi
-    cargo publish --verbose
-    cd .. && cd rlb
-    cargo publish --verbose
-    ```
-7. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla/glean/compare/main...release-v25.0.0?expand=1>
+6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla/glean/compare/main...release-v25.0.0?expand=1>
     * This is important so that no changes are lost.
     * This might have merge conflicts with the `main` branch, which you need to fix before it is merged.
-8. Once the above pull request lands, delete the specific release branch.
-9. Update `glean-ffi` in the iOS megazord. See the [application-services documentation for that](https://github.com/mozilla/application-services/blob/main/megazords/ios/README.md#glean-component).
+7. Once the above pull request lands, delete the specific release branch.
+8. Update `glean-ffi` in the iOS megazord. See the [application-services documentation for that](https://github.com/mozilla/application-services/blob/main/megazords/ios/README.md#glean-component).
 
 ## Hotfix release for latest version
 
@@ -147,18 +138,11 @@ When CI has finished and is green for your hotfix branch, you are ready to cut a
 5. Wait for the CI build to complete for the tag.
     * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla/glean).
     * You can find the TaskCluster task on the corresponding commit. See [How to find TaskCluster tasks](ci.md#how-to-find-taskcluster-tasks) for details.
-6. Release the Rust crates:
-    ```
-    cd glean-core
-    cargo publish --verbose
-    cd ffi
-    cargo publish --verbose
-    ```
-7. Send a pull request to merge back the hotfix branch to the development branch: <https://github.com/mozilla/glean/compare/main...hotfix-v25.0.1?expand=1>
+6. Send a pull request to merge back the hotfix branch to the development branch: <https://github.com/mozilla/glean/compare/main...hotfix-v25.0.1?expand=1>
     * This is important so that no changes are lost.
     * This might have merge conflicts with the `main` branch, which you need to fix before it is merged.
-8. Once the above pull request lands, delete the hotfix branch.
-9. Update `glean-ffi` in the iOS megazord. See the [application-services documentation for that](https://github.com/mozilla/application-services/blob/main/megazords/ios/README.md#glean-component).
+7. Once the above pull request lands, delete the hotfix branch.
+8. Update `glean-ffi` in the iOS megazord. See the [application-services documentation for that](https://github.com/mozilla/application-services/blob/main/megazords/ios/README.md#glean-component).
 
 ## Hotfix release for previous version
 
@@ -207,17 +191,10 @@ If you need to release a hotfix for a previously released version (that is: not 
 5. Wait for the CI build to complete for the tag.
     * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla/glean).
     * You can find the TaskCluster task on the corresponding commit. See [How to find TaskCluster tasks](ci.md#how-to-find-taskcluster-tasks) for details.
-6. Release the Rust crates:
-    ```
-    cd glean-core
-    cargo publish --verbose
-    cd ffi
-    cargo publish --verbose
-    ```
-7. Send a pull request to merge back any bug fixes to the development branch: <https://github.com/mozilla/glean/compare/main...support/v24.0?expand=1>
+6. Send a pull request to merge back any bug fixes to the development branch: <https://github.com/mozilla/glean/compare/main...support/v24.0?expand=1>
     * This is important so that no changes are lost.
     * This might have merge conflicts with the `main` branch, which you need to fix before it is merged.
-8. Once the above pull request lands, delete the support branch.
+7. Once the above pull request lands, delete the support branch.
 
 ## Upgrading android-components to a new version of Glean
 


### PR DESCRIPTION
Not yet ready -- I'm taking this for a test run with a sample crate.