### PR TITLE
Have quantity docs skip a non-counter example for counters [doc only]

### DIFF
--- a/docs/user/reference/metrics/quantity.md
+++ b/docs/user/reference/metrics/quantity.md
@@ -7,9 +7,8 @@ For example, the width of the display in pixels.
 
 ## Do not use Quantity for counting
 
-> If you need to _count_ something (e.g. number of tabs open or number of times a button is pressed)
-> prefer using the [Counter](./counter.md) metric type, which has a specific API for counting things
-> and also takes care of resetting the count at the correct time.
+> If you need to _count_ something (e.g. the number of times a button is pressed)
+> prefer using the [Counter](./counter.md) metric type, which has a specific API for counting things.
 
 ## Recording API
 


### PR DESCRIPTION
And nix the bit about clearing values. That's a lifetime thing, not a "counter vs quantity" thing.