### PR TITLE
Disable the `records_io_errors` test on Windows

### DIFF
--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -872,6 +872,7 @@ fn records_database_file_size() {
     assert!(data.sum > 0);
 }
 
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn records_io_errors() {
     use std::fs;


### PR DESCRIPTION
The test fails on Windows 10, possibly because it uses permissions. The offending line is `assert!(submitted.is_err());`. It indicates that Glean had no problem writing to disk.