### PR TITLE
Replace auto-assign bot with CODEOWNERS and GitHub's auto-assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This CODEOWNERS file defines individuals or teams that are responsible
+# for code in this repository.
+# See https://help.github.com/articles/about-codeowners/ for details.
+
+* @mozilla/glean

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,9 +1,0 @@
-addReviewers: true
-addAssignees: false
-reviewers:
-  - badboy
-  - Dexterp37
-  - travis79
-  - chutten
-
-numberOfReviewers: 1


### PR DESCRIPTION
Making use of GitHub's ability to auto-assign people from a team in a
round-robin fashion: https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#routing-algorithms