### PR TITLE
Bug 1771169 - Swift: Separate endpoints for tests

### DIFF
--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -56,6 +56,7 @@ public class HttpPingUploader {
     func upload(path: String, data: Data, headers: [String: String], callback: @escaping (UploadResult) -> Void) {
         // Build the request and create an async upload operation using a background URLSession
         if let request = self.buildRequest(path: path, data: data, headers: headers) {
+            self.logger.debug("Sending ping to \(request.url!). Data size: \(data.count)")
             // Try to write the temporary file which the URLSession will use for transfer. If this fails
             // then there is no need to create the URLSessionConfiguration or URLSession.
             let tmpFile = URL.init(fileURLWithPath: NSTemporaryDirectory(),

--- a/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
+++ b/glean-core/ios/GleanTests/Debug/GleanDebugUtilityTests.swift
@@ -52,7 +52,7 @@ class GleanDebugUtilityTests: XCTestCase {
         expectation!.expectedFulfillmentCount = 3
         expectation!.assertForOverFulfill = true
         let expectedPings = ["baseline", "events", "metrics"]
-        stubServerReceive { pingType, _ in
+        stubServerReceive(endpoint: Glean.shared.configuration!.serverEndpoint) { pingType, _ in
             XCTAssertTrue(expectedPings.contains(pingType), "\(pingType) should be valid")
 
             DispatchQueue.main.async {

--- a/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/EventMetricTests.swift
@@ -66,7 +66,7 @@ class EventMetricTypeTests: XCTestCase {
     var lastPingJson: [String: Any]?
 
     private func setupHttpResponseStub() {
-        stubServerReceive { pingType, json in
+        stubServerReceive(endpoint: Glean.shared.configuration!.serverEndpoint) { pingType, json in
             if pingType != "events" {
                 // Skip non-events pings here.
                 // This might include the initial "active" baseline ping.

--- a/glean-core/ios/GleanTests/Metrics/PingTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/PingTests.swift
@@ -20,7 +20,7 @@ class PingTests: XCTestCase {
     }
 
     private func setupHttpResponseStub(_ expectedPingType: String) {
-        stubServerReceive { pingType, json in
+        stubServerReceive(endpoint: Glean.shared.configuration!.serverEndpoint) { pingType, json in
             XCTAssertEqual(pingType, expectedPingType, "Wrong ping type received")
             XCTAssert(json != nil)
 

--- a/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
+++ b/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
@@ -12,7 +12,7 @@ class DeletionRequestPingTests: XCTestCase {
     var lastPingJson: [String: Any]?
 
     private func setupHttpResponseStub(_ expectedPingType: String) {
-        stubServerReceive { pingType, json in
+        stubServerReceive(endpoint: Glean.shared.configuration!.serverEndpoint) { pingType, json in
             XCTAssertEqual(pingType, expectedPingType, "Wrong ping type received")
 
             XCTAssert(json != nil)

--- a/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
+++ b/glean-core/ios/GleanTests/Net/HttpPingUploaderTests.swift
@@ -21,14 +21,15 @@ class HttpPingUploaderTests: XCTestCase {
         // We are explicitly setting the test mode to true here to force the uploader to not
         // run in the background, which can make this test take a long time.
         var testValue: UploadResult?
-        stubServerReceive { _, json in
+        let cfg = Configuration()
+        stubServerReceive(endpoint: cfg.serverEndpoint) { _, json in
             XCTAssert(json != nil)
             XCTAssertEqual(json?["ping"] as? String, "test")
         }
 
         expectation = expectation(description: "Completed upload")
 
-        let httpPingUploader = HttpPingUploader(configuration: Configuration(), testingMode: true)
+        let httpPingUploader = HttpPingUploader(configuration: cfg, testingMode: true)
         httpPingUploader.upload(path: testPath, data: Data(testPing.utf8), headers: [:]) { result in
             testValue = result
             self.expectation?.fulfill()

--- a/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
+++ b/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
@@ -184,7 +184,8 @@ class MetricsPingSchedulerTests: XCTestCase {
         let yesterday = Calendar.current.date(byAdding: Calendar.Component.day, value: -1, to: now)
         MetricsPingScheduler(true).updateSentDate(yesterday!)
 
-        stubServerReceive { pingType, json in
+        let cfg = Glean.shared.configuration!
+        stubServerReceive(endpoint: cfg.serverEndpoint) { pingType, json in
             if pingType != "metrics" {
                 // Skip initial "active" baseline ping
                 return
@@ -216,7 +217,7 @@ class MetricsPingSchedulerTests: XCTestCase {
         // Glean.shared.initialize(uploadEnabled: true)
         Glean.shared.enableTestingMode()
         Glean.shared.setLogPings(true)
-        Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo())
+        Glean.shared.initialize(uploadEnabled: true, configuration: cfg, buildInfo: stubBuildInfo())
         // Enable ping logging for all tests
         waitForExpectations(timeout: 5.0) { error in
             XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
@@ -259,7 +260,8 @@ class MetricsPingSchedulerTests: XCTestCase {
         Glean.shared.metricsPingScheduler!.updateSentDate(yesterday!)
 
         // Set up the interception of the ping for inspection
-        stubServerReceive { pingType, json in
+        let cfg = Glean.shared.configuration!
+        stubServerReceive(endpoint: cfg.serverEndpoint) { pingType, json in
             if pingType == "baseline" {
                 // Ignore initial "active" baseline ping
                 return
@@ -284,7 +286,7 @@ class MetricsPingSchedulerTests: XCTestCase {
         // Initialize Glean the SECOND time: it will send the expected string metric (stored from
         // the previous run) but must not send the canary string, which would be sent the next time
         // the "metrics" ping is collected after this one.
-        Glean.shared.resetGlean(clearStores: false)
+        Glean.shared.resetGlean(configuration: cfg, clearStores: false)
         waitForExpectations(timeout: 5.0) { error in
             XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
         }


### PR DESCRIPTION
This is trying to deploy an idea @travis79 had: Use test-specific endpoints so that different tests don't share endpoints. In theory then no requests will ever overlap and we wouldn't need to deal with overdue ping uploads in subsequent tests.

However this still fails occasionally for me with hard crashes, so it's definitely far from done.

---

Maybe something more like I did for Android could work: a way to hook into the lifecylce (#2116) so that in tests we can wait for the right things?
Creating a draft PR, so that I can delegate this maybe.

