### PR TITLE
Bug 1770791 - Remove duplicate initialization in python glean package

### DIFF
--- a/glean-core/python/glean/_ffi.py
+++ b/glean-core/python/glean/_ffi.py
@@ -52,6 +52,3 @@ def setup_logging():
     logging_thread = threading.Thread(target=log_handler)
     logging_thread.daemon = True
     logging_thread.start()
-
-
-setup_logging()

--- a/glean-core/python/tests/test_subprocess.py
+++ b/glean-core/python/tests/test_subprocess.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+def test_subprocess_works():
+    import glean  # noqa: F401
+    import subprocess
+
+    # Importing glean shouldn't affect subprocess.
+    output = subprocess.check_output(["echo", "hello"]).decode().strip()
+    assert output == "hello"

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -889,13 +889,12 @@ pub fn glean_enable_logging_to_fd(fd: u64) {
         // language binding should setup a pipe and pass in the descriptor to
         // the writing side of the pipe as the `fd` parameter. Log messages are
         // written as JSON to the file descriptor.
-        if FD_LOGGER.set(fd_logger::FdLogger::new(fd)).is_ok() {
-            // Set the level so everything goes through to the language
-            // binding side where it will be filtered by the language
-            // binding's logging system.
-            if log::set_logger(FD_LOGGER.get().unwrap()).is_ok() {
-                log::set_max_level(log::LevelFilter::Debug);
-            }
+        let logger = FD_LOGGER.get_or_init(|| fd_logger::FdLogger::new(fd));
+        // Set the level so everything goes through to the language
+        // binding side where it will be filtered by the language
+        // binding's logging system.
+        if log::set_logger(logger).is_ok() {
+            log::set_max_level(log::LevelFilter::Debug);
         }
     }
 }


### PR DESCRIPTION
for [bug 1770791](https://bugzilla.mozilla.org/show_bug.cgi?id=1770791)

On Windows, Creating `FdLogger` twice causes the subsequent `subprocess` operation somehow fail.
And apparently the duplicate initialization is completely unnecessary.
So, applied 2 fixes, both on Rust side and Python side.

Rust side's `glean_enable_logging_to_fd` uses `OnceCell` to prevent subsequent call overwriting the value,
but `fd_logger::FdLogger::new(fd)` is not guarded.
So, it should check `FD_LOGGER.get().is_some()` before `fd_logger::FdLogger::new(fd)`.

Python side calls `setup_logging` twice, first time from `_ffi.py` top-level, and second time from `glean.py` top-level.
Either of them should be removed, and I've removed the former one.

The attached testcase fails on windows, with `py.test -s tests/test_subprocess.py`.
the `-s` option seems to be necessary to hit the problematic case.
