### PR TITLE
Bug 1698800 - Finish including Glean.js docs to metrics reference pages

### DIFF
--- a/docs/user/reference/metrics/boolean.md
+++ b/docs/user/reference/metrics/boolean.md
@@ -274,3 +274,4 @@ N/A
 * [Swift API docs](../../../swift/Classes/BooleanMetricType.html)
 * [Python API docs](../../../python/glean/metrics/boolean.html)
 * [Rust API docs](../../../docs/glean/private/boolean/struct.BooleanMetric.html)
+* [Javascript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_boolean.default.html)

--- a/docs/user/reference/metrics/counter.md
+++ b/docs/user/reference/metrics/counter.md
@@ -322,7 +322,14 @@ assert_eq!(
 
 </div>
 
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as controls from "./path/to/generated/files/controls.js";
+
+assert.strictEqual(1, await controls.refreshPressed.testGetNumRecordedErrors("invalid_value"));
+```
+</div>
 
 <div data-lang="Firefox Desktop" class="tab" data-bug="1683171"></div>
 
@@ -364,3 +371,4 @@ N/A
 * [Swift API docs](../../../swift/Classes/CounterMetricType.html)
 * [Python API docs](../../../python/glean/metrics/counter.html)
 * [Rust API docs](../../../docs/glean/private/counter/struct.CounterMetric.html)
+* [Javascript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_counter.default.html)

--- a/docs/user/reference/metrics/datetime.md
+++ b/docs/user/reference/metrics/datetime.md
@@ -393,7 +393,14 @@ assert_eq!(0, install::first_run.test_get_num_recorded_errors(
 
 </div>
 
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as install from "./path/to/generated/files/install.js";
+
+assert.strictEqual(1, await install.firstRun.testGetNumRecordedErrors("invalid_value"));
+```
+</div>
 
 <div data-lang="Firefox Desktop" class="tab" data-bug="1683171"></div>
 
@@ -448,3 +455,4 @@ Carefully consider the required resolution for recording your metric, and choose
 * [Swift API docs](../../../swift/Classes/DatetimeMetricType.html)
 * [Python API docs](../../../python/glean/metrics/datetime.html)
 * [Rust API docs](../../../docs/glean/private/struct.DatetimeMetric.html)
+* [Datetime API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_datetime.default.html)

--- a/docs/user/reference/metrics/event.md
+++ b/docs/user/reference/metrics/event.md
@@ -357,7 +357,14 @@ assert_eq!(
 
 </div>
 
-<div data-lang="JavaScript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as views from "./path/to/generated/files/views.js";
+
+assert.strictEqual(1, await views.loginOpened.testGetNumRecordedErrors("invalid_value"));
+```
+</div>
 
 <div data-lang="Firefox Desktop" class="tab"></div>
 
@@ -416,3 +423,4 @@ Each extra key contains additional metadata:
 * [Swift API docs](../../../swift/Classes/EventMetricType.html)
 * [Python API docs](../../../python/glean/metrics/event.html)
 * [Rust API docs](../../../docs/glean/private/event/struct.EventMetric.html)
+* [Javascript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_event.default.html)

--- a/docs/user/reference/metrics/quantity.md
+++ b/docs/user/reference/metrics/quantity.md
@@ -329,7 +329,6 @@ refer to the metrics [YAML format](../yaml/index.md) reference page.
 
 Quantities have the required `unit` parameter, which is a free-form string for documentation purposes.
 
-
 ## Data questions
 
 * What is the width of the display, in pixels?

--- a/docs/user/reference/metrics/timespan.md
+++ b/docs/user/reference/metrics/timespan.md
@@ -69,7 +69,17 @@ fn show_login() {
 }
 ```
 </div>
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as auth from "./path/to/generated/files/auth.js";
+
+function onShowLogin() {
+    auth.loginTime.start();
+    // ...
+}
+```
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -96,7 +106,7 @@ function onShowLogin() {
 
 #### Limits
 * The maximum resolution of the elapsed duration is limited by the clock used on each platform.
-  This also determines the behavior of a timespan over sleep:
+* This also determines the behavior of a timespan over sleep:
   * On Android, the
     [`SystemClock.elapsedRealtimeNanos()`](https://developer.android.com/reference/android/os/SystemClock.html#elapsedRealtimeNanos())
     function is used, so it is limited by the accuracy and performance of that timer.
@@ -173,7 +183,17 @@ fn login() {
 }
 ```
 </div>
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as auth from "./path/to/generated/files/auth.js";
+
+function onLogin() {
+    auth.login_time.stop();
+    // ...
+}
+```
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -258,7 +278,17 @@ fn login_cancel() {
 }
 ```
 </div>
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as auth from "./path/to/generated/files/auth.js";
+
+function onLoginCancel() {
+    auth.login_time.cancel();
+    // ...
+}
+```
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -335,6 +365,8 @@ with metrics.auth.login_time.measure():
 
 Explicitly sets the timespan's value.
 
+Regardless of the time unit chosen for the metric, this API expects the raw value to be in **nanoseconds**.
+
 {{#include ../../../shared/blockquote-warning.html}}
 
 ## Only use this if you have to
@@ -398,7 +430,17 @@ fn after_login(login_elapsed: Duration) {
 }
 ```
 </div>
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as auth from "./path/to/generated/files/auth.js";
+
+function onAfterLogin(loginElapsedNs) {
+    auth.loginTime.setRawNanos(loginElapsedNs);
+    // ...
+}
+```
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 {{#include ../../../shared/blockquote-warning.html}}
@@ -483,7 +525,14 @@ use fog::metrics;
 assert!(metrics::login_time.test_get_value().unwrap() > 0);
 ```
 </div>
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as auth from "./path/to/generated/files/auth.js";
+
+assert(await auth.loginTime.testGetValue() > 0);
+```
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -603,14 +652,21 @@ use fog::metrics;
 assert_eq!(1, login_time.test_get_num_recorded_errors(ErrorType::InvalidValue));
 ```
 </div>
-<div data-lang="Javascript" class="tab"></div>
+<div data-lang="Javascript" class="tab">
+
+```js
+import * as auth from "./path/to/generated/files/auth.js";
+
+assert.strictEqual(1, await auth.loginTime.testGetNumRecordedErrors("invalid_value"));
+```
+</div>
 <div data-lang="Firefox Desktop" class="tab" data-bug="1683171"></div>
 
 {{#include ../../../shared/tab_footer.md}}
 
 ## Metric parameters
 
-Example datetime metric definition:
+Example timespan metric definition:
 
 ```YAML
 auth:
@@ -669,3 +725,4 @@ and use the largest possible value that will provide useful information so as to
 * [Swift API docs](../../../swift/Classes/TimespanMetricType.html)
 * [Python API docs](../../../python/glean/metrics/timespan.html)
 * [Rust API docs](../../../docs/glean/private/struct.TimespanMetric.html)
+* [Javascript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_timespan.default.html)


### PR DESCRIPTION
- [x] Document testGetNumRecordedErrors for Javascript where missing
- [x] Add reference link to where it was missing
- [x] Add Glean.js docs to timespan metric reference page (blocked by #1640)

With these done all Glean.js metrics reference is done. The metrics pages I haven't changed during this effort, were not changed because they were not implemented in Glean.js yet. I'll file bugs for each individual missing page.

[doc only]

