### PR TITLE
Re-export once_cell

### DIFF
--- a/glean-core/rlb/src/private/mod.rs
+++ b/glean-core/rlb/src/private/mod.rs
@@ -26,3 +26,9 @@ pub use glean_core::UuidMetric;
 pub use glean_core::{AllowLabeled, LabeledMetric};
 pub use glean_core::{Datetime, DatetimeMetric};
 pub use ping::PingType;
+
+// Re-export types that are used by the glean_parser-generated code.
+#[doc(hidden)]
+pub mod __export {
+    pub use once_cell::sync::Lazy;
+}


### PR DESCRIPTION
This can then be used in generated code without the end user required to
depend on the (right) version of once_cell.

---

glean_parser update coming.