### PR TITLE
[doc only] Fix typo in iOS debug command docs

### DIFF
--- a/docs/user/user/debugging/ios.md
+++ b/docs/user/user/debugging/ios.md
@@ -37,7 +37,7 @@ There are a few things to consider when creating the custom URL:
 - Invalid commands will log an error and cause the entire URL to be ignored.
 - Not all commands are required to be encoded in the URL, you can mix and match the commands that you need.
 - Multiple instances of commands are not allowed in the same URL and, if present, will cause the entire URL to be ignored.
-- The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPings` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
+- The `logPings` command doesn't trigger ping submission and you won't see any output until a ping has been submitted. You can use the `sendPing` command to force a ping to be sent, but it could be more desirable to trigger the pings submission on their normal schedule. For instance, the `baseline` and `events` pings can be triggered by moving the app out of the foreground and the `metrics` ping can be triggered normally if it is overdue for the current calendar day. See the [ping documentation](../pings/index.md) for more information on ping scheduling to learn when pings are sent.
 - Enabling debugging features through custom URLs overrides any debugging features set through environment variables.
 
 ### Instrumenting the application for Glean SDK debug functionality


### PR DESCRIPTION
Fixes a typo in the iOS debugging docs changing `sendPings` to the proper `sendPing`