### PR TITLE
Kotlin: Use the library name `xul` for the core parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "glean-bundle-android"
+version = "1.0.0"
+dependencies = [
+ "glean-core",
+]
+
+[[package]]
 name = "glean-core"
 version = "44.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "glean-core",
   "glean-core/rlb",
   "glean-core/bundle",
+  "glean-core/bundle-android",
   "tools/embedded-uniffi-bindgen",
 ]
 

--- a/glean-core/android-native/build.gradle
+++ b/glean-core/android-native/build.gradle
@@ -53,7 +53,7 @@ android {
 
 cargo {
     // The directory of the Cargo.toml to build.
-    module = '../bundle'
+    module = '../bundle-android'
 
     // The Android NDK API level to target.
     apiLevel = 21
@@ -61,7 +61,13 @@ cargo {
     // Where Cargo writes its outputs.
     targetDirectory = '../../target'
 
-    libname = 'glean_ffi'
+    // HACK:
+    // We consume this as libxul.
+    // Glean is build into libxul from mozilla-central
+    // and users consume it as part of GeckoView.
+    // Because UniFFI does not have the option to switch the library to consume,
+    // except at build time, we use this hack for now.
+    libname = 'xul'
 
     targets = rootProject.ext.rustTargets
 

--- a/glean-core/bundle-android/Cargo.toml
+++ b/glean-core/bundle-android/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "glean-bundle-android"
+# No need to ever change this version
+version = "1.0.0"
+authors = ["The Glean Team <glean-team@mozilla.com>"]
+edition = "2018"
+description = "Static/Dynamic library build of glean-ffi, for use in Android builds"
+repository = "https://github.com/mozilla/glean"
+license = "MPL-2.0"
+
+# This crate is never published to crates.io
+publish = false
+
+# We use the name `xul` for now, because we ship this through mozilla-central
+# and it is consumed as `libxul.so`.
+[lib]
+name = "xul"
+crate-type = ["cdylib"]
+# We re-use the source from `glean-bundle`,
+# no need to duplicate it, no risk of diverging
+path = "../bundle/src/lib.rs"
+
+[dependencies.glean-core]
+# No version specified, we build against what's available here.
+path = ".."
+
+[features]
+# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
+rkv-safe-mode = ["glean-core/rkv-safe-mode"]

--- a/glean-core/uniffi.toml
+++ b/glean-core/uniffi.toml
@@ -1,6 +1,6 @@
 [bindings.kotlin]
 package_name = "mozilla.telemetry.glean.internal"
-cdylib_name = "glean_ffi"
+cdylib_name = "xul"
 
 [bindings.swift]
 cdylib_name = "glean_ffi"


### PR DESCRIPTION
This is a hack:
Glean is build into libxul from mozilla-central and users consume it as part of GeckoView.
Because UniFFI does not have the option to switch the library to consume,
except at build time, we use this hack for now.