### PR TITLE
Update to Xcode 12.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,7 +528,8 @@ jobs:
       - run:
           name: Install new carthage
           command: |
-            brew upgrade carthage
+            time brew update
+            time brew upgrade carthage
       - run:
           name: Set Ruby Version
           command: echo 'chruby ruby-2.7.2' >> ~/.bash_profile
@@ -635,7 +636,8 @@ jobs:
       - run:
           name: Install new carthage
           command: |
-            brew upgrade carthage
+            time brew update
+            time brew upgrade carthage
       - install-rustup
       - setup-rust-toolchain
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ jobs:
 
   Check Swift formatting:
     macos:
-      xcode: "12.3.0"
+      xcode: "12.4.0"
     steps:
       - checkout
       - run:
@@ -522,7 +522,7 @@ jobs:
 
   iOS build and test:
     macos:
-      xcode: "12.3.0"
+      xcode: "12.4.0"
     steps:
       - checkout
       - run:
@@ -628,7 +628,7 @@ jobs:
 
   iOS integration test:
     macos:
-      xcode: "12.3.0"
+      xcode: "12.4.0"
     steps:
       - checkout
       - skip-if-doc-only
@@ -703,7 +703,7 @@ jobs:
 
   Carthage release:
     macos:
-      xcode: "12.3.0"
+      xcode: "12.4.0"
     steps:
       - checkout
       - attach_workspace:
@@ -925,7 +925,7 @@ jobs:
 
   pypi-macos-release:
     macos:
-      xcode: "12.3.0"
+      xcode: "12.4.0"
     steps:
       - install-rustup
       - setup-rust-toolchain
@@ -957,7 +957,7 @@ jobs:
 
   pypi-macos-arm64-release:
     macos:
-      xcode: "12.3.0"
+      xcode: "12.4.0"
     steps:
       - install-rustup
       - setup-rust-toolchain


### PR DESCRIPTION
We still require to update carthage though, as only 0.37.0 brings
xcframework support.

Supported software: https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4519/index.html

---

I saw that the iOS builds just broken on `main`. Not looking into this for now, but just upgrading Xcode and see if that works.