### PR TITLE
Use the correct type for the `seq` field

### DIFF
--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -243,12 +243,14 @@ glean.internal.metrics:
     expires: never
 
   seq:
-    type: string
+    type: counter
     lifetime: user
     send_in_pings:
       - glean_internal_info
     description: |
-      A running counter of the number of times pings of this type have been sent
+      A running counter of the number of times pings of this type have been sent.
+      This metric definition is only used for documentation purposed: internally,
+      Glean instantiates the metric manually and calls it `sequence`.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1556964
     data_reviews:

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -248,9 +248,11 @@ glean.internal.metrics:
     send_in_pings:
       - glean_internal_info
     description: |
-      A running counter of the number of times pings of this type have been sent.
-      This metric definition is only used for documentation purposed: internally,
-      Glean instantiates the metric manually and calls it `sequence`.
+      A running counter of the number of times pings of this type have been
+      sent.
+      This metric definition is only used for documentation purposed:
+      internally, Glean instantiates the metric manually and calls it
+      `sequence`.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1556964
     data_reviews:

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -250,7 +250,7 @@ glean.internal.metrics:
     description: |
       A running counter of the number of times pings of this type have been
       sent.
-      This metric definition is only used for documentation purposed:
+      This metric definition is only used for documentation purposes:
       internally, Glean instantiates the metric manually and calls it
       `sequence`.
     bugs:


### PR DESCRIPTION
This definition is only useful for documentation purposes, because [we are not using it internally](https://searchfox.org/glean/rev/42e5778f4aaf240330eae1ce5bebfa35e19642a0/glean-core/src/ping/mod.rs#71). We are not even using a field with the same name :-) We're using `sequence` internally, instead of `seq`.