### PR TITLE
Update to UniFFI v0.19.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,9 +1087,9 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381973fc058a27e4f4a796c4fd929e49b3d7ec2df25be10335c5be7c7594a602"
+checksum = "bc1de33ad46ce00bc9a31cea44e80ef69175d3a23007335216fe3996880a310d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad2c4497c6e9b1d091299dc39c36aa411a371ed99c4abc21028a69bdc279d1b"
+checksum = "b18e05c55840ddd690ba211f72bb1f2f6ca8c50bfeb7d7211ea5ee60b0f9be07"
 dependencies = [
  "anyhow",
  "askama",
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8305c3522a6e8bf96a864b9156781eab8c80fdb9abb77a0f0870c2972f461fe5"
+checksum = "8fff0860625e4e621f0317e5f6ac9e79966262bd86a6cfb2049e8425df23afbd"
 dependencies = [
  "anyhow",
  "camino",
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcfc5cd73ffe952b2b19de70464a220f5d856336677ab8115a74efc4935ff3ca"
+checksum = "7956a6c1fb12bff15e537028ea2174f000f90dd4f87912233b276ea782d420f2"
 dependencies = [
  "camino",
  "glob",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2111,7 +2111,7 @@ The following text applies to code linked from these dependencies:
 * [num-integer 0.1.45]( https://github.com/rust-num/num-integer )
 * [num-traits 0.2.15]( https://github.com/rust-num/num-traits )
 * [num_cpus 1.13.1]( https://github.com/seanmonstar/num_cpus )
-* [once_cell 1.12.0]( https://github.com/matklad/once_cell )
+* [once_cell 1.13.0]( https://github.com/matklad/once_cell )
 * [paste 1.0.7]( https://github.com/dtolnay/paste )
 * [percent-encoding 2.1.0]( https://github.com/servo/rust-url/ )
 * [proc-macro2 1.0.37]( https://github.com/dtolnay/proc-macro2 )
@@ -4557,10 +4557,10 @@ The following text applies to code linked from these dependencies:
 * [embedded-uniffi-bindgen 0.1.0]( https://crates.io/crates/embedded-uniffi-bindgen )
 * [glean-bundle 1.0.0]( https://github.com/mozilla/glean )
 * [glean-bundle-android 1.0.0]( https://github.com/mozilla/glean )
-* [uniffi 0.19.2]( https://github.com/mozilla/uniffi-rs )
-* [uniffi_bindgen 0.19.2]( https://github.com/mozilla/uniffi-rs )
-* [uniffi_build 0.19.2]( https://github.com/mozilla/uniffi-rs )
-* [uniffi_macros 0.19.2]( https://github.com/mozilla/uniffi-rs )
+* [uniffi 0.19.3]( https://github.com/mozilla/uniffi-rs )
+* [uniffi_bindgen 0.19.3]( https://github.com/mozilla/uniffi-rs )
+* [uniffi_build 0.19.3]( https://github.com/mozilla/uniffi-rs )
+* [uniffi_macros 0.19.3]( https://github.com/mozilla/uniffi-rs )
 
 ```
 Mozilla Public License Version 2.0

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -41,8 +41,8 @@ zeitstempel = "0.1.0"
 crossbeam-channel = "0.5"
 thiserror = "1.0.4"
 whatsys = "0.1.2"
-uniffi = "0.19.2"
-uniffi_macros = "0.19.2"
+uniffi = "0.19.3"
+uniffi_macros = "0.19.3"
 time = "0.1.40"
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -61,7 +61,7 @@ iso8601 = "0.4"
 ctor = "0.1.12"
 
 [build-dependencies]
-uniffi_build = { version = "0.19.2", features = ["builtin-bindgen"] }
+uniffi_build = { version = "0.19.3", features = ["builtin-bindgen"] }
 
 [features]
 # Enable the "safe-mode" Rust storage backend instead of the default LMDB one.

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "0.19.2"
+uniffi_bindgen = "0.19.3"


### PR DESCRIPTION
This update to UniFFI contains a fix for the Swift code generation, unbreaking the Glean iOS build.