### PR TITLE
Bug 1690751 - Clear the dirty ping on shutdown in the RLB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * BUGFIX: baseline pings with reason `dirty_startup` are no longer sent if Glean did not full initialize in the previous run ([#1476](https://github.com/mozilla/glean/pull/1476)).
 * Python
   * Expose the client activity API ([#1481](https://github.com/mozilla/glean/pull/1481)).
+* RLB
+  * BUGFIX: baseline pings with reason `dirty_startup` are no longer sent if Glean did shutdown cleanly ([#1483](https://github.com/mozilla/glean/pull/1483)).
 
 # v34.0.0 (2021-01-29)
 

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -352,6 +352,12 @@ pub fn shutdown() {
         return;
     }
 
+    dispatcher::launch(move || {
+        with_glean_mut(|glean| {
+            glean.set_dirty_flag(false);
+        })
+    });
+
     if let Err(e) = dispatcher::shutdown() {
         log::error!("Can't shutdown dispatcher thread: {:?}", e);
     }

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -311,6 +311,67 @@ fn sending_of_startup_baseline_ping() {
 }
 
 #[test]
+fn no_dirty_baseline_on_clean_shutdowns() {
+    let _lock = lock_test();
+
+    // Create an instance of Glean, wait for init and then flip the dirty
+    // bit to true.
+    let data_dir = new_glean(None, true);
+
+    crate::block_on_dispatcher();
+
+    with_glean_mut(|glean| glean.set_dirty_flag(true));
+
+    crate::shutdown();
+
+    // Restart glean and wait for a baseline ping to be generated.
+    let (s, r) = crossbeam_channel::bounded::<String>(1);
+
+    // Define a fake uploader that reports back the submission URL
+    // using a crossbeam channel.
+    #[derive(Debug)]
+    pub struct FakeUploader {
+        sender: crossbeam_channel::Sender<String>,
+    }
+    impl net::PingUploader for FakeUploader {
+        fn upload(
+            &self,
+            url: String,
+            _body: Vec<u8>,
+            _headers: Vec<(String, String)>,
+        ) -> net::UploadResult {
+            self.sender.send(url).unwrap();
+            net::UploadResult::HttpStatus(200)
+        }
+    }
+
+    // Create a custom configuration to use a fake uploader.
+    let tmpname = data_dir.path().display().to_string();
+
+    // Now reset Glean: it should not send a baseline ping, because
+    // we cleared the dirty bit.
+    test_reset_glean(
+        Configuration {
+            data_path: tmpname,
+            application_id: GLOBAL_APPLICATION_ID.into(),
+            upload_enabled: true,
+            max_events: None,
+            delay_ping_lifetime_io: false,
+            channel: Some("testing".into()),
+            server_endpoint: Some("invalid-test-host".into()),
+            uploader: Some(Box::new(FakeUploader { sender: s })),
+        },
+        ClientInfoMetrics::unknown(),
+        false,
+    );
+
+    crate::block_on_dispatcher();
+
+    // We don't expect a startup ping.
+    assert_eq!(r.try_recv(), Err(crossbeam_channel::TryRecvError::Empty));
+}
+
+#[test]
 fn initialize_must_not_crash_if_data_dir_is_messed_up() {
     let _lock = lock_test();
 


### PR DESCRIPTION
This makes sure no baseline ping with reason `dirty_startup` is generated when starting RLB consumers after a clean shutdown.