### PR TITLE
Bug 1719315 - Add documentation about the URL metric type

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 237 utf-8
+personal_ws-1.1 en 238 utf-8
 AAR
 AARs
 ABI
@@ -226,6 +226,7 @@ tooltips
 transpiler
 travis
 und
+unencoded
 unhandled
 uniffi
 uploader

--- a/docs/dev/core/internal/payload.md
+++ b/docs/dev/core/internal/payload.md
@@ -150,6 +150,16 @@ A [UUID](../../../book/reference/metrics/uuid.md) is represented by the string r
 "29711dc8-a954-11e9-898a-eb4ea7e8fd3f"
 ```
 
+### URL
+
+A [URL](../../../book/reference/metrics/url.md) is represented by the encoded string representation of the URL.
+
+#### Example
+
+```json
+"https://mysearchengine.com/?query=%25s"
+```
+
 ### Datetime
 
 A [Datetime](../../../book/reference/metrics/datetime.md) is represented by its ISO8601 string representation, truncated to the metric's time unit.

--- a/docs/user/SUMMARY.md
+++ b/docs/user/SUMMARY.md
@@ -54,6 +54,7 @@
     - [Timing Distribution](reference/metrics/timing_distribution.md)
     - [Memory Distribution](reference/metrics/memory_distribution.md)
     - [UUID](reference/metrics/uuid.md)
+    - [URL](reference/metrics/url.md)
     - [Datetime](reference/metrics/datetime.md)
     - [Event](reference/metrics/event.md)
     - [Custom Distribution](reference/metrics/custom_distribution.md)

--- a/docs/user/reference/metrics/index.md
+++ b/docs/user/reference/metrics/index.md
@@ -28,6 +28,8 @@ There are different metrics to choose from, depending on what you want to achiev
 
 * [UUID](uuid.md): Used to record universally unique identifiers (UUIDs), such as a client ID.
 
+* [URL](url.md): Used to record URL-like strings.
+
 * [Datetime](datetime.md): Used to record an absolute date and time, such as the time the user first ran the application.
 
 * [Events](event.md): Records events e.g. individual occurrences of user actions, say every time a view was open and from where.

--- a/docs/user/reference/metrics/url.md
+++ b/docs/user/reference/metrics/url.md
@@ -1,0 +1,161 @@
+# URL
+
+URL metrics allow recording URL-like[^1] strings.
+
+This metric type does not support recording [data URLs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) - please get in contact with the Glean SDK team if you're missing a type.
+
+{{#include ../../../shared/blockquote-warning.html}}
+
+## Important
+
+> Be careful using arbitrary URLs and make sure they can't accidentally contain identifying data
+> (like directory paths, user input or credentials).
+
+[^1]: The Glean SDKs specifically do not validate if a URL is fully spec compliant,
+all the validations performed are the ones listed in the
+["Recorded errors"](#recorded-errors) section of this page.
+
+## Recording API
+
+### `set`
+
+Set a URL metric to a specific string value.
+
+{{#include ../../../shared/tab_header.md}}
+<div data-lang="Kotlin" class="tab"></div>
+<div data-lang="Java" class="tab"></div>
+<div data-lang="Swift" class="tab"></div>
+<div data-lang="Python" class="tab"></div>
+<div data-lang="Rust" class="tab"></div>
+<div data-lang="JavaScript" class="tab">
+
+```js
+import * as search from "./path/to/generated/files/search.js";
+
+search.template.set("https://mysearchengine.com/");
+```
+</div>
+<div data-lang="Firefox Desktop" class="tab"></div>
+{{#include ../../../shared/tab_footer.md}}
+
+### `setUrl`
+
+Set a URL metric to a specific URL value.
+
+{{#include ../../../shared/tab_header.md}}
+<div data-lang="Kotlin" class="tab"></div>
+<div data-lang="Java" class="tab"></div>
+<div data-lang="Swift" class="tab"></div>
+<div data-lang="Python" class="tab"></div>
+<div data-lang="Rust" class="tab"></div>
+<div data-lang="JavaScript" class="tab">
+
+```js
+import * as search from "./path/to/generated/files/search.js";
+
+search.template.setUrl(new URL("https://mysearchengine.com/"));
+```
+</div>
+<div data-lang="Firefox Desktop" class="tab"></div>
+{{#include ../../../shared/tab_footer.md}}
+
+#### Recorded errors
+
+* [`invalid_value`](../../user/metrics/error-reporting.md):
+  * If the URL passed does not start with a [scheme](https://url.spec.whatwg.org/#url-representation) followed by a `:` character.
+  * If the URL passed uses the `data:` protocol.
+* [`invalid_overflow`](../../user/metrics/error-reporting.md): If the URL passed is longer than 2048 characters (before encoding).
+
+#### Limits
+
+* Fixed maximum URL length: 2048. Longer URLs are dropped.
+
+## Testing API
+
+### `testGetValue`
+
+Gets the recorded value for a given URL metric as a (unencoded) string.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab"></div>
+<div data-lang="Java" class="tab"></div>
+<div data-lang="Swift" class="tab"></div>
+<div data-lang="Python" class="tab"></div>
+<div data-lang="Rust" class="tab"></div>
+<div data-lang="JavaScript" class="tab">
+
+```js
+import * as search from "./path/to/generated/files/search.js";
+
+assert.strictEqual(, await search.template.testGetValue());
+```
+</div>
+<div data-lang="Firefox Desktop" class="tab"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+### `testGetNumRecordedErrors`
+
+Gets number of errors recorded for a given counter metric.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab"></div>
+<div data-lang="Java" class="tab"></div>
+<div data-lang="Swift" class="tab"></div>
+<div data-lang="Python" class="tab"></div>
+<div data-lang="Rust" class="tab"></div>
+<div data-lang="JavaScript" class="tab">
+
+```js
+import * as search from "./path/to/generated/files/search.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
+
+assert.strictEqual(
+  0,
+  await search.template.testGetNumRecordedErrors(ErrorType.InvalidValue)
+);
+assert.strictEqual(
+  0,
+  await search.template.testGetNumRecordedErrors(ErrorType.InvalidOverflow)
+);
+```
+</div>
+<div data-lang="Firefox Desktop" class="tab" data-info="Firefox Desktop uses testGetValue to communicate errors"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+## Metric parameters
+
+Example URL metric definition:
+
+```yaml
+search:
+  template:
+    type: url
+    description: >
+      The base URL used to build the search query for the search engine.
+    bugs:
+      - https://bugzilla.mozilla.org/000000
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=000000#c3
+    notification_emails:
+      - me@mozilla.com
+    expires: 2020-10-01
+```
+
+For a full reference on metrics parameters common to all metric types,
+refer to the metrics [YAML format](../yaml/index.md) reference page.
+
+### Extra metric parameters
+
+N/A
+
+## Data questions
+
+* What is the base URL used to build the search query for the search engine?
+
+## Reference
+
+* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_url.default.html)

--- a/docs/user/reference/metrics/url.md
+++ b/docs/user/reference/metrics/url.md
@@ -143,10 +143,20 @@ search:
     notification_emails:
       - me@mozilla.com
     expires: 2020-10-01
+    data_sensitivity:
+      - web_activity
 ```
 
 For a full reference on metrics parameters common to all metric types,
 refer to the metrics [YAML format](../yaml/index.md) reference page.
+
+{{#include ../../../shared/blockquote-warning.html}}
+
+## Note on `data_sensitivity` of URL metrics
+
+> URL metrics can only either be on categories 3 or 4, namely
+> ["Web activity data"](../yaml/metrics.md#category-3-web-activity-data-web_activity) or
+> ["Highly sensitive data"](../yaml/metrics.md#category-4-highly-sensitive-data-highly_sensitive).
 
 ### Extra metric parameters
 


### PR DESCRIPTION
Blocked until a release of Glean.js comes out with https://github.com/mozilla/glean.js/pull/529.