### PR TITLE
Bug 1702280 - Document the limit on number of statically-defined labels

### DIFF
--- a/docs/user/user/metrics/index.md
+++ b/docs/user/user/metrics/index.md
@@ -55,6 +55,7 @@ Labeled metrics come in two forms:
 
 - **Static labels**: The labels are specified at build time in the `metrics.yaml` file, in the `labels` parameter.
   If a label that isn't part of this set is used at run time, it is converted to the special label `__other__`.
+  The number of static labels is limited to 100 per metric.
 
 - **Dynamic labels**: The labels aren't known at build time, so are set at run time.
   Only the first 16 labels seen by the Glean SDK will be tracked. After that, any additional labels are converted to the special label `__other__`.

--- a/docs/user/user/metrics/labeled_booleans.md
+++ b/docs/user/user/metrics/labeled_booleans.md
@@ -175,6 +175,8 @@ assert_eq!(
 
 * If the labels are specified in the `metrics.yaml`, using any label not listed in that file will be replaced with the special value `__other__`.
 
+* The number of labels specified in the `metrics.yaml` is limited to 100.
+
 * If the labels aren't specified in the `metrics.yaml`, only 16 different dynamic labels may be used, after which the special value `__other__` will be used.
 
 ## Examples

--- a/docs/user/user/metrics/labeled_counters.md
+++ b/docs/user/user/metrics/labeled_counters.md
@@ -171,6 +171,8 @@ assert_eq!(
 
 * If the labels are specified in the `metrics.yaml`, using any label not listed in that file will be replaced with the special value `__other__`.
 
+* The number of labels specified in the `metrics.yaml` is limited to 100.
+
 * If the labels aren't specified in the `metrics.yaml`, only 16 different dynamic labels may be used, after which the special value `__other__` will be used.
 
 ## Examples

--- a/docs/user/user/metrics/labeled_strings.md
+++ b/docs/user/user/metrics/labeled_strings.md
@@ -152,6 +152,8 @@ assert_eq!(
 
 * If the labels are specified in the `metrics.yaml`, using any label not listed in that file will be replaced with the special value `__other__`.
 
+* The number of labels specified in the `metrics.yaml` is limited to 100.
+
 * If the labels aren't specified in the `metrics.yaml`, only 16 different dynamic labels may be used, after which the special value `__other__` will be used.
 
 ## Examples


### PR DESCRIPTION
The limit was raised in https://github.com/mozilla/glean_parser/pull/297

[doc only]

---

This should be landed when we update glean_parser to include that limit.