### PR TITLE
Bug 1697214 - Clarify source tags documentation about validation

### DIFF
--- a/docs/user/user/debugging/index.md
+++ b/docs/user/user/debugging/index.md
@@ -25,7 +25,7 @@ Some of the debugging features described above may be enabled using environment 
 
 - `logPings`: May be set by the `GLEAN_LOG_PINGS` environment variable. The accepted values are `true` or `false`. Any other value will be ignored.
 - `debugViewTag`: May be set by the `GLEAN_DEBUG_VIEW_TAG` environment variable. Any valid HTTP header value is expected here (e.g. any value that matches the regex `[a-zA-Z0-9-]{1,20}`). Invalid values will be ignored.
-- `sourceTags`: May be set by the `GLEAN_SOURCE_TAGS` environment variable. A comma-separated list of valid HTTP header values is expected here (e.g. any value that matches the regex `[a-zA-Z0-9-]{1,20}`). Invalid values will be ignored. The special value of `automation` is meant for tagging pings generated on automation: such pings will be specially handled on the pipeline (i.e. discarded from [non-live views](https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html#table-layout-and-naming)).
+- `sourceTags`: May be set by the `GLEAN_SOURCE_TAGS` environment variable. A comma-separated list of valid HTTP header values is expected here (e.g. any value that matches the regex `[a-zA-Z0-9-]{1,20}`). If any of the values in the list is invalid, all values will be ignored. The special value of `automation` is meant for tagging pings generated on automation: such pings will be specially handled on the pipeline (i.e. discarded from [non-live views](https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html#table-layout-and-naming)).
 
 These variables must be set at runtime, not at compile time. They will be checked upon Glean initialization.
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -552,12 +552,13 @@ public class Glean {
     /// Set the source tags to be applied as headers when uploading pings.
     ///
     /// If any of the tags is invalid nothing will be set and this function will
-    /// return `false`, although if we are not initialized yet, there won't be any validation.
+    /// return `false`.
+    /// If Glean is not initialized yet, tags will not be validated at this point.
     ///
     /// This is only meant to be used internally by the `GleanDebugActivity`.
     ///
-    /// @param tags A list of tags, which must be valid HTTP header values.
-    ///
+    /// - parameters:
+    ///    * tags: A list of tags, which must be valid HTTP header values.
     func setSourceTags(_ value: [String]) -> Bool {
         if self.isInitialized() {
             let len = value.count

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -549,6 +549,15 @@ public class Glean {
         }
     }
 
+    /// Set the source tags to be applied as headers when uploading pings.
+    ///
+    /// If any of the tags is invalid nothing will be set and this function will
+    /// return `false`, although if we are not initialized yet, there won't be any validation.
+    ///
+    /// This is only meant to be used internally by the `GleanDebugActivity`.
+    ///
+    /// @param tags A list of tags, which must be valid HTTP header values.
+    ///
     func setSourceTags(_ value: [String]) -> Bool {
         if self.isInitialized() {
             let len = value.count

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -737,6 +737,8 @@ pub fn set_log_pings(value: bool) {
 /// Overrides any existing source tags.
 /// Source tags will show in the destination datasets, after ingestion.
 ///
+/// **Note** If one or more tags are invalid, all tags are ignored.
+///
 /// # Arguments
 ///
 /// * `tags` - A vector of at most 5 valid HTTP header values. Individual

--- a/glean-core/src/debug.rs
+++ b/glean-core/src/debug.rs
@@ -229,7 +229,6 @@ fn validate_source_tags(tags: &Vec<String>) -> bool {
         return false;
     }
 
-    // Filter out tags starting with "glean". They are reserved.
     if tags.iter().any(|s| s.starts_with("glean")) {
         log::error!("Tags starting with `glean` are reserved and must not be used.");
         return false;
@@ -312,7 +311,6 @@ mod test {
         ]));
         // Invalid tags.
         assert!(!validate_source_tags(&vec!["!nv@lid-val*e".to_string()]));
-        // Entries starting with 'glean' are filtered out.
         assert!(!validate_source_tags(&vec![
             "glean-test1".to_string(),
             "test2".to_string()

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -809,6 +809,8 @@ impl Glean {
     ///
     /// Ping tags will show in the destination datasets, after ingestion.
     ///
+    /// **Note** If one or more tags are invalid, all tags are ignored.
+    ///
     /// # Arguments
     ///
     /// * `value` - A vector of at most 5 valid HTTP header values. Individual tags must match the regex: "[a-zA-Z0-9-]{1,20}".


### PR DESCRIPTION
Docs were not clear about the fact that **all** source tags
are ignored if one or more of the tags in the list are invalid.

[doc only]