### PR TITLE
Implement `setUploadEnabled` using a callback mechanism

### DIFF
--- a/glean-core/uniffi/src/glean.udl
+++ b/glean-core/uniffi/src/glean.udl
@@ -4,12 +4,23 @@ namespace glean {
 
     void glean_enable_logging();
 
-    void glean_set_upload_enabled(boolean enabled);
+    void glean_set_upload_enabled(boolean enabled, OnUploadEnabledChanges changes_callback);
 
     // Experiment reporting API
     void glean_set_experiment_active(string experiment_id, string branch, record<DOMString, string> extra);
     void glean_set_experiment_inactive(string experiment_id);
     RecordedExperiment? glean_test_get_experiment_data(string experiment_id);
+};
+
+callback interface OnUploadEnabledChanges {
+    // Called when upload is to be disabled
+    void will_be_disabled();
+
+    // Called when upload was toggled from off to on.
+    void on_enabled();
+
+    // Called when upload was toggled from on to off.
+    void on_disabled();
 };
 
 dictionary RecordedExperiment {


### PR DESCRIPTION
`setUploadEnabled` is a bit more complex than just flipping the `uploadEnabled` bit.

Before disabling upload we want any upload operation to be stopped.
The Metrics ping scheduler need to be cancelled too.

If upload is not actually changed no further action is required.

If upload is changed from on to off we need to trigger the uploader
once more to upload a deletion request ping.
If upload is changed from off to on we need to set the core metrics
again, which includes data from the application.

All of that should run in the dispatcher for 2 reasons:
* Not blocking the application
* Running in the expected order with other Glean recording operations

To keep most of current logic we can use callbacks on each of these cases.

The alternative to this would be:
* Store the required data for core metrics on the Rust side on
  initialization time.
* Store a general callback to trigger the uploader/cancel the uploader
  at initialization time.
* Make `setUploadEnabled` handle all of it in Rust using the previous
  set data/callbacks instead of relying on new ones.