### PR TITLE
Remove Xcode 12 hack

### DIFF
--- a/bin/build-carthage.sh
+++ b/bin/build-carthage.sh
@@ -10,8 +10,6 @@ FRAMEWORK_NAME="${1:-Glean}"
 CONFIGURATION="${2:-Release}"
 
 WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
-XCODE_XCCONFIG_FILE="$WORKSPACE_ROOT/xcconfig/xcode-12-fix-carthage-lipo.xcconfig"
-export XCODE_XCCONFIG_FILE
 
 set -o pipefail && \
     carthage build --archive --platform iOS --cache-builds --verbose --configuration "${CONFIGURATION}" "${FRAMEWORK_NAME}" | \

--- a/xcconfig/xcode-12-fix-carthage-lipo.xcconfig
+++ b/xcconfig/xcode-12-fix-carthage-lipo.xcconfig
@@ -1,6 +1,0 @@
-// Carthage has an issue with XCode 12 architecture changes which doesn't allow
-// it to compile dependencies for proper architecture. This works around it.
-// Ref https://github.com/Carthage/Carthage/issues/3019
-EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64 arm64e armv7 armv7s armv6 armv8
-EXCLUDED_ARCHS=$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))
-IPHONEOS_DEPLOYMENT_TARGET=11.4


### PR DESCRIPTION
We've since long supported properly building on M1 machines relying on
xcframeworks.
CI was also switched to Xcode 13 a while ago.