### PR TITLE
Bug 1700942 - Gradle plugin: Provide forward-compatibility with Gradle 6.8

### DIFF
--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -135,7 +135,15 @@ except:
             // depending on the variant type: the generated API definitions don't need to be
             // different due to that.
             TaskProvider buildConfigProvider = variant.getGenerateBuildConfigProvider()
-            def originalPackageName = buildConfigProvider.get().getBuildConfigPackageName().get()
+            def configProvider = buildConfigProvider.get()
+            def originalPackageName
+            // In Gradle 6.x `getBuildConfigPackageName` was reaplced by `namespace`.
+            // We want to be forward compatible, so we check that first or fallback to the old method.
+            if (configProvider.hasProperty("namespace")) {
+                originalPackageName = configProvider.namespace.get()
+            } else {
+                originalPackageName = configProvider.getBuildConfigPackageName().get()
+            }
 
             def fullNamespace = "${originalPackageName}.GleanMetrics"
             def generateKotlinAPI = project.task("${TASK_NAME_PREFIX}SourceFor${variant.name.capitalize()}", type: Exec) {


### PR DESCRIPTION
In Gradle 6.x `getBuildConfigPackageName` was reaplced by `namespace`.
We want to be forward compatible, so we check that first or fallback to the old method.

See changes here:
https://cs.android.com/android-studio/platform/tools/base/+/c20e34494964552a5ce2787bb4c05016ac022378:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/GenerateBuildConfig.kt;dlc=fa4d27e36ad755e7f270d342c8cb6e367ea05149