### PR TITLE
Always bootstrap the sample with release-mode dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,9 +683,8 @@ jobs:
       - run:
           name: Bootstrap dependencies
           command: |
-            # We need release mode to correctly ship bitcode for dependencies
             pushd samples/ios/app
-            ./bootstrap.sh Release
+            ./bootstrap.sh
             popd
       - run:
           name: Build sample app

--- a/samples/ios/app/bootstrap.sh
+++ b/samples/ios/app/bootstrap.sh
@@ -4,10 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-CONFIGURATION="${1:-Debug}"
-
 WORKSPACE_ROOT="$( cd "$(dirname "$0")/../../.." ; pwd -P )"
 XCODE_XCCONFIG_FILE="$WORKSPACE_ROOT/xcconfig/xcode-12-fix-carthage-lipo.xcconfig"
 export XCODE_XCCONFIG_FILE
 
-carthage bootstrap --platform iOS --color auto --cache-builds --verbose --configuration "$CONFIGURATION"
+carthage bootstrap --platform iOS --color auto --cache-builds --verbose --configuration Release


### PR DESCRIPTION
We need release mode to correctly ship bitcode for dependencies.
It fails without that, so there's no reason to keep the old way of doing it.