### PR TITLE
Bug 1672951 - Implement a Metrics Ping Scheduler in glean-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rust
   * Don't return a result from `submit_ping`. The boolean return value indicates whether a ping was submitted ([#1613](https://github.com/mozilla/glean/pull/1613))
+  * **Breaking Change**: Glean now schedules "metrics" pings, accepting a new Configuration parameter. ([#1599](https://github.com/mozilla/glean/pull/1599))
 
 # v37.0.0 (2021-04-30)
 

--- a/glean-core/examples/sample.rs
+++ b/glean-core/examples/sample.rs
@@ -25,6 +25,8 @@ fn main() {
         upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
+        app_build: "unknown".into(),
+        use_core_mps: false,
     };
     let mut glean = Glean::new(cfg).unwrap();
     glean.register_ping_type(&PingType::new("baseline", true, false, vec![]));

--- a/glean-core/ffi/src/lib.rs
+++ b/glean-core/ffi/src/lib.rs
@@ -249,6 +249,8 @@ impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
         let upload_enabled = cfg.upload_enabled != 0;
         let max_events = cfg.max_events.filter(|&&i| i >= 0).map(|m| *m as usize);
         let delay_ping_lifetime_io = cfg.delay_ping_lifetime_io != 0;
+        let app_build = "unknown".to_string();
+        let use_core_mps = false;
 
         Ok(Self {
             upload_enabled,
@@ -257,6 +259,8 @@ impl TryFrom<&FfiConfiguration<'_>> for glean_core::Configuration {
             language_binding_name,
             max_events,
             delay_ping_lifetime_io,
+            app_build,
+            use_core_mps,
         })
     }
 }

--- a/glean-core/rlb/examples/prototype.rs
+++ b/glean-core/rlb/examples/prototype.rs
@@ -52,6 +52,7 @@ fn main() {
         channel: None,
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: true,
     };
 
     let client_info = ClientInfoMetrics {

--- a/glean-core/rlb/src/common_test.rs
+++ b/glean-core/rlb/src/common_test.rs
@@ -49,6 +49,7 @@ pub(crate) fn new_glean(
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: None,
+            use_core_mps: false,
         },
     };
 

--- a/glean-core/rlb/src/configuration.rs
+++ b/glean-core/rlb/src/configuration.rs
@@ -30,4 +30,6 @@ pub struct Configuration {
     pub server_endpoint: Option<String>,
     /// The instance of the uploader used to send pings.
     pub uploader: Option<Box<dyn PingUploader + 'static>>,
+    /// Whether Glean should schedule "metrics" pings for you.
+    pub use_core_mps: bool,
 }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -187,6 +187,8 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
                 language_binding_name: LANGUAGE_BINDING_NAME.into(),
                 max_events: cfg.max_events,
                 delay_ping_lifetime_io: cfg.delay_ping_lifetime_io,
