### PR TITLE
Docs: Fix timespan example

### DIFF
--- a/docs/user/metrics/timespan.md
+++ b/docs/user/metrics/timespan.md
@@ -28,7 +28,7 @@ auth:
     type: timespan
     description: >
       Measures the time spent logging in.
-    time_unit: milliseconds
+    time_unit: millisecond
     ...
 ```
 


### PR DESCRIPTION
Used the sample and noticed that the linter complained about `milliseconds` not being right. :)