### PR TITLE
Rename 'src -> vcs' in hardcoded paths in CI tasks [ci full]

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -234,8 +234,8 @@ tasks:
 
                             command:
                                 - /usr/local/bin/run-task
-                                - '--glean-checkout=/builds/worker/checkouts/src'
-                                - '--task-cwd=/builds/worker/checkouts/src'
+                                - '--glean-checkout=/builds/worker/checkouts/vcs'
+                                - '--task-cwd=/builds/worker/checkouts/vcs'
                                 - '--'
                                 - bash
                                 - -cx
@@ -244,7 +244,7 @@ tasks:
                                   in:
                                       $if: 'tasks_for == "action"'
                                       then: >
-                                          cd /builds/worker/checkouts/src &&
+                                          cd /builds/worker/checkouts/vcs &&
                                           ln -s /builds/worker/artifacts artifacts &&
                                           ~/.local/bin/taskgraph action-callback
                                       else: >
@@ -272,7 +272,7 @@ tasks:
                                     expires: {$fromNow: '1 year'}
                                 'public/docker-contexts':
                                     type: 'directory'
-                                    path: '/builds/worker/checkouts/src/docker-contexts'
+                                    path: '/builds/worker/checkouts/vcs/docker-contexts'
                                     # This needs to be at least the deadline of the
                                     # decision task + the docker-image task deadlines.
                                     # It is set to a week to allow for some time for

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -25,7 +25,7 @@ jobs:
         # Store the test report as an artifact for later analysis
         - name: public/test
           type: directory
-          path: /builds/worker/checkouts/src/glean-core/android/build/reports/tests
+          path: /builds/worker/checkouts/vcs/glean-core/android/build/reports/tests
     run:
       pre-gradlew:
         # XXX: scripts subshell at runtime so we need to source this here

--- a/taskcluster/glean_taskgraph/transforms/module_build.py
+++ b/taskcluster/glean_taskgraph/transforms/module_build.py
@@ -29,7 +29,7 @@ def build_task(config, tasks):
                 artifact_filename = f"{publication_name}-{version}{extension}"
                 artifacts.append({
                     "name": f"public/build/{artifact_filename}",
-                    "path": f"/builds/worker/checkouts/src/build/maven/org/mozilla/telemetry/{publication_name}/{version}/{artifact_filename}",
+                    "path": f"/builds/worker/checkouts/vcs/build/maven/org/mozilla/telemetry/{publication_name}/{version}/{artifact_filename}",
                     "type": "file",
                 })
 

--- a/taskcluster/scripts/cross-compile-setup.sh
+++ b/taskcluster/scripts/cross-compile-setup.sh
@@ -58,7 +58,7 @@ pushd /tmp
 
 tooltool.py \
   --url=http://taskcluster/tooltool.mozilla-releng.net/ \
-  --manifest="/builds/worker/checkouts/src/taskcluster/scripts/macos.manifest" \
+  --manifest="/builds/worker/checkouts/vcs/taskcluster/scripts/macos.manifest" \
   fetch
 # tooltool doesn't know how to unpack zstd-files,
 # so we do it manually.


### PR DESCRIPTION
The previous commit updated Taskgraph to the latest version, which
contained a backwards incompatible change (introduced last summer) that
renamed the default checkout path from 'src' -> 'vcs'. This is causing
the build to fail.

Since this backwards incompatible change was introduced, we've since
started releasing to Pypi with proper version numbers and are now
following SemVer. So hopefully cases like this won't happen again.

(Ironically preventing cases like this is what the PR was trying to
solve).