### PR TITLE
[doc only] Bug 1703280: Move metric parameter docs to the Glean Book

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 216 utf-8
+personal_ws-1.1 en 218 utf-8
 AAR
 AARs
 ABI
@@ -146,6 +146,7 @@ io
 ios
 janerik
 js
+kibibyte
 ktlint
 lang
 latencies

--- a/docs/user/user/metrics/event.md
+++ b/docs/user/user/metrics/event.md
@@ -24,6 +24,13 @@ views:
         description: The source from which the login view was opened, e.g. "toolbar".
 ```
 
+The `extra_keys` parameter enumerates the acceptable keys on the event. This is
+an object mapping the key to an object containing metadata about the key. A
+maximum of 10 extra keys is allowed. This metadata object has the following
+keys:
+
+- `description`: **Required.** A description of the key.
+
 ## API
 
 {{#include ../../../shared/tab_header.md}}

--- a/docs/user/user/metrics/index.md
+++ b/docs/user/user/metrics/index.md
@@ -2,6 +2,8 @@
 
 > **Not sure which metric type to use?** These docs contain a [series of questions](../adding-new-metrics.html#choosing-a-metric-type) that can help. Reference information about each metric type is linked below.
 
+The parameters available that apply to any metric type are in the [metric parameters page](../metric-parameters.html).
+
 There are different metrics to choose from, depending on what you want to achieve:
 
 * [Boolean](boolean.md): Records a single truth value, for example "is a11y enabled?"
@@ -51,7 +53,7 @@ This is useful when you need to break down metrics by a label known at build tim
 
 Labeled metrics come in two forms:
 
-- **Static labels**: The labels are specified at build time in the `metrics.yaml` file.
+- **Static labels**: The labels are specified at build time in the `metrics.yaml` file, in the `labels` parameter.
   If a label that isn't part of this set is used at run time, it is converted to the special label `__other__`.
 
 - **Dynamic labels**: The labels aren't known at build time, so are set at run time.

--- a/docs/user/user/metrics/memory_distribution.md
+++ b/docs/user/user/metrics/memory_distribution.md
@@ -13,6 +13,16 @@ This makes them suitable for measuring memory sizes on a number of different sca
 
 ## Configuration
 
+Memory distributions have a required `memory_unit` parameter, which specifies
+the unit the incoming memory size values are recorded in. The units are the
+power-of-2 units, so "kilobyte" is more correctly a "kibibyte".
+
+```
+- kilobyte == 2^10 ==         1,024 bytes
+- megabyte == 2^20 ==     1,048,576 bytes
+- gigabyte == 2^30 == 1,073,741,824 bytes
+```
+
 If you wanted to create a memory distribution to measure the amount of heap memory allocated, first you need to add an entry for it to the `metrics.yaml` file:
 
 ```YAML


### PR DESCRIPTION
Relates to https://github.com/mozilla/glean_parser/pull/303