### PR TITLE
Bug 1756153 - Put Glean initialization on a async Kotlin task

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.telemetry.glean
+
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+
+@ObsoleteCoroutinesApi
+internal object Dispatchers {
+    class WaitableCoroutineScope(private val coroutineScope: CoroutineScope) {
+        // When true, jobs will be run synchronously
+        internal var testingMode = false
+
+        /**
+         * Enable testing mode, which makes all of the Glean SDK public API
+         * synchronous.
+         *
+         * @param enabled whether or not to enable the testing mode
+         */
+        @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+        fun setTestingMode(enabled: Boolean) {
+            testingMode = enabled
+        }
+
+        /**
+         * Helper function to execute the task as an asynchronous operation.
+         */
+        internal fun executeTask(block: suspend CoroutineScope.() -> Unit): Job? {
+            return when {
+                testingMode -> {
+                    runBlocking {
+                        block()
+                    }
+                    null
+                }
+                else -> coroutineScope.launch(block = block)
+            }
+        }
+    }
+
+    // This job is used to make sure the API `CoroutineContext` does not cancel
+    // children jobs when exceptions are thrown in children coroutines.
+    private val supervisorJob = SupervisorJob()
+
+    /**
+     * A coroutine scope to make it easy to dispatch API calls off the main thread.
+     * This needs to be a `var` so that our tests can override this.
+     */
+    var API = WaitableCoroutineScope(
+        CoroutineScope(
+            newSingleThreadContext("GleanAPIPool") + supervisorJob
+        )
+    )
+}


### PR DESCRIPTION
This should delay loading the bundled library, which can be quite time
consuming itself.

---

This restores the minimal functionality from our previous Dispatcher.
I opted for that way because we know it works.

I have _not_ tested this in an app yet. In our tests we rely on test mode -> synchronous, so we're not exercising that code path. The sample app though should use that code path. We don't run sample app tests in CI though.