### PR TITLE
Apply clippy suggestions everywhere

### DIFF
--- a/glean-core/ffi/src/counter.rs
+++ b/glean-core/ffi/src/counter.rs
@@ -19,7 +19,7 @@ pub extern "C" fn glean_counter_test_has_value(metric_id: u64, storage_name: Ffi
     with_glean_value(|glean| {
         COUNTER_METRICS.call_infallible(metric_id, |metric| {
             metric
-                .test_get_value(&glean, storage_name.as_str())
+                .test_get_value(glean, storage_name.as_str())
                 .is_some()
         })
     })
@@ -29,9 +29,7 @@ pub extern "C" fn glean_counter_test_has_value(metric_id: u64, storage_name: Ffi
 pub extern "C" fn glean_counter_test_get_value(metric_id: u64, storage_name: FfiStr) -> i32 {
     with_glean_value(|glean| {
         COUNTER_METRICS.call_infallible(metric_id, |metric| {
-            metric
-                .test_get_value(&glean, storage_name.as_str())
-                .unwrap()
+            metric.test_get_value(glean, storage_name.as_str()).unwrap()
         })
     })
 }

--- a/glean-core/ffi/src/jwe.rs
+++ b/glean-core/ffi/src/jwe.rs
@@ -20,7 +20,7 @@ pub extern "C" fn glean_jwe_set_with_compact_representation(metric_id: u64, valu
     with_glean_value(|glean| {
         JWE_METRICS.call_with_log(metric_id, |metric| {
             let value = value.to_string_fallible()?;
-            metric.set_with_compact_representation(&glean, value);
+            metric.set_with_compact_representation(glean, value);
             Ok(())
         })
     })
@@ -42,7 +42,7 @@ pub extern "C" fn glean_jwe_set(
             let init_vector = init_vector.to_string_fallible()?;
             let cipher_text = cipher_text.to_string_fallible()?;
             let auth_tag = auth_tag.to_string_fallible()?;
-            metric.set(&glean, header, key, init_vector, cipher_text, auth_tag);
+            metric.set(glean, header, key, init_vector, cipher_text, auth_tag);
             Ok(())
         })
     })

