### PR TITLE
 [bug 1742614] Remove legacy X-Client-Type and X-Client-Version from Glean Pings

### DIFF
--- a/docs/user/user/pings/index.md
+++ b/docs/user/user/pings/index.md
@@ -218,7 +218,7 @@ Lifetime: [Application](../../reference/yaml/metrics.md#application)_
 The locale of the application during initialization (e.g. "es-ES").
 If the locale can't be determined on the system, the value is "und", to indicate "undetermined".
 
-[`Build.MODEL`]: https://developer.android.com/reference/android/os/Build.html#MODEL
+[`build.model`]: https://developer.android.com/reference/android/os/Build.html#MODEL
 
 ## Ping submission
 
@@ -236,7 +236,7 @@ A typical submission URL looks like
 where:
 
 - `<server-address>`: the address of the server that receives the pings;
-- `<application-id>`: a unique application id, automatically detected by the Glean SDK; this is the value returned by [`Context.getPackageName()`](http://developer.android.com/reference/android/content/Context.html#getPackageName());
+- `<application-id>`: a unique application id, automatically detected by the Glean SDK; this is the value returned by [`Context.getPackageName()`](<http://developer.android.com/reference/android/content/Context.html#getPackageName()>);
 - `<doc-type>`: the name of the ping; this can be one of the pings available out of the box with the Glean SDK, or a custom ping;
 - `<glean-schema-version>`: the version of the Glean ping schema;
 - `<document-id>`: a unique identifier for this ping.
@@ -305,18 +305,6 @@ as it describes the application and the Glean SDK used for sending the ping.
 It's looks like `Glean/40.0.0 (Kotlin on Android)`, where `40.0.0` is the Glean Kotlin SDK version number
 and `Kotlin on Android` is the name of the language used by the SDK that sent the request
 plus the name of the platform it is running on.
-
-#### `X-Client-Type` (deprecated)
-
-Custom header to support handling of Glean pings in the legacy pipeline. Values is always `Glean`.
-
-This header is deprecated and will soon be removed from all Glean SDKs.
-
-#### `X-Client-Version` (deprecated)
-
-The Glean SDK version e.g. `0.40.0`, sent as a custom header to support handling of Glean pings in the legacy pipeline.
-
-This header is deprecated and will soon be removed from all Glean SDKs.
 
 #### `X-Debug-Id` _(optional)_
 

--- a/docs/user/user/pings/index.md
+++ b/docs/user/user/pings/index.md
@@ -218,7 +218,7 @@ Lifetime: [Application](../../reference/yaml/metrics.md#application)_
 The locale of the application during initialization (e.g. "es-ES").
 If the locale can't be determined on the system, the value is "und", to indicate "undetermined".
 
-[`build.model`]: https://developer.android.com/reference/android/os/Build.html#MODEL
+[`Build.MODEL`]: https://developer.android.com/reference/android/os/Build.html#MODEL
 
 ## Ping submission
 
@@ -236,7 +236,7 @@ A typical submission URL looks like
 where:
 
 - `<server-address>`: the address of the server that receives the pings;
-- `<application-id>`: a unique application id, automatically detected by the Glean SDK; this is the value returned by [`Context.getPackageName()`](<http://developer.android.com/reference/android/content/Context.html#getPackageName()>);
+- `<application-id>`: a unique application id, automatically detected by the Glean SDK; this is the value returned by [`Context.getPackageName()`](http://developer.android.com/reference/android/content/Context.html#getPackageName());
 - `<doc-type>`: the name of the ping; this can be one of the pings available out of the box with the Glean SDK, or a custom ping;
 - `<glean-schema-version>`: the version of the Glean ping schema;
 - `<document-id>`: a unique identifier for this ping.

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -49,7 +49,6 @@ public class HttpPingUploader {
     ///     * data: The serialized text data to send
     ///     * headers: Map of headers from Glean to annotate ping with
     ///     * callback: A callback to return the success/failure of the upload
-    ///
     func upload(path: String, data: Data, headers: [String: String], callback: @escaping (UploadResult) -> Void) {
         // Build the request and create an async upload operation using a background URLSession
         if let request = self.buildRequest(path: path, data: data, headers: headers) {

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -47,6 +47,7 @@ public class HttpPingUploader {
     /// - parameters:
     ///     * path: The URL path to append to the server address
     ///     * data: The serialized text data to send
+    ///     * headers: Map of headers from Glean to annotate ping with
     ///     * callback: A callback to return the success/failure of the upload
     ///
     func upload(path: String, data: Data, headers: [String: String], callback: @escaping (UploadResult) -> Void) {
@@ -106,6 +107,7 @@ public class HttpPingUploader {
     /// - parameters:
     ///     * path: The URL path to append to the server address
     ///     * data: The serialized text data to send
+    ///     * headers: Map of headers from Glean to annotate ping with
     ///     * callback: A callback to return the success/failure of the upload
     ///
     /// - returns: Optional `URLRequest` object with the configured headings set.

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -49,9 +49,6 @@ public class HttpPingUploader {
     ///     * data: The serialized text data to send
     ///     * callback: A callback to return the success/failure of the upload
     ///
-    /// Note that the `X-Client-Type`: `Glean` and `X-Client-Version`: <SDK version>
-    /// headers are added to the HTTP request in addition to the UserAgent. This allows
-    /// us to easily handle pings coming from Glean on the legacy Mozilla pipeline.
     func upload(path: String, data: Data, headers: [String: String], callback: @escaping (UploadResult) -> Void) {
         // Build the request and create an async upload operation using a background URLSession
         if let request = self.buildRequest(path: path, data: data, headers: headers) {

--- a/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
+++ b/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
@@ -51,7 +51,7 @@ class HttpPingUploaderTests: XCTestCase {
         // We specify a single additional header here.
         // In usual code they are generated on the Rust side.
         let request = HttpPingUploader(configuration: Configuration())
-            .buildRequest(path: testPath, data: Data(testPing.utf8), headers: ["X-Client-Type": "Glean"])
+            .buildRequest(path: testPath, data: Data(testPing.utf8), headers: ["X-Test-Only": "Glean"])
 
         XCTAssertEqual(
             request?.url?.path,
@@ -74,9 +74,9 @@ class HttpPingUploaderTests: XCTestCase {
             "Request cookie policy set correctly"
         )
         XCTAssertEqual(
-            request?.value(forHTTPHeaderField: "X-Client-Type"),
+            request?.value(forHTTPHeaderField: "X-Test-Only"),
             "Glean",
-            "Request X-Client-Type set correctly"
+            "Request header set correctly"
         )
     }
 }

--- a/glean-core/src/upload/request.rs
+++ b/glean-core/src/upload/request.rs
@@ -81,11 +81,6 @@ impl Builder {
             "Content-Type".to_string(),
             "application/json; charset=utf-8".to_string(),
         );
-        headers.insert("X-Client-Type".to_string(), "Glean".to_string());
-        headers.insert(
-            "X-Client-Version".to_string(),
-            crate::GLEAN_VERSION.to_string(),
-        );
 
         Self {
             document_id: None,
@@ -273,8 +268,6 @@ mod test {
         assert!(request.headers.contains_key("Date"));
         assert!(request.headers.contains_key("X-Telemetry-Agent"));
         assert!(request.headers.contains_key("Content-Type"));
-        assert!(request.headers.contains_key("X-Client-Type"));
-        assert!(request.headers.contains_key("X-Client-Version"));
         assert!(request.headers.contains_key("Content-Length"));
     }
 


### PR DESCRIPTION
- Removed references to X-Client-Type and X-Client-Version in tests & documentation
- Replaced test header X-Client-Type -> X-Test-Only

An open question I have is for the upload function in HttpPingUploader.swift are there other headers? If so, I can add a line to the documentation since there is not currently an explainer for the headers parameter. If not, can we remove it from the function? @badboy 
