### PR TITLE
Bug 1779638 - Kotlin: Add a hook to run tasks after init

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -44,6 +44,12 @@ internal class OnGleanEventsImpl(val glean: GleanInternalAPI) : OnGleanEvents {
             ProcessLifecycleOwner.get().lifecycle.addObserver(glean.gleanLifecycleObserver)
         }
         glean.initialized = true
+
+        if (glean.testingMode) {
+            glean.afterInitQueue.forEach { block ->
+                block()
+            }
+        }
     }
 
     override fun triggerUpload() {
@@ -101,6 +107,8 @@ open class GleanInternalAPI internal constructor() {
     // This object holds data related to any persistent information about the metrics ping,
     // such as the last time it was sent and the store name
     internal var metricsPingScheduler: MetricsPingScheduler? = null
+
+    internal val afterInitQueue: MutableList<() -> Unit> = mutableListOf()
 
     // This is used to cache the process state and is used by the function `isMainProcess()`
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -451,6 +459,23 @@ open class GleanInternalAPI internal constructor() {
     }
 
     /**
+     * Run a task right after initialization.
+     *
+     * If initialization already happened the task runs immediately.
+     * Otherwise it is queued and run after initialization finishes.
+     */
+    internal fun afterInitialize(block: () -> Unit) {
+        // Queueing tasks after initialize is only allowed in test mode.
+        assert(isInitialized())
+
+        if (isInitialized()) {
+            block()
+        } else {
+            this.afterInitQueue.add(block)
+        }
+    }
+
+    /**
      * TEST ONLY FUNCTION.
      * Sets the server endpoint to a local address for ingesting test pings.
      *
@@ -465,12 +490,10 @@ open class GleanInternalAPI internal constructor() {
 
         isSendingToTestEndpoint = true
 
-        // We can't set the configuration unless we're initialized.
-        assert(isInitialized())
-
-        val endpointUrl = "http://localhost:$port"
-
-        Glean.configuration = configuration.copy(serverEndpoint = endpointUrl)
+        Glean.afterInitialize {
+            val endpointUrl = "http://localhost:$port"
+            Glean.configuration = configuration.copy(serverEndpoint = endpointUrl)
+        }
     }
 
     /**


### PR DESCRIPTION
We saw some intermittents on Android Components failing in the `assert(isInitialized())` line.
This leads me to believe that it runs before Glean.initialize is
finished off-thread.
To fix this we introduce a new task queue: run things right after
Glean.initialize calls back into the wrapper.
We need to be careful though: This is triggered from the Rust side so we
can't call back and forth between Kotlin and Rust inside that task or we
risk deadlocks.
But in this instance we're safe:
1. We only allow tasks in test mode
2. We only call it in a single place

In theory there's a race condition still there, because we use
unsynchronized access to the `afterInitQueue`, but really ... it's test
mode and might just be fine enough for all we care? Let's hope so.

I am not able to reproduce the same error as in the intermittent locally
at all (neither in the simulator nor on an actual device), so really I
don't know if this "fixes" it.
The only way to test this out is to go through a release, get it into
A-C and then re-enable the tests and hope for the best.