### PR TITLE
Python: Record correct timezone offset in datetime metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Swift
   * Dropping support of the Carthage-compatible framework archive ([#1943](https://github.com/mozilla/glean/pull/1943)).
     The Swift Package (https://github.com/mozilla/glean-swift) is the recommended way of consuming Glean iOS.
+* Python
+  * BUGFIX: Datetime metrics now correctly record the local timezone ([#1953](https://github.com/mozilla/glean/pull/1953)).
 
 [Full changelog](https://github.com/mozilla/glean/compare/v43.0.2...main)
 

--- a/glean-core/python/tests/metrics/test_datetime.py
+++ b/glean-core/python/tests/metrics/test_datetime.py
@@ -26,8 +26,17 @@ def test_the_api_saves_to_its_storage_engine():
 
     assert datetime_metric.test_has_value() is False
 
+    # Regression test: We previously failed to record the timezone.
+    # We don't have a _fixed_ local timezone,
+    # but we know how to get it:
+    expected_dt = datetime.datetime.now(datetime.timezone.utc).astimezone()
+    expected_off = expected_dt.tzinfo.utcoffset(expected_dt).seconds
+
     datetime_metric.set()
     assert datetime_metric.test_has_value() is True
+    value = datetime_metric.test_get_value()
+    # Check that the set datetime contains the local timezone offset.
+    assert expected_off == value.tzinfo.utcoffset(value).seconds
 
     value = datetime.datetime(
         2004, 12, 9, 8, 3, 29, tzinfo=datetime.timezone(datetime.timedelta(hours=16))


### PR DESCRIPTION
Turns out `datetime.now` defaults to `tz=None` and thus DOES NOT record
the timezone offset.
We treat that as an offset of 0 seconds.
However Python _does_ know about local time, so turning the current
local time into UTC, then back to local time gets us a timezone, from
which we can extract the timezone offset.

---

I've checked mozregression, moz-phab, mach and burnham. None of them uses `datetime.set()` to force `now`.