### PR TITLE
Bug 1765950 - Add a workflow & substitute script to build and autopublish Glean locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ local.properties
 build
 captures
 .externalNativeBuild
+.lastAutoPublishContentsHash
 
 # iOS stuff.
 xcuserdata

--- a/build-scripts/publish_to_maven_local_if_modified.py
+++ b/build-scripts/publish_to_maven_local_if_modified.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: Publish android packages to local maven repo, but only if changed since last publish.
+# Dependencies: None
+# Usage: ./automation/publish_to_maven_local_if_modified.py
+
+import os
+import sys
+import time
+import hashlib
+import argparse
+from shared import run_cmd_checked, find_glean_root, fatal_err
+import re
+
+LAST_CONTENTS_HASH_FILE = ".lastAutoPublishContentsHash"
+
+GITIGNORED_FILES_THAT_AFFECT_THE_BUILD = ["local.properties"]
+
+parser = argparse.ArgumentParser(description="Publish android packages to local maven repo, but only if changed since last publish")
+parser.parse_args()
+
+root_dir = find_glean_root()
+if str(root_dir) != os.path.abspath(os.curdir):
+    fatal_err(f"This only works if run from the repo root ({root_dir!r} != {os.path.abspath(os.curdir)!r})")
+
+# This doesn't work on "native" windows, so let's get that out of the way now.
+if sys.platform.startswith("win"):
+    print("NOTE: The autoPublish workflows do not work on native Windows.")
+    print("You must follow the instructions in")
+    print("https://mozilla.github.io/glean/dev/android/setup-android-build-environment.html")
+    print("then, manually ensure that the following command has completed successfully in WSL:")
+    print(sys.argv)
+    print(f"(from the '{root_dir}' directory)")
+    print("Then restart the build")
+    # We don't want to fail here - the intention is that building, eg,
+    # android-components on native Windows still works, just that it prints the
+    # warning above.
+    sys.exit(0)
+
+# Calculate a hash reflecting the current state of the repo.
+
+contents_hash = hashlib.sha256()
+
+contents_hash.update(
+    run_cmd_checked(["git", "rev-parse", "HEAD"], capture_output=True).stdout
+)
+contents_hash.update(b"\x00")
+
+# Git can efficiently tell us about changes to tracked files, including
+# the diff of their contents, if you give it enough "-v"s.
+
+changes = run_cmd_checked(["git", "status", "-v", "-v"], capture_output=True).stdout
+contents_hash.update(changes)
+contents_hash.update(b"\x00")
+
+# But unfortunately it can only tell us the names of untracked
+# files, and it won't tell us anything about files that are in
+# .gitignore but can still affect the build.
+
+untracked_files = []
+
+changes_lines = iter(ln.strip() for ln in changes.split(b"\n"))
+try:
+    ln = next(changes_lines)
+    # Skip the tracked files.
+    while not ln.startswith(b"Untracked files:"):
+        ln = next(changes_lines)
+    # Skip instructional line about using `git add`.
+    ln = next(changes_lines)
+    # Now we're at the list of untracked files.
+    ln = next(changes_lines)
+    while ln:
+        untracked_files.append(ln)
+        ln = next(changes_lines)
+except StopIteration:
+    pass
+
+untracked_files.extend(GITIGNORED_FILES_THAT_AFFECT_THE_BUILD)
+
+# So, we'll need to slurp the contents of such files for ourselves.
+
+for nm in untracked_files:
+    try:
+        with open(nm, "rb") as f:
+            contents_hash.update(f.read())
+    except (FileNotFoundError, IsADirectoryError):
+        pass
+    contents_hash.update(b"\x00")
+contents_hash.update(b"\x00")
+
+contents_hash = contents_hash.hexdigest()
+
+# If the contents hash has changed since last publish, re-publish.
+
+last_contents_hash = ""
+try:
+    with open(LAST_CONTENTS_HASH_FILE) as f:
+        last_contents_hash = f.read().strip()
+except FileNotFoundError:
+    pass
+
+if contents_hash == last_contents_hash:
+    print("Contents have not changed, no need to publish")
+else:
+    print(f"Contents have changed, publishing")
+    run_cmd_checked(["./gradlew", "publishToMavenLocal", f"-Plocal={time.time_ns()}"])
+    with open(LAST_CONTENTS_HASH_FILE, "w") as f:
+        f.write(contents_hash)
+        f.write("\n")

