### PR TITLE
Swift: replace foreground notification with activation notification

### DIFF
--- a/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
+++ b/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
@@ -8,8 +8,8 @@ class GleanLifecycleObserver {
     init() {
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(GleanLifecycleObserver.appWillEnterForeground(notification:)),
-            name: UIApplication.willEnterForegroundNotification,
+            selector: #selector(GleanLifecycleObserver.didBecomeActiveNotification(notification:)),
+            name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
 
@@ -19,13 +19,9 @@ class GleanLifecycleObserver {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
-
-        // We handle init the same as an foreground event,
-        // as we won't get the enter-foreground notification.
-        Glean.shared.handleForegroundEvent()
     }
 
-    @objc func appWillEnterForeground(notification _: NSNotification) {
+    @objc func didBecomeActiveNotification(notification _: NSNotification) {
         // Note that this is sending the length of the last foreground session
         // because it belongs to the baseline ping and that ping is sent every
         // time the app goes to background.


### PR DESCRIPTION
`applicationWillEnterForeground`[1] is posted _before_ the app is actually
in the foreground, when it leaves the background stae.
This notification is NOT posted on first app launch (because it doesn't
leave a _background_ state).

Therefore we previously triggered `handleForegroundEvent` in the
constructor to work accordingly.
That's not wrong for all current uses of Glean (I assume),
but has two things worth pointing out:

1. It's different from Android behavior, where we do
   `handleForegroundEvent` only on an event (`ON_START`).
2. Because of that Android tests won't trigger `handleForegroundEvent`
   in unit tests, but only within a real app. We therefore can observe
   state after `Glean.initialize` but before `handleForegroundEvent`.
   We can't observe that currently in iOS.

`didBecomeActiveNotification`[2] on the other hand is posted when the
application is really active.
It can be observed on first startup.
Which should more closely match the behavior we also have on Android.

See also #1476, which we are currently unable to test.
We might be able to test it with this change.

[1]: https://developer.apple.com/documentation/uikit/uiapplication/1622944-willenterforegroundnotification
[2]: https://developer.apple.com/documentation/uikit/uiapplication/1622953-didbecomeactivenotification