### PR TITLE
Bug 1688178 - Big Sur/M1 updates: xcframeworks, using Xcode clang, lipo

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,0 @@
-[target.aarch64-apple-ios]
-linker="/usr/bin/clang"
-[target.x86_64-apple-darwin]
-linker="/usr/bin/clang"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,10 +656,8 @@ jobs:
             xcrun instruments -w list || true
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
             xcrun instruments -w "iPhone 11 (14" || true
-      - attach_workspace:
-          at: .
       - run:
-          name: Use binary build of Glean
+          name: Use current commit of Glean
           command: |
             GLEAN_PATH="$(pwd)"
             CARTFILE_PATH="${GLEAN_PATH}/samples/ios/app/Cartfile"
@@ -1118,8 +1116,6 @@ workflows:
             branches:
               only: main
       - iOS integration test:
-          requires:
-            - iOS build and test
           filters:
             branches:
               only: main
@@ -1170,7 +1166,7 @@ workflows:
               ignore: main
       - iOS integration test:
           requires:
-            - iOS build and test
+            - hold
           filters:
             branches:
               ignore: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,6 +528,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install new carthage
+          command: |
+            brew upgrade carthage
+      - run:
           name: Set Ruby Version
           command: echo 'chruby ruby-2.6.6' >> ~/.bash_profile
       - run:
@@ -553,7 +557,11 @@ jobs:
           name: Setup build environment
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
+            cargo install cargo-lipo
+
+            # Bootstrap dependencies
             bin/bootstrap.sh
+
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
             xcrun instruments -w "iPhone 11 (14" || true
             # Store build type for use in cache key
@@ -618,29 +626,9 @@ jobs:
             else
               bash bin/build-carthage.sh Glean
             fi
-      - run:
-          name: "Create Carthage bin-only project specification"
-          command: |
-            ZIP_URL=https://circleci.com/api/v1.1/project/github/mozilla/glean/$CIRCLE_BUILD_NUM/artifacts/0/dist/Glean.framework.zip
-            echo "{\"0.0.1\":\"$ZIP_URL\"}" > mozilla.glean.json
-            # Store the build number for retrieval in a later step.
-            echo "$CIRCLE_BUILD_NUM" > ios-build-num.txt
       - store_artifacts:
           path: Glean.framework.zip
           destination: dist/Glean.framework.zip
-      - store_artifacts:
-          path: mozilla.glean.json
-          destination: dist/mozilla.glean.json
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ios-build-num.txt
-      - run:
-          name: "Carthage binary snapshot URL"
-          command: |
-            JSON_URL=https://circleci.com/api/v1.1/project/github/mozilla/glean/$CIRCLE_BUILD_NUM/artifacts/0/dist/mozilla.glean.json
-            echo "Add the following line to your Cartfile:"
-            echo "binary \"$JSON_URL\" ~> 0.0.1-snapshot # mozilla/glean@$CIRCLE_SHA1"
       - persist_to_workspace:
           root: .
           paths:
@@ -652,12 +640,18 @@ jobs:
     steps:
       - checkout
       - skip-if-doc-only
+      - run:
+          name: Install new carthage
+          command: |
+            brew upgrade carthage
       - install-rustup
       - setup-rust-toolchain
       - run:
           name: Setup build environment
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
+            cargo install cargo-lipo
+
             # List available devices -- allows us to see what's there
             xcrun instruments -w list || true
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
@@ -667,18 +661,14 @@ jobs:
       - run:
           name: Use binary build of Glean
           command: |
-            # Retrieve the previous build number
-            IOS_BUILD_NUM=$(< ios-build-num.txt)
             GLEAN_PATH="$(pwd)"
             CARTFILE_PATH="${GLEAN_PATH}/samples/ios/app/Cartfile"
-            # The previous step generated a binary file and the corresponding JSON manifest
-            JSON_URL="https://circleci.com/api/v1.1/project/github/mozilla/glean/${IOS_BUILD_NUM}/artifacts/0/dist/mozilla.glean.json"
 
             echo "Current Cartfile:"
             cat "${CARTFILE_PATH}"
             echo "================="
             echo "New Cartfile:"
