### PR TITLE
Upgrade to glean_parser v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v40.1.1...main)
 
+* General
+  * Updated `glean_parser` version to 4.0.0
+
 # v40.1.1 (2021-09-02)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v40.1.0...v40.1.1)

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ python-docs: build-python ## Build the Python documentation
 .PHONY: docs rust-docs swift-docs
 
 metrics-docs: python-setup ## Build the internal metrics documentation
-	$(GLEAN_PYENV)/bin/pip install glean_parser==3.6.0
+	$(GLEAN_PYENV)/bin/pip install glean_parser==4.0.0
 	$(GLEAN_PYENV)/bin/glean_parser translate --allow-reserved \
 		 -f markdown \
 		 -o ./docs/user/user/collected-metrics \

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [package.metadata.glean]
-glean-parser = "3.6.0"
+glean-parser = "4.0.0"
 
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "main" }

--- a/glean-core/csharp/Glean/GleanParser.cs
+++ b/glean-core/csharp/Glean/GleanParser.cs
@@ -18,7 +18,7 @@ namespace GleanTasks
         private const string DefaultVirtualEnvDir = ".venv";
 
         // The glean_parser pypi package version 
-        private const string GleanParserVersion = "3.6.0";
+        private const string GleanParserVersion = "4.0.0";
 
         // This script runs a given Python module as a "main" module, like
         // `python -m module`. However, it first checks that the installed

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=3.6.0
+GLEAN_PARSER_VERSION=4.0.0
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034

--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -30,7 +30,7 @@ __author__ = "The Glean Team"
 __email__ = "glean-team@mozilla.com"
 
 
-GLEAN_PARSER_VERSION = "3.6.0"
+GLEAN_PARSER_VERSION = "4.0.0"
 
 
 if glean_parser.__version__ != GLEAN_PARSER_VERSION:

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -60,7 +60,7 @@ version = "40.1.1"
 
 requirements = [
     "cffi>=1.13.0",
-    "glean_parser==3.6.0",
+    "glean_parser==4.0.0",
     "iso8601>=0.1.10; python_version<='3.6'",
 ]
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -41,7 +41,7 @@ class GleanMetricsYamlTransform extends ArtifactTransform {
 @SuppressWarnings("GrPackage")
 class GleanPlugin implements Plugin<Project> {
     // The version of glean_parser to install from PyPI.
-    private String GLEAN_PARSER_VERSION = "3.6.0"
+    private String GLEAN_PARSER_VERSION = "4.0.0"
     // The version of Miniconda is explicitly specified.
     // Miniconda3-4.5.12 is known to not work on Windows.
     private String MINICONDA_VERSION = "4.5.11"


### PR DESCRIPTION
Notable changes:

* Reserve the default ping name. It can't be used as a ping name, but it can be used in send_in_pings
* New lint: Check for redundant words in ping names

---

Nothing significant for Glean, but doing that update now to see if it all continues to work (especially with the new lints)