### PR TITLE
Fixes clippy lints and warnings for Rust 1.63.0-beta.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ bench-rust: ## Run Rust benchmarks
 # Linting
 
 lint-rust: ## Run cargo-clippy to lint Rust code
-	cargo clippy --all --all-targets --all-features -- -D warnings
+	cargo clippy --all --all-targets --all-features -- -D warnings -A unknown-lints
 
 lint-kotlin: ## Run ktlint to lint Kotlin code
 	./gradlew lint ktlint detekt

--- a/glean-core/src/dispatcher/mod.rs
+++ b/glean-core/src/dispatcher/mod.rs
@@ -63,7 +63,7 @@ enum Command {
 }
 
 /// The error returned from operations on the dispatcher
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum DispatchError {
     /// The worker panicked while running a task
     #[error("The worker panicked while running a task")]

--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -27,7 +27,7 @@ use crate::Lifetime;
 /// in the platform-specific code (e.g. `ErrorType.kt`) and with the
 /// metrics in the registry files.
 // When adding a new error type ensure it's also added to `ErrorType::iter()` below.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ErrorType {
     /// For when the value to be recorded does not match the metric-specific restrictions
     InvalidValue,

--- a/glean-core/src/histogram/exponential.rs
+++ b/glean-core/src/histogram/exponential.rs
@@ -56,7 +56,7 @@ fn exponential_range(min: u64, max: u64, bucket_count: usize) -> Vec<u64> {
 ///
 /// Buckets are pre-computed at instantiation with an exponential distribution from `min` to `max`
 /// and `bucket_count` buckets.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PrecomputedExponential {
     // Don't serialize the (potentially large) array of ranges, instead compute them on first
     // access.

--- a/glean-core/src/histogram/linear.rs
+++ b/glean-core/src/histogram/linear.rs
@@ -36,7 +36,7 @@ fn linear_range(min: u64, max: u64, count: usize) -> Vec<u64> {
 ///
 /// Buckets are pre-computed at instantiation with a linear  distribution from `min` to `max`
 /// and `bucket_count` buckets.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PrecomputedLinear {
     // Don't serialize the (potentially large) array of ranges, instead compute them on first
     // access.

--- a/glean-core/src/histogram/mod.rs
+++ b/glean-core/src/histogram/mod.rs
@@ -58,7 +58,7 @@ impl TryFrom<i32> for HistogramType {
 /// assert_eq!(10, hist.count());
 /// assert_eq!(55, hist.sum());
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Histogram<B> {
     /// Mapping bucket's minimum to sample count.
     values: HashMap<u64, u64>,

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#![allow(clippy::significant_drop_in_scrutinee)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_docs)]
 

--- a/glean-core/src/metrics/recorded_experiment.rs
+++ b/glean-core/src/metrics/recorded_experiment.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map as JsonMap, Value as JsonValue};
 
 /// Deserialized experiment data.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct RecordedExperiment {
     /// The experiment's branch as set through [`set_experiment_active`](crate::glean_set_experiment_active).
     pub branch: String,

--- a/glean-core/src/metrics/time_unit.rs
+++ b/glean-core/src/metrics/time_unit.rs
@@ -11,7 +11,7 @@ use crate::error::{Error, ErrorKind};
 
 /// Different resolutions supported by the time related
 /// metric types (e.g. DatetimeMetric).
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[repr(i32)] // use i32 to be compatible with our JNA definition
 pub enum TimeUnit {

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -127,7 +127,7 @@ impl RateLimiter {
 /// the requester may receive one out of three possible tasks.
 ///
 /// If new variants are added, this should be reflected in `glean-core/ffi/src/upload.rs` as well.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum PingUploadTask {
     /// An upload task
     Upload {

--- a/glean-core/src/upload/request.rs
+++ b/glean-core/src/upload/request.rs
@@ -180,7 +180,7 @@ impl Builder {
 }
 
 /// Represents a request to upload a ping.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PingRequest {
     /// The Job ID to identify this request,
     /// this is the same as the ping UUID.


### PR DESCRIPTION
This fixes some clippy warnings that have popped up with the latest rust-beta.

In the places where I moved a method call outside of a loop or match and replaced it with a variable holding the result, it was due to this lint: https://rust-lang.github.io/rust-clippy/master/index.html#significant_drop_in_scrutinee

In the places where I added the derive for `Eq`, it was to satisfy this lint: https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq