### PR TITLE
Bug 1776445 - Bump the Android Gradle Plugin to v7.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Remove `testHasValue` from all implementations.
     `testGetValue` always returns a null value
     (`null`, `nil`, `None` depending on the language) and does not throw an exception.
+* Kotlin
+  * Fix the Glean Gradle Plugin to work with Android Gradle Plugin v7.2.1 ([#2114](https://github.com/mozilla/glean/pull/2114))
 
 # v50.1.2 (2022-07-08)
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     // changing them. Please note that, for using in Android-Components, the
     // versions below must match the ones in that repository.
     ext.versions = [
-        android_gradle_plugin: '7.0.0',
+        android_gradle_plugin: '7.2.1',
         android_maven_publish_plugin: '3.6.2',
         coroutines: '1.5.0',
         jna: '5.8.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Jun 24 17:01:45 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This additionally bumps the Gradle version and fixes the breakage due to querying the `namespace` property at configuration time. We instead query it at evaluation time now.

This unblocks mozilla-mobile/android-components#12386

**Note**: I'm making this a draft until I test it in A-C.