### PR TITLE
Bug 1647764 - Swift: Check and reset dirty flag on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * iOS
   * The metric `glean.validation.foreground_count` is now sent in the metrics ping ([#1472](https://github.com/mozilla/glean/pull/1472)).
+  * BUGFIX: baseline pings with reason `dirty_startup` are no longer sent if Glean did not full initialize in the previous run ([#1476](https://github.com/mozilla/glean/pull/1476)).
 
 # v34.0.0 (2021-01-29)
 


### PR DESCRIPTION
This will avoid sending a dirty startup ping if the previous run of the application didn't
successfully and completely initialize Glean.

Unfortunately this is impossible to really test.
Because we currently consider initialization as a "foreground notification" (for the lack of other signals)
we immediately re-set the dirty flag to true.
So once the `initialization` completes we can't observe the previous
state anymore.


---

@mdboom because he did the original implementation.
@travis79 for the Swift review.

I'm going to post another PR for discussion around the notifications shortly. Not gonna land this before we discussed that one.