### PR TITLE
Adding a uniffi.toml that is compatible with building the AppServices…

### DIFF
--- a/glean-core/megazord.uniffi.toml
+++ b/glean-core/megazord.uniffi.toml
@@ -1,0 +1,5 @@
+[bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "gleanFFI"
+generate_module_map = false
+omit_argument_labels = true


### PR DESCRIPTION
… iOS megazord for Focus/Firefox iOS

This will be used as a replacement for the existing uniffi.toml, to be swapped out as part of the megazord build process when the AppServices swift packages are bundled in rust-components-swift