### PR TITLE
Kotlin: Set required client_info fields first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Rust
   * Don't return a result from `submit_ping`. The boolean return value indicates whether a ping was submitted ([#1613](https://github.com/mozilla/glean/pull/1613))
   * **Breaking Change**: Glean now schedules "metrics" pings, accepting a new Configuration parameter. ([#1599](https://github.com/mozilla/glean/pull/1599))
+* Android
+  * Set required fields for `client_info` before optional ones ([#1633](https://github.com/mozilla/glean/pull/1633))
 
 # v37.0.0 (2021-04-30)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -562,19 +562,8 @@ open class GleanInternalAPI internal constructor () {
         // Please note that the following metrics must be set synchronously, so
         // that they are guaranteed to be available with the first ping that is
         // generated. We use an internal only API to do that.
-        // https://developer.android.com/reference/android/os/Build.VERSION
-        GleanInternalMetrics.androidSdkVersion.setSync(Build.VERSION.SDK_INT.toString())
-        GleanInternalMetrics.osVersion.setSync(Build.VERSION.RELEASE)
-        // https://developer.android.com/reference/android/os/Build
-        GleanInternalMetrics.deviceManufacturer.setSync(Build.MANUFACTURER)
-        GleanInternalMetrics.deviceModel.setSync(Build.MODEL)
-        GleanInternalMetrics.architecture.setSync(Build.SUPPORTED_ABIS[0])
-        GleanInternalMetrics.locale.setSync(getLocaleTag())
 
-        configuration.channel?.let {
-            GleanInternalMetrics.appChannel.setSync(it)
-        }
-
+        // Set required information first.
         buildInfo?.let {
             GleanInternalMetrics.appBuild.setSync(it.versionCode)
             GleanInternalMetrics.appDisplayVersion.setSync(it.versionName)
@@ -604,6 +593,21 @@ open class GleanInternalAPI internal constructor () {
                 packageInfo.versionName?.let { it } ?: "Unknown"
             )
         }
+
+        GleanInternalMetrics.architecture.setSync(Build.SUPPORTED_ABIS[0])
+        GleanInternalMetrics.osVersion.setSync(Build.VERSION.RELEASE)
+
+        // Optional data is set last.
+
+        configuration.channel?.let {
+            GleanInternalMetrics.appChannel.setSync(it)
+        }
+        // https://developer.android.com/reference/android/os/Build.VERSION
+        GleanInternalMetrics.androidSdkVersion.setSync(Build.VERSION.SDK_INT.toString())
+        // https://developer.android.com/reference/android/os/Build
+        GleanInternalMetrics.deviceManufacturer.setSync(Build.MANUFACTURER)
+        GleanInternalMetrics.deviceModel.setSync(Build.MODEL)
+        GleanInternalMetrics.locale.setSync(getLocaleTag())
     }
 
     /**


### PR DESCRIPTION
There's a chance that the app is killed at any point.
If that happens while setting core metrics, on next start a ping might
be sent, which is then missing data.

Some of this data is required; and if missing the pipeline rejects the
ping during validation. By moving these metrics first we increase the
chance for them to be set.

This is a very desperate attempt on mitigating missing data.

---

I've spent all day reading the code over and over again, starting Fenix, trying to capture any ping without the app_build data.

I've only found _one_ tiny (forced) edge case:

When adding a delay (30s) right before setting `app_build`, then killing Fenix when it's waiting there, then starting it again, will trigger a ping that's missing the app build as expected.
Now in production we of course don't have that delay.
But there's theoretically a teeny tiny window in which this could still happen.
For the lack of better approaches I propose to land this, get it into a release and land it in Fenix to gather some nightly data.
By just rearranging the data collection we merely change what would be affected by early app kills/crashes.
If we see a drop of missing app_build data after this it would underline that theory.