### PR TITLE
Bug 1772566 - Implement a glean-build crate for use in Rust consumers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,17 +62,28 @@ commands:
           name: Test
           command: |
             export GLEAN_TEST_COVERAGE=$(realpath glean_coverage.txt)
-            cargo test --all --verbose --jobs 6 -- --nocapture
+            cargo test --verbose --jobs 6 -- --nocapture
       - run:
           name: Test Glean with rkv safe-mode
           command: |
             cd glean-core
             cargo test -p glean-core --features rkv-safe-mode --jobs 6 -- --nocapture
       - run:
-          name: Upload coverage report
+          name: Install required Python dependencies
           command: |
             sudo apt update
-            sudo apt install python3-pip
+            sudo apt install --yes --no-install-recommends \
+              python3-pip \
+              python3.8-venv
+      - run:
+          name: Run Rust sample
+          command: |
+            if rustc --version | grep -q 'rustc 1.6'; then
+              cargo run -p sample
+            fi
+      - run:
+          name: Upload coverage report
+          command: |
             pip3 install glean_parser
             glean_parser coverage --allow-reserved -c glean_coverage.txt -f codecovio -o codecov.json glean-core/metrics.yaml
             bin/codecov.sh -X yaml -f codecov.json
@@ -300,6 +311,12 @@ jobs:
       - checkout
       - run: rustup component add clippy
       - run: cargo clippy --version
+      - run:
+          name: Install required Python dependencies
+          command: |
+            sudo apt update
+            sudo apt install --yes --no-install-recommends \
+              python3.8-venv
       - run:
           name: Clippy
           command: make lint-rust

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ captures
 .externalNativeBuild
 .lastAutoPublishContentsHash
 
+# Include glean-build crate again
+!/glean-core/build
+
 # iOS stuff.
 xcuserdata
 raw_xcode*log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "glean-build"
+version = "6.1.1"
+dependencies = [
+ "xshell-venv",
+]
+
+[[package]]
 name = "glean-bundle"
 version = "1.0.0"
 dependencies = [
@@ -888,6 +895,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "sample"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "glean",
+ "glean-build",
+ "tempfile",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1253,30 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "xshell"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d47097dc5c85234b1e41851b3422dd6d19b3befdd35b4ae5ce386724aeca981"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88301b56c26dd9bf5c43d858538f82d6f3f7764767defbc5d34e59459901c41a"
+
+[[package]]
+name = "xshell-venv"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43c2e9236bfd40d392b5ef2c073ef2719f7c69a758293cec4d8eff909a8917c"
+dependencies = [
+ "xshell",
+]
 
 [[package]]
 name = "zeitstempel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
   "glean-core/rlb",
   "glean-core/bundle",
   "glean-core/bundle-android",
+  "glean-core/build",
+  "samples/rust",
   "tools/embedded-uniffi-bindgen",
 ]
 
@@ -12,10 +14,6 @@ default-members = [
   "glean-core",
   "glean-core/rlb",
   "tools/embedded-uniffi-bindgen",
-]
-
-exclude = [
-  "samples/multi-bindings"
 ]
 
 [profile.release]

--- a/bin/update-glean-parser-version.sh
+++ b/bin/update-glean-parser-version.sh
@@ -63,6 +63,20 @@ run $SED -i.bak -E \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
+# update the version in glean-core/build/Cargo.toml
+FILE=glean-core/build/Cargo.toml
+run $SED -i.bak -E \
+    -e "s/^version = \"[0-9.]+\"/version = \"${NEW_VERSION}\"/" \
+    "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
+# update the version in glean-core/build/src/lib.rs
+FILE=glean-core/build/src/lib.rs
+run $SED -i.bak -E \
+    -e "s/GLEAN_PARSER_VERSION: \&str = \"[0-9.]+\"/GLEAN_PARSER_VERSION: \&str = \"${NEW_VERSION}\"/" \
+    "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
 # update the version in the Makefile
 FILE=Makefile
 run $SED -i.bak -E \

--- a/docs/user/SUMMARY.md
+++ b/docs/user/SUMMARY.md
@@ -6,6 +6,7 @@
   - [Kotlin](user/adding-glean-to-your-project/kotlin.md)
   - [Swift](user/adding-glean-to-your-project/swift.md)
   - [Python](user/adding-glean-to-your-project/python.md)
