### PR TITLE
bug 1745283 - Document file-level tags

### DIFF
--- a/docs/user/reference/yaml/metrics.md
+++ b/docs/user/reference/yaml/metrics.md
@@ -26,6 +26,9 @@ section of this book.
 # Schema
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
+$tags:
+  - frontend
+
 # Category
 toolbar:
   # Name
@@ -53,6 +56,10 @@ toolbar:
 
 Declaring the schema at the top of a metrics definitions file is required,
 as it is what indicates that the current file is a metrics definitions file.
+
+# `$tags`
+
+You may optionally declare tags at the file level that apply to all metrics in that file.
 
 ## Category
 


### PR DESCRIPTION
Should probably wait to land this until the next `glean_parser` release. mozilla/glean_parser#435 has been merged, but isn't available for use quite yet.