### PR TITLE
Downgrade to known-working version of Python/Alpine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,7 +812,8 @@ jobs:
 
   Python 3_9 on Alpine tests:
     docker:
-      - image: python:3.9-alpine
+      # FIXME(bug 1719129): Use `python:3.9-alpine` again when Docker is upgraded
+      - image: python@sha256:aded2e43ada04522e712ce507ce8a04392f8cbe047c914c5a88e4016a7141bd0
     shell: /bin/sh -leo pipefail
     environment:
       - BASH_ENV: /etc/profile


### PR DESCRIPTION
See upstream report: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
And docs: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2