### PR TITLE
Persist shared folder to workplace after building docs [doc only]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,6 +402,7 @@ jobs:
             - docs/book
             - docs/dev
             - docs/docs
+            - docs/shared
             - docs/index.html
 
   Publish Rust crates:


### PR DESCRIPTION
This was preventing the books from loading shared resources.