### PR TITLE
Implement client activity API

### DIFF
--- a/glean-core/uniffi/src/core/mod.rs
+++ b/glean-core/uniffi/src/core/mod.rs
@@ -292,4 +292,32 @@ impl Glean {
     pub(crate) fn log_pings(&self) -> bool {
         self.debug.log_pings.get().copied().unwrap_or(false)
     }
+
+    /// Performs the collection/cleanup operations required by becoming active.
+    ///
+    /// This functions generates a baseline ping with reason `active`
+    /// and then sets the dirty bit.
+    pub fn handle_client_active(&mut self) {
+        //if !self.internal_pings.baseline.submit(self, Some("active")) {
+        //    log::info!("baseline ping not submitted on active");
+        //}
+
+        //self.set_dirty_flag(true);
+    }
+
+    /// Performs the collection/cleanup operations required by becoming inactive.
+    ///
+    /// This functions generates a baseline and an events ping with reason
+    /// `inactive` and then clears the dirty bit.
+    pub fn handle_client_inactive(&mut self) {
+        //if !self.internal_pings.baseline.submit(self, Some("inactive")) {
+        //    log::info!("baseline ping not submitted on inactive");
+        //}
+
+        //if !self.internal_pings.events.submit(self, Some("inactive")) {
+        //    log::info!("events ping not submitted on inactive");
+        //}
+
+        //self.set_dirty_flag(false);
+    }
 }

--- a/glean-core/uniffi/src/glean.udl
+++ b/glean-core/uniffi/src/glean.udl
@@ -14,6 +14,13 @@ namespace glean {
     boolean glean_set_debug_view_tag(string tag);
     boolean glean_set_source_tags(sequence<string> tags);
     void glean_set_log_pings(boolean value);
+
+    void glean_handle_client_active(OnTriggerUpload callback);
+    void glean_handle_client_inactive(OnTriggerUpload callback);
+};
+
+callback interface OnTriggerUpload {
+    void trigger_upload();
 };
 
 callback interface OnUploadEnabledChanges {


### PR DESCRIPTION
This now makes me believe I _should_ store a general callback to trigger the uploader, just to avoid passing a new callback all the time