### PR TITLE
Add the time unit to the start_time/end_time

### DIFF
--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -282,6 +282,7 @@ glean.internal.metrics:
 
   start_time:
     type: datetime
+    time_unit: minute
     lifetime: user
     send_in_pings:
       - glean_internal_info
@@ -300,6 +301,7 @@ glean.internal.metrics:
 
   end_time:
     type: datetime
+    time_unit: minute
     lifetime: ping
     send_in_pings:
       - glean_internal_info


### PR DESCRIPTION
This reflects what's [happening in the code](https://searchfox.org/glean/rev/42e5778f4aaf240330eae1ce5bebfa35e19642a0/glean-core/src/ping/mod.rs#97), so that it's visible in the Glean Dictionary.