### PR TITLE
Bug 1691073, Bug 1703095: Record errors from bindings

### DIFF
--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -702,6 +702,11 @@ uint64_t glean_new_string_metric(FfiStr category,
                                  Lifetime lifetime,
                                  uint8_t disabled);
 
+void glean_string_record_error(uint64_t metric_id,
+                               int32_t error_type,
+                               FfiStr message,
+                               int32_t error_count);
+
 int32_t glean_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                   int32_t error_type,
                                                   FfiStr storage_name);

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -16,6 +16,7 @@ use once_cell::sync::OnceCell;
 
 pub use glean_core::metrics::MemoryUnit;
 pub use glean_core::metrics::TimeUnit;
+use glean_core::record_error;
 pub use glean_core::upload::ffi_upload_result::*;
 use glean_core::Glean;
 pub use glean_core::Lifetime;

--- a/glean-core/ffi/src/string.rs
+++ b/glean-core/ffi/src/string.rs
@@ -13,6 +13,7 @@ use crate::{
 
 define_metric!(StringMetric => STRING_METRICS {
     new           -> glean_new_string_metric(),
+    record_error -> glean_string_record_error,
     test_get_num_recorded_errors -> glean_string_test_get_num_recorded_errors,
     destroy       -> glean_destroy_string_metric,
 });

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -702,6 +702,11 @@ uint64_t glean_new_string_metric(FfiStr category,
                                  Lifetime lifetime,
                                  uint8_t disabled);
 
+void glean_string_record_error(uint64_t metric_id,
+                               int32_t error_type,
+                               FfiStr message,
+                               int32_t error_count);
+
 int32_t glean_string_test_get_num_recorded_errors(uint64_t metric_id,
                                                   int32_t error_type,
                                                   FfiStr storage_name);

--- a/glean-core/python/glean/testing/error_type.py
+++ b/glean-core/python/glean/testing/error_type.py
@@ -30,3 +30,8 @@ class ErrorType(Enum):
     """
     For when the value to be recorded overflows the metric-specific upper range
     """
+
+    UNEXPECTED_EXCEPTION = 4
+    """
+    When an unexpected exception occurs.
+    """

--- a/glean-core/python/tests/metrics/test_string.py
+++ b/glean-core/python/tests/metrics/test_string.py
@@ -90,3 +90,22 @@ def test_setting_a_string_as_none():
     string_metric.set(None)
 
     assert not string_metric.test_has_value()
+    assert 1 == string_metric.test_get_num_recorded_errors(
+        testing.ErrorType.UNEXPECTED_EXCEPTION
+    )
+
+
+def test_external_error_recording():
+    string_metric = metrics.StringMetricType(
+        disabled=False,
+        category="telemetry",
+        lifetime=Lifetime.APPLICATION,
+        name="string_metric",
+        send_in_pings=["store1", "store2"],
+    )
+
+    string_metric._record_error(testing.ErrorType.INVALID_VALUE, "Test message", 2)
+
+    assert 2 == string_metric.test_get_num_recorded_errors(
+        testing.ErrorType.INVALID_VALUE
+    )

--- a/glean-core/rlb/src/private/string.rs
+++ b/glean-core/rlb/src/private/string.rs
@@ -42,6 +42,20 @@ impl glean_core::traits::String for StringMetric {
         crate::launch_with_glean(move |glean| metric.set(glean, new_value));
     }
 
+    fn record_error<S: Into<std::string::String>, O: Into<Option<i32>>>(
+        &self,
+        error: ErrorType,
+        message: S,
+        num_errors: O,
+    ) {
+        let metric = Arc::clone(&self.0);
+        let new_message = message.into();
+        let new_num_errors = num_errors.into();
+        crate::launch_with_glean(move |glean| {
+            glean_core::record_error(&glean, metric.meta(), error, new_message, new_num_errors)
+        })
+    }
+
     fn test_get_value<'a, S: Into<Option<&'a str>>>(
         &self,
         ping_name: S,

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -36,6 +36,8 @@ pub enum ErrorType {
     InvalidState,
     /// For when the value to be recorded overflows the metric-specific upper range
     InvalidOverflow,
+    /// For an unexpected exception in a dynamic language binding
+    UnexpectedException,
 }
 
 impl ErrorType {
@@ -46,6 +48,7 @@ impl ErrorType {
             ErrorType::InvalidLabel => "invalid_label",
             ErrorType::InvalidState => "invalid_state",
             ErrorType::InvalidOverflow => "invalid_overflow",
+            ErrorType::UnexpectedException => "unexpected_exception",
         }
     }
 }
@@ -59,6 +62,7 @@ impl TryFrom<i32> for ErrorType {
             1 => Ok(ErrorType::InvalidLabel),
             2 => Ok(ErrorType::InvalidState),
             3 => Ok(ErrorType::InvalidOverflow),
+            4 => Ok(ErrorType::UnexpectedException),
             e => Err(ErrorKind::Lifetime(e).into()),
         }
     }
@@ -165,6 +169,8 @@ mod test {
         assert_eq!(error, ErrorType::InvalidState);
         let error: ErrorType = std::convert::TryFrom::try_from(3).unwrap();
         assert_eq!(error, ErrorType::InvalidOverflow);
+        let error: ErrorType = std::convert::TryFrom::try_from(4).unwrap();
+        assert_eq!(error, ErrorType::UnexpectedException);
     }
 
     #[test]

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::common_metric_data::{CommonMetricData, Lifetime};
 use crate::database::Database;
 use crate::debug::DebugOptions;
 pub use crate::error::{Error, ErrorKind, Result};
-pub use crate::error_recording::{test_get_num_recorded_errors, ErrorType};
+pub use crate::error_recording::{record_error, test_get_num_recorded_errors, ErrorType};
 use crate::event_database::EventDatabase;
 pub use crate::histogram::HistogramType;
 use crate::internal_metrics::{CoreMetrics, DatabaseMetrics};

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -20,6 +20,21 @@ pub trait String {
     /// Truncates the value if it is longer than `MAX_LENGTH_VALUE` bytes and logs an error.
     fn set<S: Into<std::string::String>>(&self, value: S);
 
+    /// Records an error for this metric into Glean.
+    ///
+    /// # Arguments
+    ///
+    /// * `error` -  The error type to record
+    /// * `message` - The message to log. This message is not sent with the ping.
+    ///             It does not need to include the metric id, as that is automatically prepended to the message.
+    /// * `num_errors` - The number of errors of the same type to report.
+    fn record_error<S: Into<std::string::String>, O: Into<Option<i32>>>(
+        &self,
+        error: ErrorType,
+        message: S,
+        num_errors: O,
+    );
+
     /// **Exported for test purposes.**
     ///
     /// Gets the currently stored value as a string.


### PR DESCRIPTION
This is just a PoC PR to solicit feedback before fanning it out to all of the
metric types.

This just handles the string metric type for RLB and Python.

The Python bindings add a generic decorator that can be used to catch all
exceptions when recording a metric and converting them to a Glean error.