### PR TITLE
Bug 1741229 - Public access for struct RecordedEventData fields

### DIFF
--- a/glean-core/ios/Glean/Metrics/EventMetric.swift
+++ b/glean-core/ios/Glean/Metrics/EventMetric.swift
@@ -7,13 +7,13 @@ import Foundation
 /// Deserialized event data.
 public struct RecordedEventData {
     /// The event's category, part of the full identifier
-    let category: String
+    public let category: String
     /// The event's name, part of the full identifier
-    let name: String
+    public let name: String
     /// The event's timestamp
-    let timestamp: UInt64
+    public let timestamp: UInt64
     /// Any extra data recorded for the event
-    let extra: [String: String]?
+    public let extra: [String: String]?
 
     var identifier: String {
         if category.isEmpty {


### PR DESCRIPTION
Label each field public on the RecordedEventData struct for EventMetric - otherwise internal by default.
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1741229