--- a/glean-core/ffi/src/string.rs
+++ b/glean-core/ffi/src/string.rs
@@ -22,7 +22,7 @@ pub extern "C" fn glean_string_set(metric_id: u64, value: FfiStr) {
     with_glean_value(|glean| {
         STRING_METRICS.call_with_log(metric_id, |metric| {
             let value = value.to_string_fallible()?;
-            metric.set(&glean, value);
+            metric.set(glean, value);
             Ok(())
         })
     })
@@ -33,7 +33,7 @@ pub extern "C" fn glean_string_test_has_value(metric_id: u64, storage_name: FfiS
     with_glean_value(|glean| {
         STRING_METRICS.call_infallible(metric_id, |metric| {
             metric
-                .test_get_value(&glean, storage_name.as_str())
+                .test_get_value(glean, storage_name.as_str())
                 .is_some()
         })
     })
@@ -43,9 +43,7 @@ pub extern "C" fn glean_string_test_has_value(metric_id: u64, storage_name: FfiS
 pub extern "C" fn glean_string_test_get_value(metric_id: u64, storage_name: FfiStr) -> *mut c_char {
     with_glean_value(|glean| {
         STRING_METRICS.call_infallible(metric_id, |metric| {
-            metric
-                .test_get_value(&glean, storage_name.as_str())
-                .unwrap()
+            metric.test_get_value(glean, storage_name.as_str()).unwrap()
         })
     })
 }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -296,7 +296,7 @@ fn initialize_internal(
                 // The next times we start, we would have them around already.
                 let is_first_run = glean.is_first_run();
                 if is_first_run {
-                    initialize_core_metrics(&glean, &state.client_info, state.channel.clone());
+                    initialize_core_metrics(glean, &state.client_info, state.channel.clone());
                 }
 
                 // Deal with any pending events so we can start recording new ones
@@ -333,7 +333,7 @@ fn initialize_internal(
                 // Any new value will be sent in newly generated pings after startup.
                 if !is_first_run {
                     glean.clear_application_lifetime_metrics();
-                    initialize_core_metrics(&glean, &state.client_info, state.channel.clone());
+                    initialize_core_metrics(glean, &state.client_info, state.channel.clone());
                 }
             });
 
@@ -342,7 +342,7 @@ fn initialize_internal(
                 Ok(task_count) if task_count > 0 => {
                     with_glean(|glean| {
                         glean_metrics::error::preinit_tasks_overflow
-                            .add_sync(&glean, task_count as i32);
+                            .add_sync(glean, task_count as i32);
                     });
                 }
                 Ok(_) => {}
@@ -477,7 +477,7 @@ pub fn set_upload_enabled(enabled: bool) {
             glean.start_metrics_ping_scheduler();
             // If uploading is being re-enabled, we have to restore the
             // application-lifetime metrics.
-            initialize_core_metrics(&glean, &state.client_info, state.channel.clone());
+            initialize_core_metrics(glean, &state.client_info, state.channel.clone());
         }
 
         if old_enabled && !enabled {
@@ -564,7 +564,7 @@ pub(crate) fn submit_ping_by_name_sync(ping: &str, reason: Option<&str>) {
             return false;
         }
 
-        glean.submit_ping_by_name(&ping, reason.as_deref())
+        glean.submit_ping_by_name(ping, reason.as_deref())
     });
 
     if submitted_ping {

--- a/glean-core/rlb/src/private/counter.rs
+++ b/glean-core/rlb/src/private/counter.rs
@@ -59,7 +59,7 @@ impl glean_core::traits::Counter for CounterMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/custom_distribution.rs
+++ b/glean-core/rlb/src/private/custom_distribution.rs
@@ -70,7 +70,7 @@ impl glean_core::traits::CustomDistribution for CustomDistributionMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/datetime.rs
+++ b/glean-core/rlb/src/private/datetime.rs
@@ -56,7 +56,7 @@ impl glean_core::traits::Datetime for DatetimeMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/denominator.rs
+++ b/glean-core/rlb/src/private/denominator.rs
@@ -57,7 +57,7 @@ impl glean_core::traits::Counter for DenominatorMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/event.rs
+++ b/glean-core/rlb/src/private/event.rs
@@ -87,7 +87,7 @@ impl<K: traits::ExtraKeys> traits::Event for EventMetric<K> {
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(
-                &glean,
+                glean,
                 self.inner.meta(),
                 error,
                 ping_name.into(),

--- a/glean-core/rlb/src/private/labeled.rs
+++ b/glean-core/rlb/src/private/labeled.rs
@@ -136,7 +136,7 @@ where
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(
-                &glean,
+                glean,
                 self.0.get_submetric().meta(),
                 error,
                 ping_name.into(),

--- a/glean-core/rlb/src/private/memory_distribution.rs
+++ b/glean-core/rlb/src/private/memory_distribution.rs
@@ -58,7 +58,7 @@ impl glean_core::traits::MemoryDistribution for MemoryDistributionMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/numerator.rs
+++ b/glean-core/rlb/src/private/numerator.rs
@@ -57,7 +57,7 @@ impl glean_core::traits::Numerator for NumeratorMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/quantity.rs
+++ b/glean-core/rlb/src/private/quantity.rs
@@ -54,7 +54,7 @@ impl glean_core::traits::Quantity for QuantityMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/rate.rs
+++ b/glean-core/rlb/src/private/rate.rs
@@ -64,7 +64,7 @@ impl glean_core::traits::Rate for RateMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/string.rs
+++ b/glean-core/rlb/src/private/string.rs
@@ -63,7 +63,7 @@ impl glean_core::traits::String for StringMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/string_list.rs
+++ b/glean-core/rlb/src/private/string_list.rs
@@ -59,7 +59,7 @@ impl glean_core::traits::StringList for StringListMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/timespan.rs
+++ b/glean-core/rlb/src/private/timespan.rs
@@ -114,7 +114,7 @@ impl glean_core::traits::Timespan for TimespanMetric {
             .expect("Lock poisoned for timespan metric on test_get_value.");
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, metric.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, metric.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/rlb/src/private/timing_distribution.rs
+++ b/glean-core/rlb/src/private/timing_distribution.rs
@@ -107,7 +107,7 @@ impl glean_core::traits::TimingDistribution for TimingDistributionMetric {
 
         crate::with_glean_mut(|glean| {
             glean_core::test_get_num_recorded_errors(
-                &glean,
+                glean,
                 self.0.read().unwrap().meta(),
                 error,
                 ping_name.into(),

--- a/glean-core/rlb/src/private/uuid.rs
+++ b/glean-core/rlb/src/private/uuid.rs
@@ -60,7 +60,7 @@ impl glean_core::traits::Uuid for UuidMetric {
         crate::block_on_dispatcher();
 
         crate::with_glean_mut(|glean| {
-            glean_core::test_get_num_recorded_errors(&glean, self.0.meta(), error, ping_name.into())
+            glean_core::test_get_num_recorded_errors(glean, self.0.meta(), error, ping_name.into())
                 .unwrap_or(0)
         })
     }

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -149,7 +149,7 @@ mod backend {
 
         if should_delete {
             log::debug!("Need to delete remaining LMDB files.");
-            delete_lmdb_database(&path);
+            delete_lmdb_database(path);
         }
 
         log::debug!("Migration ended. Safe-mode database in {}", path.display());
@@ -296,7 +296,7 @@ impl Database {
     fn open_rkv(path: &Path) -> Result<Rkv> {
         fs::create_dir_all(&path)?;
 
-        let rkv = rkv_new(&path)?;
+        let rkv = rkv_new(path)?;
         migrate(path, &rkv);
 
         log::info!("Database initialized");

--- a/glean-core/src/debug.rs
+++ b/glean-core/src/debug.rs
@@ -234,7 +234,7 @@ fn validate_source_tags(tags: &Vec<String>) -> bool {
         return false;
     }
 
-    tags.iter().all(|x| validate_tag(&x))
+    tags.iter().all(|x| validate_tag(x))
 }
 
 #[cfg(test)]

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -208,7 +208,7 @@ impl EventDatabase {
                 store.push(event.clone());
                 self.write_event_to_disk(store_name, &event_json);
                 if store.len() == glean.get_max_events() {
-                    stores_to_submit.push(&store_name);
+                    stores_to_submit.push(store_name);
                 }
             }
         }
@@ -366,7 +366,7 @@ mod test {
         let t = tempfile::tempdir().unwrap();
 
         {
-            let db = EventDatabase::new(&t.path()).unwrap();
+            let db = EventDatabase::new(t.path()).unwrap();
             db.write_event_to_disk("events", "{\"timestamp\": 500");
             db.write_event_to_disk("events", "{\"timestamp\"");
             db.write_event_to_disk(
@@ -376,7 +376,7 @@ mod test {
         }
 
         {
-            let db = EventDatabase::new(&t.path()).unwrap();
+            let db = EventDatabase::new(t.path()).unwrap();
             db.load_events_from_disk().unwrap();
             let events = &db.event_stores.read().unwrap()["events"];
             assert_eq!(1, events.len());
@@ -448,11 +448,8 @@ mod test {
             extra: Some(data),
         };
 
-        assert_eq!(
-            event_empty,
-            serde_json::from_str(&event_empty_json).unwrap()
-        );
-        assert_eq!(event_data, serde_json::from_str(&event_data_json).unwrap());
+        assert_eq!(event_empty, serde_json::from_str(event_empty_json).unwrap());
+        assert_eq!(event_data, serde_json::from_str(event_data_json).unwrap());
     }
 
     #[test]

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -117,7 +117,7 @@ impl DatetimeMetric {
             return;
         }
 
-        let value = value.unwrap_or_else(|| local_now_with_offset_and_record(&glean));
+        let value = value.unwrap_or_else(|| local_now_with_offset_and_record(glean));
         let value = Metric::Datetime(value, self.time_unit);
         glean.storage().record(glean, &self.meta, &value)
     }

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -159,7 +159,7 @@ where
                 let label = self.static_label(label);
                 self.new_metric_with_name(combine_base_identifier_and_label(
                     &self.submetric.meta().name,
-                    &label,
+                    label,
                 ))
             }
             None => self.new_metric_with_dynamic_label(label.to_string()),
@@ -222,7 +222,7 @@ pub fn validate_dynamic_label(
     for store in &meta.send_in_pings {
         glean
             .storage()
-            .iter_store_from(lifetime, store, Some(&prefix), &mut snapshotter);
+            .iter_store_from(lifetime, store, Some(prefix), &mut snapshotter);
     }
 
     let error = if label_count >= MAX_LABELS {

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -64,7 +64,7 @@ impl StringMetric {
     /// Non-exported API used for crate-internal storage.
     /// Gets the current-stored value as a string, or None if there is no value.
     pub(crate) fn get_value(&self, glean: &Glean, storage_name: &str) -> Option<String> {
-        self.test_get_value(&glean, &storage_name)
+        self.test_get_value(glean, storage_name)
     }
 
     /// **Test-only API (exported for FFI purposes).**

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -69,7 +69,7 @@ impl UuidMetric {
             return;
         }
 
-        if let Ok(uuid) = uuid::Uuid::parse_str(&value) {
+        if let Ok(uuid) = uuid::Uuid::parse_str(value) {
             self.set(glean, uuid);
         } else {
             let msg = format!("Unexpected UUID value '{}'", value);

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -112,7 +112,7 @@ impl PingMaker {
         let start_time_data = start_time
             .get_value(glean, INTERNAL_STORAGE)
             .unwrap_or_else(|| glean.start_time());
-        let end_time_data = local_now_with_offset_and_record(&glean);
+        let end_time_data = local_now_with_offset_and_record(glean);
 
         // Update the start time with the current time.
         start_time.set(glean, Some(end_time_data));

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -86,7 +86,7 @@ impl StorageManager {
         let mut snapshotter = |metric_id: &[u8], metric: &Metric| {
             let metric_id = String::from_utf8_lossy(metric_id).into_owned();
             if metric_id.contains('/') {
-                snapshot_labeled_metrics(&mut snapshot, &metric_id, &metric);
+                snapshot_labeled_metrics(&mut snapshot, &metric_id, metric);
             } else {
                 let map = snapshot
                     .entry(metric.ping_section().into())
@@ -95,9 +95,9 @@ impl StorageManager {
             }
         };
 
-        storage.iter_store_from(Lifetime::Ping, &store_name, None, &mut snapshotter);
-        storage.iter_store_from(Lifetime::Application, &store_name, None, &mut snapshotter);
-        storage.iter_store_from(Lifetime::User, &store_name, None, &mut snapshotter);
+        storage.iter_store_from(Lifetime::Ping, store_name, None, &mut snapshotter);
+        storage.iter_store_from(Lifetime::Application, store_name, None, &mut snapshotter);
+        storage.iter_store_from(Lifetime::User, store_name, None, &mut snapshotter);
 
         if clear_store {
             if let Err(e) = storage.clear_ping_lifetime_storage(store_name) {
@@ -139,7 +139,7 @@ impl StorageManager {
             }
         };
 
-        storage.iter_store_from(metric_lifetime, &store_name, None, &mut snapshotter);
+        storage.iter_store_from(metric_lifetime, store_name, None, &mut snapshotter);
 
         snapshot
     }

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -306,7 +306,7 @@ impl PingUploadManager {
             Ok(request) => Some(request),
             Err(e) => {
                 log::warn!("Error trying to build ping request: {}", e);
-                self.directory_manager.delete_file(&document_id);
+                self.directory_manager.delete_file(document_id);
 
                 // Record the error.
                 // Currently the only possible error is PingBodyOverflow.
@@ -420,7 +420,7 @@ impl PingUploadManager {
                     deleting = true;
                 }
 
-                if deleting && self.directory_manager.delete_file(&document_id) {
+                if deleting && self.directory_manager.delete_file(document_id) {
                     self.upload_metrics
                         .deleted_pings_after_quota_hit
                         .add(glean, 1);
@@ -668,7 +668,7 @@ impl PingUploadManager {
                     document_id,
                     status
                 );
-                self.enqueue_ping_from_file(glean, &document_id);
+                self.enqueue_ping_from_file(glean, document_id);
                 self.recoverable_failure_count
                     .fetch_add(1, Ordering::SeqCst);
             }

--- a/glean-core/src/util.rs
+++ b/glean-core/src/util.rs
@@ -103,7 +103,7 @@ pub(crate) fn local_now_with_offset_and_record(glean: &Glean) -> DateTime<FixedO
         glean
             .additional_metrics
             .invalid_timezone_offset
-            .add(&glean, 1);
+            .add(glean, 1);
     }
 
     now

--- a/glean-core/tests/datetime.rs
+++ b/glean-core/tests/datetime.rs
@@ -179,9 +179,7 @@ fn test_that_truncation_works() {
 
         assert_eq!(
             t.expected_result,
-            metric
-                .test_get_value_as_string(&glean, &store_name)
-                .unwrap()
+            metric.test_get_value_as_string(&glean, store_name).unwrap()
         );
     }
 }


### PR DESCRIPTION
The new beta clippy found all of these, mostly this should be turning
`&self` into `self` when passing as an argument, when `self` is already `&Self`, so a reference.
That double-referencing will just go away anyway (and the compiler
should be smart enough to not make that costly at all).

I ran this to apply it all automatically:

     cargo +nightly clippy --verbose --all --all-targets --all-features -Z unstable-options --fix -- -D warnings