### PR TITLE
[ci full] Bump macOS SDK to 10.12 (Sierra)

### DIFF
--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -71,6 +71,8 @@ RUN apt-get update -qq \
         unzip \
         # Required by tooltool to extract tar.xz archives.
         xz-utils \
+        # Required to unpack compiler
+        zstd \
         # Required to build libs/.
         make \
         # Required to build sqlcipher.

--- a/taskcluster/scripts/cross-compile-setup.sh
+++ b/taskcluster/scripts/cross-compile-setup.sh
@@ -2,12 +2,12 @@
 export PATH=$PATH:/tmp/clang/bin
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CC=/tmp/clang/bin/clang
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_TOOLCHAIN_PREFIX=/tmp/cctools/bin
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_AR=/tmp/cctools/bin/x86_64-darwin11-ar
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RANLIB=/tmp/cctools/bin/x86_64-darwin11-ranlib
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_AR=/tmp/cctools/bin/x86_64-apple-darwin-ar
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RANLIB=/tmp/cctools/bin/x86_64-apple-darwin-ranlib
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_LD_LIBRARY_PATH=/tmp/clang/lib
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/tmp/clang/bin/clang -C link-arg=-B -C link-arg=/tmp/cctools/bin -C link-arg=-target -C link-arg=x86_64-darwin11 -C link-arg=-isysroot -C link-arg=/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/tmp/clang/bin/clang -C link-arg=-B -C link-arg=/tmp/cctools/bin -C link-arg=-target -C link-arg=x86_64-apple-darwin -C link-arg=-isysroot -C link-arg=/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-dead_strip"
 # For ring's use of `cc`.
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /tmp/cctools/bin -target x86_64-darwin11 -isysroot /tmp/MacOSX10.12.sdk -Wl,-syslibroot,/tmp/MacOSX10.12.sdk -Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /tmp/cctools/bin -target x86_64-apple-darwin -isysroot /tmp/MacOSX10.12.sdk -Wl,-syslibroot,/tmp/MacOSX10.12.sdk -Wl,-dead_strip"
 # The wrong linker gets used otherwise: https://github.com/rust-lang/rust/issues/33465.
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C linker=x86_64-w64-mingw32-gcc"
 
@@ -25,6 +25,14 @@ tooltool.py \
   --url=http://taskcluster/tooltool.mozilla-releng.net/ \
   --manifest="/builds/worker/checkouts/src/taskcluster/scripts/macos-cc-tools.manifest" \
   fetch
+
+curl -sfSL --retry 5 --retry-delay 10 https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/NcaljhkvQOSKxGlBSWJl_w/runs/0/artifacts/public/build/cctools.tar.xz > cctools.tar.xz
+tar -xf cctools.tar.xz
+ls -l /tmp/cctools
+curl -sfSL --retry 5 --retry-delay 10 https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/eJJotfnPSt2weVG0sZlfeQ/runs/0/artifacts/public/build/clang.tar.zst > clang.tar.zst
+tar -I zstd -xf clang.tar.zst
+ls -l /tmp/clang
+ls -l /tmp/clang/bin
 
 rustup target add x86_64-apple-darwin
 rustup target add x86_64-pc-windows-gnu

--- a/taskcluster/scripts/cross-compile-setup.sh
+++ b/taskcluster/scripts/cross-compile-setup.sh
@@ -5,9 +5,9 @@ export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_TOOLCHA
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_AR=/tmp/cctools/bin/x86_64-darwin11-ar
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RANLIB=/tmp/cctools/bin/x86_64-darwin11-ranlib
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_LD_LIBRARY_PATH=/tmp/clang/lib
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/tmp/clang/bin/clang -C link-arg=-B -C link-arg=/tmp/cctools/bin -C link-arg=-target -C link-arg=x86_64-darwin11 -C link-arg=-isysroot -C link-arg=/tmp/MacOSX10.11.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX10.11.sdk -C link-arg=-Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/tmp/clang/bin/clang -C link-arg=-B -C link-arg=/tmp/cctools/bin -C link-arg=-target -C link-arg=x86_64-darwin11 -C link-arg=-isysroot -C link-arg=/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-dead_strip"
 # For ring's use of `cc`.
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /tmp/cctools/bin -target x86_64-darwin11 -isysroot /tmp/MacOSX10.11.sdk -Wl,-syslibroot,/tmp/MacOSX10.11.sdk -Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /tmp/cctools/bin -target x86_64-darwin11 -isysroot /tmp/MacOSX10.12.sdk -Wl,-syslibroot,/tmp/MacOSX10.12.sdk -Wl,-dead_strip"
 # The wrong linker gets used otherwise: https://github.com/rust-lang/rust/issues/33465.
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C linker=x86_64-w64-mingw32-gcc"
 

--- a/taskcluster/scripts/macos-cc-tools.manifest
+++ b/taskcluster/scripts/macos-cc-tools.manifest
@@ -1,11 +1,11 @@
 [
   {
-    "size": 34094283,
+    "size":  31991917,
     "visibility": "internal",
-    "digest": "8811050fe375bcc566c8b85173d86b8a87aa2148edfed93023735c2de44b66a5a28cbaa1cfd396032447fd803e03f308ed941a200c0e2a1ad9fbe16b5606ee7c",
+    "digest": "c5c0be09972b56b5980dc9d06b61ff49cf58c4572913437256a79b202e19e936af3c0ab0924df72b9f648d518c257597f84800a84bb80e68af4eabdaf1df5f24",
     "algorithm": "sha512",
     "unpack": true,
-    "filename": "MacOSX10.11.sdk.tar.xz"
+    "filename": "MacOSX10.12.sdk.tar.xz"
   },
   {
     "size": 1549588,

--- a/taskcluster/scripts/macos-cc-tools.manifest
+++ b/taskcluster/scripts/macos-cc-tools.manifest
@@ -6,21 +6,5 @@
     "algorithm": "sha512",
     "unpack": true,
     "filename": "MacOSX10.12.sdk.tar.xz"
-  },
-  {
-    "size": 1549588,
-    "visibility": "public",
-    "digest": "3653886e5ea471f6089e526c8ae63063a7e032872c051d85f91389e40baef887e7452c93f0386e23c72875853cb9c2f46f282eec8015c53c6ab4c24e964e8620",
-    "algorithm": "sha512",
-    "unpack": true,
-    "filename": "cctools.tar.xz"
-  },
-  {
-    "size": 160611724,
-    "visibility": "public",
-    "digest": "82d300433526a0a008214a2b704f8de63617751001126b62a91239ce0f002e6504200988f42e25fff273d7228daa4de835d6fe82ef7e6ff8a4f667d8636abb99",
-    "algorithm": "sha512",
-    "unpack": true,
-    "filename": "clang.tar.xz"
   }
 ]


### PR DESCRIPTION
We now use `clock_gettime_nsec_np`, which was only introduced in 10.12
(which was released in 2016).
This effectively drops support for 10.11 for Android builds.