### PR TITLE
No bug - Add missing telemetry_sdk_build metric to metrics.yaml

### DIFF
--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -248,7 +248,8 @@ glean.internal.metrics:
     send_in_pings:
       - glean_internal_info
     description: |
-      The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
+      The version of the Glean SDK
+      at the time the ping was collected (e.g. 25.0.0).
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1556966
     data_reviews:

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -242,6 +242,23 @@ glean.internal.metrics:
       - glean-team@mozilla.com
     expires: never
 
+  telemetry_sdk_build:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - glean_internal_info
+    description: |
+      The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1556966
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+
   seq:
     type: counter
     lifetime: user


### PR DESCRIPTION
[doc only]

Same change was necessary on Glean.js (https://github.com/mozilla/glean.js/pull/504).

I noticed this was missing because it is not listed on the Glean Dictionary. 

Note that `android_sdk_version` is also not there, but that is because the Android specific `metrics.yaml` file is not in `repositories.yaml` ([bug filed](https://bugzilla.mozilla.org/show_bug.cgi?id=1719310)).