### PR TITLE
Bug 1710424 - Document more precisely how the UUID type behaves

### DIFF
--- a/docs/user/reference/metrics/uuid.md
+++ b/docs/user/reference/metrics/uuid.md
@@ -6,7 +6,7 @@ UUIDs metrics are used to record values that uniquely identify some entity, such
 
 ### `generateAndSet`
 
-Sets a UUID metric to a generated [UUID](https://datatracker.ietf.org/doc/html/rfc4122) value.
+Sets a UUID metric to a randomly generated [UUID](https://datatracker.ietf.org/doc/html/rfc4122) value (UUID v4) .
 
 {{#include ../../../shared/tab_header.md}}
 
@@ -100,6 +100,7 @@ Glean.user.clientId.generateAndSet();
 ### `set`
 
 Sets a UUID metric to a specific value.
+Accepts any UUID version.
 
 {{#include ../../../shared/tab_header.md}}
 


### PR DESCRIPTION
Generate only v4 UUIDs.
Accepts any UUID in the typical 8-4-4-4-12 format.

[doc only]