### PR TITLE
Bug 1714365 - Update JS docs for testGetNumRecordedErrors to use ErrorType enum

### DIFF
--- a/docs/user/reference/metrics/counter.md
+++ b/docs/user/reference/metrics/counter.md
@@ -328,8 +328,12 @@ assert_eq!(
 
 ```js
 import * as controls from "./path/to/generated/files/controls.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
-assert.strictEqual(1, await controls.refreshPressed.testGetNumRecordedErrors("invalid_value"));
+assert.strictEqual(
+  1,
+  await controls.refreshPressed.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
 ```
 </div>
 

--- a/docs/user/reference/metrics/datetime.md
+++ b/docs/user/reference/metrics/datetime.md
@@ -403,8 +403,12 @@ assert_eq!(0, install::first_run.test_get_num_recorded_errors(
 
 ```js
 import * as install from "./path/to/generated/files/install.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
-assert.strictEqual(1, await install.firstRun.testGetNumRecordedErrors("invalid_value"));
+assert.strictEqual(
+  1,
+  await install.firstRun.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
 ```
 </div>
 

--- a/docs/user/reference/metrics/event.md
+++ b/docs/user/reference/metrics/event.md
@@ -432,8 +432,12 @@ assert_eq!(
 
 ```js
 import * as views from "./path/to/generated/files/views.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
-assert.strictEqual(1, await views.loginOpened.testGetNumRecordedErrors("invalid_value"));
+assert.strictEqual(
+  1,
+  await views.loginOpened.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_booleans.md
+++ b/docs/user/reference/metrics/labeled_booleans.md
@@ -321,8 +321,12 @@ assert_eq!(
 
 ```js
 import * as accessibility from "./path/to/generated/files/acessibility.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
-assert(await accessibility.features.testGetNumRecordedErrors("invalid_label"));
+assert(
+  1,
+  await accessibility.features.testGetNumRecordedErrors(ErrorType.InvalidLabel)
+);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_counters.md
+++ b/docs/user/reference/metrics/labeled_counters.md
@@ -336,9 +336,13 @@ assert_eq!(
 
 ```js
 import * as stability from "./path/to/generated/files/stability.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
 // Were there any invalid labels?
-assert.strictEqual(0, await stability.crashCount.testGetNumRecordedErrors("invalid_label"));
+assert(
+  0,
+  await stability.crashCount.testGetNumRecordedErrors(ErrorType.InvalidLabel)
+);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_strings.md
+++ b/docs/user/reference/metrics/labeled_strings.md
@@ -306,9 +306,13 @@ assert_eq!(
 
 ```js
 import * as login from "./path/to/generated/files/login.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
 // Were there any invalid labels?
-assert.strictEqual(0, await login.errorsByStage["server_auth"].testGetNumRecordedErrors("invalid_label"));
+assert(
+  0,
+  await login.errorsByStage.testGetNumRecordedErrors(ErrorType.InvalidLabel)
+);
 ```
 </div>
 

--- a/docs/user/reference/metrics/quantity.md
+++ b/docs/user/reference/metrics/quantity.md
@@ -306,8 +306,12 @@ assert 1 == metrics.display.width.test_get_num_recorded_errors(
 
 ```js
 import * as display from "./path/to/generated/files/display.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
-assert.strictEqual(0, await display.width.testGetNumRecordedErrors("invalid_value"));
+assert.strictEqual(
+  0,
+  await display.width.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
 ```
 
 </div>

--- a/docs/user/reference/metrics/string.md
+++ b/docs/user/reference/metrics/string.md
@@ -362,9 +362,13 @@ assert_eq!(
 
 ```js
 import * as searchDefault from "./path/to/generated/files/searchDefault.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
 // Was the string truncated, and an error reported?
-assert.strictEqual(1, await searchDefault.name.testGetNumRecordedErrors("invalid_overflow"));
+assert.strictEqual(
+  1,
+  await searchDefault.name.testGetNumRecordedErrors(ErrorType.InvalidOverflow)
+);
 ```
 </div>
 

--- a/docs/user/reference/metrics/timespan.md
+++ b/docs/user/reference/metrics/timespan.md
@@ -658,8 +658,12 @@ assert_eq!(1, login_time.test_get_num_recorded_errors(ErrorType::InvalidValue));
 
 ```js
 import * as auth from "./path/to/generated/files/auth.js";
+import { ErrorType } from "@mozilla/glean/<platform>";;
 
-assert.strictEqual(1, await auth.loginTime.testGetNumRecordedErrors("invalid_value"));
+assert.strictEqual(
+  1,
+  await auth.loginTime.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
 ```
 </div>
 <div data-lang="Firefox Desktop" class="tab" data-info="Firefox Desktop uses testGetValue to communicate errors"></div>

--- a/docs/user/reference/metrics/uuid.md
+++ b/docs/user/reference/metrics/uuid.md
@@ -429,9 +429,13 @@ assert_eq!(
 
 ```js
 import * as user from "./path/to/generated/files/user.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
 
 // Was the string truncated, and an error reported?
-assert.strictEqual(1, await user.clientId.testGetNumRecordedErrors("invalid_value"));
+assert.strictEqual(
+  1,
+  await user.clientId.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
 ```
 </div>
 


### PR DESCRIPTION
[doc only]