### PR TITLE
Bug 1695228 - RLB: API to pass in raw samples for timing distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v36.0.0...main)
 
+* RLB
+  * Provide an internal-use-only API to pass in raw samples for timing distributions ([#1561](https://github.com/mozilla/glean/pull/1561)).
 * Android
   * BUGFIX: `TimespanMetricType.measure` and `TimingDistributionMetricType.measure` won't get inlined anymore ([#1560](https://github.com/mozilla/glean/pull/1560)).
     This avoids a potential bug where a `return` used inside the closure would end up not measuring the time.

--- a/glean-core/rlb/src/private/timing_distribution.rs
+++ b/glean-core/rlb/src/private/timing_distribution.rs
@@ -32,6 +32,27 @@ impl TimingDistributionMetric {
             glean_core::metrics::TimingDistributionMetric::new(meta, time_unit),
         )))
     }
+
+    /// Accumulates the provided samples in the metric.
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - A list of samples recorded by the metric.
+    ///               Samples must be in nanoseconds.
+    ///
+    /// ## Notes
+    ///
+    /// Reports an [`ErrorType::InvalidOverflow`] error for samples that
+    /// are longer than `MAX_SAMPLE_TIME`.
+    pub fn accumulate_raw_samples_nanos(&self, samples: Vec<u64>) {
+        let metric = Arc::clone(&self.0);
+        crate::launch_with_glean(move |glean| {
+            metric
+                .write()
+                .unwrap()
+                .accumulate_raw_samples_nanos(glean, &samples);
+        });
+    }
 }
 
 #[inherent(pub)]

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -314,6 +314,63 @@ impl TimingDistributionMetric {
         }
     }
 
+    /// Accumulates the provided samples in the metric.
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - A list of samples recorded by the metric.
+    ///               Samples must be in nanoseconds.
+    /// ## Notes
+    ///
+    /// Reports an [`ErrorType::InvalidOverflow`] error for samples that
+    /// are longer than `MAX_SAMPLE_TIME`.
+    pub fn accumulate_raw_samples_nanos(&mut self, glean: &Glean, samples: &[u64]) {
+        if !self.should_record(glean) {
+            return;
+        }
+
+        let mut num_too_long_samples = 0;
+        let min_sample_time = self.time_unit.as_nanos(1);
+        let max_sample_time = self.time_unit.as_nanos(MAX_SAMPLE_TIME);
+
+        glean.storage().record_with(glean, &self.meta, |old_value| {
+            let mut hist = match old_value {
+                Some(Metric::TimingDistribution(hist)) => hist,
+                _ => Histogram::functional(LOG_BASE, BUCKETS_PER_MAGNITUDE),
+            };
+
+            for &sample in samples.iter() {
+                let mut sample = sample;
+
+                if sample < min_sample_time {
+                    sample = min_sample_time;
+                } else if sample > max_sample_time {
+                    num_too_long_samples += 1;
+                    sample = max_sample_time;
+                }
+
+                // `sample` is in nanoseconds.
+                hist.accumulate(sample);
+            }
+
+            Metric::TimingDistribution(hist)
+        });
+
+        if num_too_long_samples > 0 {
+            let msg = format!(
+                "{} samples are longer than the maximum of {}",
+                num_too_long_samples, max_sample_time
+            );
+            record_error(
+                glean,
+                &self.meta,
+                ErrorType::InvalidOverflow,
+                msg,
+                num_too_long_samples,
+            );
+        }
+    }
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as an integer.


### PR DESCRIPTION
Unfortunately this needs a new API instead of the already existing `accumulate_samples_signed`.
We want the RLB consumer (in this case: FOG) to not care about the unit,
so we expect nanosecond samples.
Internally we then do the right thing.

And because this is pure Rust we can rely on `u64` and just never need
to filter out negative samples.