-            sed -i.bak "/mozilla\/glean/s#.*#binary \"$JSON_URL\" ~> 0.0.1-SNAPSHOT#" "$CARTFILE_PATH"
+            sed -i.bak "/mozilla\/glean/s#.*#github \"mozilla/glean\" \"${CIRCLE_SHA1}\"#" "$CARTFILE_PATH"
             cat "${CARTFILE_PATH}"
       - run:
           name: Bootstrap dependencies

--- a/.circleci/jazzy.yml
+++ b/.circleci/jazzy.yml
@@ -1,0 +1,13 @@
+---
+sdk: iphone
+module: Glean
+author_url: https://mozilla.github.com/glean
+github_url: https://github.com/mozilla/glean
+readme: README.iOS.md
+xcodebuild_arguments:
+    - "-workspace"
+    - "./glean-core/ios/Glean.xcodeproj/project.xcworkspace"
+    - "-scheme"
+    - "Glean"
+    - "-destination"
+    - "platform=iOS Simulator,name=iPhone 11"

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -4,8 +4,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
-XCODE_XCCONFIG_FILE="$WORKSPACE_ROOT/xcconfig/xcode-12-fix-carthage-lipo.xcconfig"
-export XCODE_XCCONFIG_FILE
-
-carthage bootstrap --platform iOS --color auto --cache-builds
+carthage bootstrap --platform iOS --color auto --cache-builds --use-xcframeworks

--- a/bin/build-swift-docs.sh
+++ b/bin/build-swift-docs.sh
@@ -9,13 +9,11 @@ set -eo pipefail
 # Build Swift with one command
 # Requires jazzy from https://github.com/realm/jazzy
 
+WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
+cd "$WORKSPACE_ROOT"
+
 jazzy --version
 jazzy \
-    --clean \
-    --output build/docs/swift \
-    --sdk iphone \
-    --module Glean \
-    --xcodebuild-arguments -workspace,./glean-core/ios/Glean.xcodeproj/project.xcworkspace,-scheme,Glean,-destination,"generic/platform=iOS" \
-    --author_url https://mozilla.github.com/glean \
-    --github_url https://github.com/mozilla/glean \
-    --readme README.iOS.md
+  --clean \
+  --config "$WORKSPACE_ROOT/.circleci/jazzy.yml" \
+  --output "$WORKSPACE_ROOT/build/docs/swift"

--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -1,55 +1,54 @@
 #!/usr/bin/env bash
-set -euvx
 
 # This should be invoked from inside xcode, not manually
-if [ "$#" -ne 4 ]
+if [ "$#" -ne 2 ]
 then
     echo "Usage (note: only call inside xcode!):"
     echo "Args: $*"
-    echo "path/to/build-scripts/xc-universal-binary.sh <STATIC_LIB_NAME> <FFI_TARGET> <GLEAN_ROOT_PATH> <buildvariant>"
+    echo "path/to/build-scripts/xc-universal-binary.sh <FFI_TARGET> <GLEAN_ROOT_PATH>"
     exit 1
 fi
-# e.g. libglean_ffi.a
-STATIC_LIB_NAME=$1
+
 # what to pass to cargo build -p, e.g. glean_ffi
-FFI_TARGET=$2
+FFI_TARGET=$1
 # path to app services root
-GLEAN_ROOT=$3
-# buildvariant from our xcconfigs
-BUILDVARIANT=$4
+GLEAN_ROOT=$2
 
-RELFLAG=
-RELDIR="debug"
-if [[ "$BUILDVARIANT" != "debug" ]]; then
-    RELFLAG=--release
-    RELDIR=release
+if [ -d "$HOME/.cargo/bin" ]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
 fi
 