+  - [Rust](user/adding-glean-to-your-project/rust.md)
   - [JavaScript](user/adding-glean-to-your-project/javascript.md)
   - [Qt/QML](user/adding-glean-to-your-project/qt.md)
   - [Enable data ingestion](user/adding-glean-to-your-project/enable-data-ingestion.md)

--- a/docs/user/user/adding-glean-to-your-project/index.md
+++ b/docs/user/user/adding-glean-to-your-project/index.md
@@ -38,6 +38,7 @@ Additionally, applications (but not libraries) **must**:
 > - [JavaScript](./javascript.md)
 > - [Kotlin](./kotlin.md)
 > - [Python](./python.md)
+> - [Rust](./rust.md)
 > - [Swift](./swift.md)
 > - [Qt/QML](./qt.md)
 

--- a/docs/user/user/adding-glean-to-your-project/rust.md
+++ b/docs/user/user/adding-glean-to-your-project/rust.md
@@ -1,0 +1,73 @@
+# Adding Glean to your Rust project
+
+This page provides a step-by-step guide on how to integrate the Glean library into a Rust project.
+
+Nevertheless this is just one of the required steps for integrating Glean successfully into a project.
+Check you the full [Glean integration checklist](./index.md) for a comprehensive list of all the steps involved in doing so.
+
+
+## Setting up the dependency
+
+The Glean Rust SDK is published on [crates.io](https://crates.io/crates/glean).
+Add it to your dependencies in `Cargo.toml`:
+
+```toml
+[dependencies]
+glean = "50.0.0"
+```
+
+## Setting up metrics and pings code generation
+
+At build time you need to generate the metrics and ping API from your definition files.
+Add the `glean-build` crate as a build dependency in your `Cargo.toml`:
+
+```toml
+[build-dependencies]
+glean-build = "50.0.0"
+```
+
+Then add a `build.rs` file next to your `Cargo.toml` and call the builder:
+
+```Rust
+use glean_build::Builder;
+
+fn main() {
+    Builder::default()
+        .metrics("metrics.yaml")
+        .pings("pings.yaml")
+        .generate()
+        .expect("Error generating Glean Rust bindings");
+}
+```
+
+Ensure your `metrics.yaml` and `pings.yaml` files are placed next to your `Cargo.toml` or adjust the path in the code above.
+You can also leave out any of the files.
+
+### Include the generated code
+
+`glean-build` will generate a `glean_metrics.rs` file that needs to be included in your source code.
+To do so add the following lines of code in your `src/lib.rs` file:
+
+```Rust
+mod metrics {
+    include!(concat!(env!("OUT_DIR"), "/glean_metrics.rs"));
+}
+```
+
+Alternatively create `src/metrics.rs` (or a different name) with only the include line:
+
+```Rust
+include!(concat!(env!("OUT_DIR"), "/glean_metrics.rs"));
+```
+
+Then add `mod metrics;` to your `src/lib.rs` file.
+
+### Use the metrics
+
+In your code you can then access generated metrics nested within their category under the `metrics` module (or your chosen name):
+
+```Rust
+metrics::your_category::metric_name.set(true);
+```
+
+See [the metric API reference](../../reference/metrics/index.md) for details.

--- a/glean-core/build/Cargo.toml
+++ b/glean-core/build/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "glean-build"
+version = "6.1.1"
+edition = "2021"
+description = "Glean SDK Rust build helper"
+repository = "https://github.com/mozilla/glean"
+readme = "README.md"
+license = "MPL-2.0"
+keywords = ["telemetry", "glean"]
+include = [
+  "/README.md",
+  "/LICENSE",
+  "/src",
+  "/Cargo.toml",
+]
+rust-version = "1.59"
+
+[dependencies]
+xshell-venv = "1.1.0"

--- a/glean-core/build/LICENSE
+++ b/glean-core/build/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/glean-core/build/README.md
+++ b/glean-core/build/README.md
@@ -1,0 +1,63 @@
+# Glean SDK
+
+The `Glean SDK` is a modern approach for a Telemetry library and is part of the [Glean project](https://docs.telemetry.mozilla.org/concepts/glean/glean.html).
+
+## `glean-build`
+
+This library provides a code generator for use in `build.rs`.
+
+## Documentation
+
+The Glean SDK documentation is available online:
+
+* [The Glean SDK Book][book]
+
+The `glean-build` API is documented online:
+
+* [API Documentation][apidocs]
+
+[book]: https://mozilla.github.io/glean/
+[apidocs]: https://docs.rs/glean-build/
+
+## Requirements
+
+* Python 3
+* pip
+
+## Usage
+
+Add `glean-build` as a build dependency to your project in `Cargo.toml`:
+
+```
+[build-dependencies]
+glean-build = "6.0.1"
+```
+
+Then add a `build.rs` file next to your `Cargo.toml` and call the builder:
+
+```rust,no_run
+use glean_build::Builder;
+
+fn main() {
+    Builder::default()
+        .file("metrics.yaml")
+        .generate()
+        .expect("Error generating Glean Rust bindings");
+}
+```
+
+In your code add the following to include the generated code:
+
+```rust,ignore
+mod metrics {
+    include!(concat!(env!("OUT_DIR"), "/glean_metrics.rs"));
+}
+```
+
+You can then access your metrics and pings directly by name within the `metrics` module.
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/glean-core/build/src/lib.rs
+++ b/glean-core/build/src/lib.rs
@@ -1,0 +1,123 @@
+//! Glean Rust build utility
+//!
+//! `glean-build` generates the Rust bindings based on metrics and ping definitions,
+//! using [`glean-parser`] under the hood.
+//!
+//! ## Requirements
+//!
+//! * Python 3
+//! * pip
+//!
+//! ## Usage
+//!
+//! In your application add a `build.rs` file next to your `Cargo.toml`,
+//! then add this code:
+//!
+//! ```rust,ignore
+//! use glean_build::Builder;
+//!
+//! fn main() {
+//!     Builder::default()
+//!         .file("metrics.yaml")
+//!         .generate()
+//!         .expect("Error generating Glean Rust bindings");
+//! }
+//! ```
+//!
+//! In your code add the following to include the generated code:
+//!
+//! ```rust,ignore
+//! mod metrics {
+//!     include!(concat!(env!("OUT_DIR"), "/glean_metrics.rs"));
+//! }
+//! ```
+//!
+//! You can then access your metrics and pings directly by name within the `metrics` module.
+//!
+//! [`glean-parser`]: https://github.com/mozilla/glean_parser/
+use std::env;
+
+use xshell_venv::{Result, Shell, VirtualEnv};
+
+const GLEAN_PARSER_VERSION: &str = "6.1.1";
+
+/// A Glean Rust bindings generator.
+pub struct Builder {
+    files: Vec<String>,
+    out_dir: String,
+}
+
+impl Builder {
+    /// A default Glean Rust bindings generator.
+    ///
+    /// Use [`file`][`Builder::file`] and [`files`][`Builder::files`]
+    /// to specify the input files.
+    pub fn default() -> Self {
+        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "".into());
+        Self {
+            files: vec![],
+            out_dir,
+        }
+    }
+
+    /// A Glean Rust bindings generator with the given output directory.
+    ///
+    /// Use [`file`][`Builder::file`] and [`files`][`Builder::files`]
+    /// to specify the input files.
+    pub fn with_output<S: Into<String>>(out_dir: S) -> Self {
+        Self {
+            files: vec![],
+            out_dir: out_dir.into(),
+        }
+    }
+
+    /// Add a definition file, e.g. `metrics.yaml` or `pings.yaml`.
+    ///
+    /// Can be called multiple times to add more files.
+    pub fn file<S: Into<String>>(&mut self, file: S) -> &mut Self {
+        self.files.push(file.into());
+        self
+    }
+
+    /// Add multiple definition files, e.g. `metrics.yaml` or `pings.yaml`.
+    pub fn files<P>(&mut self, files: P) -> &mut Self
+    where
+        P: IntoIterator,
+        P::Item: Into<String>,
+    {
+        for file in files.into_iter() {
+            self.file(file);
+        }
+        self
+    }
+
+    /// Generate the Rust bindings.
+    ///
+    /// The consumer must include the generated `glean_metrics.rs` file, e.g.:
+    ///
+    /// ```rust,ignore
+    /// include!(concat!(env!("OUT_DIR"), "/glean_metrics.rs"));
+    /// ```
+    pub fn generate(&self) -> Result<()> {
+        let out_dir = &self.out_dir;
+        if out_dir.is_empty() {
+            panic!("Could not determine output directory.")
+        }
+
+        let sh = Shell::new()?;
+        let venv = VirtualEnv::new(&sh, "py3-glean_parser")?;
+
+        let glean_parser = format!("glean_parser~={}", GLEAN_PARSER_VERSION);
+        venv.pip_install(&glean_parser)?;
+
+        for file in &self.files {
+            println!("cargo:rerun-if-changed={}", file);
+        }
+
+        let mut args = vec!["translate", "--format", "rust", "--output", out_dir];
+        args.extend(self.files.iter().map(|s| s.as_str()));
+        venv.run_module("glean_parser", &args)?;
+
+        Ok(())
+    }
+}

--- a/samples/rust/Cargo.toml
+++ b/samples/rust/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT"
+
+[dependencies]
+env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
+glean = { path = "../../glean-core/rlb", features = ["rkv-safe-mode"] }
+tempfile = "3.3.0"
+
+[build-dependencies]
+glean-build = { path = "../../glean-core/build" }

--- a/samples/rust/build.rs
+++ b/samples/rust/build.rs
@@ -1,0 +1,9 @@
+use glean_build::Builder;
+
+fn main() {
+    Builder::default()
+        .file("metrics.yaml")
+        .file("pings.yaml")
+        .generate()
+        .expect("Error generating Glean Rust bindings");
+}

--- a/samples/rust/metrics.yaml
+++ b/samples/rust/metrics.yaml
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Kotlin code at build time using the `glean_parser`
+# PyPI package.
+
+---
+
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+test.metrics:
+  sample_boolean:
+    type: boolean
+    description: |
+      Just testing booleans
+    bugs:
+      - https://bugzilla.mozilla.org/123456789
+    data_reviews:
+      - N/A
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    send_in_pings:
+      - prototype

--- a/samples/rust/pings.yaml
+++ b/samples/rust/pings.yaml
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the built-in pings that are recorded by the Glean SDK. They
+# are automatically converted to Kotlin code at build time using the
+# `glean_parser` PyPI package.
+
+---
+
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+prototype:
+  description: |
+    A sample custom ping.
+  include_client_id: true
+  bugs:
+    - https://bugzilla.mozilla.org/123456789
+  data_reviews:
+    - N/A
+  notification_emails:
+    - CHANGE-ME@example.com

--- a/samples/rust/src/main.rs
+++ b/samples/rust/src/main.rs
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::env;
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+
+use tempfile::Builder;
+
+use glean::{ClientInfoMetrics, Configuration};
+
+pub mod glean_metrics {
+    include!(concat!(env!("OUT_DIR"), "/glean_metrics.rs"));
+}
+
+fn main() {
+    env_logger::init();
+
+    let mut args = env::args().skip(1);
+
+    let data_path = if let Some(path) = args.next() {
+        PathBuf::from(path)
+    } else {
+        let root = Builder::new().prefix("simple-db").tempdir().unwrap();
+        root.path().to_path_buf()
+    };
+
+    let cfg = Configuration {
+        data_path,
+        application_id: "org.mozilla.glean_core.example".into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        server_endpoint: Some("invalid-test-host".into()),
+        uploader: None,
+        use_core_mps: true,
+    };
+
+    let client_info = ClientInfoMetrics {
+        app_build: env!("CARGO_PKG_VERSION").to_string(),
+        app_display_version: env!("CARGO_PKG_VERSION").to_string(),
+        channel: None,
+    };
+
+    glean::initialize(cfg, client_info);
+
+    glean_metrics::test_metrics::sample_boolean.set(true);
+
+    glean_metrics::prototype.submit(None);
+    // Need to wait a short time for Glean to actually act.
+    thread::sleep(Duration::from_millis(100));
+
+    glean::shutdown();
+}

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get update -qq \
         python \
         python3 \
         python3-pip \
+        python3-venv \
         # taskcluster > mohawk > setuptools.
         python3-setuptools \
         # Required to extract the Android SDK/NDK.


### PR DESCRIPTION
This crate should be used as a build dependency in Rust consumers.
In their `build.rs` they can call the builder to auto-generate code from
`metrics.yaml` and `pings.yaml` definitions:

    glean_build::Builder::default()
        .metrics("metrics.yaml")
        .pings("pings.yaml")
        .generate()
        .expect("Error generating Glean Rust bindings");

This requires a working Python3 & pip installation.
Windows untested.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1713573 and https://bugzilla.mozilla.org/show_bug.cgi?id=1772566

---

This is my first stab at bug 1772566. It seems to work.
Todo:

* [ ] Automate the release