### PR TITLE
iOS: Don't exclude arm64 build for the simulator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,7 +555,6 @@ jobs:
           name: Setup build environment
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
-            cargo install cargo-lipo
 
             # Bootstrap dependencies
             bin/bootstrap.sh
@@ -643,12 +642,19 @@ jobs:
           name: Setup build environment
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
-            cargo install cargo-lipo
 
             # List available devices -- allows us to see what's there
             xcrun instruments -w list || true
             # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
             xcrun instruments -w "iPhone 11 (14" || true
+      - run:
+          name: Install Rust Nightly toolchain
+          command: |
+            # Need a nightly toolchain and the source code for targetting the arm64 iOS simulator
+            # We don't need that build on CI, but its hard to exclude it from the build
+            # while still allowing it in developer builds.
+            rustup toolchain add nightly --profile minimal
+            rustup component add rust-src --toolchain nightly
       - run:
           name: Use current commit of Glean
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -774,6 +774,9 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "../../target/aarch64-apple-ios/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "../../target/aarch64-apple-ios-sim/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "../../target/x86_64-apple-ios/debug";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.Glean;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -807,6 +810,9 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "../../target/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "../../target/aarch64-apple-ios-sim/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "../../target/x86_64-apple-ios/release";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.Glean;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -766,7 +766,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Glean/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -800,7 +799,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Glean/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "bash $PWD/../../build-scripts/xc-universal-binary.sh glean-ffi $PWD/../..\n";
+			shellScript = "bash $PWD/../../build-scripts/xc-universal-binary.sh glean-ffi $PWD/../.. $buildvariant\n";
 		};
 		BFB59A9723429FC000F40CA8 /* Run Glean SDK generator */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/glean-core/ios/base.xcconfig
+++ b/glean-core/ios/base.xcconfig
@@ -1,4 +1,3 @@
 #include "../../xcconfig/common.xcconfig"
 
 INFOPLIST_FILE = Glean/Info.plist
-LIBRARY_SEARCH_PATHS = "../../target/universal/$(buildvariant)"

--- a/samples/ios/app/glean-sample-app.xcodeproj/project.pbxproj
+++ b/samples/ios/app/glean-sample-app.xcodeproj/project.pbxproj
@@ -543,7 +543,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G9EAK7RA89;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "glean-sample-app/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -564,7 +563,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G9EAK7RA89;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "glean-sample-app/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
This currently requires a local build of rustc with https://github.com/rust-lang/rust/pull/81966 to enable the target (and also LLVM 12, LLVM 11 untested). Thus we can't really land that before that becomes stable.

I think it would also require direct consumers to switch over to xcframeworks.
It's untested in app-services, I guess it _could_ work for Intel builds there, but this would need to be tested.

No need for a formal review or test yet.

* [ ] Wait for [upstream changes in rustc](https://github.com/rust-lang/rust/pull/81966)
* [ ] Test it on an Intel machine
* [ ] Test it in app-services