### PR TITLE
Ensure Python linting is ignoring the venv dir, not files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ shellcheck: ## Run shellcheck against important shell scripts
 
 lint-python: python-setup ## Run flake8 and black to lint Python code
 	$(GLEAN_PYENV)/bin/python3 -m flake8 glean-core/python/glean glean-core/python/tests
-	$(GLEAN_PYENV)/bin/python3 -m black --check --exclude \(.venv\*\)\|\(.eggs\)\|_uniffi.py glean-core/python
+	$(GLEAN_PYENV)/bin/python3 -m black --check --exclude \(\.venv.\*\)\|\(.eggs\)\|_uniffi.py glean-core/python/glean glean-core/python/tests
 	$(GLEAN_PYENV)/bin/python3 -m mypy glean-core/python/glean
 
 .PHONY: lint-rust lint-kotlin lint-swift lint-yaml
@@ -124,7 +124,7 @@ fmt-rust: ## Format all Rust code
 	cargo fmt --all
 
 fmt-python: python-setup ## Run black to format Python code
-	$(GLEAN_PYENV)/bin/python3 -m black glean-core/python/glean glean-core/python/tests
+	$(GLEAN_PYENV)/bin/python3 -m black --exclude \(\.venv.\*\)\|\(.eggs\)\|_uniffi.py glean-core/python/glean glean-core/python/tests
 
 .PHONY: fmt-rust fmt-python
 

--- a/glean-core/python/glean/metrics/event.py
+++ b/glean-core/python/glean/metrics/event.py
@@ -74,7 +74,9 @@ class EventMetricType:
 
         self._inner.record(extra)
 
-    def test_get_value(self, ping_name: Optional[str] = None) -> Optional[List[RecordedEvent]]:
+    def test_get_value(
+        self, ping_name: Optional[str] = None
+    ) -> Optional[List[RecordedEvent]]:
         """
         Returns the stored value for testing purposes only.
 


### PR DESCRIPTION
Also reformats the one file that was left out previously.

[doc only]