### PR TITLE
bug 1764549 - Bump the RLB preinit queue from 10^2 to 10^3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v44.1.0...main)
 
+* Rust
+  * Raise the global dispatcher queue limit from 100 to 1000 tasks. ([bug 1764549](https://bugzilla.mozilla.org/show_bug.cgi?id=1764549))
+
 # v44.1.0 (2022-04-06)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v44.0.0...v44.1.0)

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -61,8 +61,7 @@ Before submitting a PR:
 - "Work in progress" pull requests are allowed to be submitted, but should be clearly labeled as such and should not be merged until all tests pass and the code has been reviewed.
 - For changes to Rust code
   - `make test-rust` produces no test failures
-  - `make clippy` runs without emitting any warnings or errors.
-  - `make rustfmt` does not produce any changes to the code.
+  - `make lint-rust` runs without emitting any warnings or errors.
 - For changes to Kotlin code
   - `make test-kotlin` runs without emitting any warnings or errors.
   - `make ktlint` runs without emitting any warnings.

--- a/glean-core/rlb/src/dispatcher/global.rs
+++ b/glean-core/rlb/src/dispatcher/global.rs
@@ -7,7 +7,7 @@ use std::sync::RwLock;
 
 use super::{DispatchError, DispatchGuard, Dispatcher};
 
-pub const GLOBAL_DISPATCHER_LIMIT: usize = 100;
+pub const GLOBAL_DISPATCHER_LIMIT: usize = 1000;
 static GLOBAL_DISPATCHER: Lazy<RwLock<Option<Dispatcher>>> =
     Lazy::new(|| RwLock::new(Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT))));
 

--- a/glean-core/rlb/tests/overflowing_preinit.rs
+++ b/glean-core/rlb/tests/overflowing_preinit.rs
@@ -75,21 +75,22 @@ fn overflowing_the_task_queue_records_telemetry() {
     };
 
     // Insert a bunch of tasks to overflow the queue.
-    for _ in 0..110 {
+    for _ in 0..1010 {
         metrics::rapid_counting.add(1);
     }
 
     // Now initialize Glean
     common::initialize(cfg);
 
-    assert_eq!(Some(100), metrics::rapid_counting.test_get_value(None));
+    assert_eq!(Some(1000), metrics::rapid_counting.test_get_value(None));
 
     // The metrics counts the total number of overflowing tasks,
+    // (and the count of tasks in the queue when we overflowed: bug 1764573)
     // this might include Glean-internal tasks.
     let val = metrics::preinit_tasks_overflow
         .test_get_value(None)
         .unwrap();
-    assert!(val >= 110);
+    assert!(val >= 1010);
 
     glean::shutdown();
 }


### PR DESCRIPTION
FOG's on Desktop and is init whenever BrowserGlue gets around to it.
We have the memory to play with.

This is a temporary measure until we make this configurable or limitless.