### PR TITLE
Bug 1685522 - Add the 'clients activity API' and implement the baseline ping for the RLB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@
 * General
   * Other bindings detect when RLB is used and try to flush the RLB dispatcher to unblock the Rust API ([#1442](https://github.com/mozilla/glean/pull/1442)).
     * This is detected automatically, no changes needed for consuming code.
+  * Add support for the client activity API. This API is either automatically used or exposed by the language bindings.
+  * Rename the reason `background` to `inactive` for both the `baseline` and `events` ping. Rename the reason `foreground` to `active` for the `baseline` ping.
 * RLB
   * When the pre-init task queue overruns, this is now recorded in the metric `glean.error.preinit_tasks_overflow`.
+  * Expose the client activity API.
+  * Send the `baseline` ping with reason `dirty_startup`, if needed, at startup.
 * Android
   * BUGFIX: Don't crash the ping uploader when throttled due to reading too large wait time values ([#1454](https://github.com/mozilla/glean/pull/1454)).
+  * Use the client activity API.
 
 # v33.10.3 (2021-01-18)
 

--- a/docs/user/collected-metrics/metrics.md
+++ b/docs/user/collected-metrics/metrics.md
@@ -48,18 +48,18 @@ This ping includes the [client id](https://mozilla.github.io/glean/book/user/pin
 
 **Reasons this ping may be sent:**
 
-- `background`: The ping was submitted before going to background.
-
-- `dirty_startup`: The ping was submitted at startup, because the application process was
-      killed before the Glean SDK had the chance to generate this ping, when
-      going to background, in the last session.
-
-      *Note*: this ping will not contain the `glean.baseline.duration` metric.
-
-- `foreground`: The ping was submitted when the application went to foreground, which
+- `active`: The ping was submitted when the application became active again, which
       includes when the application starts.
 
       *Note*: this ping will not contain the `glean.baseline.duration` metric.
+
+- `dirty_startup`: The ping was submitted at startup, because the application process was
+      killed before the Glean SDK had the chance to generate this ping, before
+      becoming inactive, in the last session.
+
+      *Note*: this ping will not contain the `glean.baseline.duration` metric.
+
+- `inactive`: The ping was submitted before becoming inactive.
 
 
 The following metrics are added to the ping:

--- a/docs/user/collected-metrics/metrics.md
+++ b/docs/user/collected-metrics/metrics.md
@@ -49,7 +49,8 @@ This ping includes the [client id](https://mozilla.github.io/glean/book/user/pin
 **Reasons this ping may be sent:**
 
 - `active`: The ping was submitted when the application became active again, which
-      includes when the application starts.
+      includes when the application starts. In earlier versions, this was called
+      `foreground`.
 
       *Note*: this ping will not contain the `glean.baseline.duration` metric.
 
@@ -59,7 +60,8 @@ This ping includes the [client id](https://mozilla.github.io/glean/book/user/pin
 
       *Note*: this ping will not contain the `glean.baseline.duration` metric.
 
-- `inactive`: The ping was submitted before becoming inactive.
+- `inactive`: The ping was submitted when becoming inactive. In earlier versions, this
+      was called `background`.
 
 
 The following metrics are added to the ping:

--- a/docs/user/pings/baseline.md
+++ b/docs/user/pings/baseline.md
@@ -8,10 +8,10 @@ This ping is intended to provide metrics that are managed by the Glean SDK itsel
 
 ## Scheduling
 
-The `baseline` ping is automatically submitted with a `reason: foreground` when the application is moved to the [foreground](index.md#defining-foreground-and-background-state).  These baseline pings do not contain `duration`.
+The `baseline` ping is automatically submitted with a `reason: active` when the application becomes active (on mobile it means getting to [foreground](index.md#defining-foreground-and-background-state)).  These baseline pings do not contain `duration`.
 
-The `baseline` ping is automatically submitted with a `reason: background` when the application is moved to the [background](index.md#defining-foreground-and-background-state).
-Occasionally, the `baseline` ping may fail to send when going to background (e.g. the process is killed quickly).  In that case, it will be submitted at startup with a `reason: dirty_startup`, if the previous session was not cleanly closed. This only happens from the second start onward.
+The `baseline` ping is automatically submitted with a `reason: inactive` when the application becomes inactive (on mobile it means getting to [background](index.md#defining-foreground-and-background-state)).
+Occasionally, the `baseline` ping may fail to send when becoming inactive (e.g. the process is killed quickly).  In that case, it will be submitted at startup with a `reason: dirty_startup`, if the previous session was not cleanly closed. This only happens from the second start onward.
 
 See also the [ping schedules and timing overview](ping-schedules-and-timings.html).
 

--- a/docs/user/pings/baseline.md
+++ b/docs/user/pings/baseline.md
@@ -11,7 +11,7 @@ This ping is intended to provide metrics that are managed by the Glean SDK itsel
 The `baseline` ping is automatically submitted with a `reason: active` when the application becomes active (on mobile it means getting to [foreground](index.md#defining-foreground-and-background-state)).  These baseline pings do not contain `duration`.
 
 The `baseline` ping is automatically submitted with a `reason: inactive` when the application becomes inactive (on mobile it means getting to [background](index.md#defining-foreground-and-background-state)).
-Occasionally, the `baseline` ping may fail to send when becoming inactive (e.g. the process is killed quickly).  In that case, it will be submitted at startup with a `reason: dirty_startup`, if the previous session was not cleanly closed. This only happens from the second start onward.
+If no `baseline` ping is triggered when becoming inactive (e.g. the process is abruptly killed) a `baseline` ping with reason `dirty_startup` will be submitted on the next application startup. This only happens from the second application start onward.
 
 See also the [ping schedules and timing overview](ping-schedules-and-timings.html).
 

--- a/docs/user/pings/events.md
+++ b/docs/user/pings/events.md
@@ -8,7 +8,7 @@ If the application crashes, an `events` ping is generated next time the applicat
 
 The `events` ping is collected under the following circumstances:
 
-1. Normally, it is collected when the application goes into the [background](index.md#defining-foreground-and-background-state), if there are any recorded events to send.
+1. Normally, it is collected when the application becomes inactive (on mobile, this means going to [background](index.md#defining-foreground-and-background-state)), if there are any recorded events to send.
 
 2. When the queue of events exceeds `Glean.configuration.maxEvents` (default 500).
 

--- a/docs/user/pings/index.md
+++ b/docs/user/pings/index.md
@@ -132,7 +132,7 @@ These docs refer to application 'foreground' and 'background' state in several p
 
 <div data-lang="Kotlin" class="tab">
 
-#### Foreground
+### Foreground
 
 For Android, this specifically means the activity becomes visible to the user, it has entered the `Started` state, and the system invokes the [`onStart()`](https://developer.android.com/reference/android/app/Activity.html#onStart()) callback.
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -563,8 +563,6 @@ open class GleanInternalAPI internal constructor () {
      * Handle the foreground event and send the appropriate pings.
      */
     internal fun handleForegroundEvent() {
-        GleanValidation.foregroundCount.add(1)
-
         // Note that this is sending the length of the last foreground session
         // because it belongs to the baseline ping and that ping is sent every
         // time the app goes to background.
@@ -580,6 +578,7 @@ open class GleanInternalAPI internal constructor () {
 
         // Start the timespan for the new activity period.
         GleanBaseline.duration.start()
+        GleanValidation.foregroundCount.add(1)
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/rust/LibGleanFFI.kt
@@ -97,6 +97,10 @@ internal interface LibGleanFFI : Library {
 
     fun glean_is_dirty_flag_set(): Byte
 
+    fun glean_handle_client_active()
+
+    fun glean_handle_client_inactive()
+
     fun glean_test_clear_all_stores()
 
     fun glean_is_first_run(): Byte

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/GleanLifecycleObserver.kt
@@ -7,11 +7,7 @@ package mozilla.telemetry.glean.scheduler
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
-import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.Glean
-import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
-import mozilla.telemetry.glean.rust.LibGleanFFI
-import mozilla.telemetry.glean.rust.toByte
 
 /**
  * Connects process lifecycle events from Android to Glean's handleEvent
@@ -24,22 +20,9 @@ internal class GleanLifecycleObserver : LifecycleEventObserver {
     override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
         when (event) {
             Lifecycle.Event.ON_STOP -> {
-                // We're going to background, so store how much time we spent
-                // on foreground.
-                GleanBaseline.duration.stop()
                 Glean.handleBackgroundEvent()
-
-                // Clear the "dirty flag" as the last thing when going to background.
-                // If the application is not being force-closed, we should still be
-                // alive and allowed to change this. If we're being force-closed and
-                // don't get to this point, next time Glean runs it will be detected.
-                @Suppress("EXPERIMENTAL_API_USAGE")
-                Dispatchers.API.launch {
-                    LibGleanFFI.INSTANCE.glean_set_dirty_flag(false.toByte())
-                }
             }
             Lifecycle.Event.ON_START -> {
-                // Updates the baseline.duration metric when entering the foreground.
                 // We use ON_START here because we don't want to incorrectly count metrics in
                 // ON_RESUME as pause/resume can happen when interacting with things like the
                 // navigation shade which could lead to incorrectly recording the start of a
@@ -47,17 +30,7 @@ internal class GleanLifecycleObserver : LifecycleEventObserver {
                 //
                 // https://developer.android.com/reference/android/app/Activity.html#onStart()
 
-                // Note that this is sending the length of the last foreground session
-                // because it belongs to the baseline ping and that ping is sent every
-                // time the app goes to background.
                 Glean.handleForegroundEvent()
-                GleanBaseline.duration.start()
-
-                // Set the "dirty flag" to `true`.
-                @Suppress("EXPERIMENTAL_API_USAGE")
-                Dispatchers.API.launch {
-                    LibGleanFFI.INSTANCE.glean_set_dirty_flag(true.toByte())
-                }
             }
             else -> {
                 // For other lifecycle events, do nothing

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
@@ -74,6 +74,6 @@ public class GleanFromJavaTest {
         // submit() can be called without parameters.
         Pings.INSTANCE.baseline().submit();
         // submit() can be called with a `reason`.
-        Pings.INSTANCE.baseline().submit(Pings.baselineReasonCodes.background);
+        Pings.INSTANCE.baseline().submit(Pings.baselineReasonCodes.inactive);
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -232,7 +232,7 @@ class GleanTest {
                     //   - seq: 2, reason: foreground, duration: null
                     if (seq == 1) {
                         val baselineMetricsObject = json.getJSONObject("metrics")
-                        assertEquals("background", json.getJSONObject("ping_info").getString("reason"))
+                        assertEquals("inactive", json.getJSONObject("ping_info").getString("reason"))
                         val baselineTimespanMetrics = baselineMetricsObject.getJSONObject("timespan")
                         assertEquals(1, baselineTimespanMetrics.length())
                         assertNotNull(baselineTimespanMetrics.get("glean.baseline.duration"))

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -373,6 +373,10 @@ void glean_set_dirty_flag(uint8_t flag);
 
 uint8_t glean_is_dirty_flag_set(void);
 
+void glean_handle_client_active(void);
+
+void glean_handle_client_inactive(void);
+
 void glean_test_clear_all_stores(void);
 
 void glean_destroy_glean(void);

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -410,6 +410,16 @@ pub extern "C" fn glean_is_dirty_flag_set() -> u8 {
 }
 
 #[no_mangle]
+pub extern "C" fn glean_handle_client_active() {
+    with_glean_value_mut(|glean| glean.handle_client_active());
+}
+
+#[no_mangle]
+pub extern "C" fn glean_handle_client_inactive() {
+    with_glean_value_mut(|glean| glean.handle_client_inactive());
+}
+
+#[no_mangle]
 pub extern "C" fn glean_test_clear_all_stores() {
     with_glean_value(|glean| glean.test_clear_all_stores())
 }

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -373,6 +373,10 @@ void glean_set_dirty_flag(uint8_t flag);
 
 uint8_t glean_is_dirty_flag_set(void);
 
+void glean_handle_client_active(void);
+
+void glean_handle_client_inactive(void);
+
 void glean_test_clear_all_stores(void);
 
 void glean_destroy_glean(void);

--- a/glean-core/pings.yaml
+++ b/glean-core/pings.yaml
@@ -34,10 +34,12 @@ baseline:
 
       *Note*: this ping will not contain the `glean.baseline.duration` metric.
     inactive: |
-      The ping was submitted before becoming inactive.
+      The ping was submitted when becoming inactive. In earlier versions, this
+      was called `background`.
     active: |
       The ping was submitted when the application became active again, which
-      includes when the application starts.
+      includes when the application starts. In earlier versions, this was called
+      `foreground`.
 
       *Note*: this ping will not contain the `glean.baseline.duration` metric.
 
@@ -95,7 +97,8 @@ events:
       are any pending events at startup, because event timestamps can not be
       mixed across runs of the application.
     inactive: |
-      The ping was submitted before becoming inactive.
+      The ping was submitted when becoming inactive. In earlier versions, this
+      was called `background`.
     max_capacity: |
       The maximum number of events was reached (default 500 events).
 

--- a/glean-core/pings.yaml
+++ b/glean-core/pings.yaml
@@ -80,8 +80,8 @@ metrics:
 events:
   description: |
     The events ping's purpose is to transport all of the event metric
-    information. The `events` ping is automatically sent when the application is
-    moved to the background.
+    information. The `events` ping is automatically sent when the application
+    becomes inactive.
   include_client_id: true
   bugs:
     - https://bugzilla.mozilla.org/1512938
@@ -94,8 +94,8 @@ events:
       The ping was submitted at startup. The events ping is always sent if there
       are any pending events at startup, because event timestamps can not be
       mixed across runs of the application.
-    background: |
-      The ping was submitted before going to background.
+    inactive: |
+      The ping was submitted before becoming inactive.
     max_capacity: |
       The maximum number of events was reached (default 500 events).
 

--- a/glean-core/pings.yaml
+++ b/glean-core/pings.yaml
@@ -29,14 +29,14 @@ baseline:
   reasons:
     dirty_startup: |
       The ping was submitted at startup, because the application process was
-      killed before the Glean SDK had the chance to generate this ping, when
-      going to background, in the last session.
+      killed before the Glean SDK had the chance to generate this ping, before
+      becoming inactive, in the last session.
 
       *Note*: this ping will not contain the `glean.baseline.duration` metric.
-    background: |
-      The ping was submitted before going to background.
-    foreground: |
-      The ping was submitted when the application went to foreground, which
+    inactive: |
+      The ping was submitted before becoming inactive.
+    active: |
+      The ping was submitted when the application became active again, which
       includes when the application starts.
 
       *Note*: this ping will not contain the `glean.baseline.duration` metric.

--- a/glean-core/rlb/src/core_metrics.rs
+++ b/glean-core/rlb/src/core_metrics.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::private::StringMetric;
-use crate::{CommonMetricData, Lifetime};
+use crate::private::{StringMetric, TimespanMetric};
+use crate::{CommonMetricData, Lifetime, TimeUnit};
 
 use once_cell::sync::Lazy;
 
@@ -26,10 +26,10 @@ impl ClientInfoMetrics {
     }
 }
 
+#[allow(non_upper_case_globals)]
 pub mod internal_metrics {
     use super::*;
 
-    #[allow(non_upper_case_globals)]
     pub static app_build: Lazy<StringMetric> = Lazy::new(|| {
         StringMetric::new(CommonMetricData {
             name: "app_build".into(),
@@ -41,7 +41,6 @@ pub mod internal_metrics {
         })
     });
 
-    #[allow(non_upper_case_globals)]
     pub static app_display_version: Lazy<StringMetric> = Lazy::new(|| {
         StringMetric::new(CommonMetricData {
             name: "app_display_version".into(),
@@ -53,7 +52,6 @@ pub mod internal_metrics {
         })
     });
 
-    #[allow(non_upper_case_globals)]
     pub static app_channel: Lazy<StringMetric> = Lazy::new(|| {
         StringMetric::new(CommonMetricData {
             name: "app_channel".into(),
@@ -65,7 +63,6 @@ pub mod internal_metrics {
         })
     });
 
-    #[allow(non_upper_case_globals)]
     pub static os_version: Lazy<StringMetric> = Lazy::new(|| {
         StringMetric::new(CommonMetricData {
             name: "os_version".into(),
@@ -77,7 +74,6 @@ pub mod internal_metrics {
         })
     });
 
-    #[allow(non_upper_case_globals)]
     pub static architecture: Lazy<StringMetric> = Lazy::new(|| {
         StringMetric::new(CommonMetricData {
             name: "architecture".into(),
@@ -89,7 +85,6 @@ pub mod internal_metrics {
         })
     });
 
-    #[allow(non_upper_case_globals)]
     pub static device_manufacturer: Lazy<StringMetric> = Lazy::new(|| {
         StringMetric::new(CommonMetricData {
             name: "device_manufacturer".into(),
@@ -101,7 +96,6 @@ pub mod internal_metrics {
         })
     });
 
-    #[allow(non_upper_case_globals)]
     pub static device_model: Lazy<StringMetric> = Lazy::new(|| {
         StringMetric::new(CommonMetricData {
             name: "device_model".into(),
@@ -111,5 +105,19 @@ pub mod internal_metrics {
             disabled: false,
             ..Default::default()
         })
+    });
+
+    pub static baseline_duration: Lazy<TimespanMetric> = Lazy::new(|| {
+        TimespanMetric::new(
+            CommonMetricData {
+                name: "duration".into(),
+                category: "glean.baseline".into(),
+                send_in_pings: vec!["baseline".into()],
+                lifetime: Lifetime::Ping,
+                disabled: false,
+                ..Default::default()
+            },
+            TimeUnit::Second,
+        )
     });
 }

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -171,7 +171,7 @@ fn test_experiments_recording_before_glean_inits() {
 }
 
 #[test]
-fn test_sending_of_foreground_background_pings() {
+fn sending_of_foreground_background_pings() {
     let _lock = lock_test();
 
     let click: EventMetric<traits::NoExtraKeys> = private::EventMetric::new(CommonMetricData {
@@ -223,11 +223,13 @@ fn test_sending_of_foreground_background_pings() {
 
     // Simulate becoming active.
     handle_client_active();
-    click.record(None);
 
     // We expect a baseline ping to be generated here (reason: 'active').
     let url = r.recv().unwrap();
     assert!(url.contains("baseline"));
+
+    // Recording an event so that an "events" ping will contain data.
+    click.record(None);
 
     // Simulate becoming inactive
     handle_client_inactive();
@@ -237,7 +239,7 @@ fn test_sending_of_foreground_background_pings() {
     for _ in 0..2 {
         let url = r.recv().unwrap();
         // If the url contains the expected reason, remove it from the list.
-        expected_pings.retain(|&name| url.contains(name));
+        expected_pings.retain(|&name| !url.contains(name));
     }
     // We received all the expected pings.
     assert_eq!(0, expected_pings.len());
@@ -251,7 +253,7 @@ fn test_sending_of_foreground_background_pings() {
 }
 
 #[test]
-fn test_sending_of_startup_baseline_ping() {
+fn sending_of_startup_baseline_ping() {
     let _lock = lock_test();
 
     // Create an instance of Glean, wait for init and then flip the dirty

--- a/glean-core/src/internal_pings.rs
+++ b/glean-core/src/internal_pings.rs
@@ -21,7 +21,16 @@ pub struct InternalPings {
 impl InternalPings {
     pub fn new() -> InternalPings {
         InternalPings {
-            baseline: PingType::new("baseline", true, false, vec![]),
+            baseline: PingType::new(
+                "baseline",
+                true,
+                false,
+                vec![
+                    "active".to_string(),
+                    "dirty_startup".to_string(),
+                    "inactive".to_string(),
+                ],
+            ),
             metrics: PingType::new(
                 "metrics",
                 true,

--- a/glean-core/src/internal_pings.rs
+++ b/glean-core/src/internal_pings.rs
@@ -43,7 +43,16 @@ impl InternalPings {
                     "upgrade".to_string(),
                 ],
             ),
-            events: PingType::new("events", true, false, vec![]),
+            events: PingType::new(
+                "events",
+                true,
+                false,
+                vec![
+                    "startup".to_string(),
+                    "inactive".to_string(),
+                    "max_capacity".to_string(),
+                ],
+            ),
             deletion_request: PingType::new("deletion-request", true, true, vec![]),
         }
     }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -882,6 +882,34 @@ impl Glean {
         }
     }
 
+    /// Performs the collection/cleanup operations required by becoming active.
+    ///
+    /// This functions generates a baseline ping with reason `active`
+    /// and then sets the dirty bit.
+    pub fn handle_client_active(&mut self) {
+        if let Err(err) = self.internal_pings.baseline.submit(self, Some("active")) {
+            log::error!("Failed to submit baseline ping on active: {}", err);
+        }
+
+        self.set_dirty_flag(true);
+    }
+
+    /// Performs the collection/cleanup operations required by becoming inactive.
+    ///
+    /// This functions generates a baseline and an events ping with reason
+    /// `inactive` and then clears the dirty bit.
+    pub fn handle_client_inactive(&mut self) {
+        if let Err(err) = self.internal_pings.baseline.submit(self, Some("inactive")) {
+            log::error!("Failed to submit baseline ping on inactive: {}", err);
+        }
+
+        if let Err(err) = self.internal_pings.events.submit(self, Some("inactive")) {
+            log::error!("Failed to submit events ping on inactive: {}", err);
+        }
+
+        self.set_dirty_flag(false);
+    }
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Checks if an experiment is currently active.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -888,7 +888,7 @@ impl Glean {
     /// and then sets the dirty bit.
     pub fn handle_client_active(&mut self) {
         if let Err(err) = self.internal_pings.baseline.submit(self, Some("active")) {
-            log::error!("Failed to submit baseline ping on active: {}", err);
+            log::warn!("Failed to submit baseline ping on active: {}", err);
         }
 
         self.set_dirty_flag(true);
@@ -900,11 +900,11 @@ impl Glean {
     /// `inactive` and then clears the dirty bit.
     pub fn handle_client_inactive(&mut self) {
         if let Err(err) = self.internal_pings.baseline.submit(self, Some("inactive")) {
-            log::error!("Failed to submit baseline ping on inactive: {}", err);
+            log::warn!("Failed to submit baseline ping on inactive: {}", err);
         }
 
         if let Err(err) = self.internal_pings.events.submit(self, Some("inactive")) {
-            log::error!("Failed to submit events ping on inactive: {}", err);
+            log::warn!("Failed to submit events ping on inactive: {}", err);
         }
 
         self.set_dirty_flag(false);

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -907,3 +907,23 @@ fn records_io_errors() {
     let submitted = glean.internal_pings.metrics.submit(&glean, None);
     assert!(submitted.is_ok());
 }
+
+#[test]
+fn test_activity_api() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dir = tempfile::tempdir().unwrap();
+    let (mut glean, _) = new_glean(Some(dir));
+
+    // Signal that the client was active.
+    glean.handle_client_active();
+
+    // Check that we set everything we needed for the 'active' status.
+    assert!(glean.is_dirty_flag_set());
+
+    // Signal back that client is ianctive.
+    glean.handle_client_inactive();
+
+    // Check that we set everything we needed for the 'inactuve' status.
+    assert!(!glean.is_dirty_flag_set());
+}


### PR DESCRIPTION
This PR does a bunch of things:

- it implements the client activity API in glean-core;
- it implements the startup `baseline` ping with reason `dirty_startup` for the RLB;
- it updates the other language bindings to use the clients activity API

TODO:

- [x] Fix the RLB test.
- [x] Add changelog entries (glean-core and each LB)
- [ ] ~Swift!~ (filed a bug)