### PR TITLE
Bug 1762855 - Remove testable import in Swift doc examples

### DIFF
--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -382,7 +382,6 @@ Activate it by resetting Glean in your test's setup:
 ```swift
 // All pings and metrics testing APIs are marked as `internal`
 // so you need to import `Glean` explicitly in test mode.
-@testable import Glean
 import XCTest
 
 class GleanUsageTests: XCTestCase {

--- a/docs/user/reference/metrics/boolean.md
+++ b/docs/user/reference/metrics/boolean.md
@@ -125,8 +125,6 @@ assertTrue(Flags.INSTANCE.a11yEnabled.testGetValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertTrue(try Flags.a11yEnabled.testGetValue())
 ```
 
@@ -212,8 +210,6 @@ assertTrue(Flags.INSTANCE.a11yEnabled.testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertTrue(try Flags.a11yEnabled.testHasValue())
 ```
 

--- a/docs/user/reference/metrics/counter.md
+++ b/docs/user/reference/metrics/counter.md
@@ -140,8 +140,6 @@ assertEquals(6, Controls.INSTANCE.refreshPressed.testGetValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertEqual(6, try Controls.refreshPressed.testGetValue())
 ```
 
@@ -229,8 +227,6 @@ assertTrue(Controls.INSTANCE.refreshPressed.testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssert(Controls.refreshPressed.testHasValue())
 ```
 

--- a/docs/user/reference/metrics/datetime.md
+++ b/docs/user/reference/metrics/datetime.md
@@ -144,8 +144,6 @@ assertEquals(Install.INSTANCE.firstRun.testGetValue(), Date(2019, 3, 25));
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 let expectedDate = DateComponents(
                       calendar: Calendar.current,
                       year: 2004, month: 12, day: 9, hour: 8, minute: 3, second: 29
@@ -251,8 +249,6 @@ assertEquals("2019-03-25-05:00", Install.INSTANCE.firstRun.testGetValueAsString(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 assertEquals("2019-03-25-05:00", try Install.firstRun.testGetValueAsString())
 ```
 </div>
@@ -312,8 +308,6 @@ assertTrue(Install.INSTANCE.firstRun.testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssert(Install.firstRun.testHasValue())
 ```
 </div>
@@ -368,8 +362,6 @@ assertEquals(0, Install.INSTANCE.firstRun.testGetNumRecordedErrors(ErrorType.Inv
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertEqual(0, Install.firstRun.getNumRecordedErrors(.invalidValue))
 ```
 </div>

--- a/docs/user/reference/metrics/event.md
+++ b/docs/user/reference/metrics/event.md
@@ -240,8 +240,6 @@ assertEquals(Views.INSTANCE.loginOpened.testGetValue().size)
 <div data-lang="Swift" class="tab">
 
 ```swift
-@testable import Glean
-
 val snapshot = try! Views.loginOpened.testGetValue()
 XCTAssertEqual(2, snapshot.size)
 val first = snapshot[0]
@@ -344,8 +342,6 @@ assertTrue(Views.INSTANCE.loginOpened.testHasValue())
 <div data-lang="Swift" class="tab">
 
 ```swift
-@testable import Glean
-
 XCTAssert(Views.loginOpened.testHasValue())
 ```
 
@@ -401,8 +397,6 @@ assertEquals(0, Views.INSTANCE.loginOpened.testGetNumRecordedErrors(ErrorType.In
 <div data-lang="Swift" class="tab">
 
 ```swift
-@testable import Glean
-
 XCTAssertEqual(0, Views.loginOpened.testGetNumRecordedErrors(.invalidOverflow))
 ```
 </div>

--- a/docs/user/reference/metrics/labeled_booleans.md
+++ b/docs/user/reference/metrics/labeled_booleans.md
@@ -128,8 +128,6 @@ assertEquals(False, Acessibility.INSTANCE.features["high_contrast"].testGetValue
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Do the booleans have the expected values?
 XCTAssertEqual(true, try Accessibility.features["screen_reader"].testGetValue())
 XCTAssertEqual(false, try Accessibility.features["high_contrast"].testGetValue())
@@ -224,8 +222,6 @@ assertEquals(True, Acessibility.INSTANCE.features["high_contrast"].testHasValue(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(Accessibility.features["screen_reader"].testHasValue())
 XCTAssert(Accessibility.features["high_contrast"].testHasValue())
@@ -281,8 +277,6 @@ assertEquals(0, Acessibility.INSTANCE.features.testGetNumRecordedErrors());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Were there any invalid labels?
 XCTAssertEqual(0, Accessibility.features.testGetNumRecordedErrors(.invalidLabel))
 ```

--- a/docs/user/reference/metrics/labeled_counters.md
+++ b/docs/user/reference/metrics/labeled_counters.md
@@ -143,8 +143,6 @@ assertEquals(3, Stability.INSTANCE.crashCount["native_code_crash"].testGetValue(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Do the counters have the expected values?
 XCTAssertEqual(1, try Stability.crashCount["uncaught_exception"].testGetValue())
 XCTAssertEqual(3, try Stability.crashCount["native_code_crash"].testGetValue())
@@ -239,8 +237,6 @@ assertTrue(Stability.INSTANCE.crashCount["native_code_crash"].testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(Stability.crashCount["uncaught_exception"].testHasValue())
 XCTAssert(Stability.crashCount["native_code_crash"].testHasValue())
@@ -296,8 +292,6 @@ assertEquals(0, Stability.INSTANCE.crashCount.testGetNumRecordedErrors(ErrorType
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Were there any invalid labels?
 XCTAssertEqual(0, Stability.crashCount.testGetNumRecordedErrors(.invalidLabel))
 ```

--- a/docs/user/reference/metrics/labeled_strings.md
+++ b/docs/user/reference/metrics/labeled_strings.md
@@ -123,8 +123,6 @@ assertTrue(Login.INSTANCE.errorsByStage["server_auth"].testGetValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Does the metric have the expected value?
 XCTAssert(Login.errorsByStage["server_auth"].testGetValue())
 ```
@@ -212,8 +210,6 @@ assertTrue(Login.INSTANCE.errorsByStage["server_auth"].testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(Login.errorsByStage["server_auth"].testHasValue())
 ```
@@ -265,8 +261,6 @@ assertEquals(0, Login.INSTANCE.errorsByStage.testGetNumRecordedErrors(ErrorType.
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Were there any invalid labels?
 XCTAssertEqual(0, Login.errorsByStage.testGetNumRecordedErrors(.invalidLabel))
 ```

--- a/docs/user/reference/metrics/memory_distribution.md
+++ b/docs/user/reference/metrics/memory_distribution.md
@@ -150,8 +150,6 @@ assertEquals(2L, snapshot.getCount());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Get snapshot
 let snapshot = try! Memory.heapAllocated.testGetValue()
 
@@ -255,8 +253,6 @@ assertTrue(Memory.INSTANCE.heapAllocated().testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(Memory.heapAllocated.testHasValue())
 ```
@@ -316,8 +312,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Did this record a negative value?
 XCTAssertEqual(0, Memory.heapAllocated.testGetNumRecordedErrors(.invalidValue))
 ```

--- a/docs/user/reference/metrics/quantity.md
+++ b/docs/user/reference/metrics/quantity.md
@@ -132,8 +132,6 @@ assertEquals(6, Display.INSTANCE.width.testGetValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Does the quantity have the expected value?
 XCTAssertEqual(6, try Display.width.testGetValue())
 ```
@@ -222,8 +220,6 @@ assertTrue(Display.INSTANCE.width.testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(Display.width.testHasValue())
 ```
@@ -280,8 +276,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Did the quantity record a negative value?
 XCTAssertEqual(1, Display.width.testGetNumRecordedErrors(.invalidValue))
 ```

--- a/docs/user/reference/metrics/string.md
+++ b/docs/user/reference/metrics/string.md
@@ -158,8 +158,6 @@ assertEquals("wikipedia", SearchDefault.INSTANCE.name.testGetValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Does the string metric have the expected value?
 XCTAssertEqual("wikipedia", try SearchDefault.name.testGetValue())
 ```
@@ -257,8 +255,6 @@ assertTrue(SearchDefault.INSTANCE.name.testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(SearchDefault.name.testHasValue())
 ```
@@ -321,8 +317,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was the string truncated, and an error reported?
 XCTAssertEqual(1, SearchDefault.name.testGetNumRecordedErrors(.invalidOverflow))
 ```

--- a/docs/user/reference/metrics/string_list.md
+++ b/docs/user/reference/metrics/string_list.md
@@ -221,8 +221,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertEqual(["Google", "DuckDuckGo"], try Search.engines.testGetValue())
 ```
 
@@ -310,8 +308,6 @@ assertTrue(Search.INSTANCE.engines().testHasValue())
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssert(Search.engines.testHasValue())
 ```
 
@@ -359,8 +355,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Were any of the values too long, and thus an error was recorded?
 XCTAssertEqual(1, Search.engines.testGetNumRecordedErrors(.invalidValue))
 ```

--- a/docs/user/reference/metrics/timespan.md
+++ b/docs/user/reference/metrics/timespan.md
@@ -502,8 +502,6 @@ assertTrue(Auth.INSTANCE.loginTime.testGetValue() > 0);
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssert(try Auth.loginTime.testGetValue() > 0)
 ```
 </div>
@@ -573,8 +571,6 @@ assertTrue(Auth.INSTANCE.loginTime.testHasValue() > 0);
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssert(try Auth.loginTime.testHasValue() > 0)
 ```
 </div>
@@ -629,8 +625,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertEqual(1, Auth.loginTime.testGetNumRecordedErrors(.invalidValue))
 ```
 </div>

--- a/docs/user/reference/metrics/timing_distribution.md
+++ b/docs/user/reference/metrics/timing_distribution.md
@@ -393,8 +393,6 @@ assertEquals(1L, snapshot.getCount());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Get snapshot.
 let snapshot = try! pages.pageLoad.testGetValue()
 
@@ -488,8 +486,6 @@ assertTrue(Pages.INSTANCE.pageLoad().testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(pages.pageLoad.testHasValue())
 ```
@@ -546,8 +542,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Assert that no errors were recorded.
 XCTAssertEqual(0, pages.pageLoad.testGetNumRecordedErrors(.invalidValue))
 ```

--- a/docs/user/reference/metrics/url.md
+++ b/docs/user/reference/metrics/url.md
@@ -154,8 +154,6 @@ assertEquals("https://mysearchengine.com/", Search.INSTANCE.template.testGetValu
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertEqual("https://mysearchengine.com/", try Search.template.testGetValue())
 ```
 
@@ -223,8 +221,6 @@ assertTrue(Search.INSTANCE.template.testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssert(try Search.template.testHasValue())
 ```
 
@@ -292,8 +288,6 @@ assertEquals(
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 XCTAssertEqual(0, Search.template.testGetNumRecordedErrors(.invalidValue))
 XCTAssertEqual(0, Search.template.testGetNumRecordedErrors(.invalidOverflow))
 ```

--- a/docs/user/reference/metrics/uuid.md
+++ b/docs/user/reference/metrics/uuid.md
@@ -228,8 +228,6 @@ assertEquals(uuid, User.INSTANCE.clientId.testGetValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was it the expected value?
 XCTAssertEqual(uuid, try User.clientId.testGetValue())
 ```
@@ -328,8 +326,6 @@ assertTrue(User.INSTANCE.clientId.testHasValue());
 <div data-lang="Swift" class="tab">
 
 ```Swift
-@testable import Glean
-
 // Was anything recorded?
 XCTAssert(User.clientId.testHasValue())
 ```

--- a/docs/user/reference/pings/index.md
+++ b/docs/user/reference/pings/index.md
@@ -175,8 +175,6 @@ assertTrue(validatorRun);
 <div data-lang="Swift" class="tab">
 
 ```swift
-@testable import Glean
-
 // Record some data.
 Search.defaultEngine.add(5)
 


### PR DESCRIPTION
It's not needed:
Everything in Glean is reachable without `testable`.
All test methods are on objects created in the application's scope, no
need to call things coming from Glean directly.

[doc only]