### PR TITLE
Explicitly set linker for Big Sur

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[target.aarch64-apple-ios]
+linker="/usr/bin/clang"
+[target.x86_64-apple-darwin]
+linker="/usr/bin/clang"


### PR DESCRIPTION
Currently the project fails to compile on Big Sur.

I was able to fix it by explicitly setting the linkers in the cargo config