### PR TITLE
Bug 1698800 - Conform string and UUID metric reference page to new format

### DIFF
--- a/docs/user/reference/metrics/string.md
+++ b/docs/user/reference/metrics/string.md
@@ -69,9 +69,29 @@ metrics.search_default.name.set("wikipedia")
 
 </div>
 
-<div data-lang="Rust" class="tab"></div>
+<div data-lang="Rust" class="tab">
 
-<div data-lang="Javascript" class="tab"></div>
+```rust
+use glean_metrics;
+
+// Record a value into the metric.
+search_default::name.set("duck duck go");
+// If it changed later, you can record the new value:
+search_default::name.set("wikipedia");
+```
+</div>
+
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as searchDefault from "./path/to/generated/files/searchDefault.js";
+
+// Record a value into the metric.
+searchDefault.name.set("duck duck go");
+// If it changed later, you can record the new value:
+searchDefault.name.set("wikipedia");
+```
+</div>
 
 <div data-lang="Firefox Desktop" class="tab">
 
@@ -156,9 +176,25 @@ assert "wikipedia" == metrics.search_default.name.test_get_value()
 
 </div>
 
-<div data-lang="Rust" class="tab"></div>
+<div data-lang="Rust" class="tab">
 
-<div data-lang="Javascript" class="tab"></div>
+```rust
+use glean_metrics;
+
+// Does the string metric have the expected value?
+assert_eq!(6, search_default::name.test_get_value(None).unwrap());
+```
+
+</div>
+
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as searchDefault from "./path/to/generated/files/searchDefault.js";
+
+assert.strictEqual("wikipedia", await searchDefault.name.testGetValue());
+```
+</div>
 
 <div data-lang="Firefox Desktop" class="tab">
 
@@ -256,7 +292,7 @@ Gets number of errors recorded for a given string metric.
 import org.mozilla.yourApplication.GleanMetrics.SearchDefault
 
 // Was the string truncated, and an error reported?
-assertEquals(1, SearchDefault.name.testGetNumRecordedErrors(ErrorType.InvalidValue))
+assertEquals(1, SearchDefault.name.testGetNumRecordedErrors(ErrorType.InvalidOverflow))
 ```
 
 </div>
@@ -270,7 +306,7 @@ import org.mozilla.yourApplication.GleanMetrics.SearchDefault;
 assertEquals(
     1,
     SearchDefault.INSTANCE.name.testGetNumRecordedErrors(
-        ErrorType.InvalidValue
+        ErrorType.InvalidOverflow
     )
 );
 ```