-TARGETDIR=$GLEAN_ROOT/target
-
-# We can't use cargo lipo because we can't link to universal libraries :(
-# https://github.com/rust-lang/rust/issues/55235
-IOS_TRIPLES=("x86_64-apple-ios" "aarch64-apple-ios")
-for i in "${!IOS_TRIPLES[@]}"; do
-    env -i PATH="$PATH" \
-    $HOME/.cargo/bin/cargo build -p $FFI_TARGET --lib $RELFLAG --target ${IOS_TRIPLES[$i]}
-done
-
-UNIVERSAL_BINARY=$TARGETDIR/universal/$RELDIR/$STATIC_LIB_NAME
-NEED_LIPO=
-
-# if the universal binary doesnt exist, or if it's older than the static libs,
-# we need to run `lipo` again.
-if [[ ! -f "$UNIVERSAL_BINARY" ]]; then
-    NEED_LIPO=1
-elif [[ $(stat -f "%m" $TARGETDIR/x86_64-apple-ios/$RELDIR/$STATIC_LIB_NAME) -gt $(stat -f "%m" $UNIVERSAL_BINARY) ]]; then
-    NEED_LIPO=1
-elif [[ $(stat -f "%m" $TARGETDIR/aarch64-apple-ios/$RELDIR/$STATIC_LIB_NAME) -gt $(stat -f "%m" $UNIVERSAL_BINARY) ]]; then
-    NEED_LIPO=1
+if ! command -v cargo-lipo 2>/dev/null >/dev/null;
+then
+    echo "$(basename $0) failed."
+    echo "Requires cargo-lipo to build universal library."
+    echo "Install it with:"
+    echo
+    echo "   cargo install cargo-lipo"
+    exit 1
 fi
-if [[ "$NEED_LIPO" = "1" ]]; then
-    mkdir -p $TARGETDIR/universal/$RELDIR
-    lipo -create -output "$UNIVERSAL_BINARY" \
-        $TARGETDIR/x86_64-apple-ios/$RELDIR/$STATIC_LIB_NAME \
-        $TARGETDIR/aarch64-apple-ios/$RELDIR/$STATIC_LIB_NAME
+
+# Ease testing of this script by assuming something about the environment.
+if [ -z "$ACTION" ]; then
+  export ACTION=build
 fi
+
+# Always build both architectures on x86_64.
+export ARCHS="arm64 x86_64"
+
+set -euvx
+
+if [[ -n "${DEVELOPER_SDK_DIR:-}" ]]; then
+  # Assume we're in Xcode, which means we're probably cross-compiling.
+  # In this case, we need to add an extra library search path for build scripts and proc-macros,
+  # which run on the host instead of the target.
+  # (macOS Big Sur does not have linkable libraries in /usr/lib/.)
+  export LIBRARY_PATH="${DEVELOPER_SDK_DIR}/MacOSX.sdk/usr/lib:${LIBRARY_PATH:-}"
+fi
+
+# Force correct target for dependencies compiled with `cc`.
+# Required for M1 MacBooks (Arm target).
+# Without this some dependencies might be compiled for the wrong target.
+export CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios"
+
+cargo lipo --xcode-integ --manifest-path "$GLEAN_ROOT/Cargo.toml" --package "$FFI_TARGET"

--- a/docs/dev/ios/setup-ios-build-environment.md
+++ b/docs/dev/ios/setup-ios-build-environment.md
@@ -2,7 +2,7 @@
 
 ## Prepare your build environment
 
