### PR TITLE
Do not generate markdown docs as part of Kotlin build

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -211,7 +211,6 @@ apply from: "$projectDir/publish.gradle"
 ext.configurePublish()
 
 // Generate markdown docs for the collected metrics.
-ext.gleanGenerateMarkdownDocs = true
 ext.gleanDocsDirectory = "$rootDir/docs/user/user/collected-metrics"
 ext.gleanYamlFiles = [
     "$rootDir/glean-core/metrics.yaml",


### PR DESCRIPTION
Since 186fec7d85 the generated docs include an extra header to point to
the Glean.js docs.
Because of this the file generated by the gradle plugin will always
differ from what's in the repository.

As the easy way out we just skip generating this file from Kotlin now.
It can be manually created using `make metrics-docs`, which does the
right thing.

(Alternatively we could add an post-glean plugin hook to modify the
file, but ... nah.)

[doc only]