### PR TITLE
Bug 1731963 - Document that it is unnecessary to check if Glean is enabled before submitting pings

### DIFF
--- a/docs/user/reference/pings/index.md
+++ b/docs/user/reference/pings/index.md
@@ -1,20 +1,24 @@
 # Pings
 
-## Submission API
-
-### `submit`
-Collect and queue a custom ping for eventual uploading.
-
 {{#include ../../../shared/blockquote-info.html}}
 
-##### Glean-owned pings are submitted automatically
+#### Glean-owned pings are submitted automatically
 
 > Products do not need to submit Glean built-in pings,
 > as their scheduling is managed internally. The APIs
 > on this page are only relevant for products defining
 > [custom pings](../../user/pings/custom.md#defining-a-custom-ping).
 
-By default, if the ping doesn't currently have any events or metrics set, `submit` will do nothing.  However, if the `send_if_empty` flag is set to true in the ping definition, it will always be submitted.
+## Submission API
+
+### `submit`
+
+Collect and queue a custom ping for eventual uploading.
+
+By default, if the ping doesn't currently have any events or metrics set, `submit` will do nothing. However, if the `send_if_empty` flag is set to true in the ping definition, it will always be submitted.
+
+It is not necessary for the caller to check if Glean is disabled before calling `submit`.
+If Glean is disabled `submit` is a no-op.
 
 For example, to submit the custom ping defined in [Adding new custom pings](../../user/pings/custom.md#defining-a-custom-ping):
 
@@ -103,8 +107,6 @@ GleanPings.search.submit("performed");
 </div>
 
 {{#include ../../../shared/tab_footer.md}}
-
-If none of the metrics for the ping contain data the ping is not sent (unless `send_if_empty` is set to true in the definition file)
 
 ## Testing API
 


### PR DESCRIPTION
I also removed a redundant paragraph from the bottom of the "Submission API" section and moved the info box related to built-in pings to the top of the page.