### PR TITLE
Bug 1675580: Use rkv SafeMode in Python

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -180,6 +180,7 @@ pytest
 rethrow
 rfloor
 rkv
+rkv's
 runtime
 runtimes
 rustup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * BUGFIX: `TimespanMetricType.measure` and `TimingDistributionMetricType.measure` won't get inlined anymore ([#1560](https://github.com/mozilla/glean/pull/1560)).
     This avoids a potential bug where a `return` used inside the closure would end up not measuring the time.
     Use `return@measure <val>` for early returns.
+* Python
+  * The Glean Python bindings now use rkv's safe mode backend. This should avoid intermittent segfaults in the LMDB backend.
 
 # v36.0.0 (2021-03-16)
 

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -111,7 +111,11 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
         cfg = _ffi.make_config(
             data_dir,
             application_id,
-            True,
+            # Set upload enabled to False. The subprocess should not record
+            # telemetry. In the special `glean_initialize_for_subprocess` mode,
+            # this does not have any side effects like resetting the client_id
+            # or sending a deletion-request ping.
+            False,
             configuration.max_events,
         )
         if _ffi.lib.glean_initialize_for_subprocess(cfg) == 0:

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -179,14 +179,23 @@ class build(_build):
         if target == "i686-pc-windows-gnu":
             env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " -C panic=abort"
 
-        command = ["cargo", "build", "--package", "glean-ffi", "--target", target]
+        command = [
+            "cargo",
+            "build",
+            "--package",
+            "glean-ffi",
+            "--target",
+            target,
+            "--features",
+            "rkv-safe-mode",
+        ]
         if buildvariant != "debug":
             command.append(f"--{buildvariant}")
 
         if "-darwin" in target:
             env["MACOSX_DEPLOYMENT_TARGET"] = macos_compat(target)
 
-        subprocess.run(command, cwd=SRC_ROOT, env=env)
+        subprocess.check_call(command, cwd=SRC_ROOT / "glean-core" / "ffi", env=env)
         shutil.copyfile(
             SRC_ROOT / "target" / target / buildvariant / shared_object,
             PYTHON_ROOT / "glean" / shared_object,

--- a/glean-core/python/tests/test_dispatcher.py
+++ b/glean-core/python/tests/test_dispatcher.py
@@ -197,27 +197,17 @@ def _subprocess():
         send_in_pings=["store1"],
     )
 
-    for i in range(1000):
-        string_metric.set(str(i))
+    string_metric.set("foo")
 
 
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Test only works on Linux"
 )
-def test_single_threaded_in_multiprocessing_subprocess():
+def test_recording_in_subprocess_throws_exception():
     import multiprocessing
 
     p = multiprocessing.Process(target=_subprocess)
     p.start()
-    p.join()
+    returncode = p.join()
 
-    # This must match the definition in _subprocess() above.
-    string_metric = metrics.StringMetricType(
-        disabled=False,
-        category="telemetry",
-        lifetime=Lifetime.APPLICATION,
-        name="string_metric",
-        send_in_pings=["store1"],
-    )
-
-    assert string_metric.test_get_value() == "999"
+    assert returncode != 0

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -199,9 +199,6 @@ impl Glean {
             return Err(ErrorKind::InvalidConfig.into());
         }
 
-        // Creating the data store creates the necessary path as well.
-        // If that fails we bail out and don't initialize further.
-        let data_store = Some(Database::new(&cfg.data_path, cfg.delay_ping_lifetime_io)?);
         let event_data_store = EventDatabase::new(&cfg.data_path)?;
 
         // Create an upload manager with rate limiting of 15 pings every 60 seconds.
@@ -218,7 +215,9 @@ impl Glean {
 
         Ok(Self {
             upload_enabled: cfg.upload_enabled,
-            data_store,
+            // In the subprocess, we want to avoid accessing the database entirely.
+            // The easiest way to ensure that is to just not initialize it.
+            data_store: None,
             event_data_store,
             core_metrics: CoreMetrics::new(),
             database_metrics: DatabaseMetrics::new(),
@@ -241,6 +240,10 @@ impl Glean {
     /// the core metrics.
     pub fn new(cfg: Configuration) -> Result<Self> {
         let mut glean = Self::new_for_subprocess(&cfg, false)?;
+
+        // Creating the data store creates the necessary path as well.
+        // If that fails we bail out and don't initialize further.
+        glean.data_store = Some(Database::new(&cfg.data_path, cfg.delay_ping_lifetime_io)?);
 
         // The upload enabled flag may have changed since the last run, for
         // example by the changing of a config file.


### PR DESCRIPTION
Posting this early to show the (straightforward) `setup.py` changes required to use SafeMode.

Unfortunately, safe mode isn't safe for multiple processes writing to the database at the same time.

In the general case, we can't guard against this short of some sort of lockfile (and all of the challenges that come with that). The use case of a command line tool that is run in parallel as part of a build is probably real enough that we should care someday, but is probably only a hazard waiting to be tripped on right now.

Beyond that, Glean require changes even for normal single-process usage, since the ping uploader runs in a separate process *and* sets network error metrics in the database.  This probably needs to be refactored so network error metrics are reported back to the main process through some sort of IPC, which is tricky because the ping uploader process is started and then not waited on, so it doesn't block the main process.