### PR TITLE
Bug 1679837: Set internal_metrics::os_version for specific os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
   * Send the `baseline` ping with reason `dirty_startup`, if needed, at startup.
   * Expose all required types directly ([#1452](https://github.com/mozilla/glean/pull/1452)).
     * Rust consumers will not need to depend on `glean-core` anymore.
+  * Set `internal_metrics::os_version` for MacOS, Windows and Linux ([#1538](https://github.com/mozilla/glean/pull/1538))
 * Android
   * BUGFIX: Don't crash the ping uploader when throttled due to reading too large wait time values ([#1454](https://github.com/mozilla/glean/pull/1454)).
   * Use the client activity API ([#1455](https://github.com/mozilla/glean/pull/1455)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "thiserror",
  "time",
  "uuid",
+ "whatsys",
 ]
 
 [[package]]
@@ -893,6 +894,17 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "whatsys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24fff5aa1e0973964ba23a995e8b10fa2cdeae507e0cbbbd36f8403242a765d"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.104", features = ["derive"] }
 uuid = { version = "0.8.1", features = ["v4"] }
 chrono = { version = "0.4.10", features = ["serde"] }
 time = "0.1.40"
+whatsys = "0.1.2"
 
 [dev-dependencies]
 env_logger = { version = "0.7.1", default-features = false, features = ["termcolor", "atty", "humantime"] }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -434,7 +434,7 @@ fn initialize_core_metrics(
     if let Some(app_channel) = channel {
         core_metrics::internal_metrics::app_channel.set_sync(glean, app_channel);
     }
-    core_metrics::internal_metrics::os_version.set_sync(glean, "unknown".to_string());
+    core_metrics::internal_metrics::os_version.set_sync(glean, system::get_os_version());
     core_metrics::internal_metrics::architecture.set_sync(glean, system::ARCH.to_string());
     core_metrics::internal_metrics::device_manufacturer.set_sync(glean, "unknown".to_string());
     core_metrics::internal_metrics::device_model.set_sync(glean, "unknown".to_string());


### PR DESCRIPTION
At the first glance, two existing crates could be used: `sys_info` and `os_info`.
`os_info` returns the distribution version instead of the kernel version for Linux systems, so we are only left with `sys_info`.

Following the [proposal](https://docs.google.com/document/d/1VD1z8njHu6A_vvojyIQhKcUmvhlQHVjVAlug2jitqbM/), `get_os_version()` is added to `glean_core::system.rs`, however I doubt this is the right place, since `internal_metrics::os_version` is initialized in `rlb`. 
Given the fact that we have to manipulate the `String` returned by `sys_info` in case of Linux, I failed to come up with a way to create something like `pub const OS_VERSION: String`.

Any suggestion is appreciated!