### PR TITLE
Bug 1753194 - Enable support for expiration by version on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased changes
 
+* General
+  * BREAKING CHANGE: Updated `glean_parser` version to 5.0.1 ([#1852](https://github.com/mozilla/glean/pull/1852)).
+    This update drops support for generating C# specific metrics API.
 * Rust
   * Ensure test-only `destroy_glean()` handles `initialize()` having started but not completed ([bug 1750235](https://bugzilla.mozilla.org/show_bug.cgi?id=1750235))
 * Swift

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ python-docs: build-python ## Build the Python documentation
 .PHONY: docs rust-docs swift-docs
 
 metrics-docs: python-setup ## Build the internal metrics documentation
-	$(GLEAN_PYENV)/bin/pip install glean_parser==4.4.0
+	$(GLEAN_PYENV)/bin/pip install glean_parser==5.0.1
 	$(GLEAN_PYENV)/bin/glean_parser translate --allow-reserved \
 		 -f markdown \
 		 -o ./docs/user/user/collected-metrics \

--- a/docs/user/language-bindings/android/android-build-configuration-options.md
+++ b/docs/user/language-bindings/android/android-build-configuration-options.md
@@ -66,3 +66,15 @@ To override this, `ext.gleanYamlFiles` may be set to a list of explicit paths.
 ```groovy
 ext.gleanYamlFiles = ["$rootDir/glean-core/metrics.yaml", "$rootDir/glean-core/pings.yaml"]
 ```
+
+## `gleanExpireByVersion`
+
+Expire the metrics and pings by version, using the provided major version.
+
+If enabled, expiring metrics or pings by date will produce an error.
+
+```groovy
+ext.gleanExpireByVersion = 25
+```
+
+

--- a/docs/user/language-bindings/android/android-build-configuration-options.md
+++ b/docs/user/language-bindings/android/android-build-configuration-options.md
@@ -77,4 +77,6 @@ If enabled, expiring metrics or pings by date will produce an error.
 ext.gleanExpireByVersion = 25
 ```
 
-
+Different products have different ways to compute the product version at build-time.
+For this reason the Glean Gradle plugin cannot provide an automated way to detect the product major version at build time.
+When using the expiration by version feature in Android, products must provide the major version by themselves.

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [package.metadata.glean]
-glean-parser = "4.4.0"
+glean-parser = "5.0.1"
 
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "main" }

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=4.4.0
+GLEAN_PARSER_VERSION=5.0.1
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034

--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -30,7 +30,7 @@ __author__ = "The Glean Team"
 __email__ = "glean-team@mozilla.com"
 
 
-GLEAN_PARSER_VERSION = "4.4.0"
+GLEAN_PARSER_VERSION = "5.0.1"
 
 
 if glean_parser.__version__ != GLEAN_PARSER_VERSION:

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -60,7 +60,7 @@ version = "43.0.2"
 
 requirements = [
     "cffi>=1.13.0",
-    "glean_parser==4.4.0",
+    "glean_parser==5.0.1",
     "iso8601>=0.1.10; python_version<='3.6'",
 ]
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -217,6 +217,11 @@ except:
                     }
                 }
 
+                // Enable expiration by major version, if a major version is provided.
+                if (project.ext.has("gleanExpireByVersion")) {
+                    args "--expire-by-version=${project.ext.get("gleanExpireByVersion")}"
+                }
+
                 doFirst {
                     // Add the potential 'metrics.yaml' files at evaluation-time, rather than
                     // configuration-time. Otherwise the Gradle build will fail.
@@ -284,6 +289,11 @@ except:
                 // use metrics in the "glean..." category
                 if (project.ext.has("allowGleanInternal")) {
                     args "--allow-reserved"
+                }
+
+                // Enable expiration by major version, if a major version is provided.
+                if (project.ext.has("gleanExpireByVersion")) {
+                    args "--expire-by-version=${project.ext.get("gleanExpireByVersion")}"
                 }
 
                 doFirst {

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -41,7 +41,7 @@ class GleanMetricsYamlTransform extends ArtifactTransform {
 @SuppressWarnings("GrPackage")
 class GleanPlugin implements Plugin<Project> {
     // The version of glean_parser to install from PyPI.
-    private String GLEAN_PARSER_VERSION = "4.4.0"
+    private String GLEAN_PARSER_VERSION = "5.0.1"
     // The version of Miniconda is explicitly specified.
     // Miniconda3-4.5.12 is known to not work on Windows.
     private String MINICONDA_VERSION = "4.5.11"

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -17,6 +17,8 @@ android {
         applicationId "org.mozilla.samples.gleancore"
         minSdkVersion rootProject.ext.build['minSdkVersion']
         targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        // Keep the version in sync with gleanExpireByVersion which is
+        // set below, near the end of the file.
         versionCode 1
         versionName "1.0"
 
@@ -57,6 +59,9 @@ dependencies {
 ext.gleanNamespace = "mozilla.telemetry.glean"
 // Fixed build date so we can test for it
 ext.gleanBuildDate = "2020-11-06T11:30:50+00:00"
+// Enable expiration by major version. The sample is at version 1,
+// see versionName.
+ext.gleanExpireByVersion = 1
 
 // Include the glean-gradle-plugin. This is slightly different than what is
 // recommended for external users since we are loading it from the same root Gradle

--- a/samples/android/app/metrics.yaml
+++ b/samples/android/app/metrics.yaml
@@ -28,7 +28,7 @@ browser.engagement:
       key2:
         type: string
         description: "This is key two"
-    expires: 2100-01-01
+    expires: 2
     metadata:
       tags:
         - testing
@@ -48,7 +48,7 @@ browser.engagement:
         description: "This is key one"
       key2:
         description: "This is key two"
-    expires: 2100-01-01
+    expires: 2
 
   event_no_keys:
     type: event
@@ -60,7 +60,7 @@ browser.engagement:
       - N/A
     notification_emails:
       - CHANGE-ME@example.com
-    expires: 2100-01-01
+    expires: 2
 
 basic:
   os:
@@ -73,7 +73,7 @@ basic:
       - N/A
     notification_emails:
       - CHANGE-ME@example.com
-    expires: 2100-01-01
+    expires: 2
 
 test:
   string_list:
@@ -89,7 +89,7 @@ test:
       - N/A
     notification_emails:
       - CHANGE-ME@example.com
-    expires: 2100-01-01
+    expires: 2
     no_lint:
       - USER_LIFETIME_EXPIRATION
     metadata:
@@ -109,7 +109,7 @@ test:
       - N/A
     notification_emails:
       - CHANGE-ME@example.com
-    expires: 2100-01-01
+    expires: 2
     no_lint:
       - USER_LIFETIME_EXPIRATION
     metadata:
@@ -128,7 +128,7 @@ test:
       - N/A
     notification_emails:
       - CHANGE-ME@example.com
-    expires: 2100-01-01
+    expires: 2
 
   is_started:
     type: boolean
@@ -143,7 +143,7 @@ test:
       - N/A
     notification_emails:
       - CHANGE-ME@test-only.com
-    expires: 2100-01-01
+    expires: 2
     no_lint:
       - BASELINE_PING
 
@@ -161,7 +161,7 @@ custom:
       - N/A
     notification_emails:
       - CHANGE-ME@test-only.com
-    expires: 2100-01-01
+    expires: 2
 
 legacy_ids:
   client_id:
@@ -176,4 +176,4 @@ legacy_ids:
       - N/A
     notification_emails:
       - CHANGE-ME@example.com
-    expires: 2100-01-01
+    expires: 2


### PR DESCRIPTION
This bumps the version of glean_parser currently being used by Glean and enables Android products to use expiration by version. To make sure things actually work, we change the Android sample to use expiration by version instead of a weird date.