### PR TITLE
Gradle: Point to glean dictionary when generating metrics docs

### DIFF
--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -251,6 +251,8 @@ except:
                 args "--allow-missing-files"
                 args "-f"
                 args "markdown"
+                args "--option"
+                args "introduction_extra=\"For another view of these metrics, see the [Glean Dictionary](https://dictionary.protosaur.dev/)\""
                 args "-o"
                 args gleanDocsDirectory
 


### PR DESCRIPTION
The idea is to give people skimming the markdown documentation a pointer to the Glean Dictionary, which
is usually a better way of accessing this information.

This depends on a pending change to the glean parser: https://github.com/mozilla/glean_parser/pull/298