### PR TITLE
Bug 1699505 - Kotlin: Don't inline the closure when measuring

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 215 utf-8
+personal_ws-1.1 en 216 utf-8
 AAR
 AARs
 ABI
@@ -140,6 +140,7 @@ hotfix
 html
 illumos
 init
+inlined
 integrations
 io
 ios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v36.0.0...main)
 
+* Android
+  * BUGFIX: `TimespanMetricType.measure` and `TimingDistributionMetricType.measure` won't get inlined anymore ([#1560](https://github.com/mozilla/glean/pull/1560)).
+    This avoids a potential bug where a `return` used inside the closure would end up not measuring the time.
+    Use `return@measure <val>` for early returns.
+
 # v36.0.0 (2021-03-16)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v35.0.0...v36.0.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -94,7 +94,7 @@ class TimespanMetricType internal constructor(
      * If the measured function throws, the measurement is canceled and the exception rethrown.
      */
     @Suppress("TooGenericExceptionCaught")
-    inline fun <U> measure(funcToMeasure: () -> U): U {
+    fun <U> measure(funcToMeasure: () -> U): U {
         start()
 
         val returnValue = try {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -113,7 +113,7 @@ class TimingDistributionMetricType internal constructor(
      * If the measured function throws, the measurement is canceled and the exception rethrown.
      */
     @Suppress("TooGenericExceptionCaught")
-    inline fun <U> measure(funcToMeasure: () -> U): U {
+    fun <U> measure(funcToMeasure: () -> U): U {
         val timerId = start()
 
         val returnValue = try {


### PR DESCRIPTION
This can change control flow, as the code is essentially copied 1:1 in
place, which means `return` inside will be an early return before our
measure wrapper gets to stop the timer.

Thanks to @mcomella for the detailed explanation in the bug report.
See: https://blog.mindorks.com/understanding-inline-noinline-and-crossinline-in-kotlin