### PR TITLE
Bug 1683171 test_get_value assert num_errors == 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v38.0.1...main)
 
+* General
+  * test_get_value now panics if errors have been recorded on the metric. ([#1651](https://github.com/mozilla/glean/pull/1651))
+
 # v38.0.1 (2021-05-17)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v38.0.0...v38.0.1)

--- a/glean-core/ffi/glean.h
+++ b/glean-core/ffi/glean.h
@@ -414,6 +414,8 @@ uint8_t glean_set_source_tags(RawStringArray raw_tags, int32_t tags_count);
 
 uint64_t glean_get_timestamp_ms(void);
 
+void glean_test_register_platform_panic(void (*panic_fn)(FfiStr msg));
+
 /**
  * Public destructor for strings managed by the other side of the FFI.
  *

--- a/glean-core/ios/Glean/GleanFfi.h
+++ b/glean-core/ios/Glean/GleanFfi.h
@@ -414,6 +414,8 @@ uint8_t glean_set_source_tags(RawStringArray raw_tags, int32_t tags_count);
 
 uint64_t glean_get_timestamp_ms(void);
 
+void glean_test_register_platform_panic(void (*panic_fn)(FfiStr msg));
+
 /**
  * Public destructor for strings managed by the other side of the FFI.
  *

--- a/glean-core/rlb/src/private/labeled.rs
+++ b/glean-core/rlb/src/private/labeled.rs
@@ -346,7 +346,15 @@ mod test {
 
         let invalid_label = "!#I'm invalid#--_";
         metric.get(invalid_label).set(true);
+        // We're specifically interested in testing behaviour that should cause
+        // tests to panic. Suppress this with a benign substitute panic.
+        glean_core::test_register_platform_panic(|_| {});
+
         assert!(metric.get("__other__").test_get_value(None).unwrap());
+
+        // Panicky calls done. Return to normal.
+        glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
+
         assert_eq!(
             1,
             metric.test_get_num_recorded_errors(ErrorType::InvalidLabel, None)

--- a/glean-core/rlb/src/private/numerator.rs
+++ b/glean-core/rlb/src/private/numerator.rs
@@ -89,14 +89,6 @@ mod test {
             0
         );
 
-        // Adding a negative value errors.
-        metric.add_to_numerator(-1);
-
-        assert_eq!(
-            metric.test_get_num_recorded_errors(ErrorType::InvalidValue, None),
-            1
-        );
-
         // Getting the value returns 0s if that's all we have.
         assert_eq!(metric.test_get_value(None), Some((0, 0)));
 
@@ -104,5 +96,13 @@ mod test {
         metric.add_to_numerator(22);
 
         assert_eq!(metric.test_get_value(None), Some((22, 0)));
+
+        // Adding a negative value errors.
+        metric.add_to_numerator(-1);
+
+        assert_eq!(
+            metric.test_get_num_recorded_errors(ErrorType::InvalidValue, None),
+            1
+        );
     }
 }

--- a/glean-core/rlb/src/private/rate.rs
+++ b/glean-core/rlb/src/private/rate.rs
@@ -97,15 +97,6 @@ mod test {
             0
         );
 
-        // Adding a negative value errors.
-        metric.add_to_numerator(-1);
-        metric.add_to_denominator(-1);
-
-        assert_eq!(
-            metric.test_get_num_recorded_errors(ErrorType::InvalidValue, None),
-            2
-        );
-
         // Getting the value returns 0s if that's all we have.
         assert_eq!(metric.test_get_value(None), Some((0, 0)));
 
@@ -114,5 +105,14 @@ mod test {
         metric.add_to_denominator(7);
 
         assert_eq!(metric.test_get_value(None), Some((22, 7)));
+
+        // Adding a negative value errors.
+        metric.add_to_numerator(-1);
+        metric.add_to_denominator(-1);
+
+        assert_eq!(
+            metric.test_get_num_recorded_errors(ErrorType::InvalidValue, None),
+            2
+        );
     }
 }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -38,6 +38,7 @@ mod internal_metrics;
 mod internal_pings;
 pub mod metrics;
 pub mod ping;
+pub(crate) mod platform_panic;
 mod scheduler;
 pub mod storage;
 mod system;
@@ -1034,6 +1035,14 @@ impl Glean {
 pub fn get_timestamp_ms() -> u64 {
     const NANOS_PER_MILLI: u64 = 1_000_000;
     zeitstempel::now() / NANOS_PER_MILLI
+}
+
+/// Registers a platform-specific panic function to be used in tests.
+pub fn test_register_platform_panic<F: 'static>(panic_fn: F)
+where
+    F: Fn(&str) + Send + Sync,
+{
+    platform_panic::register(panic_fn);
 }
 
 // Split unit tests to a separate file, to reduce the file of this one.

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::error_recording::test_assert_no_errors;
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -57,6 +58,7 @@ impl BooleanMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<bool> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -80,6 +80,21 @@ impl CounterMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<i32> {
+        test_assert_no_errors(glean, &self.meta);
+        self.test_get_value_no_assert(glean, storage_name)
+    }
+
+    /// **Test-only API.**
+    ///
+    /// Gets the currently stored value as an integer.
+    /// The automated checks for recorded errors are bypassed.
+    ///
+    /// This doesn't clear the stored value.
+    pub(crate) fn test_get_value_no_assert(
+        &self,
+        glean: &Glean,
+        storage_name: &str,
+    ) -> Option<i32> {
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::histogram::{Bucketing, Histogram, HistogramType};
 use crate::metrics::{DistributionData, Metric, MetricType};
 use crate::storage::StorageManager;
@@ -158,6 +158,7 @@ impl CustomDistributionMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<DistributionData> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::time_unit::TimeUnit;
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
@@ -159,6 +159,7 @@ impl DatetimeMetric {
     ///
     /// The stored value or `None` if nothing stored.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<Datetime> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,
@@ -211,6 +212,7 @@ impl DatetimeMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value_as_string(&self, glean: &Glean, storage_name: &str) -> Option<String> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/denominator.rs
+++ b/glean-core/src/metrics/denominator.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::CounterMetric;
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
@@ -86,6 +86,7 @@ impl DenominatorMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<i32> {
+        test_assert_no_errors(glean, &self.meta());
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/event.rs
+++ b/glean-core/src/metrics/event.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use serde_json::{json, Value as JsonValue};
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::event_database::RecordedEvent;
 use crate::metrics::MetricType;
 use crate::util::truncate_string_at_boundary_with_error;
@@ -121,6 +121,7 @@ impl EventMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, store_name: &str) -> Option<Vec<RecordedEvent>> {
+        test_assert_no_errors(glean, &self.meta);
         glean.event_storage().test_get_value(&self.meta, store_name)
     }
 
@@ -130,6 +131,7 @@ impl EventMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value_as_json_string(&self, glean: &Glean, store_name: &str) -> String {
+        test_assert_no_errors(glean, &self.meta);
         match self.test_get_value(glean, store_name) {
             Some(value) => json!(value),
             None => json!(JsonValue::Null),

--- a/glean-core/src/metrics/experiment.rs
+++ b/glean-core/src/metrics/experiment.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map as JsonMap, Value as JsonValue};
 use std::collections::HashMap;
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -221,6 +221,7 @@ impl ExperimentMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value_as_json_string(&self, glean: &Glean) -> Option<String> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             INTERNAL_STORAGE,

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::histogram::{Functional, Histogram};
 use crate::metrics::memory_unit::MemoryUnit;
 use crate::metrics::{DistributionData, Metric, MetricType};
@@ -186,6 +186,7 @@ impl MemoryDistributionMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<DistributionData> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/quantity.rs
+++ b/glean-core/src/metrics/quantity.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -74,6 +74,7 @@ impl QuantityMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<i64> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/rate.rs
+++ b/glean-core/src/metrics/rate.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -115,6 +115,7 @@ impl RateMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<(i32, i32)> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::error_recording::test_assert_no_errors;
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -64,15 +65,6 @@ impl StringMetric {
     /// Non-exported API used for crate-internal storage.
     /// Gets the current-stored value as a string, or None if there is no value.
     pub(crate) fn get_value(&self, glean: &Glean, storage_name: &str) -> Option<String> {
-        self.test_get_value(&glean, &storage_name)
-    }
-
-    /// **Test-only API (exported for FFI purposes).**
-    ///
-    /// Gets the currently stored value as a string.
-    ///
-    /// This doesn't clear the stored value.
-    pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<String> {
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,
@@ -82,6 +74,16 @@ impl StringMetric {
             Some(Metric::String(s)) => Some(s),
             _ => None,
         }
+    }
+
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Gets the currently stored value as a string.
+    ///
+    /// This doesn't clear the stored value.
+    pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<String> {
+        test_assert_no_errors(glean, &self.meta);
+        self.get_value(&glean, &storage_name)
     }
 }
 

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -113,7 +113,8 @@ mod test {
         metric.set(&glean, sample_string.clone());
 
         let truncated = truncate_string_at_boundary(sample_string, MAX_LENGTH_VALUE);
-        assert_eq!(truncated, metric.test_get_value(&glean, "store1").unwrap());
+        // Gonna be sneaky here and use the internal `get_value`.
+        assert_eq!(truncated, metric.get_value(&glean, "store1").unwrap());
 
         assert_eq!(
             1,

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -133,6 +133,7 @@ impl StringListMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<Vec<String>> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::time_unit::TimeUnit;
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
@@ -179,6 +179,7 @@ impl TimespanMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<u64> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::histogram::{Functional, Histogram};
 use crate::metrics::time_unit::TimeUnit;
 use crate::metrics::{DistributionData, Metric, MetricType};
@@ -377,6 +377,7 @@ impl TimingDistributionMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<DistributionData> {
+        test_assert_no_errors(glean, &self.meta);
         match StorageManager.snapshot_metric_for_test(
             glean.storage(),
             storage_name,

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -4,7 +4,7 @@
 
 use uuid::Uuid;
 
-use crate::error_recording::{record_error, ErrorType};
+use crate::error_recording::{record_error, test_assert_no_errors, ErrorType};
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
@@ -116,6 +116,7 @@ impl UuidMetric {
     ///
     /// This doesn't clear the stored value.
     pub fn test_get_value(&self, glean: &Glean, storage_name: &str) -> Option<Uuid> {
+        test_assert_no_errors(glean, &self.meta);
         self.get_value(glean, storage_name)
     }
 }

--- a/glean-core/src/platform_panic.rs
+++ b/glean-core/src/platform_panic.rs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! # Platform Panic
+//!
+//! Some test functions may need to panic because they fail an invariant.
+//! This system allows platforms to supply custom panic fns so we don't just
+//! take down the process impolitely.
+
+use once_cell::sync::Lazy;
+use std::sync::RwLock;
+
+type Callback = Box<dyn Fn(&str) + Send + Sync>;
+static GLOBAL_PLATFORM_PANIC: Lazy<RwLock<Option<Callback>>> = Lazy::new(|| RwLock::new(None));
+
+pub(crate) fn register<F: 'static>(panic_fn: F)
+where
+    F: Fn(&str) + Send + Sync,
+{
+    let mut gpp = GLOBAL_PLATFORM_PANIC.write().unwrap();
+    *gpp = Some(Box::new(panic_fn));
+}
+
+pub(crate) fn panic(msg: &str) {
+    if let Some(panic_fn) = &*GLOBAL_PLATFORM_PANIC.read().unwrap() {
+        panic_fn(&msg);
+    } else {
+        panic!("{}", msg);
+    }
+}

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -105,6 +105,10 @@ fn counters_must_not_increment_when_passed_zero_or_negative() {
         ..Default::default()
     });
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress this with a benign substitute panic.
+    glean_core::test_register_platform_panic(|_| {});
+
     // Attempt to increment the counter with zero
     metric.add(&glean, 0);
     // Check that nothing was recorded
@@ -117,8 +121,11 @@ fn counters_must_not_increment_when_passed_zero_or_negative() {
 
     // Attempt increment counter properly
     metric.add(&glean, 1);
-    // Check that nothing was recorded
+    // Check that it was recorded
     assert_eq!(1, metric.test_get_value(&glean, "store1").unwrap());
+
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Make sure that the errors have been recorded
     assert_eq!(

--- a/glean-core/tests/custom_distribution.rs
+++ b/glean-core/tests/custom_distribution.rs
@@ -174,9 +174,15 @@ mod linear {
         // Accumulate the samples.
         metric.accumulate_samples_signed(&glean, [-1, 1, 2, 3].to_vec());
 
+        // We're specifically interested in testing behaviour that should cause
+        // tests to panic. Suppress panics with a benign substitute:
+        glean_core::test_register_platform_panic(|_| {});
+        // Get the value.
         let snapshot = metric
             .test_get_value(&glean, "store1")
             .expect("Value should be stored");
+        // Panicky call done. Return to normal.
+        glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
         // Check that we got the right sum of samples.
         assert_eq!(snapshot.sum, 6);
@@ -385,9 +391,15 @@ mod exponential {
         // Accumulate the samples.
         metric.accumulate_samples_signed(&glean, [-1, 1, 2, 3].to_vec());
 
+        // We're specifically interested in testing behaviour that should cause
+        // tests to panic. Suppress panics with a benign substitute:
+        glean_core::test_register_platform_panic(|_| {});
+        // Get the value.
         let snapshot = metric
             .test_get_value(&glean, "store1")
             .expect("Value should be stored");
+        // Panicky call done. Return to normal.
+        glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
         // Check that we got the right sum of samples.
         assert_eq!(snapshot.sum, 6);

--- a/glean-core/tests/memory_distribution.rs
+++ b/glean-core/tests/memory_distribution.rs
@@ -164,9 +164,15 @@ fn the_accumulate_samples_api_correctly_handles_negative_values() {
     // Accumulate the samples.
     metric.accumulate_samples_signed(&glean, [-1, 1, 2, 3].to_vec());
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
+    // Get the value.
     let snapshot = metric
         .test_get_value(&glean, "store1")
         .expect("Value should be stored");
+    // Panicky call done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     let kb = 1024;
 

--- a/glean-core/tests/quantity.rs
+++ b/glean-core/tests/quantity.rs
@@ -107,8 +107,14 @@ fn quantities_must_not_set_when_passed_negative() {
 
     // Attempt to set the quantity with negative
     metric.set(&glean, -1);
+
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
     // Check that nothing was recorded
     assert!(metric.test_get_value(&glean, "store1").is_none());
+    // Panicky call done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Make sure that the errors have been recorded
     assert_eq!(

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -107,11 +107,16 @@ fn long_string_values_are_truncated() {
     let test_sting = "01234567890".repeat(20);
     metric.set(&glean, test_sting.clone());
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
     // Check that data was truncated
     assert_eq!(
         test_sting[..100],
         metric.test_get_value(&glean, "store1").unwrap()
     );
+    // Panicky call done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Make sure that the errors have been recorded
     assert_eq!(

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -119,6 +119,10 @@ fn long_string_values_are_truncated() {
     let test_string = "0123456789".repeat(20);
     metric.add(&glean, test_string.clone());
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
+
     // Ensure the string was truncated to the proper length.
     assert_eq!(
         vec![test_string[..50].to_string()],
@@ -138,6 +142,9 @@ fn long_string_values_are_truncated() {
         vec![test_string[..50].to_string()],
         metric.test_get_value(&glean, "store1").unwrap()
     );
+
+    // Panicky call done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Ensure the error has been recorded.
     assert_eq!(
@@ -192,6 +199,10 @@ fn string_lists_dont_exceed_max_items() {
         metric.add(&glean, "test_string");
     }
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
+
     let expected: Vec<String> = "test_string "
         .repeat(20)
         .split_whitespace()
@@ -217,6 +228,9 @@ fn string_lists_dont_exceed_max_items() {
         .collect();
     metric.set(&glean, too_many);
     assert_eq!(expected, metric.test_get_value(&glean, "store1").unwrap());
+
+    // Panicky call done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     assert_eq!(
         Ok(2),

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -125,8 +125,15 @@ fn second_timer_run_is_skipped() {
     metric.set_start(&glean, 0);
     metric.set_stop(&glean, duration * 2);
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
+
     let second_value = metric.test_get_value(&glean, "store1").unwrap();
     assert_eq!(second_value, first_value);
+
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Make sure that the error has been recorded: we had a stored value, the
     // new measurement was dropped.
@@ -275,8 +282,13 @@ fn set_raw_time_does_nothing_when_timer_running() {
     metric.set_raw(&glean, time);
     metric.set_stop(&glean, 60);
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
     // We expect the start/stop value, not the raw value.
     assert_eq!(Some(60), metric.test_get_value(&glean, "store1"));
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Make sure that the error has been recorded
     assert_eq!(
@@ -318,8 +330,13 @@ fn timespan_is_not_tracked_across_upload_toggle() {
     // None should be running.
     metric.set_stop(&glean, 200);
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
     // Nothing should have been recorded.
     assert_eq!(None, metric.test_get_value(&glean, "store1"));
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Make sure that the error has been recorded
     assert_eq!(
@@ -345,7 +362,12 @@ fn time_cannot_go_backwards() {
     // Time cannot go backwards.
     metric.set_start(&glean, 10);
     metric.set_stop(&glean, 0);
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
     assert!(metric.test_get_value(&glean, "test1").is_none());
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
     assert_eq!(
         Ok(1),
         test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None),

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -126,7 +126,14 @@ fn timing_distributions_must_not_accumulate_negative_values() {
     let id = metric.set_start(duration);
     metric.set_stop_and_accumulate(&glean, id, 0);
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
+
     assert!(metric.test_get_value(&glean, "store1").is_none());
+
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Make sure that the errors have been recorded
     assert_eq!(
@@ -205,9 +212,15 @@ fn the_accumulate_samples_api_correctly_handles_negative_values() {
     // Accumulate the samples.
     metric.accumulate_samples_signed(&glean, [-1, 1, 2, 3].to_vec());
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
+    // Get the value.
     let snapshot = metric
         .test_get_value(&glean, "store1")
         .expect("Value should be stored");
+    // Panicky call done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Check that we got the right sum and number of samples.
     assert_eq!(snapshot.sum, 6);
@@ -251,9 +264,16 @@ fn the_accumulate_samples_api_correctly_handles_overflowing_values() {
     // Accumulate the samples.
     metric.accumulate_samples_signed(&glean, [overflowing_val, 1, 2, 3].to_vec());
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress panics with a benign substitute:
+    glean_core::test_register_platform_panic(|_| {});
+
     let snapshot = metric
         .test_get_value(&glean, "store1")
         .expect("Value should be stored");
+
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Overflowing values are truncated to MAX_SAMPLE_TIME and recorded.
     assert_eq!(snapshot.sum, MAX_SAMPLE_TIME + 6);
@@ -409,9 +429,16 @@ fn raw_samples_api_error_cases() {
         ],
     );
 
+    // We're specifically interested in testing behaviour that should cause
+    // tests to panic. Suppress this with a benign substitute panic.
+    glean_core::test_register_platform_panic(|_| {});
+
     let snapshot = metric
         .test_get_value(&glean, "store1")
         .expect("Value should be stored");
+
+    // Panicky calls done. Return to normal.
+    glean_core::test_register_platform_panic(|msg| panic!("{}", msg));
 
     // Check that we got the right sum and number of samples.
     assert_eq!(snapshot.sum, 2 + max_sample_time);


### PR DESCRIPTION
Presently left undone is the task of replacing using Language Binding-specific panics instead of `panic!`. Is there any place in specific I should perform that setup in the LBs?