### PR TITLE
Fix to name given to the events ping when instantiated.

### DIFF
--- a/glean-core/rlb/src/pings.rs
+++ b/glean-core/rlb/src/pings.rs
@@ -44,7 +44,7 @@ pub mod pings {
     #[allow(non_upper_case_globals)]
     pub static events: Lazy<PingType> = Lazy::new(|| {
         PingType::new(
-            "metrics",
+            "events",
             true,
             false,
             vec![


### PR DESCRIPTION
Fix for [issue 1884](https://github.com/mozilla/glean/issues/1884).