### PR TITLE
Extend general API with logging and setUploadEnabled

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 import mozilla.telemetry.glean.GleanMetrics.GleanBaseline
 import mozilla.telemetry.glean.internal.Configuration as GleanConfiguration
 import mozilla.telemetry.glean.internal.initialize as gleanInitialize
-import mozilla.telemetry.glean.internal.gleanEnableLogging
+import mozilla.telemetry.glean.internal.enableLogging
 import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.config.FfiConfiguration
 import mozilla.telemetry.glean.utils.getLocaleTag
@@ -168,7 +168,7 @@ open class GleanInternalAPI internal constructor () {
         this.gleanDataDir = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR)
 
         Log.e(LOG_TAG, "Glean. enable logging.")
-        gleanEnableLogging()
+        enableLogging()
         // Execute startup off the main thread.
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.executeTask {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/UniffiTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/UniffiTest.kt
@@ -77,5 +77,7 @@ class UniffiTest {
         ))
 
         counterMetric.add()
+
+        assertEquals(1, counterMetric.testGetValue())
     }
 }

--- a/glean-core/uniffi/src/core/mod.rs
+++ b/glean-core/uniffi/src/core/mod.rs
@@ -47,6 +47,15 @@ where
     f(&lock)
 }
 
+pub fn with_glean_mut<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut Glean) -> R,
+{
+    let glean = global_glean().expect("Global Glean object not initialized");
+    let mut lock = glean.lock().unwrap();
+    f(&mut lock)
+}
+
 #[derive(Debug)]
 pub struct Glean {
     upload_enabled: bool,
@@ -94,5 +103,9 @@ impl Glean {
         };
 
         Ok(this)
+    }
+
+    pub fn set_upload_enabled(&mut self, enabled: bool) {
+        self.upload_enabled = enabled;
     }
 }

--- a/glean-core/uniffi/src/glean_core.udl
+++ b/glean-core/uniffi/src/glean_core.udl
@@ -1,7 +1,9 @@
 namespace glean {
     boolean initialize(Configuration cfg);
 
-    void glean_enable_logging();
+    void enable_logging();
+
+    void set_upload_enabled(boolean enabled);
 };
 
 dictionary Configuration {

--- a/glean-core/uniffi/src/glean_core.udl
+++ b/glean-core/uniffi/src/glean_core.udl
@@ -38,4 +38,6 @@ interface CounterMetric {
     constructor(CommonMetricData meta);
 
     void add(optional i32 amount = 1);
+
+    i32? test_get_value(optional string? ping_name = null);
 };

--- a/glean-core/uniffi/src/lib.rs
+++ b/glean-core/uniffi/src/lib.rs
@@ -4,8 +4,8 @@
 
 uniffi_macros::include_scaffolding!("glean_core");
 
-mod core;
 mod common_metric_data;
+mod core;
 mod private;
 
 pub use crate::core::Glean;
@@ -34,12 +34,12 @@ pub struct Configuration {
 }
 
 pub fn initialize(cfg: Configuration) -> bool {
-    Glean::new(cfg).and_then(|glean| {
-        core::setup_glean(glean)
-    }).is_ok()
+    Glean::new(cfg)
+        .and_then(|glean| core::setup_glean(glean))
+        .is_ok()
 }
 
-pub fn glean_enable_logging() {
+pub fn enable_logging() {
     #[cfg(target_os = "android")]
     {
         let _ = std::panic::catch_unwind(|| {
@@ -62,4 +62,8 @@ pub fn glean_enable_logging() {
             Err(_) => log::warn!("stdout logging was already initialized"),
         };
     }
+}
+
+pub fn set_upload_enabled(enabled: bool) {
+    core::with_glean_mut(|glean| glean.set_upload_enabled(enabled))
 }

--- a/glean-core/uniffi/src/private/counter.rs
+++ b/glean-core/uniffi/src/private/counter.rs
@@ -2,25 +2,40 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{Glean, CommonMetricData};
+use crate::{CommonMetricData, Glean};
+use std::sync::atomic::{AtomicI32, Ordering};
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CounterMetric {
     meta: CommonMetricData,
+    count: AtomicI32,
 }
 
 impl CounterMetric {
     /// The public constructor used by automatically generated metrics.
     pub fn new(meta: CommonMetricData) -> Self {
-        Self { meta }
+        Self {
+            meta,
+            count: AtomicI32::new(0),
+        }
     }
 
     /// Internal only, synchronous API for incremeting a counter
     pub(crate) fn add_sync(&self, _glean: &Glean, amount: i32) {
-        log::info!("Counter({:?}).add({})", self.meta, amount)
+        log::info!("Counter({:?}).add({})", self.meta, amount);
+        self.count.fetch_add(amount, Ordering::SeqCst);
     }
 
     pub fn add(&self, amount: i32) {
         crate::core::with_glean(|glean| self.add_sync(glean, amount))
+    }
+
+    pub fn test_get_value(&self, _ping_name: Option<String>) -> Option<i32> {
+        let val = self.count.load(Ordering::SeqCst);
+        if val > 0 {
+            Some(val)
+        } else {
+            None
+        }
     }
 }


### PR DESCRIPTION
This creates a new crate `glean-uniffi` that will be consumed by the
different foreign-language SDKs.
Eventually `glean-core` and `glean` should go away and be merged into
that `glean-uniffi`

---

This is the first PR against the `uniffi` branch.
It doesn't do much, except

* Fixing up the general API just slightly
* Extending the counter metric and implementing it (I accidentally committed the minimal counter API definition before).

Might not fully compile just yet.