### PR TITLE
Bug 1713398 - glean_parser update & desktop custom distribution API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v39.0.3...main)
 
+* General
+  * Updated `glean_parser` version to 3.6.0
+  * Allow Custom Distribution metric type on all platforms ([#1679](https://github.com/mozilla/glean/pull/1679))
+
 # v39.0.3 (2021-06-09)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v39.0.2...v39.0.3)

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ python-docs: build-python ## Build the Python documentation
 .PHONY: docs rust-docs kotlin-docs swift-docs
 
 metrics-docs: python-setup ## Build the internal metrics documentation
-	$(GLEAN_PYENV)/bin/pip install glean_parser==3.4.0
+	$(GLEAN_PYENV)/bin/pip install glean_parser==3.6.0
 	$(GLEAN_PYENV)/bin/glean_parser translate --allow-reserved \
 		 -f markdown \
 		 -o ./docs/user/user/collected-metrics \

--- a/docs/user/reference/metrics/custom_distribution.md
+++ b/docs/user/reference/metrics/custom_distribution.md
@@ -41,7 +41,23 @@ graphics::checkerboard_peak.accumulate_samples_signed(vec![23]);
 
 </div>
 <div data-lang="Javascript" class="tab"></div>
-<div data-lang="Firefox Desktop" class="tab"></div>
+<div data-lang="Firefox Desktop" class="tab">
+
+**C++**
+
+```cpp
+#include "mozilla/glean/GleanMetrics.h"
+
+mozilla::glean::graphics::checkerboard_peak.AccumulateSamples({ 23 });
+```
+
+**JavaScript**
+
+```js
+Glean.graphics.checkerboardPeak.accumulateSamples([23])
+```
+
+</div>
 
 {{#include ../../../shared/tab_footer.md}}
 
@@ -94,7 +110,25 @@ assert_eq!(23, graphics::checkerboard_peak.test_get_value(None).unwrap().sum);
 
 </div>
 <div data-lang="Javascript" class="tab"></div>
-<div data-lang="Firefox Desktop" class="tab"></div>
+<div data-lang="Firefox Desktop" class="tab">
+
+**C++**
+
+```cpp
+#include "mozilla/glean/GleanMetrics.h"
+
+auto data = mozilla::glean::graphics::checkerboard_peak.TestGetValue().value();
+ASSERT_EQ(23UL, data.sum);
+```
+
+**JavaScript**
+
+```js
+let data = Glean.graphics.checkerboardPeak.testGetValue();
+Assert.equal(23, data.sum);
+```
+
+</div>
 
 {{#include ../../../shared/tab_footer.md}}
 

--- a/docs/user/reference/metrics/custom_distribution.md
+++ b/docs/user/reference/metrics/custom_distribution.md
@@ -231,15 +231,15 @@ Custom distributions have the following required parameters:
 - `histogram_type`:
   - `linear`: The buckets are evenly spaced
   - `exponential`: The buckets follow a natural logarithmic distribution
-- `gecko_datapoint`: (String) This is a Gecko-specific property.
-  It is the name of the Gecko metric to accumulate the data from,
-  when using the Glean SDK in a product using GeckoView.
 
 > **Note** Check out how these bucketing algorithms would behave on the [Custom distribution simulator](#simulator).
 
 Custom distributions have the following optional parameters:
 
 - `unit`: (String) The unit of the values in the metric. For documentation purposes only -- does not affect data collection.
+- `gecko_datapoint`: (String) This is a Gecko-specific property.
+  It is the name of the Gecko metric to accumulate the data from,
+  when using the Glean SDK in a product using GeckoView.
 
 
 ## Reference

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [package.metadata.glean]
-glean-parser = "3.4.0"
+glean-parser = "3.6.0"
 
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "main" }

--- a/glean-core/csharp/Glean/GleanParser.cs
+++ b/glean-core/csharp/Glean/GleanParser.cs
@@ -18,7 +18,7 @@ namespace GleanTasks
         private const string DefaultVirtualEnvDir = ".venv";
 
         // The glean_parser pypi package version 
-        private const string GleanParserVersion = "3.4.0";
+        private const string GleanParserVersion = "3.6.0";
 
         // This script runs a given Python module as a "main" module, like
         // `python -m module`. However, it first checks that the installed

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=3.4.0
+GLEAN_PARSER_VERSION=3.6.0
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034

--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -30,7 +30,7 @@ __author__ = "The Glean Team"
 __email__ = "glean-team@mozilla.com"
 
 
-GLEAN_PARSER_VERSION = "3.4.0"
+GLEAN_PARSER_VERSION = "3.6.0"
 
 
 if glean_parser.__version__ != GLEAN_PARSER_VERSION:

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -60,7 +60,7 @@ version = "39.0.3"
 
 requirements = [
     "cffi>=1.13.0",
-    "glean_parser==3.4.0",
+    "glean_parser==3.6.0",
     "iso8601>=0.1.10; python_version<='3.6'",
 ]
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -36,7 +36,7 @@ class GleanMetricsYamlTransform extends ArtifactTransform {
 @SuppressWarnings("GrPackage")
 class GleanPlugin implements Plugin<Project> {
     // The version of glean_parser to install from PyPI.
-    private String GLEAN_PARSER_VERSION = "3.4.0"
+    private String GLEAN_PARSER_VERSION = "3.6.0"
     // The version of Miniconda is explicitly specified.
     // Miniconda3-4.5.12 is known to not work on Windows.
     private String MINICONDA_VERSION = "4.5.11"


### PR DESCRIPTION
Requires https://github.com/mozilla/glean_parser/pull/346 & a release.
The doc will be correct when said release lands in m-c and I can land the code there too.