### PR TITLE
Android: Ensure native library is built & bundled [ci full]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,15 +127,18 @@ ext.rustTargets = [
 // Generate libs for our current platform so we can run unit tests.
 switch (DefaultPlatform.RESOURCE_PREFIX) {
     case 'darwin':
-        ext.rustTargets += 'darwin'
+    case 'darwin-x86-64':
+    case 'darwin-aarch64':
+        ext.nativeRustTarget = 'darwin'
         break
     case 'linux-x86-64':
-        ext.rustTargets += 'linux-x86-64'
+        ext.nativeRustTarget = 'linux-x86-64'
         break
     case 'win32-x86-64':
-        ext.rustTargets += 'win32-x86-64-msvc'
+        ext.nativeRustTarget = 'win32-x86-64-gnu'
         break
 }
+ext.rustTargets += ext.nativeRustTarget
 
 subprojects {
     apply plugin: 'digital.wup.android-maven-publish'

--- a/glean-core/android-native/build.gradle
+++ b/glean-core/android-native/build.gradle
@@ -92,9 +92,15 @@ dependencies {
     implementation "net.java.dev.jna:jna:$versions.jna@aar"
 }
 
-tasks.whenTaskAdded { task ->
-    if ((task.name == 'javaPreCompileDebug' || task.name == 'javaPreCompileRelease')) {
-        task.dependsOn 'cargoBuild'
+afterEvaluate {
+    // The `cargoBuild` task isn't available until after evaluation.
+    android.libraryVariants.all { variant ->
+        def productFlavor = ""
+        variant.productFlavors.each {
+            productFlavor += "${it.name.capitalize()}"
+        }
+        def buildType = "${variant.buildType.name.capitalize()}"
+        tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
     }
 }
 

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -191,6 +191,21 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$versions.androidx_espresso"
 }
 
+evaluationDependsOn(":glean-native")
+afterEvaluate {
+  // The `cargoBuild` task isn't available until after evaluation.
+  android.libraryVariants.all { variant ->
+      def productFlavor = ""
+      variant.productFlavors.each {
+          productFlavor += "${it.name.capitalize()}"
+      }
+
+      def buildType = "${variant.buildType.name.capitalize()}"
+      def nativeCargoBuildTask = "cargoBuild${rootProject.ext.nativeRustTarget.capitalize()}"
+      tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(project(':glean-native').tasks[nativeCargoBuildTask])
+  }
+}
+
 apply from: "$projectDir/publish.gradle"
 ext.configurePublish()
 


### PR DESCRIPTION
Revert of 3cfa1bc3178faeb4e831e455ad842a8c1e7bd64b with slight
adjustements: local tests will now only build the host target, because
that's all we need.