### PR TITLE
Use ios-sim target on Rust stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,11 +543,6 @@ jobs:
             gem env
       - install-rustup
       - setup-rust-toolchain
-      - run:
-          name: Install Rust Nightly toolchain
-          command: |
-            rustup toolchain add nightly --profile minimal
-            rustup target add aarch64-apple-ios-sim --toolchain nightly
       - restore_cache:
           name: Restore rubygems cache
           key: swift-docs-gems-v10
@@ -563,7 +558,7 @@ jobs:
       - run:
           name: Setup build environment
           command: |
-            rustup target add aarch64-apple-ios x86_64-apple-ios
+            rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 
             # Bootstrap dependencies
             bin/bootstrap.sh
@@ -657,7 +652,7 @@ jobs:
       - run:
           name: Setup build environment
           command: |
-            rustup target add aarch64-apple-ios x86_64-apple-ios
+            rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 
             # List available devices -- allows us to see what's there
             DEVICES=$(xcrun xctrace list devices 2>&1)
@@ -665,14 +660,6 @@ jobs:
             # Pick a device and start it
             UDID=$(echo "$DEVICES" | grep 'iPhone 11 Simulator (14' | awk -F'[()]' '{print $4}')
             xcrun simctl boot "$UDID"
-      - run:
-          name: Install Rust Nightly toolchain
-          command: |
-            # Need a nightly toolchain and the source code for targetting the arm64 iOS simulator
-            # We don't need that build on CI, but its hard to exclude it from the build
-            # while still allowing it in developer builds.
-            rustup toolchain add nightly --profile minimal
-            rustup target add aarch64-apple-ios-sim --toolchain nightly
       - run:
           name: Use current commit of Glean
           command: |

--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -55,7 +55,7 @@ for arch in $ARCHS; do
         $HOME/.cargo/bin/cargo build -p $FFI_TARGET --lib $RELFLAG --target aarch64-apple-ios
       else
         # M1 iOS simulator -- currently in Nightly only and requires to build `libstd`
-        $HOME/.cargo/bin/cargo +nightly build -p $FFI_TARGET --lib $RELFLAG --target aarch64-apple-ios-sim
+        $HOME/.cargo/bin/cargo build -p $FFI_TARGET --lib $RELFLAG --target aarch64-apple-ios-sim
       fi
   esac
 done


### PR DESCRIPTION
[Rust 1.56.0](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html) is here and with it the ios-sim target on stable.