### PR TITLE
Bug 1745908 - Python: Copy the environment when launching the upload process

### DIFF
--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -123,11 +123,15 @@ class ProcessDispatcher:
             # Explicitly pass the contents of `sys.path` as `PYTHONPATH` to the
             # subprocess so that there aren't any module search path
             # differences.
-            python_path = ":".join(sys.path)[1:]
+            python_path = ":".join(sys.path)
+
+            # We re-use the existing environment and overwrite only the `PYTHONPATH`
+            env = os.environ.copy()
+            env["PYTHONPATH"] = python_path
 
             p = subprocess.Popen(
                 [sys.executable, _process_dispatcher_helper.__file__, payload],
-                env={"PYTHONPATH": python_path},
+                env=env,
             )
 
             cls._last_process = p


### PR DESCRIPTION
The previous fix set the `PYTHONPATH` for the subprocess.
That overwrites the complete environment, clearing out any other
variables.
That can cause problems when other parts rely on something, such as the
RNG in Python relying on `SYSTEMROOT`