### PR TITLE
No bug - Remove confusing and redundant bullet point from JS docs

### DIFF
--- a/docs/user/user/adding-glean-to-your-project/javascript.md
+++ b/docs/user/user/adding-glean-to-your-project/javascript.md
@@ -25,8 +25,6 @@ The Glean JavaScript SDK allows integration with three distinct JavaScript envir
 * [Host permissions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) to the telemetry server
   * Only necessary if the defined server endpoint denies
   [cross-origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests
-  * The default `incoming.telemetry.mozilla.org` server does require this type of permission.
-  Follow [Bug 1676676](https://bugzilla.mozilla.org/show_bug.cgi?id=1676676) for updates on this requirement
 * ["storage"](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions) API permissions
 
 {{#include ../../../shared/blockquote-info.html}}


### PR DESCRIPTION
[doc only]

It seems this warning is more confusing than not. Everything above it already gives the necessary instructions. Also allowing CORS, it turns out, does not mean Host permissions are not necessary on web extensions, so the bug link was also confusing.