### PR TITLE
Update to mdbook-dtmo v0.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,9 +392,9 @@ jobs:
       - run:
           name: Install mdbook-dtmo
           command: |
-              MDBOOK_VERSION=0.9.0
+              MDBOOK_VERSION=0.10.0
               MDBOOK="mdbook-dtmo-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-              MDBOOK_SHA256=c83f0df5b3104b283b6a6156c4394bb496f3a9c1368d90760313c98887267610
+              MDBOOK_SHA256=96d30648b21cf443d64bd181cc58c8f2ba0d98b1e390e96d4639ae1ec5985ae3
               curl -sfSL --retry 5 -O "https://github.com/badboy/mdbook-dtmo/releases/download/${MDBOOK_VERSION}/${MDBOOK}"
               echo "${MDBOOK_SHA256} *${MDBOOK}" | shasum -a 256 -c -
               tar -xvf "${MDBOOK}"


### PR DESCRIPTION
mdbook-dtmo v0.10 updates the other mdbook-* dependencies, dropping some
annoying markdown roundtripping issues.