### PR TITLE
Bug 1697469 - Rename internal function to express what it does: validate a dynamic label

### DIFF
--- a/glean-core/src/common_metric_data.rs
+++ b/glean-core/src/common_metric_data.rs
@@ -5,8 +5,9 @@
 use std::convert::TryFrom;
 
 use crate::error::{Error, ErrorKind};
+use crate::metrics::labeled::validate_dynamic_label;
 #[allow(unused_imports)]
-use crate::metrics::{dynamic_label, LabeledMetric};
+use crate::metrics::LabeledMetric;
 use crate::Glean;
 
 /// The supported metrics' lifetimes.
@@ -112,7 +113,7 @@ impl CommonMetricData {
         let base_identifier = self.base_identifier();
 
         if let Some(label) = &self.dynamic_label {
-            dynamic_label(glean, self, &base_identifier, label)
+            validate_dynamic_label(glean, self, &base_identifier, label)
         } else {
             base_identifier
         }

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -16,8 +16,8 @@ use std::convert::TryFrom;
 use std::fmt::Display;
 
 use crate::error::{Error, ErrorKind};
+use crate::metrics::labeled::{combine_base_identifier_and_label, strip_label};
 use crate::metrics::CounterMetric;
-use crate::metrics::{combine_base_identifier_and_label, strip_label};
 use crate::CommonMetricData;
 use crate::Glean;
 use crate::Lifetime;

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -200,7 +200,7 @@ pub fn strip_label(identifier: &str) -> &str {
 ///
 /// The entire identifier for the metric, including the base identifier and the corrected label.
 /// The errors are logged.
-pub fn dynamic_label(
+pub fn validate_dynamic_label(
     glean: &Glean,
     meta: &CommonMetricData,
     base_identifier: &str,

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -18,7 +18,7 @@ mod denominator;
 mod event;
 mod experiment;
 mod jwe;
-mod labeled;
+pub(crate) mod labeled;
 mod memory_distribution;
 mod memory_unit;
 mod ping;
@@ -51,9 +51,7 @@ pub use crate::histogram::HistogramType;
 #[cfg(test)]
 pub(crate) use self::experiment::RecordedExperimentData;
 pub use self::jwe::JweMetric;
-pub use self::labeled::{
-    combine_base_identifier_and_label, dynamic_label, strip_label, LabeledMetric,
-};
+pub use self::labeled::LabeledMetric;
 pub use self::memory_distribution::MemoryDistributionMetric;
 pub use self::memory_unit::MemoryUnit;
 pub use self::ping::PingType;


### PR DESCRIPTION
Additionally this hides previously publicly exported functions.
Technically this would be a breaking change, but glean-core is not
considered a stable public API, so this can be handled as a patch change
only.