### PR TITLE
Bug 1709285 - Add a section about metrics that should not go into client_info [ci skip]

### DIFF
--- a/docs/user/SUMMARY.md
+++ b/docs/user/SUMMARY.md
@@ -11,6 +11,7 @@
 - [Integrating Glean for project managers](user/integrating-glean-for-product-managers.md)
 - [Metrics](user/metrics/adding-new-metrics.md)
     - [Adding new metrics](user/metrics/adding-new-metrics.md)
+    - [Avoiding The Environment](user/metrics/avoiding-the-environment.md)
     - [Testing metrics](user/metrics/testing-metrics.md)
     - [Error reporting](user/metrics/error-reporting.md)
     - [Metrics collected by the Glean SDK](user/collected-metrics/metrics.md)

--- a/docs/user/user/metrics/avoiding-the-environment.md
+++ b/docs/user/user/metrics/avoiding-the-environment.md
@@ -1,0 +1,39 @@
+# FIXME(title): Avoiding the Environment
+
+The Glean SDK collects a limited amount of metrics that are generally useful across products.
+These metrics are sent in the [`client_info`][client_info] section of every ping.
+The data is provided by the embedding application or automatically fetched by the Glean SDK.
+It is collected at initialization time and sent in every ping afterwards.
+For historical reasons it contains metrics that are only useful on a certain platform.
+
+[client_info]: ../pings/index.md#the-client_info-section
+
+## Adding new metrics to `client_info`
+
+Adding new metrics maintained by the Glean SDK team will require a full proposal
+and details on why that value is useful across multiple platforms and products and needs SDK team ownership.
+
+The Glean SDK is not taking ownership of new metrics that are platform- or product-specific.
+
+## Adding new application-specific metrics
+
+New metrics can be added to products or libraries at any time.
+See [Adding new metrics](adding-new-metrics.md).
+If the recorded data should not be cleared once set the `application`-lifetime might be suitable.
+See [When should the Glean SDK automatically clear the measurement?](adding-new-metrics.md#when-should-the-glean-sdk-automatically-clear-the-measurement)
+for details.
+
+Note that due to scheduling of Glean-owned pings at early startup the data might still be missing from these pings.
+
+## Adding metrics to every ping
+
+For the majority of metrics it will probably not be necessary to be in every ping that is sent from the application,
+regardless of who controls the ping.
+Instead list out the exact pings the data should be in in the `send_in_pings` attribute for each metric.
+
+For the small number of metrics that should be in every ping the Glean SDK will provide a solution.
+See [bug FILL-IN](https://bugzilla.mozilla.org/show_bug.cgi?id=FILL-IN) for details.
+
+If you identified a bundle of related metrics that you consider useful for a wider variety of products,
+it might be a good idea to ship these as a library the products can consume.
+Please contact the Glean SDK team for any questions or help with this approach.


### PR DESCRIPTION
Time to finally add this.

Note: this is not yet in its final form.

* I added a fully new section just to get it written
  * I'm not 100% sure where it should live. Under `Metrics` is not too bad, but I can also see this living closer to the `client_info` section under Pings? Or split out the sections under Pings and then put it there?
* It lacks a proper title (and commit message)
* It lacks at least one bug number and another bug or proper description of what it takes to add new stuff to client_info