### PR TITLE
[no bug] Add a link to labeled boolean docs from metrics index

### DIFF
--- a/docs/user/user/metrics/index.md
+++ b/docs/user/user/metrics/index.md
@@ -6,6 +6,8 @@ There are different metrics to choose from, depending on what you want to achiev
 
 * [Boolean](boolean.md): Records a single truth value, for example "is a11y enabled?"
 
+* [Labeled boolean](labeled_booleans.md): Records truth values for a set of labels, for example "which a11y features are enabled?"
+
 * [Counter](counter.md): Used to count how often something happens, for example, how often a certain button was pressed.
 
 * [Labeled counter](labeled_counters.md): Used to count how often something happens, for example which kind of crash occurred (`"uncaught_exception"` or `"native_code_crash"`).


### PR DESCRIPTION
This was included in the docs, but not linked from the metrics index page.