### PR TITLE
Bug 1772148 - Remove rkv safe-mode toggle. It's default enabled now.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,6 @@ commands:
             export GLEAN_TEST_COVERAGE=$(realpath glean_coverage.txt)
             cargo test --verbose --jobs 6 -- --nocapture
       - run:
-          name: Test Glean with rkv safe-mode
-          command: |
-            cd glean-core
-            cargo test -p glean-core --features rkv-safe-mode --jobs 6 -- --nocapture
-      - run:
           name: Install required Python dependencies
           command: |
             sudo apt update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     (`null`, `nil`, `None` depending on the language) and does not throw an exception ([#2087](https://github.com/mozilla/glean/pull/2087)).
   * BREAKING CHANGE: Dropped `ping_name` argument from all `test_get_num_recorded_errors` methods ([#2088](https://github.com/mozilla/glean/pull/2088))  
     Errors default to the `metrics` ping, so that's what is queried internally.
+  * BREAKING: Disable `safe-mode` everywhere. This causes all clients to migrate from LMDB to safe-mode storage ([#2123](https://github.com/mozilla/glean/pull/2123))
 * Kotlin
   * Fix the Glean Gradle Plugin to work with Android Gradle Plugin v7.2.1 ([#2114](https://github.com/mozilla/glean/pull/2114))
 * Rust

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -61,7 +61,3 @@ ctor = "0.1.12"
 
 [build-dependencies]
 uniffi_build = { version = "0.19.3", features = ["builtin-bindgen"] }
-
-[features]
-# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
-rkv-safe-mode = []

--- a/glean-core/bundle-android/Cargo.toml
+++ b/glean-core/bundle-android/Cargo.toml
@@ -23,7 +23,3 @@ path = "../bundle/src/lib.rs"
 [dependencies.glean-core]
 # No version specified, we build against what's available here.
 path = ".."
-
-[features]
-# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
-rkv-safe-mode = ["glean-core/rkv-safe-mode"]

--- a/glean-core/bundle/Cargo.toml
+++ b/glean-core/bundle/Cargo.toml
@@ -20,7 +20,3 @@ crate-type = ["staticlib", "cdylib"]
 [dependencies.glean-core]
 # No version specified, we build against what's available here.
 path = ".."
-
-[features]
-# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
-rkv-safe-mode = ["glean-core/rkv-safe-mode"]

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -182,8 +182,6 @@ class build(_build):
             "glean-bundle",
             "--target",
             target,
-            "--features",
-            "rkv-safe-mode",
         ]
         if buildvariant != "debug":
             command.append(f"--{buildvariant}")

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -42,7 +42,3 @@ env_logger = { version = "0.9.0", default-features = false, features = ["termcol
 tempfile = "3.1.0"
 jsonschema-valid = "0.5.0"
 flate2 = "1.0.19"
-
-[features]
-# Enable the "safe-mode" Rust storage backend instead of the default LMDB one.
-rkv-safe-mode = ["glean-core/rkv-safe-mode"]

--- a/samples/rust/Cargo.toml
+++ b/samples/rust/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
-glean = { path = "../../glean-core/rlb", features = ["rkv-safe-mode"] }
+glean = { path = "../../glean-core/rlb" }
 tempfile = "3.3.0"
 
 [build-dependencies]


### PR DESCRIPTION
This effectively enables safe-mode everywhere, forcing migration from
LDMB to safe-mode in clients.
Note:
The iOS build was one of the last ones that really used LMDB mode.
Standalone Android builds also uses LMDB mode.
Other Android builds are shipped through GeckoView, where safe-mode was already
enabled.