-1. Install Xcode 11.0
+1. Install Xcode 12.4
 2. Install [Carthage](https://github.com/Carthage/Carthage): `brew install carthage`
 3. Ensure you have Python 3 installed: `brew install python`
 4. Install linting and formatting tools: `brew install swiftlint`
@@ -24,14 +24,18 @@ devices and iOS emulators, the following targets need to be installed:
 rustup target add aarch64-apple-ios x86_64-apple-ios
 ```
 
+Install helper tools:
+
+```
+cargo install cargo-lipo
+```
+
 ## Building
 
 This should be relatively straightforward and painless:
 
 1. Ensure your repository is up-to-date.
-
 2. Ensure Rust is up-to-date by running `rustup update`.
-
 3. Run a build using the command `make build-swift`
     * To run tests use `make test-swift`
 

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -36,6 +36,7 @@
 		BF10008023548B0500064051 /* MemoryDistributionMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF10007F23548B0500064051 /* MemoryDistributionMetric.swift */; };
 		BF10008223548C4400064051 /* MemoryDistributionMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF10008123548C4400064051 /* MemoryDistributionMetricTests.swift */; };
 		BF197BB5243DF29200132839 /* Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF197BB4243DF29200132839 /* Upload.swift */; };
+		BF234D1F25CC4A580015D957 /* Gzip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD6E200525CAD66100C7EF2B /* Gzip.xcframework */; };
 		BF2E57052334B77D00364D92 /* EventMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2E57042334B77D00364D92 /* EventMetric.swift */; };
 		BF2E57072334BD7600364D92 /* EventMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2E57062334BD7600364D92 /* EventMetricTests.swift */; };
 		BF30FDC22332312300840607 /* Sysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF30FDC12332312300840607 /* Sysctl.swift */; };
@@ -49,7 +50,6 @@
 		BF43A8CD232A615200545310 /* CounterMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43A8CC232A615200545310 /* CounterMetricTests.swift */; };
 		BF6C53B2232F870C00E3B43A /* Ping.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6C53B1232F870C00E3B43A /* Ping.swift */; };
 		BF6C53B4232F872B00E3B43A /* PingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6C53B3232F872B00E3B43A /* PingTests.swift */; };
-		BF6F2DA8224BF8F100394062 /* libglean_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BF6F2DA7224BF8F100394062 /* libglean_ffi.a */; };
 		BF7CC0A62473F61C003B166D /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7CC0A52473F61C003B166D /* Metrics.swift */; };
 		BF80AA5B2399301300A8B172 /* HttpPingUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF80AA5A2399301200A8B172 /* HttpPingUploaderTests.swift */; };
 		BF80AA5F2399305200A8B172 /* DeletionRequestPingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF80AA5E2399305200A8B172 /* DeletionRequestPingTests.swift */; };
@@ -68,6 +68,8 @@
 		BFFE183C2350A9CC0068D97B /* DistributionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE183B2350A9CC0068D97B /* DistributionData.swift */; };
 		BFFE33A92328F4EF005348FE /* GleanFfi.h in Headers */ = {isa = PBXBuildFile; fileRef = BFFE33A82328F4EF005348FE /* GleanFfi.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFFE33AB232927C3005348FE /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE33AA232927C3005348FE /* Utils.swift */; };
+		CD6E200A25CAD68900C7EF2B /* OHHTTPStubs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD6E200925CAD68900C7EF2B /* OHHTTPStubs.xcframework */; };
+		CD75918125CAE020003F2CFB /* libglean_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD75918025CAE020003F2CFB /* libglean_ffi.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,14 +110,12 @@
 		BF10007F23548B0500064051 /* MemoryDistributionMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDistributionMetric.swift; sourceTree = "<group>"; };
 		BF10008123548C4400064051 /* MemoryDistributionMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDistributionMetricTests.swift; sourceTree = "<group>"; };
 		BF197BB4243DF29200132839 /* Upload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upload.swift; sourceTree = "<group>"; };
-		BF1BF3F72333787E0036F4CC /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = ../../Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		BF2E57042334B77D00364D92 /* EventMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMetric.swift; sourceTree = "<group>"; };
 		BF2E57062334BD7600364D92 /* EventMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMetricTests.swift; sourceTree = "<group>"; };
 		BF30FDC12332312300840607 /* Sysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sysctl.swift; sourceTree = "<group>"; };
 		BF30FDC3233260B500840607 /* TimespanMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimespanMetric.swift; sourceTree = "<group>"; };
 		BF30FDC5233260C400840607 /* TimespanMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimespanMetricTests.swift; sourceTree = "<group>"; };
 		BF30FDC72332640400840607 /* TimeUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeUnit.swift; sourceTree = "<group>"; };
-		BF3A3055246E936E00E4A18E /* Gzip.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Gzip.framework; path = ../../Carthage/Build/iOS/Gzip.framework; sourceTree = "<group>"; };
 		BF3DE3912243A2F20018E23F /* Glean.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Glean.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF3DE3942243A2F20018E23F /* Glean.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Glean.h; sourceTree = "<group>"; };
 		BF3DE3952243A2F20018E23F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -150,6 +150,9 @@
 		BFFE183B2350A9CC0068D97B /* DistributionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistributionData.swift; sourceTree = "<group>"; };
 		BFFE33A82328F4EF005348FE /* GleanFfi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GleanFfi.h; sourceTree = "<group>"; };
 		BFFE33AA232927C3005348FE /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		CD6E200525CAD66100C7EF2B /* Gzip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Gzip.xcframework; path = ../../Carthage/Build/Gzip.xcframework; sourceTree = "<group>"; };
+		CD6E200925CAD68900C7EF2B /* OHHTTPStubs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OHHTTPStubs.xcframework; path = ../../Carthage/Build/OHHTTPStubs.xcframework; sourceTree = "<group>"; };
+		CD75918025CAE020003F2CFB /* libglean_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglean_ffi.a; path = ../../target/universal/debug/libglean_ffi.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,7 +160,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF6F2DA8224BF8F100394062 /* libglean_ffi.a in Frameworks */,
+				CD75918125CAE020003F2CFB /* libglean_ffi.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,6 +168,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF234D1F25CC4A580015D957 /* Gzip.xcframework in Frameworks */,
+				CD6E200A25CAD68900C7EF2B /* OHHTTPStubs.xcframework in Frameworks */,
 				BF3DE39B2243A2F20018E23F /* Glean.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -367,8 +372,9 @@
 		BF6F2DA6224BF8F000394062 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				BF3A3055246E936E00E4A18E /* Gzip.framework */,
-				BF1BF3F72333787E0036F4CC /* OHHTTPStubs.framework */,
+				CD75918025CAE020003F2CFB /* libglean_ffi.a */,
+				CD6E200925CAD68900C7EF2B /* OHHTTPStubs.xcframework */,
+				CD6E200525CAD66100C7EF2B /* Gzip.xcframework */,
 				BF6F2DA7224BF8F100394062 /* libglean_ffi.a */,
 			);
 			name = Frameworks;
@@ -430,7 +436,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BF3DE3A82243A2F20018E23F /* Build configuration list for PBXNativeTarget "GleanTests" */;
 			buildPhases = (
-				1F0A7DB72328222C00B310DD /* Copy Carthage Dependencies */,
 				BF3DE3962243A2F20018E23F /* Sources */,
 				BF3DE3972243A2F20018E23F /* Frameworks */,
 				AC1DB400237EF0D6005A0F8A /* Headers */,
@@ -502,28 +507,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1F0A7DB72328222C00B310DD /* Copy Carthage Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				../../Carthage/Build/iOS/OHHTTPStubs.framework,
-				../../Carthage/Build/iOS/Gzip.framework,
-			);
-			name = "Copy Carthage Dependencies";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/OHHTTPStubs.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Gzip.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
 		BF6F2DA5224BF2E000394062 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -783,10 +766,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					../../Carthage/Build/iOS,
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Glean/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -794,6 +774,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.Glean;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -818,10 +799,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					../../Carthage/Build/iOS,
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Glean/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -829,6 +807,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.Glean;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -847,10 +826,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 99QSBDSJN4;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					../../Carthage/Build/iOS,
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = GleanTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -871,10 +847,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 99QSBDSJN4;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					../../Carthage/Build/iOS,
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = GleanTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -766,6 +766,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Glean/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -799,6 +800,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Glean/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -540,7 +540,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "bash $PWD/../../build-scripts/xc-universal-binary.sh libglean_ffi.a glean-ffi $PWD/../.. $buildvariant\n";
+			shellScript = "bash $PWD/../../build-scripts/xc-universal-binary.sh glean-ffi $PWD/../..\n";
 		};
 		BFB59A9723429FC000F40CA8 /* Run Glean SDK generator */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/samples/ios/app/bootstrap.sh
+++ b/samples/ios/app/bootstrap.sh
@@ -4,8 +4,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-WORKSPACE_ROOT="$( cd "$(dirname "$0")/../../.." ; pwd -P )"
-XCODE_XCCONFIG_FILE="$WORKSPACE_ROOT/xcconfig/xcode-12-fix-carthage-lipo.xcconfig"
-export XCODE_XCCONFIG_FILE
-
-carthage bootstrap --platform iOS --color auto --cache-builds --verbose --configuration Release
+carthage \
+    bootstrap \
+    --platform iOS \
+    --color auto \
+    --cache-builds \
+    --verbose \
+    --configuration Release \
+    --use-xcframeworks

--- a/samples/ios/app/glean-sample-app.xcodeproj/project.pbxproj
+++ b/samples/ios/app/glean-sample-app.xcodeproj/project.pbxproj
@@ -3,15 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF1BF3FF23337E6F0036F4CC /* Glean.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF1BF3FE23337E6F0036F4CC /* Glean.framework */; };
 		BF7CC0A82473F68C003B166D /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7CC0A72473F68C003B166D /* Metrics.swift */; };
 		BF89665A2371C82E0097B7F2 /* pings.yaml in Resources */ = {isa = PBXBuildFile; fileRef = BF8966592371C82E0097B7F2 /* pings.yaml */; };
-		BF8C3866246D749400274ACE /* Gzip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF8C3865246D749400274ACE /* Gzip.framework */; };
-		BF90C913236B43A10045BD0E /* Swifter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF90C911236B42F00045BD0E /* Swifter.framework */; };
 		BFD3AB2E224D475E00AD9255 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3AB2D224D475E00AD9255 /* AppDelegate.swift */; };
 		BFD3AB30224D475E00AD9255 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3AB2F224D475E00AD9255 /* ViewController.swift */; };
 		BFD3AB33224D475E00AD9255 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD3AB31224D475E00AD9255 /* Main.storyboard */; };
@@ -21,7 +18,15 @@
 		BFD3AB4E224D475E00AD9255 /* BaselinePingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3AB4D224D475E00AD9255 /* BaselinePingTest.swift */; };
 		BFDA7AD02371CE4900575C7B /* ViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDA7ACF2371CE4900575C7B /* ViewControllerTest.swift */; };
 		BFDA7AD22371D2BA00575C7B /* MockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDA7AD12371D2BA00575C7B /* MockServer.swift */; };
+		BFEA24B625CC39B200110728 /* Glean.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24B525CC39B200110728 /* Glean.xcframework */; };
+		BFEA24B725CC39B200110728 /* Glean.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24B525CC39B200110728 /* Glean.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BFEA24D025CC3A4F00110728 /* Gzip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24BB25CC39BF00110728 /* Gzip.xcframework */; };
+		BFEA24D325CC3A5200110728 /* Swifter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24C025CC39CB00110728 /* Swifter.xcframework */; };
 		BFED6B2C238C1638006E2BC4 /* DeletionRequestPingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFED6B2B238C1638006E2BC4 /* DeletionRequestPingTest.swift */; };
+		CDDD7A9D25D1635F00837394 /* Gzip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24BB25CC39BF00110728 /* Gzip.xcframework */; };
+		CDDD7A9E25D1635F00837394 /* Gzip.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24BB25CC39BF00110728 /* Gzip.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CDDD7AA125D1636C00837394 /* Swifter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24C025CC39CB00110728 /* Swifter.xcframework */; };
+		CDDD7AA225D1636C00837394 /* Swifter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BFEA24C025CC39CB00110728 /* Swifter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,13 +46,26 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		BFEA24B825CC39B200110728 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				CDDD7AA225D1636C00837394 /* Swifter.xcframework in Embed Frameworks */,
+				BFEA24B725CC39B200110728 /* Glean.xcframework in Embed Frameworks */,
+				CDDD7A9E25D1635F00837394 /* Gzip.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		BF1BF3FE23337E6F0036F4CC /* Glean.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Glean.framework; path = Carthage/Build/iOS/Glean.framework; sourceTree = "<group>"; };
 		BF6F41C4234346A000E222A8 /* metrics.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = metrics.yaml; sourceTree = "<group>"; };
 		BF7CC0A72473F68C003B166D /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		BF8966592371C82E0097B7F2 /* pings.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = pings.yaml; sourceTree = "<group>"; };
-		BF8C3865246D749400274ACE /* Gzip.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Gzip.framework; path = Carthage/Build/iOS/Gzip.framework; sourceTree = "<group>"; };
-		BF90C911236B42F00045BD0E /* Swifter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Swifter.framework; path = Carthage/Build/iOS/Swifter.framework; sourceTree = "<group>"; };
 		BFD3AB2A224D475E00AD9255 /* glean-sample-app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "glean-sample-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD3AB2D224D475E00AD9255 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BFD3AB2F224D475E00AD9255 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -67,6 +85,9 @@
 		BFDA7ACF2371CE4900575C7B /* ViewControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTest.swift; sourceTree = "<group>"; };
 		BFDA7AD12371D2BA00575C7B /* MockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServer.swift; sourceTree = "<group>"; };
 		BFE1E7D523435A600067A12A /* sdk_generator.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = sdk_generator.sh; sourceTree = "<group>"; };
+		BFEA24B525CC39B200110728 /* Glean.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Glean.xcframework; path = Carthage/Build/Glean.xcframework; sourceTree = "<group>"; };
+		BFEA24BB25CC39BF00110728 /* Gzip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Gzip.xcframework; path = Carthage/Build/Gzip.xcframework; sourceTree = "<group>"; };
+		BFEA24C025CC39CB00110728 /* Swifter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Swifter.xcframework; path = Carthage/Build/Swifter.xcframework; sourceTree = "<group>"; };
 		BFED6B2B238C1638006E2BC4 /* DeletionRequestPingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletionRequestPingTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -75,7 +96,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF1BF3FF23337E6F0036F4CC /* Glean.framework in Frameworks */,
+				CDDD7AA125D1636C00837394 /* Swifter.xcframework in Frameworks */,
+				BFEA24B625CC39B200110728 /* Glean.xcframework in Frameworks */,
+				CDDD7A9D25D1635F00837394 /* Gzip.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,8 +113,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF8C3866246D749400274ACE /* Gzip.framework in Frameworks */,
-				BF90C913236B43A10045BD0E /* Swifter.framework in Frameworks */,
+				BFEA24D325CC3A5200110728 /* Swifter.xcframework in Frameworks */,
+				BFEA24D025CC3A4F00110728 /* Gzip.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -171,9 +194,9 @@
 		BFD3AB68224D4F9500AD9255 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				BF8C3865246D749400274ACE /* Gzip.framework */,
-				BF90C911236B42F00045BD0E /* Swifter.framework */,
-				BF1BF3FE23337E6F0036F4CC /* Glean.framework */,
+				BFEA24C025CC39CB00110728 /* Swifter.xcframework */,
+				BFEA24BB25CC39BF00110728 /* Gzip.xcframework */,
+				BFEA24B525CC39B200110728 /* Glean.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -185,11 +208,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BFD3AB52224D475E00AD9255 /* Build configuration list for PBXNativeTarget "glean-sample-app" */;
 			buildPhases = (
-				BFD3AB63224D4D5100AD9255 /* Copy Carthage frameworks */,
 				BF6F41C6234346AA00E222A8 /* ShellScript */,
 				BFD3AB26224D475E00AD9255 /* Sources */,
 				BFD3AB27224D475E00AD9255 /* Frameworks */,
 				BFD3AB28224D475E00AD9255 /* Resources */,
+				BFEA24B825CC39B200110728 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,7 +245,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BFD3AB58224D475E00AD9255 /* Build configuration list for PBXNativeTarget "glean-sample-appUITests" */;
 			buildPhases = (
-				BF90C914236B43A60045BD0E /* Copy Carthage frameworks */,
 				BFD3AB45224D475E00AD9255 /* Sources */,
 				BFD3AB46224D475E00AD9255 /* Frameworks */,
 				BFD3AB47224D475E00AD9255 /* Resources */,
@@ -330,50 +352,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "bash $PWD/sdk_generator.sh\n";
-		};
-		BF90C914236B43A60045BD0E /* Copy Carthage frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Swifter.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Gzip.framework",
-			);
-			name = "Copy Carthage frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Swifter.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Gzip.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
-		BFD3AB63224D4D5100AD9255 /* Copy Carthage frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Glean.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Gzip.framework",
-			);
-			name = "Copy Carthage frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Glean.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Gzip.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage bootstrap --platform iOS --no-use-binaries --cache-builds\n/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -566,10 +544,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G9EAK7RA89;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "glean-sample-app/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -590,10 +565,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G9EAK7RA89;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "glean-sample-app/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -658,10 +630,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G9EAK7RA89;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "glean-sample-appUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -685,10 +654,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G9EAK7RA89;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "glean-sample-appUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This is my first try at building Glean iOS on a M1 (arm) machine.

It essentially requires us to use xcframeworks, because the Carthage workaround is not suitable on M1 machines (as we can't exclude the arm64 target, because that IS the host target).
I can build Glean iOS now on my M1.
I can't run the tests though, because [Rust doesn't know the difference between the host system and the simulator](https://github.com/rust-lang/rust/issues/81632).

It's also likely that our sample app won't work the same anymore, at least not if I also want to get that compilable and runnable on an M1. It will need to start using xcframeworks too.
Carthage currently cannot produce xcframework binary releases, so the sample will always need to compile Glean.
Consumers wouldn't be affected, as long as they don't require xcframeworks. It just means I can't build those projects.

* [x] Test it on an Intel Mac
* [x] Ensure tests on CI work
* [x] Ensure sample app on CI works
* [x] Ensure our release still works for consumers
	* Actually probably not as important given that the only active consumer (firefox-ios) gets it through application-services.
* [x] Ensure that application-services doesn't break