### PR TITLE
Bug 1693489 -  Update Glean SDK development and Glean book front page content

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 212 utf-8
+personal_ws-1.1 en 213 utf-8
 AAR
 AARs
 ABI
@@ -36,6 +36,7 @@ JNI
 JSON
 JUnit
 JWE
+Javascript
 JetBrains
 Karlton
 Kotlin

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -5,6 +5,7 @@
 The `Glean SDK` is a modern approach for a Telemetry library and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
 
 To contact us you can:
+
 - Find us in the [#glean channel on chat.mozilla.org](https://chat.mozilla.org/#/room/#glean:mozilla.org).
 - To report issues or request changes, file a bug in [Bugzilla in Data Platform & Tools :: Glean: SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean%3A+SDK&priority=P3&status_whiteboard=%5Btelemetry%3Aglean-rs%3Am%3F%5D).
 - Send an email to *glean-team@mozilla.com*.
@@ -12,24 +13,13 @@ To contact us you can:
 
 The source code is available [on GitHub](https://github.com/mozilla/glean/).
 
-## Using this book
+## About this book
 
-This book is specifically about **contributing to and developing** the `Glean SDK`.
+This book is meant for developers of the `Glean SDK`.
 
-For documentation on **using** the `Glean SDK`, refer to [the Glean Book](../book/).
+For user documentation on the Glean SDK, refer to [the Glean Book](../book).
 
 For documentation about the broader end-to-end Glean project, refer to the [Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
-
-This book is divided into 2 main parts:
-
-### [Developing the Glean SDK](testing.md)
-
-This chapter describes how to develop the Glean SDK and its various implementations.
-This is relevant if you plan to contribute to the Glean SDK code base.
-
-### [API Reference Documentation](api/index.md)
-
-Reference documentation for the API in its various language bindings.
 
 ## License
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -17,7 +17,7 @@ The source code is available [on GitHub](https://github.com/mozilla/glean/).
 
 This book is meant for developers of the `Glean SDK`.
 
-For user documentation on the Glean SDK, refer to [the Glean Book](../book).
+For user documentation on the Glean SDK, refer to [the Glean Book](../book/index.html).
 
 For documentation about the broader end-to-end Glean project, refer to the [Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -40,7 +40,7 @@ file a bug in [Bugzilla in Data Platform & Tools :: Glean.js][gleanjs-bugs].
 
 ### [Using Glean](./user/index.html)
 
-In this chapter we describe how to use Glean in your own libraries and applications.
+In this section we describe how to use Glean in your own libraries and applications.
 It explains the first steps of integrating Glean into your project, choosing the right metric type for you,
 debugging products that use Glean and Glean's built-in error reporting mechanism.
 If you want to start using Glean to report data, this is the section you should read.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,6 +1,80 @@
 # Introduction
 
-Glean is a modern approach for a Telemetry library and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
+Glean is a modern approach for a telemetry library
+and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
+
+![Glean logo](glean.jpeg)
+
+There are two implementations of Glean, with support for 5 different programming languages in total.
+Both implementations strive to contain the same features with similar, but idiomatic APIs.
+
+Unless clearly stated otherwise, regard the text in this book as valid for both clients
+and all the supported programming languages and environments.
+
+### [The Glean SDK](https://github.com/mozilla/glean)
+
+The Glean SDK is an implementation of Glean in Rust, with language bindings for **Kotlin**,
+**Python**, **Rust** and **Swift**.
+
+For development documentation on the `Glean SDK`,
+refer to [the Glean SDK development book](https://mozilla.github.io/glean/).
+
+To report issues or request changes on the Glean SDK,
+file a bug in [Bugzilla in Data Platform & Tools :: Glean: SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean%3A+SDK&priority=P3&status_whiteboard=%5Btelemetry%3Aglean-rs%3Am%3F%5D).
+
+### [Glean.js](https://github.com/mozilla/glean.js)
+
+Glean.js is an implementation of Glean in **Javascript**. Currently, it only has support
+for usage in web extensions.
+
+For development documentation on `Glean.js`,
+refer to [the Glean.js development documentation](https://github.com/mozilla/glean.js/tree/main/docs).
+
+To report issues or request changes on the Glean SDK,
+file a bug in [Bugzilla in Data Platform & Tools :: Glean.js](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean.js&priority=P4&status_whiteboard=%5Btelemetry%3Aglean-js%3Am%3F%5D).
+
+> **Note** Glean.js is still in development and does not provide all the features the Glean SDK does.
+> Feature parity will be worked on after initial validation. Do not hesitate to [file a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean.js&priority=P4&status_whiteboard=%5Btelemetry%3Aglean-js%3Am%3F%5D)
+> if you want to use Glean.js and is missing some key Glean feature.
+
+## Sections
+
+### [Using Glean](./user/index.html)
+
+In this chapter we describe how to use Glean in your own libraries and applications.
+It explains the first steps of integrating Glean into your project, choosing the right metric type for you,
+debugging products that use Glean and Glean's built-in error reporting mechanism.
+If you want to start using Glean to report data, this is the section you should read.
+
+### [Metric Types](./user/metrics/index.html)
+
+This sections lists all the metric types provided by Glean, with examples on how to define them
+and record data using them. Before diving into Glean's metric types details, don't forget to
+read the [Choosing a metric type](https://mozilla.github.io/glean/book/user/adding-new-metrics.html#choosing-a-metric-type) page.
+
+### [Pings](./user/pings/index.html)
+
+This section goes through what is a ping and how to define custom pings. A Glean client may provide
+off-the-shelf pings, such as the [`metrics`](https://mozilla.github.io/glean/book/user/pings/metrics.html)
+or [`baseline`](https://mozilla.github.io/glean/book/user/pings/baseline.html) pings. In this section,
+you will also find the descriptions and the schedules of each of these pings.
+
+### Appendix
+
+#### [Glossary](./appendix/glossary.html)
+
+In this book we use a lot of Glean specific terminology. In the glossary, we go through
+many of the terms used throughout this book and describe exactly what we mean when we use them.
+
+#### [Changelog](./appendix/changelog.html)
+
+This section contains detailed notes about changes in Glean, per release.
+
+#### [This Week in Glean](./appendix/twig.html)
+
+“This Week in Glean” is a series of blog posts that the Glean Team at Mozilla is using to try
+to communicate better about our work. They could be release notes, documentation, hopes, dreams,
+or whatever: so long as it is inspired by Glean.
 
 ## Contact
 
@@ -10,58 +84,7 @@ To contact the Glean team you can:
 - Send an email to *glean-team@mozilla.com*.
 - The Glean SDK team is: *:janerik*, *:dexter*, *:travis*, *:mdroettboom*, *:gfritzsche*, *:chutten*, *:brizental*.
 
-![Glean logo](glean.jpeg)
-
-There are two implementations of Glean, with support for 5 different programming languages in total. Both implementations strive to contain the same features with similar, but idiomatic APIs.
-
-Unless clearly stated otherwise, regard the text in this book as valid for both clients and all the supported programming languages and environments.
-
-### [The Glean SDK](https://github.com/mozilla/glean)
-
-The Glean SDK is an implementation of Glean in Rust, with language bindings for **Kotlin**, **Python**, **Rust** and **Swift**.
-
-For development documentation on the `Glean SDK`, refer to [the Glean SDK development book](https://mozilla.github.io/glean/).
-
-To report issues or request changes on the Glean SDK, file a bug in [Bugzilla in Data Platform & Tools :: Glean: SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean%3A+SDK&priority=P3&status_whiteboard=%5Btelemetry%3Aglean-rs%3Am%3F%5D).
-
-### [Glean.js](https://github.com/mozilla/glean.js)
-
-Glean.js is an implementation of Glean in **Javascript**. Currently, it only has support for usage in web extensions.
-
-For development documentation on `Glean.js`, refer to [the Glean.js development documentation](https://github.com/mozilla/glean.js/tree/main/docs).
-
-To report issues or request changes on the Glean SDK, file a bug in [Bugzilla in Data Platform & Tools :: Glean.js](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean.js&priority=P4&status_whiteboard=%5Btelemetry%3Aglean-js%3Am%3F%5D).
-
-> **Note** Glean.js is still on the MVP stage and does not provide all the features the Glean SDK does. Feature parity will be worked on after initial validation. Do not hesitate to file bugs using the link above if you want to use Glean.js and is missing some key Glean feature.
-
-## Sections
-
-### [Using Glean](./user/index.html)
-
-If you want to start using Glean to report data then this is the section you should read. It explains the first steps of integrating Glean into your project, choosing the right metric type for you, debugging products that use Glean and even Glean's internal error reporting mechanism.
-
-### [Metric Types](./user/metrics/index.html)
-
-This sections lists all the metric types provided by Glean, with examples on how to define them and record data using them. Before diving into Glean's metric types details, don't forget to read the [Choosing a metric type](https://mozilla.github.io/glean/book/user/adding-new-metrics.html#choosing-a-metric-type).
-
-### [Pings](./user/pings/index.html)
-
-This section goes through what is a ping and how to define custom pings. A Glean client may provide off-the-shelf pings, such as the [`metrics`](https://mozilla.github.io/glean/book/user/pings/metrics.html) or [`baseline`](https://mozilla.github.io/glean/book/user/pings/baseline.html) pings. In this section you also will find the descriptions and the schedules of each of these pings.
-
-### Appendix
-
-#### [Glossary](./appendix/glossary.html)
-
-In this book we use a lot of Glean specific terminology. In the glossary we go through many of the terms used throughout this book and describe exactly what we mean when we use them.
-
-#### [Changelog](./appendix/changelog.html)
-
-This section contains detailed notes about changes in Glean, per release.
-
-#### [This Week in Glean](./appendix/twig.html)
-
-“This Week in Glean” is a series of blog posts that the Glean Team at Mozilla is using to try to communicate better about our work. They could be release notes, documentation, hopes, dreams, or whatever: so long as it is inspired by Glean.
-
 ## License
 
-Glean.js and the Glean SDK Source Code is subject to the terms of the Mozilla Public License v2.0. You can obtain a copy of the MPL at <https://mozilla.org/MPL/2.0/>.
+Glean.js and the Glean SDK Source Code is subject to the terms of the Mozilla Public License v2.0.
+You can obtain a copy of the MPL at <https://mozilla.org/MPL/2.0/>.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -12,6 +12,28 @@ To contact the Glean team you can:
 
 ![Glean logo](glean.jpeg)
 
+There are two implementations of Glean, with support for 5 different programming languages in total. Both implementations strive to contain the same features with similar, but idiomatic APIs.
+
+Unless clearly stated otherwise, regard the text in this book as valid for both clients and all the supported programming languages and environments.
+
+### [The Glean SDK](https://github.com/mozilla/glean)
+
+The Glean SDK is an implementation of Glean in Rust, with language bindings for **Kotlin**, **Python**, **Rust** and **Swift**.
+
+For development documentation on the `Glean SDK`, refer to [the Glean SDK development book](https://mozilla.github.io/glean/).
+
+To report issues or request changes on the Glean SDK, file a bug in [Bugzilla in Data Platform & Tools :: Glean: SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean%3A+SDK&priority=P3&status_whiteboard=%5Btelemetry%3Aglean-rs%3Am%3F%5D).
+
+### [Glean.js](https://github.com/mozilla/glean.js)
+
+Glean.js is an implementation of Glean in **Javascript**. Currently, it only has support for usage in web extensions.
+
+For development documentation on `Glean.js`, refer to [the Glean.js development documentation](https://github.com/mozilla/glean.js/tree/main/docs).
+
+To report issues or request changes on the Glean SDK, file a bug in [Bugzilla in Data Platform & Tools :: Glean.js](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean.js&priority=P4&status_whiteboard=%5Btelemetry%3Aglean-js%3Am%3F%5D).
+
+> **Note** Glean.js is still on the MVP stage and does not provide all the features the Glean SDK does. Feature parity will be worked on after initial validation. Do not hesitate to file bugs using the link above if you want to use Glean.js and is missing some key Glean feature.
+
 ## Sections
 
 ### [Using Glean](./user/index.html)

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -30,13 +30,12 @@ for usage in web extensions.
 For development documentation on `Glean.js`,
 refer to [the Glean.js development documentation](https://github.com/mozilla/glean.js/tree/main/docs).
 
-To report issues or request changes on the Glean SDK,
-file a bug in [Bugzilla in Data Platform & Tools :: Glean.js](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean.js&priority=P4&status_whiteboard=%5Btelemetry%3Aglean-js%3Am%3F%5D).
+To report issues or request changes on Glean.js,
+file a bug in [Bugzilla in Data Platform & Tools :: Glean.js][gleanjs-bugs].
 
 > **Note** Glean.js is still in development and does not provide all the features the Glean SDK does.
-> Feature parity will be worked on after initial validation. Do not hesitate to [file a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean.js&priority=P4&status_whiteboard=%5Btelemetry%3Aglean-js%3Am%3F%5D)
+> Feature parity will be worked on after initial validation. Do not hesitate to [file a bug][gleanjs-bugs]
 > if you want to use Glean.js and is missing some key Glean feature.
-
 ## Sections
 
 ### [Using Glean](./user/index.html)
@@ -88,3 +87,5 @@ To contact the Glean team you can:
 
 Glean.js and the Glean SDK Source Code is subject to the terms of the Mozilla Public License v2.0.
 You can obtain a copy of the MPL at <https://mozilla.org/MPL/2.0/>.
+
+[gleanjs-bugs]: https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean.js&priority=P4&status_whiteboard=%5Btelemetry%3Aglean-js%3Am%3F%5D

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,44 +1,45 @@
-# Glean SDK
+# Introduction
 
-![Glean logo](glean.jpeg)
+Glean is a modern approach for a Telemetry library and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
 
-The `Glean SDK` is a modern approach for a Telemetry library and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
+## Contact
 
-To contact us you can:
+To contact the Glean team you can:
+
 - Find us in the [#glean channel on chat.mozilla.org](https://chat.mozilla.org/#/room/#glean:mozilla.org).
-- To report issues or request changes, file a bug in [Bugzilla in Data Platform & Tools :: Glean: SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=Glean%3A+SDK&priority=P3&status_whiteboard=%5Btelemetry%3Aglean-rs%3Am%3F%5D).
 - Send an email to *glean-team@mozilla.com*.
 - The Glean SDK team is: *:janerik*, *:dexter*, *:travis*, *:mdroettboom*, *:gfritzsche*, *:chutten*, *:brizental*.
 
-The source code is available [on GitHub](https://github.com/mozilla/glean/).
+![Glean logo](glean.jpeg)
 
-## Using this book
+## Sections
 
-This book is specifically about **using** the `Glean SDK`.
+### [Using Glean](./user/index.html)
 
-For documentation on **contributing to and developing** the `Glean SDK`, refer to [the Glean SDK development book](../dev/).
+If you want to start using Glean to report data then this is the section you should read. It explains the first steps of integrating Glean into your project, choosing the right metric type for you, debugging products that use Glean and even Glean's internal error reporting mechanism.
 
-For documentation about the broader end-to-end Glean project, refer to the [Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
+### [Metric Types](./user/metrics/index.html)
 
-This book is divided into 3 main chapters:
+This sections lists all the metric types provided by Glean, with examples on how to define them and record data using them. Before diving into Glean's metric types details, don't forget to read the [Choosing a metric type](https://mozilla.github.io/glean/book/user/adding-new-metrics.html#choosing-a-metric-type).
 
-### [Using the Glean SDK](user/index.html)
+### [Pings](./user/pings/index.html)
 
-If you want to use the Glean SDK to report data then this is the section you should read.
-It explains the first steps from integrating Glean into your project,
-contains details about all available metric types
-and how to do send your own custom pings.
+This section goes through what is a ping and how to define custom pings. A Glean client may provide off-the-shelf pings, such as the [`metrics`](https://mozilla.github.io/glean/book/user/pings/metrics.html) or [`baseline`](https://mozilla.github.io/glean/book/user/pings/baseline.html) pings. In this section you also will find the descriptions and the schedules of each of these pings.
 
-### [Metrics collected by the Glean SDK](user/collected-metrics/metrics.md)
+### Appendix
 
-This chapter lists all metrics collected by the Glean SDK itself.
+#### [Glossary](./appendix/glossary.html)
 
-### [This Week in Glean](appendix/twig.md)
+In this book we use a lot of Glean specific terminology. In the glossary we go through many of the terms used throughout this book and describe exactly what we mean when we use them.
 
-“This Week in Glean” is a series of blog posts that the Glean Team at Mozilla is using to try to communicate better about our work.
-They could be release notes, documentation, hopes, dreams, or whatever: so long as it is inspired by Glean.
+#### [Changelog](./appendix/changelog.html)
+
+This section contains detailed notes about changes in Glean, per release.
+
+#### [This Week in Glean](./appendix/twig.html)
+
+“This Week in Glean” is a series of blog posts that the Glean Team at Mozilla is using to try to communicate better about our work. They could be release notes, documentation, hopes, dreams, or whatever: so long as it is inspired by Glean.
 
 ## License
 
-The Glean SDK Source Code is subject to the terms of the Mozilla Public License v2.0.
-You can obtain a copy of the MPL at <https://mozilla.org/MPL/2.0/>.
+Glean.js and the Glean SDK Source Code is subject to the terms of the Mozilla Public License v2.0. You can obtain a copy of the MPL at <https://mozilla.org/MPL/2.0/>.


### PR DESCRIPTION
I tried to make the content on the front page of the user book a bit less SDK specific with the future addition of Glean.js documentation in mind.

I sent a third commit where I mention both Glean clients in the user book's front page. I made it into a separate commit on purpose, after I was done and read it, I wondered if we should hold off on mentioning it in the front page (since all the rest of the book is still heavily SDK specific).