--- a/build-scripts/shared.py
+++ b/build-scripts/shared.py
@@ -1,0 +1,70 @@
+# Common code used by the automation python scripts.
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def step_msg(msg):
+    print(f"> \033[34m{msg}\033[0m")
+
+def fatal_err(msg):
+    print(f"\033[31mError: {msg}\033[0m")
+    exit(1)
+
+def run_cmd_checked(*args, **kwargs):
+    """Run a command, throwing an exception if it exits with non-zero status."""
+    kwargs["check"] = True
+    return subprocess.run(*args, **kwargs)
+
+def ensure_working_tree_clean():
+    """Error out if there are un-committed or staged files in the working tree."""
+    if run_cmd_checked(["git", "status", "--porcelain"], capture_output=True).stdout:
+        fatal_err("The working tree has un-commited or staged files.")
+
+def find_glean_root():
+    """Find the absolute path of the Glean repository root."""
+    cur_dir = Path(__file__).parent
+    while not Path(cur_dir, "LICENSE").exists():
+        cur_dir = cur_dir.parent
+    return cur_dir.absolute()
+
+def set_gradle_substitution_path(project_dir, name, value):
+    """Set a substitution path property in a gradle `local.properties` file.
+
+    Given the path to a gradle project directory, this helper will set the named
+    property to the given path value in that directory's `local.properties` file.
+    If the named property already exists with the correct value then it will
+    silently succeed; if the named property already exists with a different value
+    then it will noisily fail.
+    """
+    project_dir = Path(project_dir).resolve()
+    properties_file = project_dir / "local.properties"
+    step_msg(f"Configuring local publication in project at {properties_file}")
+    name_eq = name + "="
+    abs_value = Path(value).resolve()
+    # Check if the named property already exists.
+    if properties_file.exists():
+        with properties_file.open() as f:
+            for ln in f:
+                # Not exactly a thorough parser, but should be good enough...
+                if ln.startswith(name_eq):
+                    cur_value = ln[len(name_eq):].strip()
+                    if Path(project_dir, cur_value).resolve() != abs_value:
+                        fatal_error(f"Conflicting property {name}={cur_value} (not {abs_value})")
+                    return
+    # The file does not contain the required property, append it.
+    # Note that the project probably expects a path relative to the project root.
+    ancestor = Path(os.path.commonpath([project_dir, abs_value]))
+    relpath = Path(".")
+    for _ in project_dir.parts[len(ancestor.parts):]:
+        relpath /= ".."
+    for nm in abs_value.parts[len(ancestor.parts):]:
+        relpath /= nm
+    step_msg(f"Setting relative path from {project_dir} to {abs_value} as {relpath}")
+    with properties_file.open("a") as f:
+        f.write(f"{name}={relpath}\n")

