### PR TITLE
Bug 1753975 - Support expiration by major version on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Rust
   * Raise the global dispatcher queue limit from 100 to 1000 tasks. ([bug 1764549](https://bugzilla.mozilla.org/show_bug.cgi?id=1764549))
+* iOS
+  * Enable expiry by version in the `sdk_generator.sh` script ([#2013](https://github.com/mozilla/glean/pull/2013))
 
 # v44.1.0 (2022-04-06)
 

--- a/docs/user/language-bindings/ios/ios-build-configuration-options.md
+++ b/docs/user/language-bindings/ios/ios-build-configuration-options.md
@@ -26,6 +26,23 @@ For other values it will throw an error.
 bash sdk_generator.sh --build-date 2022-01-03T17:30:00
 ```
 
+## `--expire-by-version <INTEGER>`
+
+Default: none.
+
+Expire the metrics and pings by version, using the provided major version.
+
+If enabled, expiring metrics or pings by date will produce an error.
+
+```sh
+bash sdk_generator.sh --expire-by-version 95
+```
+
+Different products have different ways to compute the product version at build-time.
+For this reason the `sdk_generator.sh` script cannot provide an automated way to detect the product major version at build time.
+When using the expiration by version feature in iOS,
+products must provide the major version by themselves.
+
 ## `--markdown <PATH>` / `-m <PATH>`
 
 Default: unset.

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -53,12 +53,13 @@ ARGS:
                If not specified the plugin will use the \$SCRIPT_INPUT_FILE_{N} environment variables.
 
 OPTIONS:
-    -a, --allow-reserved             Allow reserved names.
-    -o, --output  <PATH>             Folder to place generated code in. Default: \$SOURCE_ROOT/\$PROJECT/Generated
-    -g, --glean-namespace <NAME>     The Glean namespace to use in generated code.
-    -m, --markdown <PATH>            Generate markdown documentation in provided directory.
-    -b, --build-date <TEXT>          Set a specific build date or disable build date generation with `0`.
-    -h, --help                       Display this help message.
+    -a, --allow-reserved               Allow reserved names.
+    -o, --output  <PATH>               Folder to place generated code in. Default: \$SOURCE_ROOT/\$PROJECT/Generated
+    -g, --glean-namespace <NAME>       The Glean namespace to use in generated code.
+    -m, --markdown <PATH>              Generate markdown documentation in provided directory.
+    -b, --build-date <TEXT>            Set a specific build date or disable build date generation with `0`.
+        --expire-by-version <INTEGER>  Expire metrics by version, with the provided major version.
+    -h, --help                         Display this help message.
 HEREDOC
 )
 
@@ -71,6 +72,7 @@ ALLOW_RESERVED=""
 GLEAN_NAMESPACE=Glean
 DOCS_DIRECTORY=""
 BUILD_DATE=""
+EXPIRE_VERSION=""
 declare -a YAML_FILES=()
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 
@@ -94,6 +96,10 @@ while (( "$#" )); do
             ;;
         -b|--build-date)
             BUILD_DATE="--option build_date=$2"
+            shift 2
+            ;;
+        --expire-by-version)
+            EXPIRE_VERSION="--expire-by-version $2"
             shift 2
             ;;
         -h|--help)
@@ -170,6 +176,7 @@ PARSER_OUTPUT=$("${VENVDIR}"/bin/python -m glean_parser \
     -o "${OUTPUT_DIR}" \
     -s "glean_namespace=${GLEAN_NAMESPACE}" \
     $BUILD_DATE \
+    $EXPIRE_VERSION \
     $ALLOW_RESERVED \
     "${YAML_FILES[@]}" 2>&1) || { echo "$PARSER_OUTPUT"; echo "error: glean_parser failed. See errors above."; exit 1; }
 


### PR DESCRIPTION
It's up to the embedding application to provide the correct version
number.