### PR TITLE
Remove `rlb_flush_dispatcher` symbol

### DIFF
--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -707,6 +707,7 @@ def test_app_display_version_unknown():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="bug 1771157: Windows failures")
 def test_flipping_upload_enabled_respects_order_of_events(tmpdir, monkeypatch):
     # This test relies on testing mode to be disabled, since we need to prove the
     # real-world async behaviour of this.

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -128,21 +128,6 @@ pub fn shutdown() {
     glean_core::shutdown()
 }
 
-/// Unblock the global dispatcher to start processing queued tasks.
-///
-/// This should _only_ be called if it is guaranteed that `initialize` will never be called.
-///
-/// **Note**: Exported as a FFI function to be used by other language bindings (e.g. Kotlin/Swift)
-/// to unblock the RLB-internal dispatcher.
-/// This allows the usage of both the RLB and other language bindings (e.g. Kotlin/Swift)
-/// within the same application.
-#[no_mangle]
-#[inline(never)]
-pub extern "C" fn rlb_flush_dispatcher() {
-    log::trace!("FLushing RLB dispatcher through the FFI");
-    glean_core::rlb_flush_dispatcher()
-}
-
 /// Sets whether upload is enabled or not.
 ///
 /// See [`glean_core::Glean::set_upload_enabled`].

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -486,26 +486,6 @@ pub fn persist_ping_lifetime_data() {
     });
 }
 
-/// Unblock the global dispatcher to start processing queued tasks.
-pub extern "C" fn rlb_flush_dispatcher() {
-    let was_initialized = was_initialize_called();
-
-    // Panic in debug mode
-    debug_assert!(!was_initialized);
-
-    // In release do a check and bail out
-    if was_initialized {
-        log::error!(
-            "Tried to flush the dispatcher from outside, but Glean was initialized in the RLB."
-        );
-        return;
-    }
-
-    if let Err(err) = dispatcher::flush_init() {
-        log::error!("Unable to flush the preinit queue: {}", err);
-    }
-}
-
 fn initialize_core_metrics(glean: &Glean, client_info: &ClientInfoMetrics) {
     core_metrics::internal_metrics::app_build.set_sync(glean, &client_info.app_build[..]);
     core_metrics::internal_metrics::app_display_version


### PR DESCRIPTION
This was used to unblock the Rust dispatcher from foreign language bindings.
Now that we have _only_ the Rust dispatcher it's of course the one
that's going to be unblocked by `initialize`.
The functionality to automatically call this from `glean-ffi` was
removed when `glean-ffi` itself was removed.

This is thus just a cleanup of already unused functionality.