### PR TITLE
[doc only] Add in labeling and doc only info

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -76,7 +76,7 @@ When submitting a PR:
 - Base your branch off the current `main`.
 - Add both your code and new tests if relevant.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
-- When submitting a PR for a bug, label the PR "Bug XXXXX"
+- When submitting a PR for a bug, label the PR "Bug <Insert bug number here>"
 - When committing a PR and when it makes sense to skip the CI, add in a `doc only` annotation to the commit message
 
 ## Code Review

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -77,7 +77,7 @@ When submitting a PR:
 - Add both your code and new tests if relevant.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 - When submitting a PR for a bug, label the PR "Bug <Insert bug number here>"
-- When committing a PR and when it makes sense to skip the CI, add in a `doc only` annotation to the commit message
+- When committing a PR and when it makes sense to skip the CI, add in a `[doc only]` annotation to the commit message
 
 ## Code Review
 

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -76,6 +76,8 @@ When submitting a PR:
 - Base your branch off the current `main`.
 - Add both your code and new tests if relevant.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
+- When submitting a PR for a bug, label the PR "Bug XXXXX"
+- When committing a PR and when it makes sense to skip the CI, add in a `doc only` annotation to the commit message
 
 ## Code Review
 


### PR DESCRIPTION
These two parts of the bug have not been addressed:

- Only explains how to run the Kotlin and Switf tests
- Mentions a CODEOWNERS file which does not exist