### PR TITLE
Bug 1691080 - Check for glean.validation keys as well

### DIFF
--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -118,7 +118,10 @@ class GleanTests: XCTestCase {
                 XCTAssertEqual(metrics?.count, 2, "metrics has more keys than expected: \(JSONStringify(metrics!))")
                 let labeledCounters = metrics?["labeled_counter"] as? [String: Any]
                 labeledCounters!.forEach { key, _ in
-                    XCTAssertTrue(key.starts(with: "glean.error"))
+                    XCTAssertTrue(
+                        key.starts(with: "glean.error") || key.starts(with: "glean.validation"),
+                        "Should only see glean.* counters, saw \(key)"
+                    )
                 }
             }
 
@@ -179,7 +182,10 @@ class GleanTests: XCTestCase {
                     XCTAssertEqual(metrics?.count, 2, "metrics has more keys than expected: \(JSONStringify(metrics!))")
                     let labeledCounters = metrics?["labeled_counter"] as? [String: Any]
                     labeledCounters!.forEach { key, _ in
-                        XCTAssertTrue(key.starts(with: "glean.error"))
+                        XCTAssertTrue(
+                            key.starts(with: "glean.error") || key.starts(with: "glean.validation"),
+                            "Should only see glean.* counters, saw \(key)"
+                        )
                     }
                 }
             }


### PR DESCRIPTION
We recently got a new `glean.validation.pings_submitted` labeled counter
that now shows up.
We need to take care of that in tests.