### PR TITLE
bug 1732988 - Make glean::persist_ping_lifetime_data async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Remove reliance on `Operation` for uploading and instead use the background capabilities of `URLSession` ([#1783](https://github.com/mozilla/glean/pull/1783))
 * Rust
   * BUGFIX: No panic if trying to flush ping-lifetime data after shutdown ([#1800](https://github.com/mozilla/glean/pull/1800))
+  * BREAKING CHANGE: `glean::persist_ping_lifetime_data` is now async ([#1812](https://github.com/mozilla/glean/pull/1812))
 
 # v41.1.1 (2021-09-29)
 

--- a/glean-core/rlb/tests/persist_ping_lifetime_nopanic.rs
+++ b/glean-core/rlb/tests/persist_ping_lifetime_nopanic.rs
@@ -37,8 +37,10 @@ fn delayed_ping_data() {
     let tmpname = dir.path().to_path_buf();
 
     common::initialize(cfg_new(tmpname));
-    assert!(glean::persist_ping_lifetime_data().is_ok());
+    glean::persist_ping_lifetime_data();
 
+    // This flushes the queue, including the ping lifetime persist.
     glean::shutdown();
-    assert!(glean::persist_ping_lifetime_data().is_err());
+    // This shouldn't panic.
+    glean::persist_ping_lifetime_data();
 }


### PR DESCRIPTION
By its nature, persist_ping_lifetime_data performs I/O.
To be consistent across our public API surface, we should dispatch the call.