### PR TITLE
Bug 1706411 - Use proper `Path`s throughout glean-core

### DIFF
--- a/glean-core/examples/sample.rs
+++ b/glean-core/examples/sample.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::PathBuf;
 
 use glean_core::metrics::*;
 use glean_core::ping::PingMaker;
@@ -11,10 +12,10 @@ fn main() {
     let mut args = env::args().skip(1);
 
     let data_path = if let Some(path) = args.next() {
-        path
+        PathBuf::from(path)
     } else {
         let root = Builder::new().prefix("simple-db").tempdir().unwrap();
-        root.path().display().to_string()
+        root.path().into()
     };
 
     let cfg = glean_core::Configuration {

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -8,6 +8,7 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::panic::UnwindSafe;
+use std::path::PathBuf;
 
 use ffi_support::{define_string_destructor, ConcurrentHandleMap, FfiStr, IntoFfi};
 
@@ -242,6 +243,7 @@ impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
 
     fn try_from(cfg: &FfiConfiguration) -> Result<Self, Self::Error> {
         let data_path = cfg.data_dir.to_string_fallible()?;
+        let data_path = PathBuf::from(data_path);
         let application_id = cfg.package_name.to_string_fallible()?;
         let language_binding_name = cfg.language_binding_name.to_string_fallible()?;
         let upload_enabled = cfg.upload_enabled != 0;

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -182,7 +182,7 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
         .spawn(move || {
             let core_cfg = glean_core::Configuration {
                 upload_enabled: cfg.upload_enabled,
-                data_path: cfg.data_path.into_os_string().into_string().unwrap(),
+                data_path: cfg.data_path,
                 application_id: cfg.application_id.clone(),
                 language_binding_name: LANGUAGE_BINDING_NAME.into(),
                 max_events: cfg.max_events,

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -86,8 +86,8 @@ impl EventDatabase {
     ///
     /// * `data_path` - The directory to store events in. A new directory
     /// * `events` - will be created inside of this directory.
-    pub fn new(data_path: &str) -> Result<Self> {
-        let path = Path::new(data_path).join("events");
+    pub fn new(data_path: &Path) -> Result<Self> {
+        let path = data_path.join("events");
         create_dir_all(&path)?;
 
         Ok(Self {
@@ -380,7 +380,7 @@ mod test {
         let t = tempfile::tempdir().unwrap();
 
         {
-            let db = EventDatabase::new(&t.path().display().to_string()).unwrap();
+            let db = EventDatabase::new(&t.path()).unwrap();
             db.write_event_to_disk("events", "{\"timestamp\": 500");
             db.write_event_to_disk("events", "{\"timestamp\"");
             db.write_event_to_disk(
@@ -390,7 +390,7 @@ mod test {
         }
 
         {
-            let db = EventDatabase::new(&t.path().display().to_string()).unwrap();
+            let db = EventDatabase::new(&t.path()).unwrap();
             db.load_events_from_disk().unwrap();
             let events = &db.event_stores.read().unwrap()["events"];
             assert_eq!(1, events.len());
@@ -472,7 +472,7 @@ mod test {
     #[test]
     fn doesnt_record_when_upload_is_disabled() {
         let (mut glean, dir) = new_glean(None);
-        let db = EventDatabase::new(dir.path().to_str().unwrap()).unwrap();
+        let db = EventDatabase::new(dir.path()).unwrap();
 
         let test_storage = "test-storage";
         let test_category = "category";

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -120,7 +120,7 @@ pub struct Configuration {
     /// Whether upload should be enabled.
     pub upload_enabled: bool,
     /// Path to a directory to store all data in.
-    pub data_path: String,
+    pub data_path: PathBuf,
     /// The application ID (will be sanitized during initialization).
     pub application_id: String,
     /// The name of the programming language used by the binding creating this instance of Glean.

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -48,10 +48,9 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
         Some(tempdir) => tempdir,
         None => tempfile::tempdir().unwrap(),
     };
-    let tmpname = dir.path().display().to_string();
 
     let cfg = glean_core::Configuration {
-        data_path: tmpname,
+        data_path: dir.path().into(),
         application_id: GLOBAL_APPLICATION_ID.into(),
         language_binding_name: "Rust".into(),
         upload_enabled: true,


### PR DESCRIPTION
This might or might not avoid the crash in the linked bug.