### PR TITLE
Bug 1690887: Fix Android build for Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         jna: '5.6.0',
         junit: '4.12',
         mockito: '2.28.2',  // This is different than a-c, but we're fine, it's only tests.
-        mockwebserver: '3.10.0',
+        mockwebserver: '4.9.1', // This is different than a-c, but we're fine, it's only tests.
         kotlin: '1.4.10',
         robolectric: '4.2.1', // This is different than a-c, but we're fine, it's only tests.
         rust_android_plugin: '0.8.3',

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -131,6 +131,8 @@ afterEvaluate {
 
     tasks.withType(Test) {
       jacoco.includeNoLocationClasses = true
+      // See https://github.com/gradle/gradle/issues/5184#issuecomment-457865951
+      jacoco.excludes = ['jdk.internal.*']
 
       finalizedBy jacocoTestReport
     }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -84,12 +84,12 @@ class GleanTest {
         // we are only expecting one baseline ping.
         assertEquals(server.requestCount, 2)
 
-        var request = server.takeRequest(20L, TimeUnit.SECONDS)
-        var docType = request.path.split("/")[3]
+        var request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        var docType = request.path!!.split("/")[3]
         assertEquals("baseline", docType)
 
-        request = server.takeRequest(20L, TimeUnit.SECONDS)
-        docType = request.path.split("/")[3]
+        request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        docType = request.path!!.split("/")[3]
         assertEquals("metrics", docType)
     }
 
@@ -108,7 +108,7 @@ class GleanTest {
         triggerWorkManager(context)
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        assertEquals(request.getHeader("X-Debug-ID"), "this-ping-is-tagged")
+        assertEquals(request!!.getHeader("X-Debug-ID"), "this-ping-is-tagged")
     }
 
     // Tests from glean-ac (706af1f).
@@ -217,8 +217,9 @@ class GleanTest {
             triggerWorkManager(context)
 
             for (i in 0..5) {
-                val request = server.takeRequest(20L, TimeUnit.SECONDS)
-                val docType = request.path.split("/")[3]
+                val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+                val docType = request.path!!.split("/")[3]
+
                 val json = JSONObject(request.getPlainBody())
                 checkPingSchema(json)
                 if (docType == "events") {
@@ -274,16 +275,16 @@ class GleanTest {
             // Trigger worker task to upload the pings in the background
             triggerWorkManager(context)
 
-            var request = server.takeRequest(20L, TimeUnit.SECONDS)
-            var docType = request.path.split("/")[3]
+            var request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+            var docType = request.path!!.split("/")[3]
             assertEquals("The received ping must be a 'baseline' ping", "baseline", docType)
 
             val baselineJson = JSONObject(request.getPlainBody())
             assertEquals("dirty_startup", baselineJson.getJSONObject("ping_info")["reason"])
             checkPingSchema(baselineJson)
 
-            request = server.takeRequest(20L, TimeUnit.SECONDS)
-            docType = request.path.split("/")[3]
+            request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+            docType = request.path!!.split("/")[3]
             assertEquals("The received ping must be a 'metrics' ping", "metrics", docType)
         } finally {
             server.shutdown()
@@ -470,8 +471,8 @@ class GleanTest {
         triggerWorkManager(context)
 
         // Validate the received data.
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals(pingName, docType)
 
         val pingJson = JSONObject(request.getPlainBody())
@@ -603,7 +604,7 @@ class GleanTest {
         // Now trigger it to upload
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
         val jsonContent = JSONObject(request.getPlainBody())
         assertEquals(
             110,
@@ -639,8 +640,8 @@ class GleanTest {
         // Now trigger it to upload
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("deletion-request", docType)
     }
 
@@ -693,8 +694,8 @@ class GleanTest {
             // Trigger worker task to upload the pings in the background
             triggerWorkManager(context)
 
-            val request = server.takeRequest(20L, TimeUnit.SECONDS)
-            val docType = request.path.split("/")[3]
+            val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+            val docType = request.path!!.split("/")[3]
             assertEquals("The received ping must be a 'baseline' ping", "baseline", docType)
 
             val baselineJson = JSONObject(request.getPlainBody())
@@ -738,7 +739,7 @@ class GleanTest {
         // Trigger it to upload
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
         assertEquals(request.getHeader("X-Debug-ID"), "valid-tag")
     }
 
@@ -809,8 +810,8 @@ class GleanTest {
         triggerWorkManager(context)
 
         // Validate the received data.
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("deletion-request", docType)
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -239,7 +239,7 @@ internal fun triggerWorkManager(context: Context) {
  */
 internal fun getMockWebServer(): MockWebServer {
     val server = MockWebServer()
-    server.setDispatcher(object : Dispatcher() {
+    server.dispatcher = (object : Dispatcher() {
         override fun dispatch(request: RecordedRequest): MockResponse {
             return MockResponse().setBody("OK")
         }
@@ -337,7 +337,7 @@ fun waitForPingContent(
     var parsedPayload: JSONObject? = null
     for (attempts in 1..maxAttempts) {
         val request = server.takeRequest(20L, java.util.concurrent.TimeUnit.SECONDS) ?: break
-        val docType = request.path.split("/")[3]
+        val docType = request.path!!.split("/")[3]
         if (pingName == docType) {
             parsedPayload = JSONObject(request.getPlainBody())
             if (pingReason == null) {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -156,10 +156,10 @@ class GleanDebugActivityTest {
         )
 
         triggerWorkManager(context)
-        val request = server.takeRequest(10L, TimeUnit.SECONDS)
+        val request = server.takeRequest(10L, TimeUnit.SECONDS)!!
 
         assertTrue(
-            request.requestUrl.encodedPath().startsWith("/submit/mozilla-telemetry-glean-test/metrics")
+            request.requestUrl!!.encodedPath.startsWith("/submit/mozilla-telemetry-glean-test/metrics")
         )
 
         server.shutdown()
@@ -200,11 +200,11 @@ class GleanDebugActivityTest {
             "http://" + server.hostName + ":" + server.port, Glean.configuration.serverEndpoint)
 
         triggerWorkManager(context)
-        val request = server.takeRequest(10L, TimeUnit.SECONDS)
+        val request = server.takeRequest(10L, TimeUnit.SECONDS)!!
 
         assertTrue(
             "Request path must be correct",
-            request.requestUrl.encodedPath().startsWith("/submit/mozilla-telemetry-glean-test/metrics")
+            request.requestUrl!!.encodedPath.startsWith("/submit/mozilla-telemetry-glean-test/metrics")
         )
 
         // resetGlean doesn't actually reset the debug view tag,

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
@@ -75,8 +75,8 @@ class CustomPingTest {
         customPing.submit()
         triggerWorkManager(context)
 
-        val request = server.takeRequest(2L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(2L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("custom-ping", docType)
     }
 
@@ -104,8 +104,8 @@ class CustomPingTest {
         triggerWorkManager(context)
 
         // Receive the first ping.
-        var request = server.takeRequest(2L, TimeUnit.SECONDS)
-        var docType = request.path.split("/")[3]
+        var request = server.takeRequest(2L, TimeUnit.SECONDS)!!
+        var docType = request.path!!.split("/")[3]
         assertEquals("custom-ping", docType)
 
         // Not much data in these pings,
@@ -116,8 +116,8 @@ class CustomPingTest {
         assertEquals(0L, pingInfo.tryGetLong("seq"))
 
         // Receive the second ping.
-        request = server.takeRequest(2L, TimeUnit.SECONDS)
-        docType = request.path.split("/")[3]
+        request = server.takeRequest(2L, TimeUnit.SECONDS)!!
+        docType = request.path!!.split("/")[3]
         assertEquals("custom-ping", docType)
 
         pingJson = JSONObject(request.getPlainBody())
@@ -170,8 +170,8 @@ class CustomPingTest {
         triggerWorkManager(context)
 
         // Receive the custom events ping.
-        var request = server.takeRequest(2L, TimeUnit.SECONDS)
-        var docType = request.path.split("/")[3]
+        var request = server.takeRequest(2L, TimeUnit.SECONDS)!!
+        var docType = request.path!!.split("/")[3]
         assertEquals(pingName, docType)
 
         val pingJson = JSONObject(request.getPlainBody())

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
@@ -65,8 +65,8 @@ class DeletionPingTest {
         ), clearStores = true, uploadEnabled = false)
         triggerWorkManager(context)
 
-        val request = server.takeRequest(2L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(2L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("deletion-request", docType)
     }
 
@@ -86,8 +86,8 @@ class DeletionPingTest {
         Glean.setUploadEnabled(false)
         triggerWorkManager(context)
 
-        val request = server.takeRequest(2L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(2L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("deletion-request", docType)
 
         // File is deleted afterwards.
@@ -134,8 +134,8 @@ class DeletionPingTest {
         ), clearStores = true, uploadEnabled = false)
         triggerWorkManager(context)
 
-        var request = server.takeRequest(20L, TimeUnit.SECONDS)
-        var docType = request.path.split("/")[3]
+        var request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        var docType = request.path!!.split("/")[3]
         assertEquals("Should have received a deletion-request ping", "deletion-request", docType)
 
         // deletion-request ping is gone
@@ -143,8 +143,7 @@ class DeletionPingTest {
 
         // Wait a bit to ensure no further ping is received.
         // Unfortunately this requires us to wait for the timeout.
-        request = server.takeRequest(2L, TimeUnit.SECONDS)
-        assertNull("Should not receive any further pings", request)
+        assertNull("Should not receive any further pings", server.takeRequest(2L, TimeUnit.SECONDS))
 
         // 'baseline' ping is removed from disk.
         assertEquals(0, pendingPingDir.listFiles()?.size)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -267,11 +267,11 @@ class EventMetricTypeTest {
 
         triggerWorkManager(context)
 
-        val request = server.takeRequest(1L, TimeUnit.SECONDS)
+        val request = server.takeRequest(1L, TimeUnit.SECONDS)!!
         assertEquals("POST", request.method)
         val applicationId = "mozilla-telemetry-glean-test"
         assert(
-            request.path.startsWith("/submit/$applicationId/events/")
+            request.path!!.startsWith("/submit/$applicationId/events/")
         )
         val pingJsonData = request.getPlainBody()
         val pingJson = JSONObject(pingJsonData)
@@ -448,8 +448,8 @@ class EventMetricTypeTest {
         // Trigger worker task to upload the pings in the background
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals(pingName, docType)
 
         val pingJsonData = request.getPlainBody()

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -66,8 +66,8 @@ class PingTypeTest {
         // Trigger worker task to upload the pings in the background
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("custom", docType)
 
         val pingJson = JSONObject(request.getPlainBody())
@@ -107,8 +107,8 @@ class PingTypeTest {
         // Trigger worker task to upload the pings in the background
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("custom_ping", docType)
 
         val pingJson = JSONObject(request.getPlainBody())
@@ -148,8 +148,8 @@ class PingTypeTest {
         // Trigger worker task to upload the pings in the background
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("custom-ping", docType)
 
         val pingJson = JSONObject(request.getPlainBody())
@@ -189,8 +189,8 @@ class PingTypeTest {
         // Trigger worker task to upload the pings in the background
         triggerWorkManager(context)
 
-        val request = server.takeRequest(20L, TimeUnit.SECONDS)
-        val docType = request.path.split("/")[3]
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
         assertEquals("custom", docType)
 
         val pingJson = JSONObject(request.getPlainBody())

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -267,8 +267,8 @@ class MetricsPingSchedulerTest {
         triggerWorkManager(context)
 
         // Fetch the ping from the server and decode its JSON body.
-        var request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)
-        var docType = request.path.split("/")[3]
+        var request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)!!
+        var docType = request.path!!.split("/")[3]
         assertEquals("The received ping must be a 'metrics' ping", "metrics", docType)
 
         try {
@@ -296,8 +296,8 @@ class MetricsPingSchedulerTest {
             triggerWorkManager(context)
 
             // Fetch the ping from the server and decode its JSON body.
-            request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)
-            docType = request.path.split("/")[3]
+            request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)!!
+            docType = request.path!!.split("/")[3]
             assertEquals("The received ping must be a 'metrics' ping", "metrics", docType)
 
             val metricsJsonData = request.getPlainBody()
@@ -547,8 +547,8 @@ class MetricsPingSchedulerTest {
             triggerWorkManager(context)
 
             // Wait for the metrics ping to be received.
-            val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)
-            val docType = request.path.split("/")[3]
+            val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)!!
+            val docType = request.path!!.split("/")[3]
             assertEquals("The received ping must be a 'metrics' ping", "metrics", docType)
 
             val metricsJsonData = request.getPlainBody()
@@ -740,8 +740,8 @@ class MetricsPingSchedulerTest {
             triggerWorkManager(context)
 
             // Wait for the metrics ping to be received.
-            val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)
-            val docType = request.path.split("/")[3]
+            val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)!!
+            val docType = request.path!!.split("/")[3]
             assertEquals("The received ping must be a 'metrics' ping", "metrics", docType)
 
             val metricsJsonData = request.getPlainBody()
@@ -819,8 +819,8 @@ class MetricsPingSchedulerTest {
             triggerWorkManager(context)
 
             // Wait for the metrics ping to be received.
-            val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)
-            val docType = request.path.split("/")[3]
+            val request = server.takeRequest(20L, AndroidTimeUnit.SECONDS)!!
+            val docType = request.path!!.split("/")[3]
             assertEquals("The received ping must be a 'metrics' ping", "metrics", docType)
 
             val metricsJsonData = request.getPlainBody()


### PR DESCRIPTION
My system Java recently upgraded to Java 11, breaking the Glean build.
CI is still on Java 8 so is not seeing these issues, but if we can find
a way to be compatible across these versions, I guess we should try.

One issue was just requiring a new jacoco config flag (which I admit I don't
really understand, but it works):
https://github.com/gradle/gradle/issues/5184#issuecomment-457865951

Behind that is the old version of okhttp3.mockwebserver is no longer compatible.
Upgrading that lead to some incompatible API changes, mostly that the API is now
much more shouty -- resulting in most of the changes here.

~It remains to be seen whether these fixes will work on CI with Java 8.~  They work!