### PR TITLE
Bug 1659706 - CI: Use up-to-date CircleCI-provided Android image again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,8 +435,7 @@ jobs:
 
   Lint Android with ktlint and detekt:
     docker:
-      # FIXME(bug 1659706): Use `circleci/android:api-28-ndk` again
-      - image: circleci/android@sha256:467c03465c664de6c915cfd94f4a8fc91cd16d87f704e8323704b2576330bf6e
+      - image: circleci/android:api-28-ndk
     steps:
       - checkout
       - run: ./gradlew --no-daemon lint
@@ -445,8 +444,7 @@ jobs:
 
   Android tests:
     docker:
-      # FIXME(bug 1659706): Use `circleci/android:api-28-ndk` again
-      - image: circleci/android@sha256:467c03465c664de6c915cfd94f4a8fc91cd16d87f704e8323704b2576330bf6e
+      - image: circleci/android:api-28-ndk
     steps:
       - android-setup
       - skip-if-doc-only
@@ -492,8 +490,7 @@ jobs:
 
   Generate Kotlin documentation:
     docker:
-      # FIXME(bug 1659706): Use `circleci/android:api-28-ndk` again
-      - image: circleci/android@sha256:467c03465c664de6c915cfd94f4a8fc91cd16d87f704e8323704b2576330bf6e
+      - image: circleci/android:api-28-ndk
     steps:
       - android-setup
       - run:


### PR DESCRIPTION
This brings Java 11.
We fixed support for that in commit 3ff81f0794696491cc6b094d74550fffe4e3211d