### PR TITLE
Android: Use correct release target when publishing  [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v40.0.0...main)
 
+* Android
+  * Updated to Kotlin 1.5, Android Gradle Plugin 4.2.2 and Gradle 6.7.1 ([#1747](https://github.com/mozilla/glean/pull/1747))
+
 # v40.0.0 (2021-07-28)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v39.1.0...v40.0.0)

--- a/glean-core/android-native/publish.gradle
+++ b/glean-core/android-native/publish.gradle
@@ -79,7 +79,7 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
         publications {
             aar(MavenPublication) {
                 project.afterEvaluate {
-                    from components.findByName("androidRelease")
+                    from components.release
                 }
                 artifact sourcesJar
                 // Can't publish Javadoc yet: Glean isn't well behaved.

--- a/glean-core/android/publish.gradle
+++ b/glean-core/android/publish.gradle
@@ -38,7 +38,7 @@ ext.configurePublish = {
         publications {
             aar(MavenPublication) {
                 project.afterEvaluate {
-                    from components.findByName("androidRelease")
+                    from components.release
                 }
                 artifact sourcesJar
                 // Can't publish Javadoc yet: Glean isn't well behaved.


### PR DESCRIPTION
Also includes a changelog entry for the kotlin upgrade.

---

full ci run on TaskCluster to ensure it works.