### PR TITLE
Bug 1733757 - Store created label metrics to avoid rapidly reconstructing them all …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v42.0.0...main)
 
+* General
+  * BUGFIX: Avoid a crash when accessing labeled metrics by caching created objects ([#1823](https://github.com/mozilla/glean/pull/1823)).
+
 # v42.0.0 (2021-10-06)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v41.1.1...v42.0.0)
@@ -78,8 +81,8 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v39.1.0...v40.0.0)
 
 * Android
-  * **Breaking Change**: Split the Glean Kotlin SDK into two packages: `glean` and `glean-native` ([#1595](https://github.com/mozilla/glean/pull/1595)).  
-    Consumers will need to switch to `org.mozilla.telemetry:glean-native-forUnitTests`.  
+  * **Breaking Change**: Split the Glean Kotlin SDK into two packages: `glean` and `glean-native` ([#1595](https://github.com/mozilla/glean/pull/1595)).
+    Consumers will need to switch to `org.mozilla.telemetry:glean-native-forUnitTests`.
     Old code in `build.gradle`:
 
     ```

--- a/glean-core/ios/Glean/Metrics/BooleanMetric.swift
+++ b/glean-core/ios/Glean/Metrics/BooleanMetric.swift
@@ -39,13 +39,6 @@ public class BooleanMetricType {
         self.sendInPings = sendInPings
     }
 
-    /// Destroy this metric.
-    deinit {
-        if self.handle != 0 {
-            glean_destroy_boolean_metric(self.handle)
-        }
-    }
-
     /// Set a boolean value.
     ///
     /// - parameters:

--- a/glean-core/ios/Glean/Metrics/CounterMetric.swift
+++ b/glean-core/ios/Glean/Metrics/CounterMetric.swift
@@ -39,13 +39,6 @@ public class CounterMetricType {
         self.sendInPings = sendInPings
     }
 
-    /// Destroy this metric.
-    deinit {
-        if self.handle != 0 {
-            glean_destroy_counter_metric(self.handle)
-        }
-    }
-
     /// Add to counter value.
     ///
     /// - parameters:

--- a/glean-core/ios/Glean/Metrics/StringMetric.swift
+++ b/glean-core/ios/Glean/Metrics/StringMetric.swift
@@ -39,13 +39,6 @@ public class StringMetricType {
         self.sendInPings = sendInPings
     }
 
-    /// Destroy this metric.
-    deinit {
-        if self.handle != 0 {
-            glean_destroy_string_metric(self.handle)
-        }
-    }
-
     /// Set a string value.
     ///
     /// - parameters:

--- a/glean-core/python/glean/metrics/boolean.py
+++ b/glean-core/python/glean/metrics/boolean.py
@@ -44,10 +44,6 @@ class BooleanMetricType:
             disabled,
         )
 
-    def __del__(self):
-        if getattr(self, "_handle", 0) != 0:
-            _ffi.lib.glean_destroy_boolean_metric(self._handle)
-
     def set(self, value: bool) -> None:
         """
         Set a boolean value.

--- a/glean-core/python/glean/metrics/counter.py
+++ b/glean-core/python/glean/metrics/counter.py
@@ -47,10 +47,6 @@ class CounterMetricType:
             disabled,
         )
 
-    def __del__(self):
-        if getattr(self, "_handle", 0) != 0:
-            _ffi.lib.glean_destroy_counter_metric(self._handle)
-
     def add(self, amount: int = 1) -> None:
         """
         Add to counter value.

--- a/glean-core/python/glean/metrics/event.py
+++ b/glean-core/python/glean/metrics/event.py
@@ -127,7 +127,9 @@ class EventMetricType:
         if getattr(self, "_handle", 0) != 0:
             _ffi.lib.glean_destroy_event_metric(self._handle)
 
-    def record(self, extra: Optional[Union[Dict[int, str], EventExtras]] = None) -> None:
+    def record(
+        self, extra: Optional[Union[Dict[int, str], EventExtras]] = None
+    ) -> None:
         """
         Record an event by using the information provided by the instance of
         this class.

--- a/glean-core/python/glean/metrics/string.py
+++ b/glean-core/python/glean/metrics/string.py
@@ -47,10 +47,6 @@ class StringMetricType:
             disabled,
         )
 
-    def __del__(self):
-        if getattr(self, "_handle", 0) != 0:
-            _ffi.lib.glean_destroy_string_metric(self._handle)
-
     def set(self, value: str) -> None:
         """
         Set a string value.

--- a/glean-core/python/tests/metrics/test_event.py
+++ b/glean-core/python/tests/metrics/test_event.py
@@ -318,7 +318,8 @@ def test_event_enum_is_generated_correctly():
 
 def test_event_extra_is_generated_correctly():
     metrics = load_metrics(
-        ROOT.parent / "data" / "events_with_types.yaml", config={"allow_reserved": False}
+        ROOT.parent / "data" / "events_with_types.yaml",
+        config={"allow_reserved": False},
     )
 
     metrics.core.preference_toggled.record(
@@ -333,7 +334,9 @@ def test_event_extra_is_generated_correctly():
 
 def test_the_convenient_extrakeys_api():
     class ClickKeys(metrics.EventExtras):
-        def __init__(self, object_id: Optional[str] = None, other: Optional[str] = None) -> None:
+        def __init__(
+            self, object_id: Optional[str] = None, other: Optional[str] = None
+        ) -> None:
             self._object_id = object_id
             self._other = other
 
@@ -390,7 +393,8 @@ def test_the_convenient_extrakeys_api():
 
 def test_event_extra_does_typechecks():
     metrics = load_metrics(
-        ROOT.parent / "data" / "events_with_types.yaml", config={"allow_reserved": False}
+        ROOT.parent / "data" / "events_with_types.yaml",
+        config={"allow_reserved": False},
     )
 
     # Valid combinations of extras.
@@ -398,7 +402,9 @@ def test_event_extra_does_typechecks():
     metrics.core.PreferenceToggledExtra(preference="value1")
     metrics.core.PreferenceToggledExtra(enabled=True)
     metrics.core.PreferenceToggledExtra(swapped=1)
-    extras = metrics.core.PreferenceToggledExtra(preference="value1", enabled=True, swapped=1)
+    extras = metrics.core.PreferenceToggledExtra(
+        preference="value1", enabled=True, swapped=1
+    )
     # Check conversion to FFI types, extras are sorted by name
     ffi = extras.to_ffi_extra()
     expected = ([0, 1, 2], ["true", "value1", "1"])


### PR DESCRIPTION
…the time

This fixes a crashing bug, that probably started being an issue since
March 2020 / Glean v26, when we removed finalizers from the Kotlin
library[1]. Depending on how GC runs it was theoretically possible to
hit that even with finalizers in the SDK.

Contrary to the commit message in [1] we do have one more place where we
dynamically construct metrics: Labeled Metrics!
It used to be the case that whenever you access the submetric of a
labeled metric, that is `Metrics.Category.Name["label"]`, we created a
new Rust object, put that into the internal ConcurrentHandleMap and
returned a handle to it.

A ConcurrentHandleMap does a lot of work to ensure that you can't misuse
handles against the wrong map, when the item was already replaced, etc.
It also sets an upper limit of entries it can handle[2].
That limit is high enough for the static use of Rust (you would have to
use 32767+ metrics of a single type), but quickly[3] breaks down

The solution is to not re-create labeled submetrics on every access.
We cache those ourselves now, identified by the parent's metric handle
and the label.
Now accessing the same label 32768+ times is fine, you get the same
Rust object every time (as long as it exists).

There's one last piece: We do expose a way to destroy metrics, even if
that shouldn't happen for any statically defined ones.
This is not happening on Kotlin, where we removed finalizers some time
ago [1].
We're now removing those finalizers on Swift and Python as well.
We could try to get smart and do some double-checks that the handle is
not stale when the submetric is accessed.
But that breaks down quickly, because the metric could be destroyed
between the access and the recording, still leading to issues.
The only way to handle that would be some reference counting on the
object itself, but the current implementation doens't easily allow that.
So for now we just don't destroy boolean/counter/string metrics, ever.

The included tests fail without the corresponding library changes,
giving us a bit more confidence that the fix works.

Now there's still one way to trigger a crash, in theory:
Keep accessing previously-unused labels 32768+ times.
If you do that you're really on your own.

[1]: https://github.com/mozilla/glean/commit/25bf9ea0b26791f80235e2a421884ee63aae2326
[2]: https://github.com/mozilla/ffi-support/blob/0fdc22a8dfe3731be5fd39b311e4e4885219e26c/src/handle_map.rs#L160-L166
[3]: Well, "quickly". Reproducing that on get.webgl.org takes 8+ minutes.