### PR TITLE
Expose rkv-safe-mode feature on the crates that are directly consumed

### DIFF
--- a/glean-core/ffi/Cargo.toml
+++ b/glean-core/ffi/Cargo.toml
@@ -49,3 +49,7 @@ env_logger = { version = "0.7.1", default-features = false, features = ["termcol
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.82"
+
+[features]
+# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
+rkv-safe-mode = ["glean-core/rkv-safe-mode"]

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -42,3 +42,7 @@ env_logger = { version = "0.7.1", default-features = false, features = ["termcol
 tempfile = "3.1.0"
 jsonschema-valid = "0.4.0"
 flate2 = "1.0.19"
+
+[features]
+# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
+rkv-safe-mode = ["glean-core/rkv-safe-mode"]


### PR DESCRIPTION
Otherwise e.g. Rust users need to awkwardly also depend on `glean-core`
to set that feature (FOG does just that).
Plus now that we might switch Python we need it on glean-ffi too to
activate it in a wheel build.

---

Prerequisite for #1551 