### PR TITLE
Migrate timespan metric implementation to UniFFI

### DIFF
--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -126,6 +126,34 @@ enum Lifetime {
     "User",
 };
 
+enum TimeUnit {
+    // Represents nanosecond precision.
+    "Nanosecond",
+    // Represents microsecond precision.
+    "Microsecond",
+    // Represents millisecond precision.
+    "Millisecond",
+    // Represents second precision.
+    "Second",
+    // Represents minute precision.
+    "Minute",
+    // Represents hour precision.
+    "Hour",
+    // Represents day precision.
+    "Day",
+};
+
+enum ErrorType {
+    /// For when the value to be recorded does not match the metric-specific restrictions
+    "InvalidValue",
+    /// For when the label of a labeled metric does not match the restrictions
+    "InvalidLabel",
+    /// For when the metric caught an invalid state while recording
+    "InvalidState",
+    /// For when the value to be recorded overflows the metric-specific upper range
+    "InvalidOverflow",
+};
+
 dictionary CommonMetricData {
     string category;
     string name;
@@ -148,4 +176,20 @@ interface CounterMetric {
 interface PingType {
     constructor(string name, boolean include_client_id, boolean send_if_empty, sequence<string> reason_codes);
     void submit(optional string? reason = null);
+};
+
+interface TimespanMetric {
+    constructor(CommonMetricData meta, TimeUnit time_unit);
+
+    void start();
+
+    void stop();
+
+    void cancel();
+
+    void set_raw_nanos(i64 elapsed);
+
+    i64? test_get_value(optional string? ping_name = null);
+
+    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
 };

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::core::Glean;
 use crate::core_metrics::ClientInfoMetrics;
 pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::error_recording::{test_get_num_recorded_errors, ErrorType};
-pub use crate::metrics::{CounterMetric, PingType, RecordedExperiment};
+pub use crate::metrics::{CounterMetric, PingType, RecordedExperiment, TimeUnit, TimespanMetric};
 pub use crate::upload::{PingRequest, PingUploadTask, UploadResult};
 
 const GLEAN_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -687,14 +687,14 @@ fn test_change_metric_type_runtime() {
     timespan_metric.set_stop(&glean, duration);
 
     assert_eq!(
-        timespan_metric.get_value(&glean, Some(ping_name)).unwrap(),
+        timespan_metric.get_value(&glean, ping_name).unwrap(),
         60,
         "Expected properly deserialized time"
     );
 
     // We expect old data to be lost forever. See the following bug comment
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1621757#c1 for more context.
-    assert_eq!(None, string_metric.test_get_value(&glean, ping_name));
+    assert_eq!(None, string_metric.get_value(&glean, ping_name));
 }
 
 #[test]

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -44,7 +44,7 @@ fn serializer_should_correctly_serialize_timespans() {
         metric.set_stop(&glean, duration);
 
         let val = metric
-            .get_value(&glean, Some("store1"))
+            .get_value(&glean, "store1")
             .expect("Value should be stored");
         assert_eq!(duration, val, "Recorded timespan should be positive.");
     }
@@ -86,7 +86,7 @@ fn single_elapsed_time_must_be_recorded() {
     metric.set_stop(&glean, duration);
 
     let val = metric
-        .get_value(&glean, Some("store1"))
+        .get_value(&glean, "store1")
         .expect("Value should be stored");
     assert_eq!(duration, val, "Recorded timespan should be positive.");
 }
@@ -119,13 +119,13 @@ fn second_timer_run_is_skipped() {
         test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None).is_err()
     );
 
-    let first_value = metric.get_value(&glean, Some("store1")).unwrap();
+    let first_value = metric.get_value(&glean, "store1").unwrap();
     assert_eq!(duration, first_value);
 
     metric.set_start(&glean, 0);
     metric.set_stop(&glean, duration * 2);
 
-    let second_value = metric.get_value(&glean, Some("store1")).unwrap();
+    let second_value = metric.get_value(&glean, "store1").unwrap();
     assert_eq!(second_value, first_value);
 
     // Make sure that the error has been recorded: we had a stored value, the
@@ -168,7 +168,7 @@ fn recorded_time_conforms_to_resolution() {
     ns_metric.set_start(&glean, 0);
     ns_metric.set_stop(&glean, duration);
 
-    let ns_value = ns_metric.get_value(&glean, Some("store1")).unwrap();
+    let ns_value = ns_metric.get_value(&glean, "store1").unwrap();
     assert_eq!(duration, ns_value);
 
     // 1 minute in nanoseconds
@@ -176,7 +176,7 @@ fn recorded_time_conforms_to_resolution() {
     minute_metric.set_start(&glean, 0);
     minute_metric.set_stop(&glean, duration_minute);
 
-    let minute_value = minute_metric.get_value(&glean, Some("store1")).unwrap();
+    let minute_value = minute_metric.get_value(&glean, "store1").unwrap();
     assert_eq!(1, minute_value);
 }
 
@@ -201,7 +201,7 @@ fn cancel_does_not_store() {
     metric.set_start(&glean, 0);
     metric.cancel();
 
-    assert_eq!(None, metric.get_value(&glean, Some("store1")));
+    assert_eq!(None, metric.get_value(&glean, "store1"));
 }
 
 #[test]
@@ -224,10 +224,10 @@ fn nothing_stored_before_stop() {
 
     metric.set_start(&glean, 0);
 
-    assert_eq!(None, metric.get_value(&glean, Some("store1")));
+    assert_eq!(None, metric.get_value(&glean, "store1"));
 
     metric.set_stop(&glean, duration);
-    assert_eq!(duration, metric.get_value(&glean, Some("store1")).unwrap());
+    assert_eq!(duration, metric.get_value(&glean, "store1").unwrap());
 }
 
 #[test]
@@ -250,7 +250,7 @@ fn set_raw_time() {
     metric.set_raw_sync(&glean, time);
 
     let time_in_ns = time.as_nanos() as u64;
-    assert_eq!(Some(time_in_ns), metric.get_value(&glean, Some("store1")));
+    assert_eq!(Some(time_in_ns), metric.get_value(&glean, "store1"));
 }
 
 #[test]
@@ -276,7 +276,7 @@ fn set_raw_time_does_nothing_when_timer_running() {
     metric.set_stop(&glean, 60);
 
     // We expect the start/stop value, not the raw value.
-    assert_eq!(Some(60), metric.get_value(&glean, Some("store1")));
+    assert_eq!(Some(60), metric.get_value(&glean, "store1"));
 
     // Make sure that the error has been recorded
     assert_eq!(
@@ -319,7 +319,7 @@ fn timespan_is_not_tracked_across_upload_toggle() {
     metric.set_stop(&glean, 200);
 
     // Nothing should have been recorded.
-    assert_eq!(None, metric.get_value(&glean, Some("store1")));
+    assert_eq!(None, metric.get_value(&glean, "store1"));
 
     // Make sure that the error has been recorded
     assert_eq!(
@@ -345,7 +345,7 @@ fn time_cannot_go_backwards() {
     // Time cannot go backwards.
     metric.set_start(&glean, 10);
     metric.set_stop(&glean, 0);
-    assert!(metric.get_value(&glean, Some("test1")).is_none());
+    assert!(metric.get_value(&glean, "test1").is_none());
     assert_eq!(
         Ok(1),
         test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None),


### PR DESCRIPTION
This is based on #1868 and enables the timespan metric tests. 
~~They pass now, at least those not ignored. The API still lacks `setRaw`.~~