### PR TITLE
Bug 1771705 - Remove ping name from test_get_num_recorded_errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 * General
   * Remove `testHasValue` from all implementations.
     `testGetValue` always returns a null value
-    (`null`, `nil`, `None` depending on the language) and does not throw an exception.
+    (`null`, `nil`, `None` depending on the language) and does not throw an exception ([#2087](https://github.com/mozilla/glean/pull/2087)).
+  * BREAKING CHANGE: Dropped `ping_name` argument from all `test_get_num_recorded_errors` methods ([#2088](https://github.com/mozilla/glean/pull/2088))  
+    Errors default to the `metrics` ping, so that's what is queried internally.
 * Kotlin
   * Fix the Glean Gradle Plugin to work with Android Gradle Plugin v7.2.1 ([#2114](https://github.com/mozilla/glean/pull/2114))
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -48,7 +48,5 @@ class CustomDistributionMetricType(
     fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    @JvmOverloads
-    fun testGetNumRecordedErrors(error: ErrorType, pingName: String? = null) =
-        inner.testGetNumRecordedErrors(error, pingName)
+    fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
@@ -126,13 +126,9 @@ class EventMetricType<ExtraKeysEnum, ExtraObject> internal constructor(
      * Returns the number of errors recorded for the given metric.
      *
      * @param errorType The type of the error recorded.
-     * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String? = null): Int {
-        return inner.testGetNumRecordedErrors(errorType, pingName)
-    }
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -112,11 +112,11 @@ class LabeledMetricType<T>(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetNumRecordedErrors(errorType: ErrorType, pingName: String = sendInPings.first()): Int {
+    fun testGetNumRecordedErrors(errorType: ErrorType): Int {
         return when (this.inner) {
-            is LabeledCounter -> this.inner.testGetNumRecordedErrors(errorType, pingName)
-            is LabeledBoolean -> this.inner.testGetNumRecordedErrors(errorType, pingName)
-            is LabeledString -> this.inner.testGetNumRecordedErrors(errorType, pingName)
+            is LabeledCounter -> this.inner.testGetNumRecordedErrors(errorType)
+            is LabeledBoolean -> this.inner.testGetNumRecordedErrors(errorType)
+            is LabeledString -> this.inner.testGetNumRecordedErrors(errorType)
             else -> throw IllegalStateException(
                 "Can not create a labeled version of this metric type"
             )

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -34,7 +34,5 @@ class MemoryDistributionMetricType(meta: CommonMetricData, memoryUnit: MemoryUni
     fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    @JvmOverloads
-    fun testGetNumRecordedErrors(error: ErrorType, pingName: String? = null) =
-        inner.testGetNumRecordedErrors(error, pingName)
+    fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -61,7 +61,5 @@ class TimingDistributionMetricType(meta: CommonMetricData, timeUnit: TimeUnit) :
     fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    @JvmOverloads
-    fun testGetNumRecordedErrors(error: ErrorType, pingName: String? = null) =
-        inner.testGetNumRecordedErrors(error, pingName)
+    fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
 }

--- a/glean-core/ios/Glean/Metrics/DatetimeMetric.swift
+++ b/glean-core/ios/Glean/Metrics/DatetimeMetric.swift
@@ -77,11 +77,9 @@ public class DatetimeMetricType {
     ///
     /// - parameters:
     ///     * errorType: The type of error recorded.
-    ///     * pingName: represents the name of the ping to retrieve the metric for.
-    ///                 Defaults to the first value in `sendInPings`.
     ///
     /// - returns: The number of errors recorded for the metric for the given error type.
-    public func testGetNumRecordedErrors(_ error: ErrorType, pingName: String? = nil) -> Int32 {
-        inner.testGetNumRecordedErrors(error, pingName)
+    public func testGetNumRecordedErrors(_ error: ErrorType) -> Int32 {
+        inner.testGetNumRecordedErrors(error)
     }
 }

--- a/glean-core/ios/Glean/Metrics/EventMetric.swift
+++ b/glean-core/ios/Glean/Metrics/EventMetric.swift
@@ -108,11 +108,9 @@ public class EventMetricType<ExtraKeysEnum: EventExtraKey, ExtraObject: EventExt
     ///
     /// - parameters:
     ///     * errorType: The type of error recorded.
-    ///     * pingName: represents the name of the ping to retrieve the metric for.
-    ///                 Defaults to the first value in `sendInPings`.
     ///
     /// - returns: The number of errors recorded for the metric for the given error type.
-    public func testGetNumRecordedErrors(_ errorType: ErrorType, pingName: String? = nil) -> Int32 {
-        return self.inner.testGetNumRecordedErrors(errorType, pingName)
+    public func testGetNumRecordedErrors(_ errorType: ErrorType) -> Int32 {
+        return self.inner.testGetNumRecordedErrors(errorType)
     }
 }

--- a/glean-core/ios/Glean/Metrics/LabeledMetric.swift
+++ b/glean-core/ios/Glean/Metrics/LabeledMetric.swift
@@ -93,19 +93,15 @@ public class LabeledMetricType<T> {
     ///
     /// - parameters:
     ///     * errorType: The type of the error recorded.
-    ///     * pingName: represents the name of the ping to retrieve the metric for.
-    ///                 Defaults to the first value in `sendInPings`.
     /// - returns: the number of errors recorded for the metric.
-    public func testGetNumRecordedErrors(_ errorType: ErrorType, pingName: String? = nil) -> Int32 {
-        let pingName = pingName ?? self.sendInPings[0]
-
+    public func testGetNumRecordedErrors(_ errorType: ErrorType) -> Int32 {
         switch self.inner {
         case is LabeledCounter:
-            return (self.inner as! LabeledCounter).testGetNumRecordedErrors(errorType, pingName)
+            return (self.inner as! LabeledCounter).testGetNumRecordedErrors(errorType)
         case is LabeledBoolean:
-            return (self.inner as! LabeledBoolean).testGetNumRecordedErrors(errorType, pingName)
+            return (self.inner as! LabeledBoolean).testGetNumRecordedErrors(errorType)
         case is LabeledString:
-            return (self.inner as! LabeledString).testGetNumRecordedErrors(errorType, pingName)
+            return (self.inner as! LabeledString).testGetNumRecordedErrors(errorType)
         default:
             // The constructor will already throw an exception on an unhandled sub-metric type
             assertUnreachable()

--- a/glean-core/ios/Glean/Metrics/UrlMetric.swift
+++ b/glean-core/ios/Glean/Metrics/UrlMetric.swift
@@ -56,11 +56,9 @@ public class UrlMetricType {
     ///
     /// - parameters:
     ///     * errorType: The type of error recorded.
-    ///     * pingName: represents the name of the ping to retrieve the metric for.
-    ///                 Defaults to the first value in `sendInPings`.
     ///
     /// - returns: The number of errors recorded for the metric for the given error type.
-    public func testGetNumRecordedErrors(_ error: ErrorType, pingName: String? = nil) -> Int32 {
-        inner.testGetNumRecordedErrors(error, pingName)
+    public func testGetNumRecordedErrors(_ error: ErrorType) -> Int32 {
+        inner.testGetNumRecordedErrors(error)
     }
 }

--- a/glean-core/python/glean/metrics/datetime.py
+++ b/glean-core/python/glean/metrics/datetime.py
@@ -116,10 +116,8 @@ class DatetimeMetricType:
         )
         return dt
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 __all__ = ["DatetimeMetricType"]

--- a/glean-core/python/glean/metrics/event.py
+++ b/glean-core/python/glean/metrics/event.py
@@ -97,9 +97,7 @@ class EventMetricType:
 
         return recordings
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
         """
         Returns the number of errors recorded for the given metric.
 
@@ -112,7 +110,7 @@ class EventMetricType:
             num_errors (int): The number of errors recorded for the metric for
                 the given error type.
         """
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 __all__ = ["EventMetricType", "RecordedEvent", "EventExtras"]

--- a/glean-core/python/glean/metrics/labeled.py
+++ b/glean-core/python/glean/metrics/labeled.py
@@ -60,9 +60,7 @@ class LabeledMetricBase:
         """
         return self._inner.get(item)
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
         """
         Returns the number of errors recorded for the given metric.
 
@@ -75,7 +73,7 @@ class LabeledMetricBase:
             num_errors (int): The number of errors recorded for the metric for
                 the given error type.
         """
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 class LabeledBooleanMetricType(LabeledMetricBase):

--- a/glean-core/python/glean/metrics/string.py
+++ b/glean-core/python/glean/metrics/string.py
@@ -43,10 +43,8 @@ class StringMetricType:
     def test_get_value(self, ping_name: Optional[str] = None) -> Optional[str]:
         return self._inner.test_get_value(ping_name)
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 __all__ = ["StringMetricType"]

--- a/glean-core/python/glean/metrics/timespan.py
+++ b/glean-core/python/glean/metrics/timespan.py
@@ -116,9 +116,7 @@ class TimespanMetricType:
         """
         return self._inner.test_get_value(ping_name)
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
         """
         Returns the number of errors recorded for the given metric.
 
@@ -131,7 +129,7 @@ class TimespanMetricType:
             num_errors (int): The number of errors recorded for the metric for
                 the given error type.
         """
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 __all__ = ["TimespanMetricType"]

--- a/glean-core/python/glean/metrics/timing_distribution.py
+++ b/glean-core/python/glean/metrics/timing_distribution.py
@@ -111,9 +111,7 @@ class TimingDistributionMetricType:
         """
         return self._inner.test_get_value(ping_name)
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
         """
         Returns the number of errors recorded for the given metric.
 
@@ -126,7 +124,7 @@ class TimingDistributionMetricType:
             num_errors (int): The number of errors recorded for the metric for
                 the given error type.
         """
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 __all__ = ["TimingDistributionMetricType"]

--- a/glean-core/python/glean/metrics/url.py
+++ b/glean-core/python/glean/metrics/url.py
@@ -44,10 +44,8 @@ class UrlMetricType:
     def test_get_value(self, ping_name: Optional[str] = None) -> Optional[str]:
         return self._inner.test_get_value(ping_name)
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 __all__ = ["UrlMetricType"]

--- a/glean-core/python/glean/metrics/uuid.py
+++ b/glean-core/python/glean/metrics/uuid.py
@@ -50,10 +50,8 @@ class UuidMetricType:
         else:
             return None
 
-    def test_get_num_recorded_errors(
-        self, error_type: ErrorType, ping_name: Optional[str] = None
-    ) -> int:
-        return self._inner.test_get_num_recorded_errors(error_type, ping_name)
+    def test_get_num_recorded_errors(self, error_type: ErrorType) -> int:
+        return self._inner.test_get_num_recorded_errors(error_type)
 
 
 __all__ = ["UuidMetricType"]

--- a/glean-core/rlb/src/private/event.rs
+++ b/glean-core/rlb/src/private/event.rs
@@ -154,12 +154,7 @@ impl<K: traits::ExtraKeys> traits::Event for EventMetric<K> {
         self.inner.test_get_value(ping_name)
     }
 
-    pub fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32 {
-        let ping_name = ping_name.into().map(|s| s.to_string());
-        self.inner.test_get_num_recorded_errors(error, ping_name)
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
+        self.inner.test_get_num_recorded_errors(error)
     }
 }

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -1127,7 +1127,7 @@ fn test_boolean_get_num_errors() {
     });
 
     // Check specifically for an invalid label
-    let result = metric.test_get_num_recorded_errors(ErrorType::InvalidLabel, None);
+    let result = metric.test_get_num_recorded_errors(ErrorType::InvalidLabel);
 
     assert_eq!(result, 0);
 }

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -242,7 +242,7 @@ interface CounterMetric {
 
     i32? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 // Different resolutions supported by the time related metric types
@@ -277,7 +277,7 @@ interface TimespanMetric {
 
     i64? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface BooleanMetric {
@@ -287,7 +287,7 @@ interface BooleanMetric {
 
     boolean? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface StringMetric {
@@ -297,7 +297,7 @@ interface StringMetric {
 
     string? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface LabeledCounter {
@@ -305,7 +305,7 @@ interface LabeledCounter {
 
     CounterMetric get(string label);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface LabeledBoolean {
@@ -313,7 +313,7 @@ interface LabeledBoolean {
 
     BooleanMetric get(string label);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface LabeledString {
@@ -321,7 +321,7 @@ interface LabeledString {
 
     StringMetric get(string label);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface StringListMetric {
@@ -333,7 +333,7 @@ interface StringListMetric {
 
     sequence<string>? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface UrlMetric {
@@ -343,7 +343,7 @@ interface UrlMetric {
 
     string? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface UuidMetric {
@@ -355,7 +355,7 @@ interface UuidMetric {
 
     string? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface QuantityMetric {
@@ -365,7 +365,7 @@ interface QuantityMetric {
 
     i64? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 // A snapshot of all buckets and the accumulated sum of a distribution.
@@ -398,7 +398,7 @@ interface TimingDistributionMetric {
 
     DistributionData? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 // Different resolutions supported by the memory related metric types
@@ -423,7 +423,7 @@ interface MemoryDistributionMetric {
 
     DistributionData? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 // Different kinds of histograms.
@@ -441,7 +441,7 @@ interface CustomDistributionMetric {
 
     DistributionData? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 // Representation of a date, time and timezone.
@@ -465,7 +465,7 @@ interface DatetimeMetric {
 
     string? test_get_value_as_string(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 // Represents the recorded data for a single event.
@@ -498,7 +498,7 @@ interface EventMetric {
 
     sequence<RecordedEvent>? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 dictionary Rate {
@@ -515,7 +515,7 @@ interface RateMetric {
 
     Rate? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface DenominatorMetric {
@@ -525,7 +525,7 @@ interface DenominatorMetric {
 
     i32? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface NumeratorMetric {
@@ -535,7 +535,7 @@ interface NumeratorMetric {
 
     Rate? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };
 
 interface TextMetric {
@@ -545,5 +545,5 @@ interface TextMetric {
 
     string? test_get_value(optional string? ping_name = null);
 
-    i32 test_get_num_recorded_errors(ErrorType error, optional string? ping_name = null);
+    i32 test_get_num_recorded_errors(ErrorType error);
 };

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -123,12 +123,11 @@ impl BooleanMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -152,12 +152,11 @@ impl CounterMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -210,12 +210,11 @@ impl CustomDistributionMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -316,12 +316,11 @@ impl DatetimeMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/denominator.rs
+++ b/glean-core/src/metrics/denominator.rs
@@ -129,12 +129,11 @@ impl DenominatorMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/event.rs
+++ b/glean-core/src/metrics/event.rs
@@ -160,12 +160,11 @@ impl EventMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -270,11 +270,10 @@ where
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.submetric.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.submetric.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -259,12 +259,11 @@ impl MemoryDistributionMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/numerator.rs
+++ b/glean-core/src/metrics/numerator.rs
@@ -87,7 +87,7 @@ impl NumeratorMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
-        self.0.test_get_num_recorded_errors(error, ping_name)
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
+        self.0.test_get_num_recorded_errors(error)
     }
 }

--- a/glean-core/src/metrics/quantity.rs
+++ b/glean-core/src/metrics/quantity.rs
@@ -115,12 +115,11 @@ impl QuantityMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/rate.rs
+++ b/glean-core/src/metrics/rate.rs
@@ -180,12 +180,11 @@ impl RateMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -129,12 +129,11 @@ impl StringMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }
@@ -169,7 +168,7 @@ mod test {
 
         assert_eq!(
             1,
-            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
                 .unwrap()
         );
     }

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -188,12 +188,11 @@ impl StringListMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/text.rs
+++ b/glean-core/src/metrics/text.rs
@@ -133,12 +133,11 @@ impl TextMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }
@@ -173,7 +172,7 @@ mod test {
 
         assert_eq!(
             1,
-            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
                 .unwrap()
         );
     }

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -297,12 +297,11 @@ impl TimespanMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -461,12 +461,11 @@ impl TimingDistributionMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/metrics/url.rs
+++ b/glean-core/src/metrics/url.rs
@@ -156,12 +156,11 @@ impl UrlMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }
@@ -213,7 +212,7 @@ mod test {
 
         assert_eq!(
             1,
-            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
                 .unwrap()
         );
     }
@@ -238,8 +237,7 @@ mod test {
 
         assert_eq!(
             1,
-            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
-                .unwrap()
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).unwrap()
         );
     }
 
@@ -297,8 +295,8 @@ mod test {
 
         assert_eq!(
             incorrects.len(),
-            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
-                .unwrap() as usize
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).unwrap()
+                as usize
         );
 
         for correct in corrects.into_iter() {

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -148,12 +148,11 @@ impl UuidMetric {
     /// # Returns
     ///
     /// The number of errors reported.
-    pub fn test_get_num_recorded_errors(&self, error: ErrorType, ping_name: Option<String>) -> i32 {
+    pub fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32 {
         crate::block_on_dispatcher();
 
         crate::core::with_glean(|glean| {
-            test_get_num_recorded_errors(glean, self.meta(), error, ping_name.as_deref())
-                .unwrap_or(0)
+            test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
 }

--- a/glean-core/src/traits/boolean.rs
+++ b/glean-core/src/traits/boolean.rs
@@ -35,15 +35,9 @@ pub trait Boolean {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/counter.rs
+++ b/glean-core/src/traits/counter.rs
@@ -39,15 +39,9 @@ pub trait Counter {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/custom_distribution.rs
+++ b/glean-core/src/traits/custom_distribution.rs
@@ -50,15 +50,9 @@ pub trait CustomDistribution {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors recorded.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/datetime.rs
+++ b/glean-core/src/traits/datetime.rs
@@ -44,15 +44,9 @@ pub trait Datetime {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/event.rs
+++ b/glean-core/src/traits/event.rs
@@ -110,15 +110,9 @@ pub trait Event {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/labeled.rs
+++ b/glean-core/src/traits/labeled.rs
@@ -32,15 +32,9 @@ where
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/memory_distribution.rs
+++ b/glean-core/src/traits/memory_distribution.rs
@@ -46,15 +46,9 @@ pub trait MemoryDistribution {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors recorded.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/numerator.rs
+++ b/glean-core/src/traits/numerator.rs
@@ -39,15 +39,9 @@ pub trait Numerator {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - the optional name of the ping to retrieve the metric
-    ///                 for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/quantity.rs
+++ b/glean-core/src/traits/quantity.rs
@@ -39,15 +39,9 @@ pub trait Quantity {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/rate.rs
+++ b/glean-core/src/traits/rate.rs
@@ -49,15 +49,9 @@ pub trait Rate {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - the optional name of the ping to retrieve the metric
-    ///                 for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -42,15 +42,9 @@ pub trait String {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/string_list.rs
+++ b/glean-core/src/traits/string_list.rs
@@ -52,15 +52,9 @@ pub trait StringList {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors recorded.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/text.rs
+++ b/glean-core/src/traits/text.rs
@@ -42,15 +42,9 @@ pub trait Text {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/timespan.rs
+++ b/glean-core/src/traits/timespan.rs
@@ -59,15 +59,9 @@ pub trait Timespan {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -65,15 +65,9 @@ pub trait TimingDistribution {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors recorded.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/url.rs
+++ b/glean-core/src/traits/url.rs
@@ -43,15 +43,9 @@ pub trait Url {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/src/traits/uuid.rs
+++ b/glean-core/src/traits/uuid.rs
@@ -38,15 +38,9 @@ pub trait Uuid {
     /// # Arguments
     ///
     /// * `error` - The type of error
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
     ///
     /// # Returns
     ///
     /// The number of errors reported.
-    fn test_get_num_recorded_errors<'a, S: Into<Option<&'a str>>>(
-        &self,
-        error: ErrorType,
-        ping_name: S,
-    ) -> i32;
+    fn test_get_num_recorded_errors(&self, error: ErrorType) -> i32;
 }

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -123,7 +123,7 @@ fn counters_must_not_increment_when_passed_zero_or_negative() {
     // Make sure that the errors have been recorded
     assert_eq!(
         Ok(2),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 }
 

--- a/glean-core/tests/custom_distribution.rs
+++ b/glean-core/tests/custom_distribution.rs
@@ -143,13 +143,9 @@ mod linear {
         assert_eq!(1, snapshot.values[&3]);
 
         // No errors should be reported.
-        assert!(test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidValue,
-            Some("store1")
-        )
-        .is_err());
+        assert!(
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err()
+        );
     }
 
     #[test]
@@ -191,12 +187,7 @@ mod linear {
         // 1 error should be reported.
         assert_eq!(
             Ok(1),
-            test_get_num_recorded_errors(
-                &glean,
-                metric.meta(),
-                ErrorType::InvalidValue,
-                Some("store1")
-            )
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
         );
     }
 
@@ -354,13 +345,9 @@ mod exponential {
         assert_eq!(1, snapshot.values[&3]);
 
         // No errors should be reported.
-        assert!(test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidValue,
-            Some("store1")
-        )
-        .is_err());
+        assert!(
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err()
+        );
     }
 
     #[test]
@@ -402,12 +389,7 @@ mod exponential {
         // 1 error should be reported.
         assert_eq!(
             Ok(1),
-            test_get_num_recorded_errors(
-                &glean,
-                metric.meta(),
-                ErrorType::InvalidValue,
-                Some("store1")
-            )
+            test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
         );
     }
 

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -167,7 +167,7 @@ fn can_record_error_for_submetric() {
     // Make sure that the errors have been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
     );
 }
 

--- a/glean-core/tests/memory_distribution.rs
+++ b/glean-core/tests/memory_distribution.rs
@@ -136,13 +136,7 @@ fn the_accumulate_samples_api_correctly_stores_memory_values() {
     assert_eq!(1, snapshot.values[&3024]);
 
     // No errors should be reported.
-    assert!(test_get_num_recorded_errors(
-        &glean,
-        metric.meta(),
-        ErrorType::InvalidValue,
-        Some("store1")
-    )
-    .is_err());
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err());
 }
 
 #[test]
@@ -183,11 +177,6 @@ fn the_accumulate_samples_api_correctly_handles_negative_values() {
     // 1 error should be reported.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidValue,
-            Some("store1")
-        )
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 }

--- a/glean-core/tests/quantity.rs
+++ b/glean-core/tests/quantity.rs
@@ -113,6 +113,6 @@ fn quantities_must_not_set_when_passed_negative() {
     // Make sure that the errors have been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 }

--- a/glean-core/tests/rate.rs
+++ b/glean-core/tests/rate.rs
@@ -24,9 +24,7 @@ fn rate_smoke() {
     metric.add_to_numerator_sync(&glean, 0);
     metric.add_to_denominator_sync(&glean, 0);
 
-    assert!(
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None).is_err(),
-    );
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err());
 
     // Adding a negative value errors.
     metric.add_to_numerator_sync(&glean, -1);
@@ -34,7 +32,7 @@ fn rate_smoke() {
 
     assert_eq!(
         Ok(2),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None),
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue),
     );
 
     // Getting the value returns 0s if that's all we have.
@@ -61,16 +59,14 @@ fn numerator_smoke() {
     // Adding 0 doesn't error.
     metric.add_to_numerator_sync(&glean, 0);
 
-    assert!(
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None).is_err()
-    );
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err());
 
     // Adding a negative value errors.
     metric.add_to_numerator_sync(&glean, -1);
 
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None),
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue),
     );
 
     // Getting the value returns 0s if that's all we have.
@@ -124,12 +120,8 @@ fn denominator_smoke() {
     denom.add_sync(&glean, 7);
 
     // no errors.
-    assert!(
-        test_get_num_recorded_errors(&glean, num1.meta(), ErrorType::InvalidValue, None).is_err()
-    );
-    assert!(
-        test_get_num_recorded_errors(&glean, num2.meta(), ErrorType::InvalidValue, None).is_err()
-    );
+    assert!(test_get_num_recorded_errors(&glean, num1.meta(), ErrorType::InvalidValue).is_err());
+    assert!(test_get_num_recorded_errors(&glean, num2.meta(), ErrorType::InvalidValue).is_err());
 
     // Getting the value returns 0s if that's all we have.
     let data = num1.get_value(&glean, None).unwrap();

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -116,6 +116,6 @@ fn long_string_values_are_truncated() {
     // Make sure that the errors have been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
     );
 }

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -128,7 +128,7 @@ fn long_string_values_are_truncated() {
     // Ensure the error has been recorded.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
     );
 
     metric.set_sync(&glean, vec![test_string.clone()]);
@@ -142,7 +142,7 @@ fn long_string_values_are_truncated() {
     // Ensure the error has been recorded.
     assert_eq!(
         Ok(2),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
     );
 }
 
@@ -170,9 +170,7 @@ fn disabled_string_lists_dont_record() {
     assert_eq!(None, metric.get_value(&glean, "store1"));
 
     // Ensure no error was recorded.
-    assert!(
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None).is_err()
-    );
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err());
 }
 
 #[test]
@@ -206,7 +204,7 @@ fn string_lists_dont_exceed_max_items() {
     // Ensure we recorded the error.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 
     // Try to set it to a list that's too long. Ensure it cuts off at 20 elements.
@@ -220,7 +218,7 @@ fn string_lists_dont_exceed_max_items() {
 
     assert_eq!(
         Ok(2),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 }
 
@@ -243,7 +241,5 @@ fn set_does_not_record_error_when_receiving_empty_list() {
     assert_eq!(Some(vec![]), metric.get_value(&glean, "store1"));
 
     // Ensure we didn't record an error.
-    assert!(
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None).is_err()
-    );
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err());
 }

--- a/glean-core/tests/text.rs
+++ b/glean-core/tests/text.rs
@@ -110,6 +110,6 @@ fn long_text_values_are_truncated() {
     // Make sure that the errors have been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
     );
 }

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -115,9 +115,7 @@ fn second_timer_run_is_skipped() {
     metric.set_stop(&glean, duration);
 
     // No error should be recorded here: we had no prior value stored.
-    assert!(
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None).is_err()
-    );
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState).is_err());
 
     let first_value = metric.get_value(&glean, "store1").unwrap();
     assert_eq!(duration, first_value);
@@ -132,7 +130,7 @@ fn second_timer_run_is_skipped() {
     // new measurement was dropped.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState)
     );
 }
 
@@ -281,7 +279,7 @@ fn set_raw_time_does_nothing_when_timer_running() {
     // Make sure that the error has been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState)
     );
 }
 
@@ -324,7 +322,7 @@ fn timespan_is_not_tracked_across_upload_toggle() {
     // Make sure that the error has been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState, None)
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState)
     );
 }
 
@@ -348,6 +346,6 @@ fn time_cannot_go_backwards() {
     assert!(metric.get_value(&glean, "test1").is_none());
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue, None),
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue),
     );
 }

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -134,12 +134,7 @@ fn timing_distributions_must_not_accumulate_negative_values() {
     // Make sure that the errors have been recorded
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidValue,
-            Some("store1")
-        )
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 }
 
@@ -180,13 +175,7 @@ fn the_accumulate_samples_api_correctly_stores_timing_values() {
     assert_eq!(1, snapshot.values[&2784941737]);
 
     // No errors should be reported.
-    assert!(test_get_num_recorded_errors(
-        &glean,
-        metric.meta(),
-        ErrorType::InvalidValue,
-        Some("store1")
-    )
-    .is_err());
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue).is_err());
 }
 
 #[test]
@@ -223,12 +212,7 @@ fn the_accumulate_samples_api_correctly_handles_negative_values() {
     // 1 error should be reported.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidValue,
-            Some("store1")
-        )
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 }
 
@@ -269,12 +253,7 @@ fn the_accumulate_samples_api_correctly_handles_overflowing_values() {
     // 1 error should be reported.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidOverflow,
-            Some("store1")
-        )
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
     );
 }
 
@@ -331,12 +310,7 @@ fn stopping_non_existing_id_records_an_error() {
     // 1 error should be reported.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidState,
-            Some("store1")
-        )
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState)
     );
 }
 
@@ -377,13 +351,7 @@ fn the_accumulate_raw_samples_api_correctly_stores_timing_values() {
     assert_eq!(1, snapshot.values[&2784941737]);
 
     // No errors should be reported.
-    assert!(test_get_num_recorded_errors(
-        &glean,
-        metric.meta(),
-        ErrorType::InvalidState,
-        Some("store1")
-    )
-    .is_err());
+    assert!(test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidState).is_err());
 }
 
 #[test]
@@ -430,11 +398,6 @@ fn raw_samples_api_error_cases() {
     // No errors should be reported.
     assert_eq!(
         Ok(1),
-        test_get_num_recorded_errors(
-            &glean,
-            metric.meta(),
-            ErrorType::InvalidOverflow,
-            Some("store1")
-        )
+        test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidOverflow)
     );
 }


### PR DESCRIPTION
Errors are always in the `metrics` ping.
We don't expose sending the metrics ping really,
so always checking there should be safe for all consumers
and it simplifies the API.