### PR TITLE
Use in-tree references for the YAML format documentation

### DIFF
--- a/docs/user/appendix/glossary.md
+++ b/docs/user/appendix/glossary.md
@@ -43,7 +43,7 @@ Glean provides additional tools for its usage:
 ## Metric
 
 Metrics are the individual things being measured using Glean.
-They are defined in [metrics.yaml](https://mozilla.github.io/glean_parser/metrics-yaml.html) files, also known as _registry files_.
+They are defined in [metrics.yaml](../reference/yaml/metrics.md) files, also known as _registry files_.
 
 Glean itself provides [some metrics out of the box](../user/collected-metrics/metrics.md).
 

--- a/docs/user/user/metrics/adding-new-metrics.md
+++ b/docs/user/user/metrics/adding-new-metrics.md
@@ -164,7 +164,7 @@ dashboard when that's ready
 
 ## Adding the metric to the `metrics.yaml` file
 
-The [`metrics.yaml` file](https://mozilla.github.io/glean_parser/metrics-yaml.html) defines the metrics your application or library will send.
+The [`metrics.yaml` file](../../reference/yaml/metrics.md) defines the metrics your application or library will send.
 They are organized into categories.
 The overall organization is:
 

--- a/docs/user/user/pings/custom.md
+++ b/docs/user/user/pings/custom.md
@@ -8,7 +8,7 @@ This is especially useful when metrics need to be tightly related to one another
 
 ## Defining a custom ping
 
-Custom pings must be defined in a [`pings.yaml` file](https://mozilla.github.io/glean_parser/pings-yaml.html), placed in the same directory alongside your app's `metrics.yaml` file.
+Custom pings must be defined in a [`pings.yaml` file](../../reference/yaml/pings.md), placed in the same directory alongside your app's `metrics.yaml` file.
 
 For example, to define a custom ping called `search` specifically for search information:
 

--- a/docs/user/user/pings/metrics.md
+++ b/docs/user/user/pings/metrics.md
@@ -42,7 +42,7 @@ See also the [ping schedules and timing overview](ping-schedules-and-timings.htm
 
 ## Contents
 
-The `metrics` ping contains all of the metrics defined in `metrics.yaml` (except events) that don't specify a ping or where `default` is specified in their [`send in pings`](https://mozilla.github.io/glean_parser/metrics-yaml.html#send-in-pings) property.
+The `metrics` ping contains all of the metrics defined in `metrics.yaml` (except events) that don't specify a ping or where `default` is specified in their [`send in pings`](../../reference/yaml/metrics.md#send_in_pings) property.
 
 Additionally, error metrics in the `glean.error` category are included in the `metrics` ping.
 


### PR DESCRIPTION
The glean_parser documentation just redirects back to this, so let's
save our users some trouble. We still link to the glean_parser
documentation for the actual schema definition.
