### PR TITLE
Bug 1726765 - Force a compile failure when multiple Glean versions are detected in the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Android
   * Updated to Kotlin 1.5, Android Gradle Plugin 4.2.2 and Gradle 6.7.1 ([#1747](https://github.com/mozilla/glean/pull/1747))
+  * The `glean-gradle-plugin` now forces a compile failure when multiple Glean versions are detected in the build ([#1756](https://github.com/mozilla/glean/pull/1756))
 
 # v40.0.0 (2021-07-28)
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -567,6 +567,16 @@ except:
                 }
                 because 'use GeckoView Glean instead of standalone Glean'
             }
+
+            incoming.afterResolve {
+                resolutionResult.allComponents {
+                    if (selectionReason.conflictResolution && moduleVersion != null) {
+                        if (moduleVersion.group.contains("org.mozilla.telemetry") && moduleVersion.name.contains("glean")) {
+                            throw AssertionError("Cannot have a conflict on Glean ${selectionReason}")
+                        }
+                    }
+                }
+            }
         }
 
         if (project.android.hasProperty('applicationVariants')) {


### PR DESCRIPTION
Because of the native code shipped it's essential that all downstream
users rely on the same Glean version.
Gradle can be overeager in chosing a single version when multiple are in
the dependency tree, always picking the latest, even across potentially
breaking-change (that is: major) releases.

Gradle has a way to influence dependency resolution and can even
disallow differing versions using `failOnVersionConflict`.
But that applies to all dependencies and there's no native way to
enforce that for a single dependency.
So the recommended solution[1] is to "manually" check if a dependency was
resolved from multiple versions and raise an issue.

For the ease of consumption by users, such as Fenix, we can apply this
in the Gradle plugin, because that's guaranteed to execute as part of
the build (because if not how are they even using Glean?)

[1]: https://github.com/gradle/gradle/issues/8813

---

Once landed this will go into a release.