### PR TITLE
bug 1767037 - RLB: Add a new ctor to Event that takes a list of allowed event extra keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     (`null`, `nil`, `None` depending on the language) and does not throw an exception.
 * Kotlin
   * Fix the Glean Gradle Plugin to work with Android Gradle Plugin v7.2.1 ([#2114](https://github.com/mozilla/glean/pull/2114))
+* Rust
+  * Add a method to construct an Event with runtime-known allowed extra keys. ([bug 1767037](https://bugzilla.mozilla.org/show_bug.cgi?id=1767037))
 
 # v50.1.2 (2022-07-08)
 

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -62,6 +62,7 @@ Before submitting a PR:
 - For changes to Rust code
   - `make test-rust` produces no test failures
   - `make lint-rust` runs without emitting any warnings or errors.
+  - `make fmt-rust` should be used to format your changed Rust code.
 - For changes to Kotlin code
   - `make test-kotlin` runs without emitting any warnings or errors.
   - `make ktlint` runs without emitting any warnings.


### PR DESCRIPTION
This enables runtime-defined extra keys for runtime-defined event metrics.

Alternatively to this we could give RLB a RuntimeExtraKeys like NoExtraKeys and
specialize the impl of EventMetric to not use ALLOWED_EXTRA or into_ffi_extra,
but given that runtime-defined metrics are a dev-only feature (at present)
maybe this is enough?