### PR TITLE
Use Python 3.9 on macOS on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -953,10 +953,10 @@ jobs:
           name: Build macOS wheel
           command: |
             cd glean-core/python
-            .venv3.8/bin/python3 setup.py bdist_wheel
+            .venv3.9/bin/python3 setup.py bdist_wheel
             # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment
             # variables are configured in CircleCI's environment variables.
-            .venv3.8/bin/python3 -m twine upload dist/*
+            .venv3.9/bin/python3 -m twine upload dist/*
           environment:
             GLEAN_BUILD_VARIANT: release
       - install-ghr-darwin


### PR DESCRIPTION
---

Now we release everything else with Python 3.8.
Is that gonna be a problem?