### PR TITLE
Bug 1737656 - Document that url and text metric types are not usable inside Mozilla

### DIFF
--- a/docs/user/reference/metrics/text.md
+++ b/docs/user/reference/metrics/text.md
@@ -2,6 +2,13 @@
 
 Records a single long Unicode text, used when the limits on `String` are too low.
 
+{{#include ../../shared/blockquote-stop.html}}
+
+## Warning
+
+> This metric is not yet usable for most Mozilla products due to a data pipeline issue.
+> See [bug 1737656](https://bugzilla.mozilla.org/show_bug.cgi?id=1737656) for more information.
+
 {{#include ../../../shared/blockquote-warning.html}}
 
 ## Important

--- a/docs/user/reference/metrics/url.md
+++ b/docs/user/reference/metrics/url.md
@@ -4,6 +4,13 @@ URL metrics allow recording URL-like[^1] strings.
 
 This metric type does not support recording [data URLs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) - please get in contact with the Glean team if you're missing a type.
 
+{{#include ../../shared/blockquote-stop.html}}
+
+## Warning
+
+> This metric is not yet usable for most Mozilla products and releases due to a data pipeline issue.
+> See [bug 1737656](https://bugzilla.mozilla.org/show_bug.cgi?id=1737656) for more information.
+
 {{#include ../../../shared/blockquote-warning.html}}
 
 ## Important


### PR DESCRIPTION
I feel a bit guilty putting this very Mozilla-data-pipeline-specific
text in there, but it does seem important to warn people.
