### PR TITLE
Bug 1766988 - Gradle Plugin: Allow override of the glean_parser to be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v44.1.1...main)
 
+* Kotlin
+  * (Development only) Allow to override the used `glean_parser` in the Glean Gradle Plugin ([#2029](https://github.com/mozilla/glean/pull/2029))
+
 # v44.1.1 (2022-04-14)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v44.1.0...v44.1.1)

--- a/docs/dev/SUMMARY.md
+++ b/docs/dev/SUMMARY.md
@@ -12,6 +12,7 @@
     - [Android SDK/NDK versions](android/sdk-ndk-versions.md)
     - [Development with android-components](android/development-with-android-components.md)
     - [Locally-published components in Fenix](android/locally-published-components-in-fenix.md)
+    - [Substituting glean_parser](android/glean-parser-substitution.md)
 - [iOS bindings](ios/index.md)
     - [Setup Build Environment](ios/setup-ios-build-environment.md)
     - [Debugging Different Versions of Glean](ios/debug-glean-on-ios.md)

--- a/docs/dev/android/glean-parser-substitution.md
+++ b/docs/dev/android/glean-parser-substitution.md
@@ -1,0 +1,20 @@
+# Substituting `glean_parser`
+
+By default the Glean Kotlin SDK requires an exact version of the [`glean_parser`].
+It's automatically installed as part of the Glean Gradle Plugin.
+
+For upgrading the required `glean_parser` see [Upgrading glean_parser](../upgrading-glean-parser.md).
+
+For local development the `glean_parser` can be replaced with a development version.
+To use `glean_parser` from a git repository, add this to the project's `build.gradle`:
+
+```groovy
+ext.gleanParserOverride = "git+ssh://git@github.com/mozilla/glean_parser@main#glean-parser"
+```
+
+Adjust the repository URL as needed. `main` can be any available branch.
+Ensure the suffix `#glean_parser` exists, as it tells the Python package management about the name.
+
+
+
+[`glean_parser`]: https://github.com/mozilla/glean_parser/


### PR DESCRIPTION
A user can set an override for the glean_parser to be installed in the
virtual environment.

    ext.gleanParserOverride = "git+ssh://git@github.com/mozilla/glean_parser@main#glean-parser"

This allows to switch out the used glean_parser version for local
testing.

---

It's a bit of magic in the code, but I didn't want to learn more groovy to make it "nice"