### PR TITLE
Bug 1706729 - RLB: Dispatch setting the source tag.

### DIFF
--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -743,22 +743,16 @@ pub fn set_log_pings(value: bool) {
 ///
 /// * `tags` - A vector of at most 5 valid HTTP header values. Individual
 ///   tags must match the regex: "[a-zA-Z0-9-]{1,20}".
-///
-/// # Returns
-///
-/// This will return `false` in case `value` contains invalid tags and `true`
-/// otherwise or if the tag is set before Glean is initialized.
-pub fn set_source_tags(tags: Vec<String>) -> bool {
+pub fn set_source_tags(tags: Vec<String>) {
     if was_initialize_called() {
-        with_glean_mut(|glean| glean.set_source_tags(tags))
+        crate::launch_with_glean_mut(|glean| {
+            glean.set_source_tags(tags);
+        });
     } else {
         // Glean has not been initialized yet. Cache the provided source tags.
         let m = PRE_INIT_SOURCE_TAGS.get_or_init(Default::default);
         let mut lock = m.lock().unwrap();
         *lock = tags;
-        // When setting the source tags before initialization,
-        // we don't validate the tags, thus this function always returns true.
-        true
     }
 }
 

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -850,6 +850,72 @@ fn setting_source_tags_before_initialization_should_not_crash() {
 }
 
 #[test]
+fn setting_source_tags_after_initialization_should_not_crash() {
+    let _lock = lock_test();
+
+    destroy_glean(true);
+    assert!(!was_initialize_called());
+
+    // Define a fake uploader that reports back the submission headers
+    // using a crossbeam channel.
+    let (s, r) = crossbeam_channel::bounded::<Vec<(String, String)>>(1);
+
+    #[derive(Debug)]
+    pub struct FakeUploader {
+        sender: crossbeam_channel::Sender<Vec<(String, String)>>,
+    }
+    impl net::PingUploader for FakeUploader {
+        fn upload(
+            &self,
+            _url: String,
+            _body: Vec<u8>,
+            headers: Vec<(String, String)>,
+        ) -> net::UploadResult {
+            self.sender.send(headers).unwrap();
+            net::UploadResult::HttpStatus(200)
+        }
+    }
+
+    // Create a custom configuration to use a fake uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().to_path_buf();
+
+    let cfg = Configuration {
+        data_path: tmpname,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        channel: Some("testing".into()),
+        server_endpoint: Some("invalid-test-host".into()),
+        uploader: Some(Box::new(FakeUploader { sender: s })),
+    };
+
+    let _t = new_glean(Some(cfg), true);
+
+    // Attempt to set source tags after `Glean.initialize` is called,
+    // but before Glean is fully initialized.
+    assert!(was_initialize_called());
+    set_source_tags(vec!["valid-tag1".to_string(), "valid-tag2".to_string()]);
+
+    crate::block_on_dispatcher();
+
+    // Submit a baseline ping.
+    submit_ping_by_name("baseline", Some("background"));
+
+    // Wait for the ping to arrive.
+    let headers = r.recv().unwrap();
+    assert_eq!(
+        "valid-tag1,valid-tag2",
+        headers
+            .iter()
+            .find(|&kv| kv.0 == "X-Source-Tags")
+            .unwrap()
+            .1
+    );
+}
+
+#[test]
 fn flipping_upload_enabled_respects_order_of_events() {
     // NOTES(janerik):
     // I'm reasonably sure this test is excercising the right code paths


### PR DESCRIPTION
This avoids a race condition where there might not be a global Glean
yet.
But source tags are only needed for the ping assembly, and that's also
dispatched, so either happened before anyway or will happens afterwards.