### PR TITLE
CI: Run Rust tests on 1.60.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,8 @@ jobs:
       - image: cimg/rust:1.60
     resource_class: "medium+"
     steps:
-      - test-rust
+      - test-rust:
+          rust-version: "1.60.0"
 
   Rust tests - beta:
     docker:


### PR DESCRIPTION
1.61.0, released yesterday (2022-05-19) seems to lead to memory
exhaustion on CircleCI.
Let's go back to 1.60 for now.