@@ -283,7 +319,7 @@ assertEquals(
 @testable import Glean
 
 // Was the string truncated, and an error reported?
-XCTAssertEqual(1, SearchDefault.name.testGetNumRecordedErrors(.invalidValue))
+XCTAssertEqual(1, SearchDefault.name.testGetNumRecordedErrors(.invalidOverflow))
 ```
 
 </div>
@@ -296,15 +332,38 @@ metrics = load_metrics("metrics.yaml")
 
 # Was the string truncated, and an error reported?
 assert 1 == metrics.search_default.name.test_get_num_recorded_errors(
-    ErrorType.INVALID_VALUE
+    ErrorType.INVALID_OVERFLOW
 )
 ```
 
 </div>
 
-<div data-lang="Rust" class="tab"></div>
+<div data-lang="Rust" class="tab">
 
-<div data-lang="Javascript" class="tab"></div>
+```rust
+use glean::ErrorType;
+
+use glean_metrics;
+
+// Was the string truncated, and an error reported?
+assert_eq!(
+  1,
+  search_default::name.test_get_num_recorded_errors(
+    ErrorType::InvalidOverflow
+  )
+);
+```
+</div>
+
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as searchDefault from "./path/to/generated/files/searchDefault.js";
+
+// Was the string truncated, and an error reported?
+assert.strictEqual(1, await searchDefault.name.testGetNumRecordedErrors("invalid_overflow"));
+```
+</div>
 
 <div data-lang="Firefox Desktop" class="tab" data-bug="1683171"></div>
 
@@ -344,6 +403,8 @@ N/A
 
 ## Reference
 
-* [Kotlin API docs](../../../javadoc/glean/mozilla.telemetry.glean.private/-string-metric-type/index.html).
+* [Kotlin API docs](../../../javadoc/glean/mozilla.telemetry.glean.private/-string-metric-type/index.html)
 * [Swift API docs](../../../swift/Classes/StringMetricType.html)
 * [Python API docs](../../../python/glean/metrics/string.html)
+* [Rust API docs](../../../docs/glean/private/struct.StringMetric.html)
+* [Javascript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_string.default.html#set)

--- a/docs/user/reference/metrics/string.md
+++ b/docs/user/reference/metrics/string.md
@@ -1,26 +1,20 @@
 # Strings
 
-This allows recording a Unicode string value with arbitrary content.
+String metrics allow recording a Unicode string value with arbitrary content.
 
-> **Note**: Be careful using arbitrary strings and make sure they can't accidentally contain identifying data (like directory paths or user input).
+This metric type does not support recording JSON blobs - please get in contact with the Glean SDK team if you're missing a type.
 
-> **Note**: This is does not support recording JSON blobs - please get in contact with the Telemetry team if you're missing a type.
+{{#include ../../../shared/blockquote-warning.html}}
 
-## Configuration
+## Important
 
-Say you're adding a metric to find out what the default search in a browser is. First you need to add an entry for the metric to the `metrics.yaml` file:
+> Be careful using arbitrary strings and make sure they can't accidentally contain identifying data (like directory paths or user input).
 
-```YAML
-search.default:
-  name:
-    type: string
-    description: >
-      The name of the default search engine.
-    lifetime: application
-    ...
-```
+## Recording API
 
-## API
+### `set`
+
+Set a string metric to a specific value.
 
 {{#include ../../../shared/tab_header.md}}
 
@@ -33,20 +27,6 @@ import org.mozilla.yourApplication.GleanMetrics.SearchDefault
 SearchDefault.name.set("duck duck go")
 // If it changed later, you can record the new value:
 SearchDefault.name.set("wikipedia")
-```
-
-There are test APIs available too:
-
-```Kotlin
-import org.mozilla.yourApplication.GleanMetrics.SearchDefault
-
-// Was anything recorded?
-assertTrue(SearchDefault.name.testHasValue())
-// Does the string metric have the expected value?
-// IMPORTANT: It may have been truncated -- see "Limits" below
-assertEquals("wikipedia", SearchDefault.name.testGetValue())
-// Was the string truncated, and an error reported?
-assertEquals(1, SearchDefault.name.testGetNumRecordedErrors(ErrorType.InvalidValue))
 ```
 
 </div>
@@ -62,25 +42,6 @@ SearchDefault.INSTANCE.name.set("duck duck go");
 SearchDefault.INSTANCE.name.set("wikipedia");
 ```
 
-There are test APIs available too:
-
-```Java
-import org.mozilla.yourApplication.GleanMetrics.SearchDefault
-
-// Was anything recorded?
-assertTrue(SearchDefault.INSTANCE.name.testHasValue());
-// Does the string metric have the expected value?
-// IMPORTANT: It may have been truncated -- see "Limits" below
-assertEquals("wikipedia", SearchDefault.INSTANCE.name.testGetValue());
-// Was the string truncated, and an error reported?
-assertEquals(
-    1,
-    SearchDefault.INSTANCE.name.testGetNumRecordedErrors(
-        ErrorType.InvalidValue
-    )
-);
-```
-
 </div>
 
 <div data-lang="Swift" class="tab">
@@ -90,20 +51,6 @@ assertEquals(
 SearchDefault.name.set("duck duck go")
 // If it changed later, you can record the new value:
 SearchDefault.name.set("wikipedia")
-```
-
-There are test APIs available too:
-
-```Swift
-@testable import Glean
-
-// Was anything recorded?
-XCTAssert(SearchDefault.name.testHasValue())
-// Does the string metric have the expected value?
-// IMPORTANT: It may have been truncated -- see "Limits" below
-XCTAssertEqual("wikipedia", try SearchDefault.name.testGetValue())
-// Was the string truncated, and an error reported?
-XCTAssertEqual(1, SearchDefault.name.testGetNumRecordedErrors(.invalidValue))
 ```
 
 </div>
@@ -120,58 +67,15 @@ metrics.search_default.name.set("duck duck go")
 metrics.search_default.name.set("wikipedia")
 ```
 
-There are test APIs available too:
-
-```Python
-# Was anything recorded?
-assert metrics.search_default.name.test_has_value()
-# Does the string metric have the expected value?
-# IMPORTANT: It may have been truncated -- see "Limits" below
-assert "wikipedia" == metrics.search_default.name.test_get_value()
-# Was the string truncated, and an error reported?
-assert 1 == metrics.search_default.name.test_get_num_recorded_errors(
-    ErrorType.INVALID_VALUE
-)
-```
-
 </div>
 
-<div data-lang="C#" class="tab">
+<div data-lang="Rust" class="tab"></div>
 
-```C#
-using static Mozilla.YourApplication.GleanMetrics.SearchDefault;
+<div data-lang="Javascript" class="tab"></div>
 
-// Record a value into the metric.
-SearchDefault.name.Set("duck duck go");
-// If it changed later, you can record the new value:
-SearchDefault.name.Set("wikipedia");
-```
+<div data-lang="Firefox Desktop" class="tab">
 
-There are test APIs available too:
-
-```C#
-using static Mozilla.YourApplication.GleanMetrics.SearchDefault;
-
-// Was anything recorded?
-Assert.True(SearchDefault.name.TestHasValue());
-// Does the string metric have the expected value?
-// IMPORTANT: It may have been truncated -- see "Limits" below
-Assert.Equal("wikipedia", SearchDefault.name.TestGetValue());
-// Was the string truncated, and an error reported?
-Assert.Equal(
-    1,
-    SearchDefault.name.TestGetNumRecordedErrors(
-        ErrorType.InvalidValue
-    )
-);
-```
-
-
-</div>
-
-<div data-lang="C++" class="tab">
-
-> **Note**: C++ APIs are only available in Firefox Desktop.
+**C++**
 
 ```c++
 #include "mozilla/glean/GleanMetrics.h"
@@ -179,7 +83,86 @@ Assert.Equal(
 mozilla::glean::search_default::name.Set("wikipedia"_ns);
 ```
 
-There are test APIs available too:
+**Javascript**
+
+```js
+Glean.searchDefault.name.set("wikipedia");
+```
+
+</div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+#### Limits
+
+* Fixed maximum string length: 100. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
+
+#### Recorded errors
+
+* [`invalid_overflow`](../../user/metrics/error-reporting.md): if the string is too long. (Prior to Glean 31.5.0, this recorded an `invalid_value`).
+
+## Testing API
+
+### `testGetValue`
+
+Get the recorded value for a given string metric.
+
+The recorded value may have been truncated. See ["Limits"](#limits) section above.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault
+
+// Does the string metric have the expected value?
+assertEquals("wikipedia", SearchDefault.name.testGetValue())
+```
+
+</div>
+
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault
+
+// Does the string metric have the expected value?
+assertEquals("wikipedia", SearchDefault.INSTANCE.name.testGetValue());
+```
+
+</div>
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+@testable import Glean
+
+// Does the string metric have the expected value?
+XCTAssertEqual("wikipedia", try SearchDefault.name.testGetValue())
+```
+
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+# Does the string metric have the expected value?
+assert "wikipedia" == metrics.search_default.name.test_get_value()
+```
+
+</div>
+
+<div data-lang="Rust" class="tab"></div>
+
+<div data-lang="Javascript" class="tab"></div>
+
+<div data-lang="Firefox Desktop" class="tab">
+
+**C++**
 
 ```c++
 #include "mozilla/glean/GleanMetrics.h"
@@ -189,46 +172,175 @@ ASSERT_STREQ(
   "wikipedia",
   mozilla::glean::search_default::name.TestGetValue().value().get()
 );
-// Did it run across any errors?
-// TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=1683171
 ```
 
-</div>
-
-<div data-lang="JS" class="tab">
-
-> **Note**: JS APIs are currently only available in Firefox Desktop.
-> General JavaScript support is coming soon via [the Glean.js project](https://github.com/mozilla/glean.js/).
+**Javascript**
 
 ```js
-Glean.searchDefault.name.set("wikipedia");
-```
-
-There are test APIs available too:
-
-```js
+// Does it have the expected value?
 Assert.equal("wikipedia", Glean.searchDefault.name.testGetValue());
-// Did it run across any errors?
-// TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=1683171
 ```
 
 </div>
 
 {{#include ../../../shared/tab_footer.md}}
 
-## Limits
+### `testHasValue`
 
-* Fixed maximum string length: 100. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
+Whether or not **any** value was recorded for a given string metric.
 
-## Examples
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault
+
+// Was anything recorded?
+assertTrue(SearchDefault.name.testHasValue())
+```
+
+</div>
+
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault
+
+// Was anything recorded?
+assertTrue(SearchDefault.INSTANCE.name.testHasValue());
+```
+
+</div>
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+@testable import Glean
+
+// Was anything recorded?
+XCTAssert(SearchDefault.name.testHasValue())
+```
+
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+# Was anything recorded?
+assert metrics.search_default.name.test_has_value()
+```
+
+</div>
+
+<div data-lang="Rust" class="tab"></div>
+
+<div data-lang="Javascript" class="tab"></div>
+
+<div data-lang="Firefox Desktop" class="tab"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+### `testGetNumRecordedErrors`
+
+Gets number of errors recorded for a given string metric.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault
+
+// Was the string truncated, and an error reported?
+assertEquals(1, SearchDefault.name.testGetNumRecordedErrors(ErrorType.InvalidValue))
+```
+
+</div>
+
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.SearchDefault;
+
+// Was the string truncated, and an error reported?
+assertEquals(
+    1,
+    SearchDefault.INSTANCE.name.testGetNumRecordedErrors(
+        ErrorType.InvalidValue
+    )
+);
+```
+
+</div>
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+@testable import Glean
+
+// Was the string truncated, and an error reported?
+XCTAssertEqual(1, SearchDefault.name.testGetNumRecordedErrors(.invalidValue))
+```
+
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+# Was the string truncated, and an error reported?
+assert 1 == metrics.search_default.name.test_get_num_recorded_errors(
+    ErrorType.INVALID_VALUE
+)
+```
+
+</div>
+
+<div data-lang="Rust" class="tab"></div>
+
+<div data-lang="Javascript" class="tab"></div>
+
+<div data-lang="Firefox Desktop" class="tab" data-bug="1683171"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+## Metric parameters
+
+Example string metric definition:
+
+```yaml
+controls:
+  refresh_pressed:
+    type: string
+    description: >
+      The name of the default search engine.
+    bugs:
+      - https://bugzilla.mozilla.org/000000
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=000000#c3
+    notification_emails:
+      - me@mozilla.com
+    expires: 2020-10-01
+```
+
+For a full reference on metrics parameters common to all metric types,
+refer to the metrics [YAML format](../yaml/index.md) reference page.
+
+### Extra metric parameters
+
+N/A
+
+## Data questions
 
 * Record the operating system name with a value of `"android"`.
 
 * Recording the device model with a value of `"SAMSUNG-SGH-I997"`.
-
-## Recorded errors
-
-* `invalid_overflow`: if the string is too long. (Prior to Glean 31.5.0, this recorded an `invalid_value`).
 
 ## Reference
 

--- a/docs/user/reference/metrics/uuid.md
+++ b/docs/user/reference/metrics/uuid.md
@@ -1,24 +1,12 @@
 # UUID
 
-UUIDs are used to record values that uniquely identify some entity, such as a client id.
+UUIDs metrics are used to record values that uniquely identify some entity, such as a client id.
 
-## Configuration
+## Recording API
 
-You first need to add an entry for it to the `metrics.yaml` file:
+### `generateAndSet`
 
-```YAML
-user:
-  client_id:
-    type: uuid
-    description: >
-      A unique identifier for the client's profile
-    lifetime: user
-    ...
-```
-
-## API
-
-Now that the UUID is defined in `metrics.yaml`, you can use the metric to record values in the application's code.
+Sets a UUID metric to a generated [UUID](https://datatracker.ietf.org/doc/html/rfc4122) value.
 
 {{#include ../../../shared/tab_header.md}}
 
@@ -27,19 +15,8 @@ Now that the UUID is defined in `metrics.yaml`, you can use the metric to record
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.User
 
-User.clientId.generateAndSet() // Generate a new UUID and record it
-User.clientId.set(UUID.randomUUID())  // Set a UUID explicitly
-```
-
-There are test APIs available too.
-
-```Kotlin
-import org.mozilla.yourApplication.GleanMetrics.User
-
-// Was anything recorded?
-assertTrue(User.clientId.testHasValue())
-// Was it the expected value?
-assertEquals(uuid, User.clientId.testGetValue())
+// Generate a new UUID and record it
+User.clientId.generateAndSet()
 ```
 
 </div>
@@ -49,19 +26,8 @@ assertEquals(uuid, User.clientId.testGetValue())
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.User;
 
-User.INSTANCE.clientId.generateAndSet(); // Generate a new UUID and record it
-User.INSTANCE.clientId.set(UUID.randomUUID());  // Set a UUID explicitly
-```
-
-There are test APIs available too:
-
-```Java
-import org.mozilla.yourApplication.GleanMetrics.User;
-
-// Was anything recorded?
-assertTrue(User.INSTANCE.clientId.testHasValue());
-// Was it the expected value?
-assertEquals(uuid, User.INSTANCE.clientId.testGetValue());
+// Generate a new UUID and record it
+User.INSTANCE.clientId.generateAndSet();
 ```
 
 </div>
@@ -70,19 +36,8 @@ assertEquals(uuid, User.INSTANCE.clientId.testGetValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-User.clientId.generateAndSet() // Generate a new UUID and record it
-User.clientId.set(UUID())  // Set a UUID explicitly
-```
-
-There are test APIs available too.
-
-```Swift
-@testable import Glean
-
-// Was anything recorded?
-XCTAssert(User.clientId.testHasValue())
-// Was it the expected value?
-XCTAssertEqual(uuid, try User.clientId.testGetValue())
+// Generate a new UUID and record it
+User.clientId.generateAndSet()
 ```
 
 </div>
@@ -90,46 +45,11 @@ XCTAssertEqual(uuid, try User.clientId.testGetValue())
 <div data-lang="Python" class="tab">
 
 ```Python
-import uuid
-
 from glean import load_metrics
 metrics = load_metrics("metrics.yaml")
 
 # Generate a new UUID and record it
 metrics.user.client_id.generate_and_set()
-# Set a UUID explicitly
-metrics.user.client_id.set(uuid.uuid4())
-```
-
-There are test APIs available too.
-
-```Python
-# Was anything recorded?
-assert metrics.user.client_id.test_has_value()
-# Was it the expected value?
-assert uuid == metrics.user.client_id.test_get_value()
-```
-
-</div>
-
-<div data-lang="C#" class="tab">
-
-```C#
-using static Mozilla.YourApplication.GleanMetrics.User;
-
-User.clientId.GenerateAndSet(); // Generate a new UUID and record it
-User.clientId.Set(System.Guid.NewGuid()); // Set a UUID explicitly
-```
-
-There are test APIs available too:
-
-```C#
-using static Mozilla.YourApplication.GleanMetrics.User;
-
-// Was anything recorded?
-Assert.True(User.clientId.TestHasValue());
-// Was it the expected value?
-Assert.Equal(uuid, User.clientId.TestGetValue());
 ```
 
 </div>
@@ -140,88 +60,410 @@ Assert.Equal(uuid, User.clientId.TestGetValue());
 use glean_metrics;
 use uuid::Uuid;
 
-user::client_id.generate_and_set(); // Generate a new UUID and record it
-user::client_id.set(Uuid::new_v4()); // Set a UUID explicitly
+// Generate a new UUID and record it
+user::client_id.generate_and_set();
 ```
-
-There are test APIs available too:
-
-```rust
-use glean_metrics;
-
-let u = Uuid::new_v4();
-user::client_id.set(u);
-// Was anything recorded?
-assert!(user::client_id.test_get_value(None).is_some());
-// Does it have the expected value?
-assert_eq!(u, user::client_id.test_get_value(None).unwrap());
-```
-
 </div>
 
-<div data-lang="C++" class="tab">
+<div data-lang="Javascript" class="tab">
 
-> **Note**: C++ APIs are only available in Firefox Desktop.
+```js
+import * as user from "./path/to/generated/files/user.js";
+
+user.clientId.generateAndSet();
+```
+</div>
+
+<div data-lang="Firefox Desktop" class="tab">
+
+**C++**
 
 ```c++
 #include "mozilla/glean/GleanMetrics.h"
 
 // Generate a new UUID and record it.
 mozilla::glean::user::client_id.GenerateAndSet();
-// Set a specific value.
-nsCString kUuid("decafdec-afde-cafd-ecaf-decafdecafde");
-mozilla::glean::user::client_id.Set(kUuid);
 ```
 
-There are test APIs available too:
-
-```c++
-#include "mozilla/glean/GleanMetrics.h"
-
-// Does it have an expected values?
-ASSERT_STREQ(kUuid.get(), mozilla::glean::user::client_id.TestGetValue().value().get());
-// Did it run across any errors?
-// TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=1683171
-```
-
-</div>
-
-<div data-lang="JS" class="tab">
-
-> **Note**: JS APIs are currently only available in Firefox Desktop.
-> General JavaScript support is coming soon via [the Glean.js project](https://github.com/mozilla/glean.js/).
+**Javascript**
 
 ```js
 // Generate a new UUID and record it.
 Glean.user.clientId.generateAndSet();
-// Set a specific value.
-const uuid = "decafdec-afde-cafd-ecaf-decafdecafde";
-Glean.user.clientId.set(uuid);
-```
-
-There are test APIs available too:
-
-```js
-Assert.equal(Glean.user.clientId.testGetValue(), uuid);
-// Did it run across any errors?
-// TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=1683171
 ```
 
 </div>
 
 {{#include ../../../shared/tab_footer.md}}
 
-## Limits
 
-* None.
+### `set`
 
-## Examples
+Sets a UUID metric to a specific value.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.User
+
+// Set a UUID explicitly
+User.clientId.set(UUID.randomUUID())  // Set a UUID explicitly
+```
+
+</div>
+
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.User;
+
+// Set a UUID explicitly
+User.INSTANCE.clientId.set(UUID.randomUUID());
+```
+</div>
+
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+User.clientId.set(UUID())  // Set a UUID explicitly
+```
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+import uuid
+
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+# Set a UUID explicitly
+metrics.user.client_id.set(uuid.uuid4())
+```
+</div>
+
+<div data-lang="Rust" class="tab">
+
+```rust
+use glean_metrics;
+use uuid::Uuid;
+
+// Set a UUID explicitly
+user::client_id.set(Uuid::new_v4());
+```
+</div>
+
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as user from "./path/to/generated/files/user.js";
+
+const uuid = "decafdec-afde-cafd-ecaf-decafdecafde";
+user.clientId.set(uuid);
+```
+</div>
+
+<div data-lang="Firefox Desktop" class="tab">
+
+**C++**
+
+```c++
+#include "mozilla/glean/GleanMetrics.h"
+
+// Set a specific value.
+nsCString kUuid("decafdec-afde-cafd-ecaf-decafdecafde");
+mozilla::glean::user::client_id.Set(kUuid);
+```
+
+**Javascript**
+
+```js
+// Set a specific value.
+const uuid = "decafdec-afde-cafd-ecaf-decafdecafde";
+Glean.user.clientId.set(uuid);
+```
+</div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+#### Recorded errors
+
+* [`invalid_value`](../../user/metrics/error-reporting.md): if the value is set to a string that is not a UUID (only applies for dynamically-typed languages, such as Python).
+
+
+## Testing API
+
+### `testGetValue`
+
+Gets the recorded value for a given UUID metric.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.User
+
+// Was it the expected value?
+assertEquals(uuid, User.clientId.testGetValue())
+```
+</div>
+
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.User;
+
+// Was it the expected value?
+assertEquals(uuid, User.INSTANCE.clientId.testGetValue());
+```
+</div>
+
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+@testable import Glean
+
+// Was it the expected value?
+XCTAssertEqual(uuid, try User.clientId.testGetValue())
+```
+
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+# Was it the expected value?
+assert uuid == metrics.user.client_id.test_get_value()
+```
+
+</div>
+
+<div data-lang="Rust" class="tab">
+
+```rust
+use glean_metrics;
+use uuid::Uuid;
+
+let u = Uuid::new_v4();
+// Does it have the expected value?
+assert_eq!(u, user::client_id.test_get_value(None).unwrap());
+```
+
+</div>
+
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as user from "./path/to/generated/files/user.js";
+
+const uuid = "decafdec-afde-cafd-ecaf-decafdecafde";
+assert(uuid, await user.clientId.testGetValue());
+```
+</div>
+
+<div data-lang="Firefox Desktop" class="tab">
+
+**C++**
+
+```c++
+#include "mozilla/glean/GleanMetrics.h"
+
+// Does it have an expected values?
+ASSERT_STREQ(kUuid.get(), mozilla::glean::user::client_id.TestGetValue().value().get());
+```
+
+**Javascript**
+
+```js
+const uuid = "decafdec-afde-cafd-ecaf-decafdecafde";
+Assert.equal(Glean.user.clientId.testGetValue(), uuid);
+```
+
+</div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+### `testHasValue`
+
+Whether or not **any** value was recorded for a given UUID metric.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.User
+
+// Was anything recorded?
+assertTrue(User.clientId.testHasValue())
+```
+
+</div>
+
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.User;
+
+// Was anything recorded?
+assertTrue(User.INSTANCE.clientId.testHasValue());
+```
+
+</div>
+
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+@testable import Glean
+
+// Was anything recorded?
+XCTAssert(User.clientId.testHasValue())
+```
+
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+# Was anything recorded?
+assert metrics.user.client_id.test_has_value()
+```
+
+</div>
+
+<div data-lang="Rust" class="tab"></div>
+
+<div data-lang="Javascript" class="tab"></div>
+
+<div data-lang="Firefox Desktop" class="tab"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+### `testGetNumRecordedErrors`
+
+Gets number of errors recorded for a given UUID metric.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.User
+
+assertEquals(
+    1, User.clientId.testGetNumRecordedErrors(ErrorType.InvalidValue)
+)
+```
+
+</div>
+
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.User;
+
+assertEquals(
+    1, User.INSTANCE.clientId.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
+```
+
+</div>
+
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+XCTAssertEqual(1, User.clientId.testGetNumRecordedErrors(.invalidValue))
+```
+
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+from glean.testing import ErrorType
+
+assert 1 == metrics.user.client_id.test_get_num_recorded_errors(
+    ErrorType.INVALID_VALUE
+)
+```
+</div>
+
+<div data-lang="Rust" class="tab">
+
+```rust
+use glean::ErrorType;
+
+use glean_metrics;
+
+assert_eq!(
+  1,
+  user::client_id.test_get_num_recorded_errors(
+    ErrorType::InvalidValue
+  )
+);
+```
+
+</div>
+
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as user from "./path/to/generated/files/user.js";
+
+// Was the string truncated, and an error reported?
+assert.strictEqual(1, await user.clientId.testGetNumRecordedErrors("invalid_value"));
+```
+</div>
+
+<div data-lang="Firefox Desktop" class="tab" data-bug="1683171"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+## Metric Parameters
+
+You first need to add an entry for it to the `metrics.yaml` file:
+
+```YAML
+user:
+  client_id:
+    type: uuid
+    description: >
+      A unique identifier for the client's profile
+    bugs:
+      - https://bugzilla.mozilla.org/000000
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=000000#c3
+    notification_emails:
+      - me@mozilla.com
+    expires: 2020-10-01
+```
+
+For a full reference on metrics parameters common to all metric types,
+refer to the metrics [YAML format](../yaml/index.md) reference page.
+
+### Extra metric parameters
+
+N/A
+
+## Data questions
 
 * A unique identifier for the client.
-
-## Recorded errors
-
-* `invalid_value`: if the value is set to a string that is not a UUID (only applies for dynamically-typed languages, such as Python).
 
 ## Reference
 
@@ -229,3 +471,4 @@ Assert.equal(Glean.user.clientId.testGetValue(), uuid);
 * [Swift API docs](../../../swift/Classes/UuidMetricType.html)
 * [Python API docs](../../../python/glean/metrics/uuid.html)
 * [Rust API docs](../../../docs/glean/private/uuid/struct.UuidMetric.html)
+* [Javascript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_uuid.default.html#set)


### PR DESCRIPTION
...and add Glean.js and Rust information to string and UUID metric page.

- String page: I also updated the error type in the `testGetNumRecordedErrors` examples to `InvalidOverflow`.
- UUID page: I also added `testGetNumRecordedErrors` docs.

[Rendered String](https://innate-earth.surge.sh/reference/metrics/string.html).
[Rendered UUID](https://innate-earth.surge.sh/reference/metrics/uuid.html).