### PR TITLE
Python: increase minimal supported cffi version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v35.0.0...main)
 
+* Python
+  * Update minimal required version of `cffi` dependency to 1.13.0 ([#1520](https://github.com/mozilla/glean/pull/1520)).
+
 # v35.0.0 (2021-02-22)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v34.1.0...v35.0.0)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(GLEAN_PYENV)/bin/python3:
 	python3 -m venv $(GLEAN_PYENV)
 	$(GLEAN_PYENV)/bin/pip install --upgrade pip
 	$(GLEAN_PYENV)/bin/pip install --use-feature=2020-resolver -r glean-core/python/requirements_dev.txt
-	sh -c "if [ \"$(GLEAN_PYDEPS)\" == \"min\" ]; then \
+	sh -c "if [ \"$(GLEAN_PYDEPS)\" = \"min\" ]; then \
 		$(GLEAN_PYENV)/bin/pip install requirements-builder; \
 		$(GLEAN_PYENV)/bin/requirements-builder --level=min glean-core/python/setup.py > min_requirements.txt; \
 		$(GLEAN_PYENV)/bin/pip install --use-feature=2020-resolver -r min_requirements.txt; \

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -71,12 +71,12 @@ with (SRC_ROOT / "CHANGELOG.md").open() as history_file:
 version = "35.0.0"
 
 requirements = [
-    "cffi>=1",
+    "cffi>=1.13.0",
     "glean_parser==2.2.0",
     "iso8601>=0.1.10; python_version<='3.6'",
 ]
 
-setup_requirements = ["cffi>=1.0.0"]
+setup_requirements = ["cffi>=1.13.0"]
 
 # The environment variable `GLEAN_BUILD_VARIANT` can be set to `debug` or `release`
 buildvariant = os.environ.get("GLEAN_BUILD_VARIANT", "debug")


### PR DESCRIPTION
I think this fixes test failures such as this one: https://app.circleci.com/pipelines/github/mozilla/glean/7162/workflows/33e489f9-56fa-4f0b-b2fa-c4bf03b52604/jobs/124598 (see #1507).

I ran it locally and saw this:

```
Traceback (most recent call last):
  File "/home/jer/src/mozilla/glean/glean-core/python/.venv3.8/lib64/python3.9/site-packages/glean_sdk-34.1.0-py3.9-linux-x86_64.egg/glean/_subprocess/_process_dispatcher_helper.py", line 36, in <module>
    success = func(*args)
  File "/home/jer/src/mozilla/glean/glean-core/python/.venv3.8/lib64/python3.9/site-packages/glean_sdk-34.1.0-py3.9-linux-x86_64.egg/glean/net/ping_upload_worker.py", line 152, in _process
    time.sleep(incoming_task.wait / 1000)
OverflowError: timestamp too large to convert to C _PyTime_t
```

Adding some logging it shows that `incoming_task.wait` is some huge value, likely because it reads the wrong bytes from memory because of the wrong encoding of an anonymous struct inside a union.

cffi 1.0.0 was released in 2015.
cffi 1.11.5 was released in 2018.
IMO it's a safe-bet to increase our minimum required version there.