+                app_build: client_info.app_build.clone(),
+                use_core_mps: true,
             };
 
             let glean = match Glean::new(core_cfg) {
@@ -361,6 +363,7 @@ pub fn shutdown() {
     }
 
     crate::launch_with_glean_mut(|glean| {
+        glean_core::cancel_metrics_ping_scheduler();
         glean.set_dirty_flag(false);
     });
 

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -28,6 +28,7 @@
 //!     channel: None,
 //!     server_endpoint: None,
 //!     uploader: None,
+//!     use_core_mps: false,
 //! };
 //! glean::initialize(cfg, ClientInfoMetrics::unknown());
 //!
@@ -188,7 +189,7 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
                 max_events: cfg.max_events,
                 delay_ping_lifetime_io: cfg.delay_ping_lifetime_io,
                 app_build: client_info.app_build.clone(),
-                use_core_mps: true,
+                use_core_mps: cfg.use_core_mps,
             };
 
             let glean = match Glean::new(core_cfg) {
@@ -304,7 +305,7 @@ pub fn initialize(cfg: Configuration, client_info: ClientInfoMetrics) {
                 // Set up information and scheduling for Glean owned pings. Ideally, the "metrics"
                 // ping startup check should be performed before any other ping, since it relies
                 // on being dispatched to the API context before any other metric.
-                // TODO: start the metrics ping scheduler, will happen in bug 1672951.
+                glean.start_metrics_ping_scheduler();
 
                 // Check if the "dirty flag" is set. That means the product was probably
                 // force-closed. If that's the case, submit a 'baseline' ping with the
@@ -363,7 +364,7 @@ pub fn shutdown() {
     }
 
     crate::launch_with_glean_mut(|glean| {
-        glean_core::cancel_metrics_ping_scheduler();
+        glean.cancel_metrics_ping_scheduler();
         glean.set_dirty_flag(false);
     });
 
@@ -464,16 +465,15 @@ pub fn set_upload_enabled(enabled: bool) {
         let old_enabled = glean.is_upload_enabled();
         glean.set_upload_enabled(enabled);
 
-        // TODO: Cancel upload and any outstanding metrics ping scheduler
-        // task. Will happen on bug 1672951.
-
         if !old_enabled && enabled {
+            glean.start_metrics_ping_scheduler();
             // If uploading is being re-enabled, we have to restore the
             // application-lifetime metrics.
             initialize_core_metrics(&glean, &state.client_info, state.channel.clone());
         }
 
         if old_enabled && !enabled {
+            glean.cancel_metrics_ping_scheduler();
             // If uploading is disabled, we need to send the deletion-request ping:
             // note that glean-core takes care of generating it.
             state.upload_manager.trigger_upload();
@@ -684,8 +684,6 @@ pub(crate) fn destroy_glean(clear_stores: bool) {
 pub fn test_reset_glean(cfg: Configuration, client_info: ClientInfoMetrics, clear_stores: bool) {
     destroy_glean(clear_stores);
 
-    // Always log pings for tests
-    //Glean.setLogPings(true)
     initialize(cfg, client_info);
 }
 

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -45,6 +45,7 @@ fn send_a_ping() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -155,6 +156,7 @@ fn test_experiments_recording_before_glean_inits() {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: None,
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         false,
@@ -215,6 +217,7 @@ fn sending_of_foreground_background_pings() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -299,6 +302,7 @@ fn sending_of_startup_baseline_ping() {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: Some(Box::new(FakeUploader { sender: s })),
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         false,
@@ -359,6 +363,7 @@ fn no_dirty_baseline_on_clean_shutdowns() {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: Some(Box::new(FakeUploader { sender: s })),
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         false,
@@ -390,6 +395,7 @@ fn initialize_must_not_crash_if_data_dir_is_messed_up() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: false,
     };
 
     test_reset_glean(cfg, ClientInfoMetrics::unknown(), false);
@@ -453,6 +459,7 @@ fn initializing_twice_is_a_noop() {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: None,
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         true,
@@ -470,6 +477,7 @@ fn initializing_twice_is_a_noop() {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: None,
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         false,
@@ -508,6 +516,7 @@ fn the_app_channel_must_be_correctly_set_if_requested() {
             channel: None,
             server_endpoint: Some("invalid-test-host".into()),
             uploader: None,
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         true,
@@ -622,6 +631,7 @@ fn sending_deletion_ping_if_disabled_outside_of_run() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -640,6 +650,7 @@ fn sending_deletion_ping_if_disabled_outside_of_run() {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: Some(Box::new(FakeUploader { sender: s })),
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         false,
@@ -687,6 +698,7 @@ fn no_sending_of_deletion_ping_if_unchanged_outside_of_run() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -705,6 +717,7 @@ fn no_sending_of_deletion_ping_if_unchanged_outside_of_run() {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: Some(Box::new(FakeUploader { sender: s })),
+            use_core_mps: false,
         },
         ClientInfoMetrics::unknown(),
         false,
@@ -770,6 +783,7 @@ fn setting_debug_view_tag_before_initialization_should_not_crash() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -829,6 +843,7 @@ fn setting_source_tags_before_initialization_should_not_crash() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -889,6 +904,7 @@ fn setting_source_tags_after_initialization_should_not_crash() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -961,6 +977,7 @@ fn flipping_upload_enabled_respects_order_of_events() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     // We create a ping and a metric before we initialize Glean
@@ -1031,6 +1048,7 @@ fn registering_pings_before_init_must_work() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);
@@ -1081,6 +1099,7 @@ fn test_a_ping_before_submission() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(FakeUploader { sender: s })),
+        use_core_mps: false,
     };
 
     let _t = new_glean(Some(cfg), true);

--- a/glean-core/rlb/tests/init_fails.rs
+++ b/glean-core/rlb/tests/init_fails.rs
@@ -68,6 +68,7 @@ fn init_fails() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: false,
     };
     common::initialize(cfg);
 

--- a/glean-core/rlb/tests/no_time_to_init.rs
+++ b/glean-core/rlb/tests/no_time_to_init.rs
@@ -66,6 +66,7 @@ fn init_fails() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: false,
     };
     common::initialize(cfg);
 

--- a/glean-core/rlb/tests/overflowing_preinit.rs
+++ b/glean-core/rlb/tests/overflowing_preinit.rs
@@ -71,6 +71,7 @@ fn overflowing_the_task_queue_records_telemetry() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: false,
     };
 
     // Insert a bunch of tasks to overflow the queue.

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -36,6 +36,7 @@ fn new_glean(configuration: Option<Configuration>) -> tempfile::TempDir {
             channel: Some("testing".into()),
             server_endpoint: Some("invalid-test-host".into()),
             uploader: None,
+            use_core_mps: false,
         },
     };
 
@@ -86,6 +87,7 @@ fn validate_against_schema() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: Some(Box::new(ValidatingUploader { sender: s })),
+        use_core_mps: false,
     };
     let _ = new_glean(Some(cfg));
 

--- a/glean-core/rlb/tests/simple.rs
+++ b/glean-core/rlb/tests/simple.rs
@@ -68,6 +68,7 @@ fn simple_lifecycle() {
         channel: Some("testing".into()),
         server_endpoint: Some("invalid-test-host".into()),
         uploader: None,
+        use_core_mps: false,
     };
     common::initialize(cfg);
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -38,6 +38,7 @@ mod internal_metrics;
 mod internal_pings;
 pub mod metrics;
 pub mod ping;
+mod scheduler;
 pub mod storage;
 mod system;
 pub mod traits;
@@ -97,7 +98,12 @@ pub fn setup_glean(glean: Glean) -> Result<()> {
     // calling `initialize` on the global singleton and further operations check that it has been
     // initialized.
     if GLEAN.get().is_none() {
-        if GLEAN.set(Mutex::new(glean)).is_err() {
+        if GLEAN.set(Mutex::new(glean)).is_ok() {
+            let glean = &GLEAN.get().unwrap().lock().unwrap();
+            if glean.schedule_metrics_pings {
+                scheduler::schedule(&glean);
+            }
+        } else {
             log::warn!(
                 "Global Glean object is initialized already. This probably happened concurrently."
             )
@@ -129,6 +135,11 @@ pub struct Configuration {
     pub max_events: Option<usize>,
     /// Whether Glean should delay persistence of data from metrics with ping lifetime.
     pub delay_ping_lifetime_io: bool,
+    /// The application's build identifier. If this is different from the one provided for a previous init,
+    /// and use_core_mps is `true`, we will trigger a "metrics" ping.
+    pub app_build: String,
+    /// Whether Glean should schedule "metrics" pings.
+    pub use_core_mps: bool,
 }
 
 /// The object holding meta information about a Glean instance.
@@ -147,6 +158,8 @@ pub struct Configuration {
 ///     upload_enabled: true,
 ///     max_events: None,
 ///     delay_ping_lifetime_io: false,
+///     app_build: "".into(),
+///     use_core_mps: false,
 /// };
 /// let mut glean = Glean::new(cfg).unwrap();
 /// let ping = PingType::new("sample", true, false, vec![]);
@@ -185,6 +198,8 @@ pub struct Glean {
     is_first_run: bool,
     upload_manager: PingUploadManager,
     debug: DebugOptions,
+    app_build: String,
+    schedule_metrics_pings: bool,
 }
 
 impl Glean {
@@ -208,7 +223,7 @@ impl Glean {
             /* seconds per interval */ 60, /* max pings per interval */ 15,
         );
 
-        // We only scan the pending ping sdirectories when calling this from a subprocess,
+        // We only scan the pending ping directories when calling this from a subprocess,
         // when calling this from ::new we need to scan the directories after dealing with the upload state.
         if scan_directories {
             let _scanning_thread = upload_manager.scan_pending_pings_directories();
@@ -233,6 +248,9 @@ impl Glean {
             max_events: cfg.max_events.unwrap_or(DEFAULT_MAX_EVENTS),
             is_first_run: false,
             debug: DebugOptions::new(),
+            app_build: cfg.app_build.to_string(),
+            // Subprocess doesn't use "metrics" pings so has no need for a scheduler.
+            schedule_metrics_pings: false,
         };
 
         // Can't use `local_now_with_offset_and_record` above, because we needed a valid `Glean` first.
@@ -288,6 +306,9 @@ impl Glean {
             }
         }
 
+        // We set this only for non-subprocess situations.
+        glean.schedule_metrics_pings = cfg.use_core_mps;
+
         // We only scan the pendings pings directories **after** dealing with the upload state.
         // If upload is disabled, we delete all pending pings files
         // and we need to do that **before** scanning the pending pings folder
@@ -311,6 +332,8 @@ impl Glean {
             upload_enabled,
             max_events: None,
             delay_ping_lifetime_io: false,
+            app_build: "unknown".into(),
+            use_core_mps: false,
         };
 
         let mut glean = Self::new(cfg).unwrap();
@@ -1000,6 +1023,12 @@ impl Glean {
 pub fn get_timestamp_ms() -> u64 {
     const NANOS_PER_MILLI: u64 = 1_000_000;
     zeitstempel::now() / NANOS_PER_MILLI
+}
+
+/// Instructs the Metrics Ping Scheduler's thread to exit cleanly.
+/// If Glean was configured with `use_core_mps: false`, this has no effect.
+pub fn cancel_metrics_ping_scheduler() {
+    scheduler::cancel();
 }
 
 // Split unit tests to a separate file, to reduce the file of this one.

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -61,6 +61,12 @@ impl StringMetric {
         glean.storage().record(glean, &self.meta, &value)
     }
 
+    /// Non-exported API used for crate-internal storage.
+    /// Gets the current-stored value as a string, or None if there is no value.
+    pub(crate) fn get_value(&self, glean: &Glean, storage_name: &str) -> Option<String> {
+        self.test_get_value(&glean, &storage_name)
+    }
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as a string.

--- a/glean-core/src/scheduler.rs
+++ b/glean-core/src/scheduler.rs
@@ -1,0 +1,509 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! # Metrics Ping Scheduler
+//!
+//! The Metrics Ping Scheduler (MPS) is responsible for scheduling "metrics" pings.
+//! It implements the spec described in
+//! [the docs](https://mozilla.github.io/glean/book/user/pings/metrics.html#scheduling)
+
+use crate::metrics::{DatetimeMetric, StringMetric, TimeUnit};
+use crate::{local_now_with_offset, CommonMetricData, Glean, Lifetime, INTERNAL_STORAGE};
+use chrono::prelude::*;
+use chrono::Duration;
+use once_cell::sync::Lazy;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+
+const SCHEDULED_HOUR: u32 = 4;
+
+// Clippy thinks an AtomicBool would be preferred, but Condvar requires a full Mutex.
+// See https://github.com/rust-lang/rust-clippy/issues/1516
+#[allow(clippy::mutex_atomic)]
+static TASK_CONDVAR: Lazy<Arc<(Mutex<bool>, Condvar)>> =
+    Lazy::new(|| Arc::new((Mutex::new(false), Condvar::new())));
+
+/// Describes the interface for a submitter of "metrics" pings.
+/// Used to decouple the implementation so we can test it.
+trait MetricsPingSubmitter {
+    /// Submits a metrics ping, updating the last sent time to `now`
+    /// (which might not be _right now_ due to processing delays (or in tests))
+    fn submit_metrics_ping(&self, glean: &Glean, reason: Option<&str>, now: DateTime<FixedOffset>);
+}
+
+/// Describes the interface for a scheduler of "metrics" pings.
+/// Used to decouple the implementation so we can test it.
+trait MetricsPingScheduler {
+    /// Begins a recurring schedule of "metrics" ping submissions, on another thread.
+    /// `now` is used with `when` to determine the first schedule interval and
+    /// may not be _right now_ due to processing delays (or in tests).
+    fn start_scheduler(
+        &self,
+        submitter: impl MetricsPingSubmitter + Send + 'static,
+        now: DateTime<FixedOffset>,
+        when: When,
+    );
+}
+
+/// Uses Glean to submit "metrics" pings directly.
+struct GleanMetricsPingSubmitter {}
+impl MetricsPingSubmitter for GleanMetricsPingSubmitter {
+    fn submit_metrics_ping(&self, glean: &Glean, reason: Option<&str>, now: DateTime<FixedOffset>) {
+        glean.submit_ping_by_name("metrics", reason);
+        // Always update the collection date, irrespective of the ping being sent.
+        get_last_sent_time_metric().set(&glean, Some(now));
+    }
+}
+
+/// Schedule "metrics" pings directly using the default behaviour.
+struct GleanMetricsPingScheduler {}
+impl MetricsPingScheduler for GleanMetricsPingScheduler {
+    fn start_scheduler(
+        &self,
+        submitter: impl MetricsPingSubmitter + Send + 'static,
+        now: DateTime<FixedOffset>,
+        when: When,
+    ) {
+        start_scheduler(submitter, now, when);
+    }
+}
+
+/// Performs startup checks to decide when to schedule the next "metrics" ping collection.
+/// **Must** be called before draining the preinit queue.
+/// (We're at the Language Bindings' mercy for that)
+pub fn schedule(glean: &Glean) {
+    let now = local_now_with_offset().0;
+
+    let submitter = GleanMetricsPingSubmitter {};
+    let scheduler = GleanMetricsPingScheduler {};
+
+    schedule_internal(&glean, submitter, scheduler, now)
+}
+
+/// Tells the scheduler task to exit quickly and cleanly.
+pub fn cancel() {
+    let (cancelled_lock, condvar) = &**TASK_CONDVAR; // One `*` for Lazy, the second for Arc
+    *cancelled_lock.lock().unwrap() = true; // Cancel the scheduler thread.
+    condvar.notify_all(); // Notify any/all listening schedulers to check whether they were cancelled.
+}
+
+fn schedule_internal(
+    glean: &Glean,
+    submitter: impl MetricsPingSubmitter + Send + 'static,
+    scheduler: impl MetricsPingScheduler,
+    now: DateTime<FixedOffset>,
+) {
+    let last_sent_build_metric = get_last_sent_build_metric();
+    if let Some(last_sent_build) = last_sent_build_metric.get_value(&glean, INTERNAL_STORAGE) {
+        // If `app_build` is longer than StringMetric's max length, we will always
+        // treat it as a changed build when really it isn't.
+        // This will be externally-observable as InvalidOverflow errors on both the core
+        // `client_info.app_build` metric and the scheduler's internal metric.
+        if last_sent_build != glean.app_build {
+            last_sent_build_metric.set(&glean, &glean.app_build);
+            log::info!("App build changed. Sending 'metrics' ping");
+            submitter.submit_metrics_ping(&glean, Some("upgrade"), now);
+            scheduler.start_scheduler(submitter, now, When::Reschedule);
+            return;
+        }
+    }
+
+    let last_sent_time = get_last_sent_time_metric().get_value(&glean, INTERNAL_STORAGE);
+    if let Some(last_sent) = last_sent_time {
+        log::info!("The 'metrics' ping was last sent on {}", last_sent);
+    }
+
+    // We aim to cover 3 cases here:
+    //
+    // 1. The ping was already collected on the current calendar day;
+    //    only schedule one for collection on the next calendar day at the due time.
+    // 2. The ping was NOT collected on the current calendar day AND we're later
+    //    than today's due time; collect the ping immediately.
+    // 3. The ping was NOT collected on the current calendar day BUT we still have
+    //    some time to the due time; schedule for submitting the current calendar day.
+
+    let already_sent_today = last_sent_time.map_or(false, |d| d.date() == now.date());
+    if already_sent_today {
+        // Case #1
+        log::info!("The 'metrics' ping was already sent today, {}", now);
+        scheduler.start_scheduler(submitter, now, When::Tomorrow);
+    } else if now > now.date().and_hms(SCHEDULED_HOUR, 0, 0) {
+        // Case #2
+        log::info!("Sending the 'metrics' ping immediately, {}", now);
+        submitter.submit_metrics_ping(&glean, Some("overdue"), now);
+        scheduler.start_scheduler(submitter, now, When::Reschedule);
+    } else {
+        // Case #3
+        log::info!("The 'metrics' collection is scheduled for today, {}", now);
+        scheduler.start_scheduler(submitter, now, When::Today);
+    }
+}
+
+/// "metrics" ping scheduling deadlines.
+#[derive(Debug, PartialEq)]
+enum When {
+    Today,
+    Tomorrow,
+    Reschedule,
+}
+
+impl When {
+    /// Returns the duration from now until our deadline.
+    /// Note that std::time::Duration doesn't do negative time spans, so if
+    /// our deadline has passed, this will return zero.
+    fn until(&self, now: DateTime<FixedOffset>) -> std::time::Duration {
+        let fire_date = match self {
+            Self::Today => now.date().and_hms(SCHEDULED_HOUR, 0, 0),
+            // Doesn't actually save us from being an hour off on DST because
+            // chrono doesn't know when DST changes. : (
+            Self::Tomorrow | Self::Reschedule => {
+                (now.date() + Duration::days(1)).and_hms(SCHEDULED_HOUR, 0, 0)
+            }
+        };
+        // After rust-lang/rust#73544 can use std::time::Duration::ZERO
+        (fire_date - now)
+            .to_std()
+            .unwrap_or_else(|_| std::time::Duration::from_millis(0))
+    }
+
+    /// The "metrics" ping reason corresponding to our deadline.
+    fn reason(&self) -> &'static str {
+        match self {
+            Self::Today => "today",
+            Self::Tomorrow => "tomorrow",
+            Self::Reschedule => "reschedule",
+        }
+    }
+}
+
+fn start_scheduler(
+    submitter: impl MetricsPingSubmitter + Send + 'static,
+    now: DateTime<FixedOffset>,
+    when: When,
+) -> JoinHandle<()> {
+    let pair = Arc::clone(&TASK_CONDVAR);
+    std::thread::Builder::new()
+        .name("glean.mps".into())
+        .spawn(move || {
+            let (cancelled_lock, condvar) = &*pair;
+            let mut when = when;
+            let mut now = now;
+            loop {
+                let dur = when.until(now);
+                log::info!("Scheduling for {:?} after {}, reason {:?}", dur, now, when);
+                let result = condvar.wait_timeout_while(cancelled_lock.lock().unwrap(), dur, |cancelled| !*cancelled);
+                now = local_now_with_offset().0;
+                match result {
+                    Err(err) => {
+                        log::warn!("Condvar wait failure, {}", err);
+                        break;
+                    }
+                    Ok((cancelled, wait_result)) => {
+                        if *cancelled {
+                            log::info!("Metrics Ping Scheduler cancelled. Exiting.");
+                            break;
+                        } else if wait_result.timed_out() {
+                            log::info!("Time to submit our metrics ping, {:?}", when);
+                            let glean = crate::global_glean().expect("Global Glean not present when trying to send scheduled 'metrics' ping?!").lock().unwrap();
+                            submitter.submit_metrics_ping(&glean, Some(when.reason()), now);
+                            when = When::Reschedule;
+                        } else {
+                            // This should be impossible. `cancelled_lock` is acquired, and
+                            // `!*cancelled` is checked by the condvar before it is allowed
+                            // to return from `wait_timeout_while` (I checked).
+                            // So `Ok(_)` implies `*cancelled || wait_result.timed_out`.
+                            log::warn!("Spurious wakeup of the MPS condvar should be impossible.");
+                        }
+                    }
+                }
+            }
+        }).expect("Unable to spawn Metrics Ping Scheduler thread.")
+}
+
+fn get_last_sent_time_metric() -> DatetimeMetric {
+    DatetimeMetric::new(
+        CommonMetricData {
+            name: "last_sent_time".into(),
+            category: "mps".into(),
+            send_in_pings: vec![INTERNAL_STORAGE.into()],
+            lifetime: Lifetime::User,
+            ..Default::default()
+        },
+        TimeUnit::Minute,
+    )
+}
+
+fn get_last_sent_build_metric() -> StringMetric {
+    StringMetric::new(CommonMetricData {
+        name: "last_sent_build".into(),
+        category: "mps".into(),
+        send_in_pings: vec![INTERNAL_STORAGE.into()],
+        lifetime: Lifetime::User,
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tests::new_glean;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct ValidatingSubmitter<F: Fn(DateTime<FixedOffset>, Option<&str>)> {
+        submit_validator: F,
+        validator_run_count: Arc<AtomicU32>,
+    }
+    struct ValidatingScheduler<F: Fn(DateTime<FixedOffset>, When)> {
+        schedule_validator: F,
+        validator_run_count: Arc<AtomicU32>,
+    }
+    impl<F: Fn(DateTime<FixedOffset>, Option<&str>)> MetricsPingSubmitter for ValidatingSubmitter<F> {
+        fn submit_metrics_ping(
+            &self,
+            _glean: &Glean,
+            reason: Option<&str>,
+            now: DateTime<FixedOffset>,
+        ) {
+            (self.submit_validator)(now, reason);
+            self.validator_run_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    impl<F: Fn(DateTime<FixedOffset>, When)> MetricsPingScheduler for ValidatingScheduler<F> {
+        fn start_scheduler(
+            &self,
+            _submitter: impl MetricsPingSubmitter + Send + 'static,
+            now: DateTime<FixedOffset>,
+            when: When,
+        ) {
+            (self.schedule_validator)(now, when);
+            self.validator_run_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn new_proxies<
+        F1: Fn(DateTime<FixedOffset>, Option<&str>),
+        F2: Fn(DateTime<FixedOffset>, When),
+    >(
+        submit_validator: F1,
+        schedule_validator: F2,
+    ) -> (
+        ValidatingSubmitter<F1>,
+        Arc<AtomicU32>,
+        ValidatingScheduler<F2>,
+        Arc<AtomicU32>,
+    ) {
+        let submitter_count = Arc::new(AtomicU32::new(0));
+        let submitter = ValidatingSubmitter {
+            submit_validator,
+            validator_run_count: Arc::clone(&submitter_count),
+        };
+        let scheduler_count = Arc::new(AtomicU32::new(0));
+        let scheduler = ValidatingScheduler {
+            schedule_validator,
+            validator_run_count: Arc::clone(&scheduler_count),
+        };
+        (submitter, submitter_count, scheduler, scheduler_count)
+    }
+
+    // Ensure that if we have a different build, we immediately submit an "upgrade" ping
+    // and schedule a "reschedule" ping for tomorrow.
+    #[test]
+    fn different_app_builds_submit_and_reschedule() {
+        let (mut glean, _t) = new_glean(None);
+
+        glean.app_build = "a build".into();
+        get_last_sent_build_metric().set(&glean, "a different build");
+
+        let (submitter, submitter_count, scheduler, scheduler_count) = new_proxies(
+            |_, reason| assert_eq!(reason, Some("upgrade")),
+            |_, when| assert_eq!(when, When::Reschedule),
+        );
+
+        schedule_internal(&glean, submitter, scheduler, local_now_with_offset().0);
+        assert_eq!(1, submitter_count.swap(0, Ordering::Relaxed));
+        assert_eq!(1, scheduler_count.swap(0, Ordering::Relaxed));
+    }
+
+    // If we've already sent a ping today, ensure we don't send a ping but we
+    // do schedule a ping for tomorrow. ("Case #1" in schedule_internal)
+    #[test]
+    fn case_1_no_submit_but_schedule_tomorrow() {
+        let (glean, _t) = new_glean(None);
+
+        let fake_now = FixedOffset::east(0).ymd(2021, 4, 30).and_hms(14, 36, 14);
+        get_last_sent_time_metric().set(&glean, Some(fake_now));
+
+        let (submitter, submitter_count, scheduler, scheduler_count) = new_proxies(
+            |_, reason| panic!("Case #1 shouldn't submit a ping! reason: {:?}", reason),
+            |_, when| assert_eq!(when, When::Tomorrow),
+        );
+        schedule_internal(&glean, submitter, scheduler, fake_now);
+        assert_eq!(0, submitter_count.swap(0, Ordering::Relaxed));
+        assert_eq!(1, scheduler_count.swap(0, Ordering::Relaxed));
+    }
+
+    // If we haven't sent a ping today and we're after the scheduled time,
+    // ensure we send a ping and then schedule a "reschedule" ping for tomorrow.
+    // ("Case #2" in schedule_internal)
+    #[test]
+    fn case_2_submit_ping_and_reschedule() {
+        let (glean, _t) = new_glean(None);
+
+        let fake_yesterday = FixedOffset::east(0)
+            .ymd(2021, 4, 29)
+            .and_hms(SCHEDULED_HOUR, 0, 1);
+        get_last_sent_time_metric().set(&glean, Some(fake_yesterday));
+        let fake_now = fake_yesterday + Duration::days(1);
+
+        let (submitter, submitter_count, scheduler, scheduler_count) = new_proxies(
+            |_, reason| assert_eq!(reason, Some("overdue")),
+            |_, when| assert_eq!(when, When::Reschedule),
+        );
+        schedule_internal(&glean, submitter, scheduler, fake_now);
+        assert_eq!(1, submitter_count.swap(0, Ordering::Relaxed));
+        assert_eq!(1, scheduler_count.swap(0, Ordering::Relaxed));
+    }
+
+    // If we haven't sent a ping today and we're before the scheduled time,
+    // ensure we don't send a ping but schedule a "today" ping for today.
+    // ("Case #3" in schedule_internal)
+    #[test]
+    fn case_3_no_submit_but_schedule_today() {
+        let (glean, _t) = new_glean(None);
+
+        let fake_yesterday =
+            FixedOffset::east(0)
+                .ymd(2021, 4, 29)
+                .and_hms(SCHEDULED_HOUR - 1, 0, 1);
+        get_last_sent_time_metric().set(&glean, Some(fake_yesterday));
+        let fake_now = fake_yesterday + Duration::days(1);
+
+        let (submitter, submitter_count, scheduler, scheduler_count) = new_proxies(
+            |_, reason| panic!("Case #3 shouldn't submit a ping! reason: {:?}", reason),
+            |_, when| assert_eq!(when, When::Today),
+        );
+        schedule_internal(&glean, submitter, scheduler, fake_now);
+        assert_eq!(0, submitter_count.swap(0, Ordering::Relaxed));
+        assert_eq!(1, scheduler_count.swap(0, Ordering::Relaxed));
+    }
+
+    // `When` is responsible for date math. Let's make sure it's correct.
+    #[test]
+    fn when_gets_at_least_some_date_math_correct() {
+        let now = FixedOffset::east(0).ymd(2021, 4, 30).and_hms(15, 2, 10);
+        // `now` is after `SCHEDULED_HOUR` so should be zero:
+        assert_eq!(std::time::Duration::from_secs(0), When::Today.until(now));
+        // If we bring it back before `SCHEDULED_HOUR` it should give us the duration:
+        let earlier = now.date().and_hms(SCHEDULED_HOUR - 1, 0, 0);
+        assert_eq!(
+            std::time::Duration::from_secs(3600),
+            When::Today.until(earlier)
+        );
+
+        // `Tomorrow` and `Reschedule` should differ only in their `reason()`
+        // 46670 is 12h57m10s (aka, the time from 15:02:10 to 04:00:00
+        // (when the timezone doesn't change between them)).
+        assert_eq!(
+            std::time::Duration::from_secs(46670),
+            When::Tomorrow.until(now)
+        );
+        assert_eq!(
+            std::time::Duration::from_secs(46670),
+            When::Reschedule.until(now)
+        );
+        assert_eq!(When::Tomorrow.until(now), When::Reschedule.until(now));
+        assert_ne!(When::Tomorrow.reason(), When::Reschedule.reason());
+    }
+
+    // Scheduler tests mutate global state and thus must not be run in parallel.
+    // Otherwise one test could cancel the other.
+    // This Mutex aims to solve that.
+    static SCHEDULER_TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    // The scheduler has been designed to be cancellable. Can we cancel it?
+    #[test]
+    fn cancellable_tasks_can_be_cancelled() {
+        // First and foremost, all scheduler tests must ensure they start uncancelled.
+        // Perils of having shared state.
+        let _test_lock = SCHEDULER_TEST_MUTEX.lock().unwrap();
+        let (cancelled_lock, _condvar) = &**TASK_CONDVAR; // One `*` for Lazy, the second for Arc
+        *cancelled_lock.lock().unwrap() = false;
+
+        // Pick a time at least two hours from the next scheduled submission.
+        // (So that this test will time out if cancellation fails).
+        let now = FixedOffset::east(0)
+            .ymd(2021, 4, 30)
+            .and_hms(SCHEDULED_HOUR - 2, 0, 0);
+
+        let proxy_factory = || {
+            new_proxies(
+                |_, reason| {
+                    panic!(
+                        "Shouldn't submit when testing scheduler. reason: {:?}",
+                        reason
+                    )
+                },
+                |_, _| panic!("Not even using the scheduler this time."),
+            )
+        };
+
+        // Test Today.
+        let (submitter, submitter_count, _, _) = proxy_factory();
+        let handle = start_scheduler(submitter, now, When::Today);
+        super::cancel();
+        handle.join().unwrap(); // Should complete immediately.
+        assert_eq!(0, submitter_count.swap(0, Ordering::Relaxed));
+
+        // Test Tomorrow.
+        let (submitter, submitter_count, _, _) = proxy_factory();
+        *cancelled_lock.lock().unwrap() = false; // Uncancel.
+        let handle = start_scheduler(submitter, now, When::Tomorrow);
+        super::cancel();
+        handle.join().unwrap(); // Should complete immediately.
+        assert_eq!(0, submitter_count.swap(0, Ordering::Relaxed));
+
+        // Test Reschedule.
+        let (submitter, submitter_count, _, _) = proxy_factory();
+        *cancelled_lock.lock().unwrap() = false; // Uncancel.
+        let handle = start_scheduler(submitter, now, When::Reschedule);
+        super::cancel();
+        handle.join().unwrap(); // Should complete immediately.
+        assert_eq!(0, submitter_count.swap(0, Ordering::Relaxed));
+    }
+
+    // We're not keen to wait like the scheduler is, but we can test a quick schedule.
+    #[test]
+    fn immediate_task_runs_immediately() {
+        // First and foremost, all scheduler tests must ensure they start uncancelled.
+        // Perils of having shared state.
+        let _test_lock = SCHEDULER_TEST_MUTEX.lock().unwrap();
+        let (cancelled_lock, _condvar) = &**TASK_CONDVAR; // One `*` for Lazy, the second for Arc
+        *cancelled_lock.lock().unwrap() = false;
+
+        // We're actually going to submit a ping from the scheduler, which requires a global glean.
+        let (glean, _t) = new_glean(None);
+        assert_eq!(
+            false, glean.schedule_metrics_pings,
+            "Real schedulers not allowed in tests!"
+        );
+        assert!(crate::setup_glean(glean).is_ok());
+
+        // We're choosing a time after SCHEDULED_HOUR so `When::Today` will give us a duration of 0.
+        let now = FixedOffset::east(0).ymd(2021, 4, 20).and_hms(15, 42, 0);
+
+        let (submitter, submitter_count, _, _) = new_proxies(
+            move |_, reason| {
+                assert_eq!(reason, Some("today"));
+                // After submitting the ping we expect, let's cancel this scheduler so the thread exits.
+                // (But do it on another thread because the condvar loop is currently holding `cancelled`'s mutex)
+                std::thread::spawn(super::cancel);
+            },
+            |_, _| panic!("Not using the scheduler this time."),
+        );
+
+        let handle = start_scheduler(submitter, now, When::Today);
+        handle.join().unwrap();
+        assert_eq!(1, submitter_count.swap(0, Ordering::Relaxed));
+    }
+}

--- a/glean-core/src/scheduler.rs
+++ b/glean-core/src/scheduler.rs
@@ -75,6 +75,12 @@ impl MetricsPingScheduler for GleanMetricsPingScheduler {
 pub fn schedule(glean: &Glean) {
     let now = local_now_with_offset().0;
 
+    let (cancelled_lock, _condvar) = &**TASK_CONDVAR;
+    if *cancelled_lock.lock().unwrap() {
+        log::debug!("Told to schedule, but already cancelled. Are we in a test?");
+    }
+    *cancelled_lock.lock().unwrap() = false; // Uncancel the thread.
+
     let submitter = GleanMetricsPingSubmitter {};
     let scheduler = GleanMetricsPingScheduler {};
 

--- a/glean-core/src/scheduler.rs
+++ b/glean-core/src/scheduler.rs
@@ -408,7 +408,7 @@ mod test {
         );
 
         // `Tomorrow` and `Reschedule` should differ only in their `reason()`
-        // 46670 is 12h57m10s (aka, the time from 15:02:10 to 04:00:00
+        // 46670s is 12h57m10s (aka, the time from 15:02:10 to 04:00:00
         // (when the timezone doesn't change between them)).
         assert_eq!(
             std::time::Duration::from_secs(46670),

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -56,6 +56,8 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
         upload_enabled: true,
         max_events: None,
         delay_ping_lifetime_io: false,
+        app_build: "unknown".into(),
+        use_core_mps: false,
     };
     let glean = Glean::new(cfg).unwrap();
 


### PR DESCRIPTION
The MPS has actually been written for a little while. I strove for as direct a translation of `MetricsPingScheduler.{kt|swift}` as was practicable (we can always refactor it later). The hard part has been tests. 

I've tried making this testable in a few ways. The first way you can see in the second commit and is straightforward, but it can't actually observe most of the behaviour we hope to test.

The second way apes the `Policy` approach of gecko JSMs. (I had some struggles with the borrow checker on this approach, so it's very possible this is more ornate than it needs to be) I think this `Policy` approach is the better one because it allows us to inspect and test every operation of the MPS which, as history has taught us, is absolutely crucial for peace of mind.

(( I also attempted to automock Glean, but it would require some serious modifications to make the Glean struct's impl suit the mocking library (mockall), so I abandoned it. ))

I'm looking for some honest feedback about this, both for whether the approach itself is distasteful as well as what patterns I've missed in pursuing things in this manner. I've taken heart from the [Book suggesting RefCell-based interior mutability for test mocks itself](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html) to mean I'm not completely out to lunch here, but I might be.