### PR TITLE
Bug 1773262 - Relax glean_parser version requirement to "all compatible releases"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v51.1.0...main)
 
+* General
+  * Relax `glean_parser` version requirement. All "compatible releases" are now allowed ([#2086](https://github.com/mozilla/glean/pull/2086))
 * Kotlin
   * BUGFIX: Re-enable correctly connecting `glean.validation.foreground_count` again ([#2153](https://github.com/mozilla/glean/pull/2153))
 

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ python-docs: build-python ## Build the Python documentation
 .PHONY: docs rust-docs swift-docs
 
 metrics-docs: python-setup ## Build the internal metrics documentation
-	$(GLEAN_PYENV)/bin/pip install glean_parser==6.1.2
+	$(GLEAN_PYENV)/bin/pip install glean_parser~=6.1
 	$(GLEAN_PYENV)/bin/glean_parser translate --allow-reserved \
 		 -f markdown \
 		 -o ./docs/user/user/collected-metrics \

--- a/bin/update-glean-parser-version.sh
+++ b/bin/update-glean-parser-version.sh
@@ -27,18 +27,19 @@ if [ -z "$1" ]; then
 fi
 
 NEW_VERSION="$1"
+NEW_VERSION_MAJOR_MINOR="$(echo "$NEW_VERSION" | awk -F'.' '{print $1"."$2}')"
 
 # Update the version in glean-core/ios/sdk_generator.sh
 FILE=glean-core/ios/sdk_generator.sh
 run $SED -i.bak -E \
-    -e "s/^GLEAN_PARSER_VERSION=[0-9.]+/GLEAN_PARSER_VERSION=${NEW_VERSION}/" \
+    -e "s/^GLEAN_PARSER_VERSION=[0-9.]+/GLEAN_PARSER_VERSION=${NEW_VERSION_MAJOR_MINOR}/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
 # Update the version in glean-core/python/setup.py
 FILE=glean-core/python/setup.py
 run $SED -i.bak -E \
-    -e "s/\"glean_parser==[0-9.]+\"/\"glean_parser==${NEW_VERSION}\"/" \
+    -e "s/\"glean_parser~=[0-9.]+\"/\"glean_parser~=${NEW_VERSION_MAJOR_MINOR}\"/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
@@ -52,7 +53,7 @@ run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 # update the version in gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
 FILE=gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
 run $SED -i.bak -E \
-    -e "s/GLEAN_PARSER_VERSION = \"[0-9.]+\"/GLEAN_PARSER_VERSION = \"${NEW_VERSION}\"/" \
+    -e "s/GLEAN_PARSER_VERSION = \"[0-9.]+\"/GLEAN_PARSER_VERSION = \"${NEW_VERSION_MAJOR_MINOR}\"/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
@@ -80,6 +81,6 @@ run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 # update the version in the Makefile
 FILE=Makefile
 run $SED -i.bak -E \
-    -e "s/glean_parser==[0-9.]+/glean_parser==${NEW_VERSION}/" \
+    -e "s/glean_parser~=[0-9.]+/glean_parser~=${NEW_VERSION_MAJOR_MINOR}/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=6.1.2
+GLEAN_PARSER_VERSION=6.1
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034
@@ -159,7 +159,7 @@ VENVDIR="${SOURCE_ROOT}/.venv"
 # We need at least pip 20.3 for Big Sur support, see https://pip.pypa.io/en/stable/news/#id48
 # Latest pip is 21.0.1
 "${VENVDIR}"/bin/pip install "pip>=20.3"
-"${VENVDIR}"/bin/pip install --upgrade glean_parser==$GLEAN_PARSER_VERSION
+"${VENVDIR}"/bin/pip install --upgrade "glean_parser~=$GLEAN_PARSER_VERSION"
 
 # Run the glinter
 # Turn its warnings into warnings visible in Xcode (but don't do for the success message)

--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -9,6 +9,7 @@ import warnings
 
 
 from pkg_resources import get_distribution, DistributionNotFound
+from semver import VersionInfo  # type: ignore
 
 
 import glean_parser  # type: ignore
@@ -31,11 +32,14 @@ __email__ = "glean-team@mozilla.com"
 
 
 GLEAN_PARSER_VERSION = "6.1.2"
+parser_version = VersionInfo.parse(GLEAN_PARSER_VERSION)
+parser_version_next_major = parser_version.bump_major()
 
 
-if glean_parser.__version__ != GLEAN_PARSER_VERSION:
+current_parser = VersionInfo.parse(glean_parser.__version__)
+if current_parser < parser_version or current_parser >= parser_version_next_major:
     warnings.warn(
-        f"glean_sdk expected glean_parser v{GLEAN_PARSER_VERSION}, "
+        f"glean_sdk expected glean_parser ~= v{GLEAN_PARSER_VERSION}, "
         f"found v{glean_parser.__version__}",
         Warning,
     )

--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -10,6 +10,7 @@ pip
 pytest-localserver==0.5.1
 pytest-runner==5.3.1
 pytest==7.0.1
+semver==2.13.0
 setuptools-git==1.2
 twine==3.8.0
 types-pkg_resources==0.1.3

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -59,7 +59,8 @@ with (SRC_ROOT / "CHANGELOG.md").open() as history_file:
 version = "51.1.0"
 
 requirements = [
-    "glean_parser==6.1.2",
+    "semver>=2.13.0",
+    "glean_parser~=6.1",
 ]
 
 # The environment variable `GLEAN_BUILD_VARIANT` can be set to `debug` or `release`

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -406,6 +406,7 @@ except:
                     args "pip"
                     args "install"
                     args "glean_parser"
+                    args "--no-index"
                     args "-f"
                     args pythonPackagesDir
                 }


### PR DESCRIPTION
In pip `~=V.N` is equivalent to `>= V.N, == V.*`
So we essentially allow everything from the specified minor version
upwards until the next major version (excluded).
As long as glean_parser is careful to not introduce breaking changes
before that this will simplify work a lot by allowing small bug fixes
without requiring subsequent Glean releases to bump versions all the
time.