### PR TITLE
Bug 1686736 - (RLB) Record the number of tasks queued in the pre-initialization buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.10.3...main)
 
+* RLB
+  * When the pre-init task queue overruns, this is now recorded in the metric `glean.error.preinit_tasks_overflow`.
+
 # v33.10.3 (2021-01-18)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v33.10.2...v33.10.3)

--- a/glean-core/rlb/src/dispatcher/global.rs
+++ b/glean-core/rlb/src/dispatcher/global.rs
@@ -7,7 +7,7 @@ use std::sync::RwLock;
 
 use super::{DispatchError, DispatchGuard, Dispatcher};
 
-const GLOBAL_DISPATCHER_LIMIT: usize = 100;
+pub const GLOBAL_DISPATCHER_LIMIT: usize = 100;
 static GLOBAL_DISPATCHER: Lazy<RwLock<Option<Dispatcher>>> =
     Lazy::new(|| RwLock::new(Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT))));
 
@@ -55,7 +55,12 @@ pub fn block_on_queue() {
 ///
 /// This function blocks until queued tasks prior to this call are finished.
 /// Once the initial queue is empty the dispatcher will wait for new tasks to be launched.
-pub fn flush_init() -> Result<(), DispatchError> {
+///
+/// # Returns
+///
+/// Returns the total number of items that were added to the queue before being flushed,
+/// or an error if the queue couldn't be flushed.
+pub fn flush_init() -> Result<usize, DispatchError> {
     guard().flush_init()
 }
 

--- a/glean-core/rlb/src/dispatcher/mod.rs
+++ b/glean-core/rlb/src/dispatcher/mod.rs
@@ -29,7 +29,7 @@
 use std::{
     mem,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     thread::{self, JoinHandle},
@@ -107,6 +107,9 @@ struct DispatchGuard {
     /// Whether to queue on the preinit buffer or on the unbounded queue
     queue_preinit: Arc<AtomicBool>,
 
+    /// The number of items that were added to the queue after it filled up.
+    overflow_count: Arc<AtomicUsize>,
+
     /// Used to unblock the worker thread initially.
     block_sender: Sender<Blocked>,
 
@@ -132,10 +135,20 @@ impl DispatchGuard {
 
     fn send(&self, task: Command) -> Result<(), DispatchError> {
         if self.queue_preinit.load(Ordering::SeqCst) {
-            match self.preinit_sender.try_send(task) {
-                Ok(()) => Ok(()),
-                Err(TrySendError::Full(_)) => Err(DispatchError::QueueFull),
-                Err(TrySendError::Disconnected(_)) => Err(DispatchError::SendError),
+            match self
+                .preinit_sender
+                .try_send(task)
+                .map_err(DispatchError::from)
+            {
+                Err(err @ DispatchError::QueueFull) => {
+                    // This value ends up in the `preinit_tasks_overflow` metric, but we
+                    // can't record directly there, because that would only add
+                    // the recording to an already-overflowing task queue and would be
+                    // silently dropped.
+                    self.overflow_count.fetch_add(1, Ordering::SeqCst);
+                    Err(err)
+                }
+                err => err,
             }
         } else {
             self.sender.send(task)?;
@@ -175,7 +188,7 @@ impl DispatchGuard {
         Ok(())
     }
 
-    fn flush_init(&mut self) -> Result<(), DispatchError> {
+    fn flush_init(&mut self) -> Result<usize, DispatchError> {
         // We immediately stop queueing in the pre-init buffer.
         let old_val = self.queue_preinit.swap(false, Ordering::SeqCst);
         if !old_val {
@@ -196,7 +209,7 @@ impl DispatchGuard {
         // Now wait for the worker thread to do the swap and inform us.
         // This blocks until all tasks in the preinit buffer have been processed.
         swap_receiver.recv()?;
-        Ok(())
+        Ok(self.overflow_count.load(Ordering::SeqCst) + global::GLOBAL_DISPATCHER_LIMIT)
     }
 }
 
@@ -227,6 +240,7 @@ impl Dispatcher {
         let (sender, mut unbounded_receiver) = unbounded();
 
         let queue_preinit = Arc::new(AtomicBool::new(true));
+        let overflow_count = Arc::new(AtomicUsize::new(0));
 
         let worker = thread::Builder::new()
             .name("glean.dispatcher".into())
@@ -291,6 +305,7 @@ impl Dispatcher {
 
         let guard = DispatchGuard {
             queue_preinit,
+            overflow_count,
             block_sender,
             preinit_sender,
             sender,
@@ -326,7 +341,7 @@ impl Dispatcher {
     /// Once the initial queue is empty the dispatcher will wait for new tasks to be launched.
     ///
     /// Returns an error if called multiple times.
-    pub fn flush_init(&mut self) -> Result<(), DispatchError> {
+    pub fn flush_init(&mut self) -> Result<usize, DispatchError> {
         self.guard().flush_init()
     }
 }

--- a/glean-core/rlb/src/dispatcher/mod.rs
+++ b/glean-core/rlb/src/dispatcher/mod.rs
@@ -209,7 +209,12 @@ impl DispatchGuard {
         // Now wait for the worker thread to do the swap and inform us.
         // This blocks until all tasks in the preinit buffer have been processed.
         swap_receiver.recv()?;
-        Ok(self.overflow_count.load(Ordering::SeqCst) + global::GLOBAL_DISPATCHER_LIMIT)
+        let overflow_count = self.overflow_count.load(Ordering::SeqCst);
+        if overflow_count > 0 {
+            Ok(overflow_count + global::GLOBAL_DISPATCHER_LIMIT)
+        } else {
+            Ok(0)
+        }
     }
 }
 

--- a/glean-core/rlb/src/glean_metrics.rs
+++ b/glean-core/rlb/src/glean_metrics.rs
@@ -8,3 +8,21 @@
 // 'glean-parser' from the SDK registry files.
 
 include!(concat!("pings.rs"));
+
+pub mod error {
+    use crate::private::CounterMetric;
+    use crate::{CommonMetricData, Lifetime};
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static preinit_tasks_overflow: Lazy<CounterMetric> = Lazy::new(|| {
+        CounterMetric::new(CommonMetricData {
+            name: "glean.error".into(),
+            category: "preinit_tasks_overflow".into(),
+            send_in_pings: vec!["metrics".into()],
+            lifetime: Lifetime::Ping,
+            disabled: false,
+            ..Default::default()
+        })
+    });
+}

--- a/glean-core/rlb/src/private/counter.rs
+++ b/glean-core/rlb/src/private/counter.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use glean_core::Glean;
 use inherent::inherent;
 use std::sync::Arc;
 
@@ -27,6 +28,11 @@ impl CounterMetric {
     /// The public constructor used by automatically generated metrics.
     pub fn new(meta: glean_core::CommonMetricData) -> Self {
         Self(Arc::new(glean_core::metrics::CounterMetric::new(meta)))
+    }
+
+    /// Internal only, synchronous API for incremeting a counter
+    pub(crate) fn add_sync(&self, glean: &Glean, amount: i32) {
+        self.0.add(glean, amount);
     }
 }
 

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -398,12 +398,6 @@ fn core_metrics_should_be_cleared_and_restored_when_disabling_and_enabling_uploa
 }
 
 #[test]
-#[ignore] // TODO: To be done in bug 1686736.
-fn overflowing_the_task_queue_records_telemetry() {
-    todo!()
-}
-
-#[test]
 fn sending_deletion_ping_if_disabled_outside_of_run() {
     let _lock = lock_test();
 

--- a/glean-core/rlb/tests/overflowing_preinit.rs
+++ b/glean-core/rlb/tests/overflowing_preinit.rs
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This integration test should model how the RLB is used when embedded in another Rust application
+//! (e.g. FOG/Firefox Desktop).
+//!
+//! We write a single test scenario per file to avoid any state keeping across runs
+//! (different files run as different processes).
+
+mod common;
+
+use glean::Configuration;
+
+/// Some user metrics.
+mod metrics {
+    use glean::private::*;
+    use glean::Lifetime;
+    use glean_core::CommonMetricData;
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static rapid_counting: Lazy<CounterMetric> = Lazy::new(|| {
+        CounterMetric::new(CommonMetricData {
+            name: "rapid_counting".into(),
+            category: "sample".into(),
+            send_in_pings: vec!["metrics".into()],
+            lifetime: Lifetime::Ping,
+            disabled: false,
+            ..Default::default()
+        })
+    });
+
+    // This is a hack, but a good one:
+    //
+    // To avoid reaching into RLB internals we re-create the metric so we can look at it.
+    #[allow(non_upper_case_globals)]
+    pub static preinit_tasks_overflow: Lazy<CounterMetric> = Lazy::new(|| {
+        CounterMetric::new(CommonMetricData {
+            name: "glean.error".into(),
+            category: "preinit_tasks_overflow".into(),
+            send_in_pings: vec!["metrics".into()],
+            lifetime: Lifetime::Ping,
+            disabled: false,
+            ..Default::default()
+        })
+    });
+}
+
+/// Test scenario: Lots of metric recordings before  init.
+///
+/// The app starts recording metrics before Glean is initialized.
+/// Once initialized the recordings are processed and data is persisted.
+/// The pre-init dispatcher queue records how many recordings over the limit it saw.
+///
+/// This is an integration test to avoid dealing with resetting the dispatcher.
+#[test]
+fn overflowing_the_task_queue_records_telemetry() {
+    common::enable_test_logging();
+
+    // Create a custom configuration to use a validating uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+
+    let cfg = Configuration {
+        data_path: tmpname,
+        application_id: "firefox-desktop".into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        channel: Some("testing".into()),
+        server_endpoint: Some("invalid-test-host".into()),
+        uploader: None,
+    };
+
+    // Insert a bunch of tasks to overflow the queue.
+    for _ in 0..110 {
+        metrics::rapid_counting.add(1);
+    }
+
+    // Now initialize Glean
+    common::initialize(cfg);
+
+    assert_eq!(Some(100), metrics::rapid_counting.test_get_value(None));
+
+    // The metrics counts the total number of overflowing tasks,
+    // this might include Glean-internal tasks.
+    let val = metrics::preinit_tasks_overflow
+        .test_get_value(None)
+        .unwrap();
+    assert!(val >= 110);
+
+    glean::shutdown();
+}


### PR DESCRIPTION
Based on #1437.
The last 3 commits are the new implementation.

I went for an integration test to avoid having to deal with resetting the dispatcher and Glean.