### PR TITLE
Bug 1697100: Don't let environment affect subprocess module search path

### DIFF
--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -120,8 +120,14 @@ class ProcessDispatcher:
                     Path(".coveragerc").absolute()
                 )
 
+            # Explicitly pass the contents of `sys.path` as `PYTHONPATH` to the
+            # subprocess so that there aren't any module search path
+            # differences.
+            python_path = ":".join(sys.path)[1:]
+
             p = subprocess.Popen(
-                [sys.executable, _process_dispatcher_helper.__file__, payload]
+                [sys.executable, _process_dispatcher_helper.__file__, payload],
+                env={"PYTHONPATH": python_path},
             )
 
             cls._last_process = p

--- a/glean-core/python/tests/test_dispatcher.py
+++ b/glean-core/python/tests/test_dispatcher.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
+from pathlib import Path
 import threading
 import sys
 import time
@@ -12,9 +13,11 @@ import pytest
 
 
 from glean._dispatcher import Dispatcher
+from glean._process_dispatcher import ProcessDispatcher
 from glean import Glean
 from glean import metrics
 from glean.metrics import Lifetime
+from glean.glean import _rmtree
 
 
 def test_launch_correctly_adds_tasks_to_queue_if_queue_tasks_is_true():
@@ -211,3 +214,47 @@ def test_recording_in_subprocess_throws_exception():
     returncode = p.join()
 
     assert returncode != 0
+
+
+def test_module_path_change_pythonpath(tmpdir, monkeypatch):
+    """
+    If PYTHONPATH gets set to a place with a broken installation of Glean,
+    running a subprocess task should still work.
+    """
+
+    tmpdir = Path(tmpdir)
+    (tmpdir / "glean").mkdir()
+    with open(tmpdir / "glean" / "__init__.py", "w") as fd:
+        fd.write("\n")
+    (tmpdir / "foo").mkdir()
+
+    monkeypatch.setenv("PYTHONPATH", str(tmpdir))
+
+    ProcessDispatcher.dispatch(_rmtree, (str(tmpdir),))
+
+    returncode = ProcessDispatcher._last_process.wait()
+
+    assert returncode == 0
+
+    assert not (tmpdir / "foo").exists()
+
+
+def test_module_path_working(tmpdir):
+    """
+    Test that running a subprocess task works under normal circumstances
+    (without monkeying with PYTHONPATH).
+    """
+
+    tmpdir = Path(tmpdir)
+    (tmpdir / "glean").mkdir()
+    with open(tmpdir / "glean" / "__init__.py", "w") as fd:
+        fd.write("\n")
+    (tmpdir / "foo").mkdir()
+
+    ProcessDispatcher.dispatch(_rmtree, (str(tmpdir / "foo"),))
+
+    returncode = ProcessDispatcher._last_process.wait()
+
+    assert returncode == 0
+
+    assert not (tmpdir / "foo").exists()


### PR DESCRIPTION
@cpeterso: Can you confirm this addresses your issue by copying `_process_dispatcher.py` on this branch to `/Users/chris/Code/mozilla/firefox/obj-x86_64-apple-darwin20.3.0-clang-mozbuild/_virtualenvs/init_py3/lib/python3.8/site-packages/glean/`?