### PR TITLE
CI: Don't force brew update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,8 +528,7 @@ jobs:
       - run:
           name: Install new carthage
           command: |
-            time brew update
-            time brew upgrade carthage
+            brew upgrade carthage
       - run:
           name: Set Ruby Version
           command: echo 'chruby ruby-2.7.2' >> ~/.bash_profile
@@ -636,8 +635,7 @@ jobs:
       - run:
           name: Install new carthage
           command: |
-            time brew update
-            time brew upgrade carthage
+            brew upgrade carthage
       - install-rustup
       - setup-rust-toolchain
       - run:


### PR DESCRIPTION
CircleCI rolled out a quickfix that does the `brew update` now,
and will soon update their machine to already contain an updated
homebrew.

Details: https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872/2