### PR TITLE
Bug 1677441: Add launch_with_glean and launch_with_glean_mut for readibility

### DIFF
--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -151,6 +151,17 @@ where
     f(&mut lock)
 }
 
+/// Launches a new task on the global dispatch queue with a reference to the Glean singleton.
+fn launch_with_glean(callback: impl FnOnce(&Glean) + Send + 'static) {
+    dispatcher::launch(|| crate::with_glean(callback));
+}
+
+/// Launches a new task on the global dispatch queue with a mutable reference to the
+/// Glean singleton.
+fn launch_with_glean_mut(callback: impl FnOnce(&mut Glean) + Send + 'static) {
+    dispatcher::launch(|| crate::with_glean_mut(callback));
+}
+
 /// Creates and initializes a new Glean object.
 ///
 /// See [`glean_core::Glean::new`] for more information.
@@ -352,10 +363,8 @@ pub fn shutdown() {
         return;
     }
 
-    dispatcher::launch(move || {
-        with_glean_mut(|glean| {
-            glean.set_dirty_flag(false);
-        })
+    crate::launch_with_glean_mut(|glean| {
+        glean.set_dirty_flag(false);
     });
 
     if let Err(e) = dispatcher::shutdown() {
@@ -450,27 +459,25 @@ pub fn set_upload_enabled(enabled: bool) {
     //
     // Because the dispatch queue is halted until Glean is fully initialized
     // we can safely enqueue here and it will execute after initialization.
-    dispatcher::launch(move || {
-        with_glean_mut(|glean| {
-            let state = global_state().lock().unwrap();
-            let old_enabled = glean.is_upload_enabled();
-            glean.set_upload_enabled(enabled);
+    crate::launch_with_glean_mut(move |glean| {
+        let state = global_state().lock().unwrap();
+        let old_enabled = glean.is_upload_enabled();
+        glean.set_upload_enabled(enabled);
 
-            // TODO: Cancel upload and any outstanding metrics ping scheduler
-            // task. Will happen on bug 1672951.
+        // TODO: Cancel upload and any outstanding metrics ping scheduler
+        // task. Will happen on bug 1672951.
 
-            if !old_enabled && enabled {
-                // If uploading is being re-enabled, we have to restore the
-                // application-lifetime metrics.
-                initialize_core_metrics(&glean, &state.client_info, state.channel.clone());
-            }
+        if !old_enabled && enabled {
+            // If uploading is being re-enabled, we have to restore the
+            // application-lifetime metrics.
+            initialize_core_metrics(&glean, &state.client_info, state.channel.clone());
+        }
 
-            if old_enabled && !enabled {
-                // If uploading is disabled, we need to send the deletion-request ping:
-                // note that glean-core takes care of generating it.
-                state.upload_manager.trigger_upload();
-            }
-        });
+        if old_enabled && !enabled {
+            // If uploading is disabled, we need to send the deletion-request ping:
+            // note that glean-core takes care of generating it.
+            state.upload_manager.trigger_upload();
+        }
     });
 }
 
@@ -482,10 +489,8 @@ pub fn register_ping_type(ping: &private::PingType) {
     // Submission itself is also dispatched, so it will always come after the registration.
     if was_initialize_called() {
         let ping = ping.clone();
-        dispatcher::launch(move || {
-            with_glean_mut(|glean| {
-                glean.register_ping_type(&ping.ping_type);
-            })
+        crate::launch_with_glean_mut(move |glean| {
+            glean.register_ping_type(&ping.ping_type);
         })
     } else {
         // We need to keep track of pings, so they get re-registered after a reset or
@@ -570,14 +575,8 @@ pub fn set_experiment_active(
     branch: String,
     extra: Option<HashMap<String, String>>,
 ) {
-    dispatcher::launch(move || {
-        with_glean(|glean| {
-            glean.set_experiment_active(
-                experiment_id.to_owned(),
-                branch.to_owned(),
-                extra.to_owned(),
-            )
-        });
+    crate::launch_with_glean(move |glean| {
+        glean.set_experiment_active(experiment_id.to_owned(), branch.to_owned(), extra)
     })
 }
 
@@ -585,9 +584,7 @@ pub fn set_experiment_active(
 ///
 /// See [`glean_core::Glean::set_experiment_inactive`].
 pub fn set_experiment_inactive(experiment_id: String) {
-    dispatcher::launch(move || {
-        with_glean(|glean| glean.set_experiment_inactive(experiment_id.to_owned()))
-    })
+    crate::launch_with_glean(move |glean| glean.set_experiment_inactive(experiment_id))
 }
 
 /// Performs the collection/cleanup operations required by becoming active.
@@ -597,16 +594,14 @@ pub fn set_experiment_inactive(experiment_id: String) {
 /// This should be called whenever the consuming product becomes active (e.g.
 /// getting to foreground).
 pub fn handle_client_active() {
-    dispatcher::launch(move || {
-        with_glean_mut(|glean| {
-            glean.handle_client_active();
+    crate::launch_with_glean_mut(|glean| {
+        glean.handle_client_active();
 
-            // The above call may generate pings, so we need to trigger
-            // the uploader. It's fine to trigger it if no ping was generated:
-            // it will bail out.
-            let state = global_state().lock().unwrap();
-            state.upload_manager.trigger_upload();
-        })
+        // The above call may generate pings, so we need to trigger
+        // the uploader. It's fine to trigger it if no ping was generated:
+        // it will bail out.
+        let state = global_state().lock().unwrap();
+        state.upload_manager.trigger_upload();
     });
 
     // The previous block of code may send a ping containing the `duration` metric,
@@ -628,16 +623,14 @@ pub fn handle_client_inactive() {
     // by the next call.
     core_metrics::internal_metrics::baseline_duration.stop();
 
-    dispatcher::launch(move || {
-        with_glean_mut(|glean| {
-            glean.handle_client_inactive();
+    crate::launch_with_glean_mut(|glean| {
+        glean.handle_client_inactive();
 
-            // The above call may generate pings, so we need to trigger
-            // the uploader. It's fine to trigger it if no ping was generated:
-            // it will bail out.
-            let state = global_state().lock().unwrap();
-            state.upload_manager.trigger_upload();
-        })
+        // The above call may generate pings, so we need to trigger
+        // the uploader. It's fine to trigger it if no ping was generated:
+        // it will bail out.
+        let state = global_state().lock().unwrap();
+        state.upload_manager.trigger_upload();
     })
 }
 

--- a/glean-core/rlb/src/private/boolean.rs
+++ b/glean-core/rlb/src/private/boolean.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 
 use glean_core::metrics::MetricType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type: otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -33,7 +31,7 @@ impl BooleanMetric {
 impl glean_core::traits::Boolean for BooleanMetric {
     fn set(&self, value: bool) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.set(glean, value)));
+        crate::launch_with_glean(move |glean| metric.set(glean, value));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<bool> {

--- a/glean-core/rlb/src/private/counter.rs
+++ b/glean-core/rlb/src/private/counter.rs
@@ -9,8 +9,6 @@ use std::sync::Arc;
 use glean_core::metrics::MetricType;
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type: otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -40,7 +38,7 @@ impl CounterMetric {
 impl glean_core::traits::Counter for CounterMetric {
     fn add(&self, amount: i32) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.add(glean, amount)));
+        crate::launch_with_glean(move |glean| metric.add(glean, amount));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i32> {

--- a/glean-core/rlb/src/private/custom_distribution.rs
+++ b/glean-core/rlb/src/private/custom_distribution.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 use glean_core::metrics::{DistributionData, MetricType};
 use glean_core::{CommonMetricData, ErrorType, HistogramType};
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type: otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -48,9 +46,7 @@ impl CustomDistributionMetric {
 impl glean_core::traits::CustomDistribution for CustomDistributionMetric {
     fn accumulate_samples_signed(&self, samples: Vec<i64>) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || {
-            crate::with_glean(|glean| metric.accumulate_samples_signed(glean, samples))
-        });
+        crate::launch_with_glean(move |glean| metric.accumulate_samples_signed(glean, samples));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(

--- a/glean-core/rlb/src/private/datetime.rs
+++ b/glean-core/rlb/src/private/datetime.rs
@@ -9,8 +9,6 @@ use glean_core::metrics::MetricType;
 pub use glean_core::metrics::{Datetime, TimeUnit};
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type: otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -37,7 +35,7 @@ impl DatetimeMetric {
 impl glean_core::traits::Datetime for DatetimeMetric {
     fn set(&self, value: Option<Datetime>) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.set(glean, value)));
+        crate::launch_with_glean(move |glean| metric.set(glean, value));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<Datetime> {

--- a/glean-core/rlb/src/private/event.rs
+++ b/glean-core/rlb/src/private/event.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 use glean_core::metrics::MetricType;
 use glean_core::traits;
 
-use crate::{dispatcher, ErrorType, RecordedEvent};
+use crate::{ErrorType, RecordedEvent};
 
 pub use glean_core::traits::NoExtraKeys;
 
@@ -56,7 +56,7 @@ impl<K: traits::ExtraKeys> traits::Event for EventMetric<K> {
             .into()
             .map(|h| h.into_iter().map(|(k, v)| (k.index(), v)).collect());
         let metric = Arc::clone(&self.inner);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.record(glean, now, extra)));
+        crate::launch_with_glean(move |glean| metric.record(glean, now, extra));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(

--- a/glean-core/rlb/src/private/memory_distribution.rs
+++ b/glean-core/rlb/src/private/memory_distribution.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 use glean_core::metrics::{DistributionData, MemoryUnit, MetricType};
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type: otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -36,7 +34,7 @@ impl MemoryDistributionMetric {
 impl glean_core::traits::MemoryDistribution for MemoryDistributionMetric {
     fn accumulate(&self, sample: u64) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.accumulate(glean, sample)));
+        crate::launch_with_glean(move |glean| metric.accumulate(glean, sample));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(

--- a/glean-core/rlb/src/private/quantity.rs
+++ b/glean-core/rlb/src/private/quantity.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 use glean_core::metrics::MetricType;
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type, otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -34,7 +32,7 @@ impl QuantityMetric {
 impl glean_core::traits::Quantity for QuantityMetric {
     fn set(&self, value: i64) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.set(glean, value)));
+        crate::launch_with_glean(move |glean| metric.set(glean, value));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i64> {

--- a/glean-core/rlb/src/private/string.rs
+++ b/glean-core/rlb/src/private/string.rs
@@ -9,8 +9,6 @@ use std::sync::Arc;
 use glean_core::metrics::MetricType;
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type, otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -41,7 +39,7 @@ impl glean_core::traits::String for StringMetric {
     fn set<S: Into<std::string::String>>(&self, value: S) {
         let metric = Arc::clone(&self.0);
         let new_value = value.into();
-        dispatcher::launch(move || crate::with_glean(|glean| metric.set(glean, new_value)));
+        crate::launch_with_glean(move |glean| metric.set(glean, new_value));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(

--- a/glean-core/rlb/src/private/string_list.rs
+++ b/glean-core/rlb/src/private/string_list.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 use glean_core::metrics::MetricType;
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type: otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -35,12 +33,12 @@ impl glean_core::traits::StringList for StringListMetric {
     fn add<S: Into<String>>(&self, value: S) {
         let metric = Arc::clone(&self.0);
         let new_value = value.into();
-        dispatcher::launch(move || crate::with_glean(|glean| metric.add(glean, new_value)));
+        crate::launch_with_glean(move |glean| metric.add(glean, new_value));
     }
 
     fn set(&self, value: Vec<String>) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.set(glean, value)));
+        crate::launch_with_glean(move |glean| metric.set(glean, value));
     }
 
     fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<Vec<String>> {

--- a/glean-core/rlb/src/private/timespan.rs
+++ b/glean-core/rlb/src/private/timespan.rs
@@ -38,13 +38,11 @@ impl glean_core::traits::Timespan for TimespanMetric {
         let start_time = time::precise_time_ns();
 
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || {
-            crate::with_glean(|glean| {
-                let mut lock = metric
-                    .write()
-                    .expect("Lock poisoned for timespan metric on start.");
-                lock.set_start(glean, start_time)
-            })
+        crate::launch_with_glean(move |glean| {
+            let mut lock = metric
+                .write()
+                .expect("Lock poisoned for timespan metric on start.");
+            lock.set_start(glean, start_time)
         });
     }
 
@@ -52,13 +50,11 @@ impl glean_core::traits::Timespan for TimespanMetric {
         let stop_time = time::precise_time_ns();
 
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || {
-            crate::with_glean(|glean| {
-                let mut lock = metric
-                    .write()
-                    .expect("Lock poisoned for timespan metric on stop.");
-                lock.set_stop(glean, stop_time)
-            })
+        crate::launch_with_glean(move |glean| {
+            let mut lock = metric
+                .write()
+                .expect("Lock poisoned for timespan metric on stop.");
+            lock.set_stop(glean, stop_time)
         });
     }
 

--- a/glean-core/rlb/src/private/timing_distribution.rs
+++ b/glean-core/rlb/src/private/timing_distribution.rs
@@ -44,13 +44,11 @@ impl glean_core::traits::TimingDistribution for TimingDistributionMetric {
     fn stop_and_accumulate(&self, id: TimerId) {
         let stop_time = time::precise_time_ns();
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || {
-            crate::with_glean(|glean| {
-                metric
-                    .write()
-                    .unwrap()
-                    .set_stop_and_accumulate(glean, id, stop_time)
-            })
+        crate::launch_with_glean(move |glean| {
+            metric
+                .write()
+                .unwrap()
+                .set_stop_and_accumulate(glean, id, stop_time)
         });
     }
 

--- a/glean-core/rlb/src/private/uuid.rs
+++ b/glean-core/rlb/src/private/uuid.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 use glean_core::metrics::MetricType;
 use glean_core::ErrorType;
 
-use crate::dispatcher;
-
 // We need to wrap the glean-core type, otherwise if we try to implement
 // the trait for the metric in `glean_core::metrics` we hit error[E0117]:
 // only traits defined in the current crate can be implemented for arbitrary
@@ -34,7 +32,7 @@ impl UuidMetric {
 impl glean_core::traits::Uuid for UuidMetric {
     fn set(&self, value: uuid::Uuid) {
         let metric = Arc::clone(&self.0);
-        dispatcher::launch(move || crate::with_glean(|glean| metric.set(glean, value)));
+        crate::launch_with_glean(move |glean| metric.set(glean, value));
     }
 
     fn generate_and_set(&self) -> uuid::Uuid {


### PR DESCRIPTION
Two functions were added: `launch_with_glean` & `launch_with_glean_mut`; test cases passes.
When running `make clippy`, clippy says `extra` in the following snippet is a redundant clone:
```
pub fn set_experiment_active(
     branch: String,
     extra: Option<HashMap<String, String>>,
 ) {
     dispatcher::launch_with_glean(move |glean| {
     glean.set_experiment_active(experiment_id.to_owned(), branch.to_owned(), extra.to_owned)
     })
 }
```
while the original `set_experiment_active`, which doesn't causes the "redundant clone" error, looks like this:
```
pub fn set_experiment_active(
     branch: String,
     extra: Option<HashMap<String, String>>,
 ) {
    dispatcher::launch(move || {
        with_glean(|glean| {
            glean.set_experiment_active(
                experiment_id.to_owned(),
                branch.to_owned(),
                extra.to_owned(),
            )
        });
     })
 }
```
I am still trying to figure out clippy's rule on this, and had removed `to_owned()` for now to make clippy happy.
@badboy Any suggestion is appreciated!