### PR TITLE
Python: drop dependency on cffi

### DIFF
--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -1,6 +1,5 @@
 auditwheel==5.1.2
 black==22.6.0
-cffi==1.15.0
 coverage==6.2
 flake8==4.0.1
 flake8-bugbear==22.7.1

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -59,11 +59,8 @@ with (SRC_ROOT / "CHANGELOG.md").open() as history_file:
 version = "50.1.1"
 
 requirements = [
-    "cffi>=1.13.0",
     "glean_parser==6.1.1",
 ]
-
-setup_requirements = ["cffi>=1.13.0"]
 
 # The environment variable `GLEAN_BUILD_VARIANT` can be set to `debug` or `release`
 buildvariant = os.environ.get("GLEAN_BUILD_VARIANT", "debug")


### PR DESCRIPTION
UniFFI uses ctypes which comes with Python.
No need for anything else anymore.