### PR TITLE
[doc only]Bug 1736674 - Update limitations of event extras in the docs

### DIFF
--- a/docs/user/reference/metrics/event.md
+++ b/docs/user/reference/metrics/event.md
@@ -506,7 +506,7 @@ Each extra key contains additional metadata:
 * When 500 events are queued on the client an events ping is immediately sent.
 * The `extra_keys` allows for a maximum of 10 keys.
 * The keys in the `extra_keys` list must be in dotted snake case, with a maximum length of 40 bytes, when encoded as UTF-8.
-* The values in the `extras` object have a maximum of 50 bytes, when encoded as UTF-8.
+* The values in the `extras` object have a maximum length of 100 bytes, when serialized and encoded as UTF-8.
   
 ## Reference
 


### PR DESCRIPTION
This updates the limits described in the Glean docs around event extras, specifically the value limitation of "50" utf-8 bytes is actually "100" utf-8 bytes.