### PR TITLE
bug 1750235 - Ensure init is complete before destroying Glean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased changes
 
+* Rust
+  * Ensure test-only `destroy_glean()` handles `initialize()` having started but not completed ([bug 1750235](https://bugzilla.mozilla.org/show_bug.cgi?id=1750235))
+
 [Full changelog](https://github.com/mozilla/glean/compare/v43.0.2...main)
 
 # v43.0.2 (2022-01-17)


### PR DESCRIPTION
This is important, because most of `destroy_glean` assumes init has completed:
1) Dispatcher reset? Runs all its tasks. Including ones using `with_glean`
2) Global state reset? Assumes the global state was setup.

Despite being important, this is not something that I've found a way to test.
The join behaviour's well tested, but the thing I want to test --
"Calling destroy_glean between `initialize()` being called and `glean.init`
completing." -- isn't. Ah well.

Note that we store multiple JoinHandles. There's nothing stopping N threads
from all calling `initialize()` simultaneously, starting N glean.init threads.
We'd need to compare_and_swap on INITIALIZE_CALLED for that guarantee.
(Not sure why we don't).