### PR TITLE
Bug 1682244: Add set_now method to DatetimeMetric

### DIFF
--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -122,6 +122,16 @@ impl DatetimeMetric {
         glean.storage().record(glean, &self.meta, &value)
     }
 
+    /// Sets the metric to the current date/time with the timezone offset.
+    /// See [`self.set`] for details.
+    ///
+    /// # Arguments
+    ///
+    /// * `glean` - the Glean instance this metric belongs to.
+    pub fn set_now(&self, glean: &Glean) {
+        self.set(glean, None);
+    }
+
     /// Gets the stored datetime value.
     ///
     /// # Arguments


### PR DESCRIPTION
A small patch to address the bug; any suggestion is appreciated!
I don't see these `set` methods in the test cases, or am I missing something?