--- a/build-scripts/substitute-local-glean.gradle
+++ b/build-scripts/substitute-local-glean.gradle
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This script is designed to be used by consuming apps that want to support locally-published
+// development versions of Glean. A build that `apply from`'s this script
+// will be configured to look for development versions published to the local maven repository.
+//
+// There is a companion gradle command `autoPublishForLocalDevelopment` that can be used to publish
+// the local development versions that are targetted by this script.
+
+logger.lifecycle("[local-glean] adjusting ${project} to use locally published Glean module")
+
+// Inject mavenLocal repository. This is where we're expected to publish modules.
+repositories {
+    mavenLocal()
+}
+
+configurations.all { config ->
+    if (config.isCanBeResolved()) {
+        config.resolutionStrategy { strategy ->
+            dependencySubstitution {
+                all { dependency ->
+                    // We only care about substituting for a module, not a project.
+                    if (!(dependency.requested instanceof ModuleComponentSelector)) {
+                        return
+                    }
+
+                    // For every org.mozilla.telemetry.* module, substitute its version for one
+                    // formatted like `0.0.1-SNAPSHOT-*`. This syntax will pick the latest such version
+                    // published locally by the `autoPublishForLocalDevelopment` command.
+                    def group = dependency.requested.group
+                    if (group == 'org.mozilla.telemetry') {
+                        def name = dependency.requested.module
+                        dependency.useTarget([group: group, name: name, version: '0.0.1-SNAPSHOT-+'])
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -201,3 +201,12 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     main = "com.github.shyiko.ktlint.Main"
     args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build"
 }
+
+// Extremely unsophisticated way to publish a local development version while hiding implementation details.
+//
+// This shells out to a python script that tries to detect whether the working directory has changed since the last
+// time it was run, and it so then it shells out to `./gradlew publishToMavenLocal -Plocal=<timestamp>` to publish
+// a new version of of the code with an auto-incrementing version number.
+task autoPublishForLocalDevelopment(type: Exec) {
+  commandLine "./build-scripts/publish_to_maven_local_if_modified.py"
+}

--- a/docs/dev/android/development-with-android-components.md
+++ b/docs/dev/android/development-with-android-components.md
@@ -7,11 +7,8 @@ Modern Gradle supports [composite builds](https://docs.gradle.org/current/usergu
 1. publish library snapshot to the local Maven repository
 1. consume library snapshot in application
 
-> **Note**: this substitution-based approach will not work for testing updates to the Glean Gradle Plugin.
-> For that to work, the library and the plugin need to be published to a local maven and manually imported
-> in the consuming projects.
-> Please refer to [Using locally-published Glean in Fenix](./locally-published-components-in-fenix.md) for
-> how to do that.
+> **Note**: this substitution-based approach will not work for testing updates to `glean_parser` as shipped in the Glean Gradle Plugin.
+> For replacing `glean_parser` in a local build, see [Substituting `glean_parser`](glean-parser-substitution.md).
 
 ## Preparation
 
@@ -24,8 +21,8 @@ git clone https://github.com/mozilla-mobile/android-components
 
 ## Cargo build targets
 
-By default when building Android Components using gradle, the gradle-cargo plugin will compile Glean for every possible platform,
-which might end up in failures.
+By default when building Android Components using gradle, the rust-android plugin will compile Glean for every possible platform,
+which might end up in build failures.
 You can customize which targets are built in `glean/local.properties`
 ([more information](https://github.com/ncalexan/rust-android-gradle/blob/HEAD/README.md#specifying-local-targets)):
 
@@ -46,42 +43,9 @@ android-components has custom build logic for dealing with composite builds,
 so you should be able to configure it by simply adding the path to the Glean repository in the correct `local.properties` file:
 
 In `android-components/local.properties`:
+
 ```groovy
-substitutions.glean.dir=../glean
+localProperties.autoPublish.glean.dir=../glean
 ```
 
-If this doesn't seem to work, or if you need to configure composite builds for a project that does not contain this custom logic,
-add the following to `settings.gradle`:
-
-In `android-components/settings.gradle`:
-```groovy
-includeBuild('../glean') {
-  dependencySubstitution {
-    substitute module('org.mozilla.telemetry:glean') with project(':glean')
-    substitute module('org.mozilla.telemetry:glean-forUnitTests') with project(':glean')
-  }
-}
-```
-
-Composite builds will ensure the Glean SDK is build as part of tasks inside `android-components`.
-
-## Caveat
-
-There's a big gotcha with library substitutions: the Gradle build computes lazily, and AARs don't include their transitive dependencies' JNI libraries.
-This means that in `android-components`, `./gradlew :service-glean:assembleDebug` **does not** invoke `:glean:cargoBuild`,
-even though `:service-glean` depends on the substitution for `:glean` and even if the inputs to Cargo have changed!
-It's the final consumer of the `:service-glean` project (or publication) that will incorporate the JNI libraries.
-
-In practice that means _you should always be targeting something that produces an APK_: a test or a sample module.
-Then you should find that the `cargoBuild` tasks are invoked as you expect.
-
-Inside the `android-components` repository `./gradlew :samples-glean:connectedAndroidTest` should work.
-Other tests like `:service-glean:testDebugUnitTest` or `:support-sync-telemetry:testDebugUnitTest` will currently fail, because the JNI libraries are not included.
-
-
-## Notes
-
-This document is based on the equivalent documentation for application-services:
-[Development with the Reference Browser](https://github.com/mozilla/application-services/blob/HEAD/docs/howtos/working-with-reference-browser.md)
-
-1. Transitive substitutions (as shown above) work but require newer Gradle versions (4.10+).
+This will auto-publish Glean SDK changes to a local repository and consume them in android-components.

--- a/docs/dev/android/locally-published-components-in-fenix.md
+++ b/docs/dev/android/locally-published-components-in-fenix.md
@@ -1,12 +1,7 @@
 # Using locally-published Glean in Fenix
 
-> Note: This is a bit tedious, and you might like to try the substitution-based approach documented in
-> [Working on unreleased Glean code in android-components](./development-with-android-components.md).
-> That approach is still fairly new, and the local-publishing approach in this document is necessary if it fails.
-
-> Note: This is Fenix-specific only in that some links on the page go to the `mozilla-mobile/fenix` repository,
-> however these steps should work for e.g. `reference-browser`, as well.
-> (Same goes for Lockwise, or any other consumer of Glean, but they may use a different structure -- Lockwise has no Dependencies.kt, for example)
+> **Note**: this substitution-based approach will not work for testing updates to `glean_parser` as shipped in the Glean Gradle Plugin.
+> For replacing `glean_parser` in a local build, see [Substituting `glean_parser`](glean-parser-substitution.md).
 
 ## Preparation
 
@@ -14,80 +9,21 @@ Clone the Glean SDK, android-components and Fenix repositories:
 
 ```sh
 git clone https://github.com/mozilla/glean
-git clone https://github.com/mozilla-mobile/android-components
-git clone https://github.com/mozilla-mobile/fenix/
+git clone https://github.com/mozilla-mobile/fenix
 ```
 
-## Local publishing
+## Substituting projects
 
+android-components has custom build logic for dealing with composite builds,
+so you should be able to configure it by simply adding the path to the Glean repository in the correct `local.properties` file:
 
-1. Inside the `glean` repository root:
-    1. In [`.buildconfig.yml`][glean-yaml], change
-       `libraryVersion` to end in `-TESTING$N`[^1],
-       where `$N` is some number that you haven't used for this before.
+In `fenix/local.properties`:
 
-       Example: `libraryVersion: 22.0.0-TESTING1`
-    2. Check your `local.properties` file,
-       and add `rust.targets=x86` if you're testing on the emulator,
-       `rust.targets=arm` if you're testing on 32-bit arm (arm64 for 64-bit arm, etc).
-       This will make the build that's done in the next step much faster.
-    3. Run `./gradlew publishToMavenLocal`. This may take a few minutes.
+```groovy
+localProperties.autoPublish.glean.dir=../glean
+```
 
-2. Inside the `android-components` repository root:
-    1. In [`.buildconfig.yml`][android-components-yaml], change
-       `componentsVersion` to end in `-TESTING$N`[^1],
-       where `$N` is some number that you haven't used for this before.
-
-       Example: `componentsVersion: 24.0.0-TESTING1`
-    2. Inside [`buildSrc/src/main/java/Dependencies.kt`][android-components-deps],
-       change `mozilla_glean` to reference the `libraryVersion` you published in step 2 part 1.
-
-       Example: `const val mozilla_glean = "22.0.0-TESTING1"`
-
-    3. Inside [`build.gradle`][android-components-build-gradle], add
-       `mavenLocal()` inside `allprojects { repositories { <here> } }`.
-
-    4. Add the following block in the [`settings.gradle`](https://github.com/mozilla-mobile/android-components/blob/d67f83af679a2e847e5bd284ea4a30b412403241/settings.gradle#L7) file, before any other statement in the script, in order to have the Glean Gradle plugin loaded from the local Maven repository.
-       ```
-       pluginManagement {
-         repositories {
-             mavenLocal()
-             gradlePluginPortal()
-         }
-       }
-       ```
-
-    5. Inside the android-component's `local.properties` file, ensure
-       `substitutions.glean.dir` is *NOT* set.
-
-    6. Run `./gradlew publishToMavenLocal`.
-
-3. Inside the `fenix` repository root:
-    1. Inside [`build.gradle`][fenix-build-gradle] you need to add `mavenLocal()` twice.  
-       First add `mavenLocal()` inside `buildscript` like this:
-       ```
-       buildscript {
-           repositories {
-               mavenLocal()
-               ...
-       ```
-
-       Second add `mavenLocal()` inside `allprojects`:
-       ```
-       allprojects {
-           repositories {
-               mavenLocal()
-               ...
-       ```
-
-    2. Inside [`buildSrc/src/main/java/AndroidComponents.kt`][fenix-deps], change
-       `VERSION` to the version you defined in step 3 part 1.
-
-       Example:
-       ```
-       const val VERSION = "24.0.0-TESTING1"
-       ```
-
+This will auto-publish Glean SDK changes to a local repository and consume them in Fenix.
 You should now be able to build and run Fenix (assuming you could before all this).
 
 ## Caveats
@@ -98,23 +34,3 @@ You should now be able to build and run Fenix (assuming you could before all thi
    These should be understandable to fix, you usually should be able to find a PR with the fixes somewhere in the android-component's list of pending PRs
    (or, failing that, a description of what to do in the Glean changelog).
 4. Ask in the [#glean channel on chat.mozilla.org](https://chat.mozilla.org/#/room/#glean:mozilla.org).
-
-## Notes
-
-This document is based on the equivalent documentation for application-services:
-[Using locally-published components in Fenix](https://github.com/mozilla/application-services/blob/HEAD/docs/howtos/locally-published-components-in-fenix.md)
-
----
-
-[^1]: It doesn't have to end with `-TESTING$N`, it only needs to have the format `-someidentifier`.
-`-SNAPSHOT$N` is also very common to use, however without the numeric suffix, this has specific meaning to gradle,
-so we avoid it.
-Additionally, while the `$N` we have used in our running example has matched
-(e.g. all of the identifiers ended in `-TESTING1`, this is not required, so long as you match everything up correctly at the end).
-
-[glean-yaml]: https://github.com/mozilla/glean/blob/main/.buildconfig.yml#L1
-[android-components-yaml]: https://github.com/mozilla-mobile/android-components/blob/HEAD/.buildconfig.yml#L1
-[android-components-deps]: https://github.com/mozilla-mobile/android-components/blob/50a2f28027f291bf1c6056d42b55e75ba3c050db/buildSrc/src/main/java/Dependencies.kt#L32
-[android-components-build-gradle]: https://github.com/mozilla-mobile/android-components/blob/b98206cf8de818499bdc87c00de942a41f8aa2fb/build.gradle#L28
-[fenix-build-gradle]: https://github.com/mozilla-mobile/fenix/blob/c21b41c1b23e6e25e0b5a8392f0c6dcb5ad25473/build.gradle#L5
-[fenix-deps]: https://github.com/mozilla-mobile/fenix/blob/c21b41c1b23e6e25e0b5a8392f0c6dcb5ad25473/buildSrc/src/main/java/AndroidComponents.kt#L6

--- a/glean-core/android-native/publish.gradle
+++ b/glean-core/android-native/publish.gradle
@@ -93,7 +93,8 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                     groupId = theGroupId
                     artifactId = theArtifactId
                     description = theDescription
-                    version = rootProject.ext.library.version
+                    // For mavenLocal publishing workflow, increment the version number every publish.
+                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
                     packaging = "aar"
 
                     licenses {
@@ -133,7 +134,8 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                     groupId = theGroupId
                     artifactId = "${theArtifactId}-forUnitTests"
                     description = theDescription + " " + forUnitTestDescriptionSuffix
-                    version = rootProject.ext.library.version
+                    // For mavenLocal publishing workflow, increment the version number every publish.
+                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
                     packaging = "jar"
 
                     licenses {

--- a/glean-core/android/publish.gradle
+++ b/glean-core/android/publish.gradle
@@ -52,7 +52,8 @@ ext.configurePublish = {
                     groupId = theGroupId
                     artifactId = theArtifactId
                     description = theDescription
-                    version = rootProject.ext.library.version
+                    // For mavenLocal publishing workflow, increment the version number every publish.
+                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
                     packaging = "aar"
 
                     licenses {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -34,7 +34,7 @@ if (project.name == 'glean-gradle-plugin') {
                     groupId = rootProject.ext.library.groupId
                     artifactId = project.ext.artifactId
                     description = project.ext.description
-                    version = rootProject.ext.library.version
+                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
 
                     licenses {
                         license {

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,11 @@ gradle.projectsLoaded { ->
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
     // gradle files. This means that they can just access "config.<value>", and it'll function properly
     gradle.rootProject.ext.library = [
-        version: buildconfig.libraryVersion,
+        // You can use -Plocal=true to help with mavenLocal publishing workflow.
+        // It makes a fake version number that's smaller than any published version,
+        // which can be depended on specifically by the ./build-scripts/substitute-local-appservices.gradle
+        // but which is unlikely to be depended on by accident otherwise.
+        version: gradle.rootProject.hasProperty('local') ? '0.0.1-SNAPSHOT' : buildconfig.libraryVersion,
         groupId: buildconfig.groupId,
     ]
 }


### PR DESCRIPTION
This is part of my effort to make local Glean testing across the Android apps easier again.
This will require some changes to A-C and Fenix as well, that I'm putting up next.
It's all based directly on what application-services is doing [here](https://github.com/mozilla/application-services/blob/main/build-scripts/substitute-local-appservices.gradle) and [here](https://github.com/mozilla/application-services/blob/main/automation/publish_to_maven_local_if_modified.py).

It's still not perfect, because Glean gets shipped through GeckoView and we also have the gradle plugin, which we can't just substitute in.

Putting this into draft as we will also need doc changes.

---

* [Android Components changes](https://github.com/badboy/android-components/commit/c376be4736a45f0e6ae2f99ec494a63da95b5c39)
* [Fenix changes](https://github.com/badboy/fenix/commit/1e77452c2d13229628229e2eb7a7c9a3fbb73970)