### PR TITLE
Bug 1719136 - Use enum for ping reason in JS ref [doc only]

### DIFF
--- a/docs/user/reference/pings/index.md
+++ b/docs/user/reference/pings/index.md
@@ -82,7 +82,7 @@ pings::search.submit(pings::SearchReasonCodes::Performed);
 ```js
 import * as pings from "./path/to/generated/files/pings.js";
 
-pings.search.submit("performed");
+pings.search.submit(pings.searchReasonCodes.Performed);
 ```
 </div>
 


### PR DESCRIPTION
~Draft until https://github.com/mozilla/glean_parser/pull/365 makes it into a release.~

Made it into [v3.8.0](https://github.com/mozilla/glean_parser/releases/tag/v3.8.0).