### PR TITLE
Bug 1655112: Add messages to NullPointerExceptions in testing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v34.1.0...main)
 
+* Kotlin
+  * The `testGetValue` APIs now include a message on the `NullPointerException` thrown when the value is missing.
+
 # v34.1.0 (2021-02-04)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v34.0.0...v34.1.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -478,7 +478,7 @@ open class GleanInternalAPI internal constructor () {
 
         val ptr = LibGleanFFI.INSTANCE.glean_experiment_test_get_data(
             experimentId
-        ) ?: throw NullPointerException("experiment data is not set")
+        ) ?: throw NullPointerException("Experiment data is not set")
 
         var branchId: String
         var extraMap: Map<String, String>?

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -478,7 +478,7 @@ open class GleanInternalAPI internal constructor () {
 
         val ptr = LibGleanFFI.INSTANCE.glean_experiment_test_get_data(
             experimentId
-        )!!
+        ) ?: throw NullPointerException("experiment data is not set")
 
         var branchId: String
         var extraMap: Map<String, String>?
@@ -491,7 +491,7 @@ open class GleanInternalAPI internal constructor () {
             branchId = jsonRes.getString("branch")
             extraMap = getMapFromJSONObject(jsonRes)
         } catch (e: org.json.JSONException) {
-            throw NullPointerException()
+            throw NullPointerException("Could not parse experiment data as JSON")
         }
 
         return RecordedExperimentData(branchId, extraMap)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -117,7 +117,7 @@ class BooleanMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         return LibGleanFFI.INSTANCE.glean_boolean_test_get_value(this.handle, pingName).toBoolean()
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -121,7 +121,7 @@ class CounterMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         return LibGleanFFI.INSTANCE.glean_counter_test_get_value(this.handle, pingName)
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -120,7 +120,7 @@ data class CustomDistributionMetricType(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
 
         val ptr = LibGleanFFI.INSTANCE.glean_custom_distribution_test_get_value_as_json_string(

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DatetimeMetricType.kt
@@ -159,7 +159,7 @@ class DatetimeMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         val ptr = LibGleanFFI
             .INSTANCE

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
@@ -201,6 +201,7 @@ class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>> internal constructor(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
+    @Suppress("ThrowsCount")
     fun testGetValue(pingName: String = sendInPings.first()): List<RecordedEventData> {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -208,15 +209,15 @@ class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>> internal constructor(
         val ptr = LibGleanFFI.INSTANCE.glean_event_test_get_value_as_json_string(
             this.handle,
             pingName
-        )!!
+        ) ?: throw NullPointerException("Could not get metric data")
 
         val jsonRes = try {
             JSONArray(ptr.getAndConsumeRustString())
         } catch (e: org.json.JSONException) {
-            throw NullPointerException()
+            throw NullPointerException("Could not parse metric data as JSON")
         }
         if (jsonRes.length() == 0) {
-            throw NullPointerException()
+            throw NullPointerException("Metric data not found")
         }
 
         val result: MutableList<RecordedEventData> = mutableListOf()

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/JweMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/JweMetricType.kt
@@ -135,7 +135,7 @@ class JweMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
 
         val ptr = LibGleanFFI.INSTANCE.glean_jwe_test_get_value_as_json_string(this.handle, pingName)!!
@@ -167,7 +167,7 @@ class JweMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         val ptr = LibGleanFFI.INSTANCE.glean_jwe_test_get_value(this.handle, pingName)!!
         return ptr.getAndConsumeRustString()

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -125,7 +125,7 @@ class MemoryDistributionMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
 
         val ptr = LibGleanFFI.INSTANCE.glean_memory_distribution_test_get_value_as_json_string(

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -98,7 +98,7 @@ class QuantityMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         return LibGleanFFI.INSTANCE.glean_quantity_test_get_value(this.handle, pingName)
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -147,7 +147,7 @@ class StringListMetricType(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
 
         val jsonRes: JSONArray
@@ -157,7 +157,7 @@ class StringListMetricType(
         try {
             jsonRes = JSONArray(ptr.getAndConsumeRustString())
         } catch (e: org.json.JSONException) {
-            throw NullPointerException()
+            throw NullPointerException("Could not parse metric as JSON")
         }
         return jsonRes.toList()
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -108,7 +108,7 @@ class StringMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         val ptr = LibGleanFFI.INSTANCE.glean_string_test_get_value(this.handle, pingName)!!
         return ptr.getAndConsumeRustString()

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -178,7 +178,7 @@ class TimespanMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         return LibGleanFFI.INSTANCE.glean_timespan_test_get_value(this.handle, pingName)
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -203,7 +203,7 @@ class TimingDistributionMetricType internal constructor(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
 
         val ptr = LibGleanFFI.INSTANCE.glean_timing_distribution_test_get_value_as_json_string(

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
@@ -132,7 +132,7 @@ class UuidMetricType(
         Dispatchers.API.assertInTestingMode()
 
         if (!testHasValue(pingName)) {
-            throw NullPointerException()
+            throw NullPointerException("Metric has no value")
         }
         val ptr = LibGleanFFI.INSTANCE.glean_uuid_test_get_value(this.handle, pingName)!!
         return UUID.fromString(ptr.getAndConsumeRustString())


### PR DESCRIPTION
This just adds a better informational message when a `NullPointerException` is thrown from the Kotlin testing APIs.

As the bug contemplates, we could throw a different exception, but that's strictly speaking a breaking API change...  How much that matters in practice is perhaps up for debate, however.