### PR TITLE
Bug 1717402 - Extend `invalid_timezone_offset` metric until the end of the year

### DIFF
--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -634,11 +634,13 @@ glean.time:
       - metrics
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1611770
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1717402#c1
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1611770#c9
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1717402#c4
     data_sensitivity:
       - technical
     notification_emails:
       - jrediger@mozilla.com
       - glean-team@mozilla.com
-    expires: 2021-06-30
+    expires: 2021-12-31


### PR DESCRIPTION
This is an internal metric and thus the code already uses a never-ending
metric. All prior versions will continue to collect this metric too,
even beyond the initial date.
This is therefore mostly a documentation update.

[doc only]