### PR TITLE
Bug 1780806 - Allow the uploader to signal it is done handling uploads.

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -9,6 +9,14 @@ style:
   # Multiple returns are ok
   ReturnCount:
     active: false
+
+  # Go ahead and jump (Jump!)
+  # Go ahead and jump
+  #
+  # break/continue in loops are ok.
+  LoopWithTooManyJumpStatements:
+    active: false
+
 build:
   maxIssues: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Relax `glean_parser` version requirement. All "compatible releases" are now allowed ([#2086](https://github.com/mozilla/glean/pull/2086))
+  * Uploaders can now signal that they can't upload anymore ([#2136](https://github.com/mozilla/glean/pull/2136))
 * Kotlin
   * BUGFIX: Re-enable correctly connecting `glean.validation.foreground_count` again ([#2153](https://github.com/mozilla/glean/pull/2153))
   * BUGFIX: Gradle plugin: Correctly remove the version conflict check. Now the consuming module need to ensure it uses a single version across all dependencies ([#2155](https://github.com/mozilla/glean/pull/2155))

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -158,12 +158,17 @@ public class HttpPingUploader {
                 var body = Data(capacity: request.body.count)
                 body.append(contentsOf: request.body)
                 self.upload(path: request.path, data: body, headers: request.headers) { result in
-                    gleanProcessPingUploadResponse(request.documentId, result)
-
-                    // launch a new iteration.
-                    Dispatchers.shared.launchAsync {
-                        HttpPingUploader(configuration: self.config, testingMode: self.testingMode).process()
+                    let action = gleanProcessPingUploadResponse(request.documentId, result)
+                    switch action {
+                    case .next:
+                        // launch a new iteration.
+                        Dispatchers.shared.launchAsync {
+                            HttpPingUploader(configuration: self.config, testingMode: self.testingMode).process()
+                        }
+                    case .end:
+                        return
                     }
+
                 }
 
                 // we don't want to launch multiple uploads at once.

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -16,7 +16,7 @@ from .._uniffi import (
     glean_initialize_for_subprocess,
     glean_process_ping_upload_response,
 )
-from .._uniffi import InternalConfiguration
+from .._uniffi import InternalConfiguration, UploadTaskAction
 from .._process_dispatcher import ProcessDispatcher
 
 
@@ -145,7 +145,12 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
             )
 
             # Process the response.
-            glean_process_ping_upload_response(doc_id, upload_result)
+            action = glean_process_ping_upload_response(doc_id, upload_result)
+            if action == UploadTaskAction.NEXT:
+                continue
+            else:  # action == UploadTaskAction.END
+                return True
+
         elif task.is_wait():
             time.sleep(task.time / 1000)
         elif task.is_done():

--- a/glean-core/rlb/src/net/mod.rs
+++ b/glean-core/rlb/src/net/mod.rs
@@ -15,7 +15,7 @@ use std::thread;
 use std::time::Duration;
 
 use glean_core::upload::PingUploadTask;
-pub use glean_core::upload::{PingRequest, UploadResult};
+pub use glean_core::upload::{PingRequest, UploadResult, UploadTaskAction};
 
 pub use http_uploader::*;
 
@@ -87,31 +87,38 @@ impl UploadManager {
         thread::Builder::new()
             .name("glean.upload".into())
             .spawn(move || {
+                log::trace!("Started glean.upload thread");
                 loop {
                     let incoming_task = glean_core::glean_get_upload_task();
 
-                    log::trace!("Received upload task: {:?}", incoming_task);
                     match incoming_task {
                         PingUploadTask::Upload { request } => {
+                            log::trace!("Received upload task with request {:?}", request);
                             let doc_id = request.document_id.clone();
                             let upload_url = format!("{}{}", inner.server_endpoint, request.path);
                             let headers: Vec<(String, String)> =
                                 request.headers.into_iter().collect();
                             let result = inner.uploader.upload(upload_url, request.body, headers);
                             // Process the upload response.
-                            glean_core::glean_process_ping_upload_response(doc_id, result);
+                            match glean_core::glean_process_ping_upload_response(doc_id, result) {
+                                UploadTaskAction::Next => continue,
+                                UploadTaskAction::End => break,
+                            }
                         }
                         PingUploadTask::Wait { time } => {
+                            log::trace!("Instructed to wait for {:?}ms", time);
                             thread::sleep(Duration::from_millis(time));
                         }
                         PingUploadTask::Done { .. } => {
-                            // Nothing to do here, break out of the loop and clear the
-                            // running flag.
-                            inner.thread_running.store(false, Ordering::SeqCst);
-                            return;
+                            log::trace!("Received PingUploadTask::Done. Exiting.");
+                            // Nothing to do here, break out of the loop.
+                            break;
                         }
                     }
                 }
+
+                // Clear the running flag to signal that this thread is done.
+                inner.thread_running.store(false, Ordering::SeqCst);
             })
             .expect("Failed to spawn Glean's uploader thread");
     }

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -13,7 +13,7 @@ use crate::internal_pings::InternalPings;
 use crate::metrics::{self, ExperimentMetric, Metric, MetricType, PingType, RecordedExperiment};
 use crate::ping::PingMaker;
 use crate::storage::{StorageManager, INTERNAL_STORAGE};
-use crate::upload::{PingUploadManager, PingUploadTask, UploadResult};
+use crate::upload::{PingUploadManager, PingUploadTask, UploadResult, UploadTaskAction};
 use crate::util::{local_now_with_offset, sanitize_application_id};
 use crate::{
     scheduler, system, CommonMetricData, ErrorKind, InternalConfiguration, Lifetime, Result,
@@ -565,9 +565,13 @@ impl Glean {
     ///
     /// * `uuid` - The UUID of the ping in question.
     /// * `status` - The upload result.
-    pub fn process_ping_upload_response(&self, uuid: &str, status: UploadResult) {
+    pub fn process_ping_upload_response(
+        &self,
+        uuid: &str,
+        status: UploadResult,
+    ) -> UploadTaskAction {
         self.upload_manager
-            .process_ping_upload_response(self, uuid, status);
+            .process_ping_upload_response(self, uuid, status)
     }
 
     /// Takes a snapshot for the given store and optionally clear it.

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -45,7 +45,7 @@ namespace glean {
     void glean_set_dirty_flag(boolean flag);
 
     PingUploadTask glean_get_upload_task();
-    void glean_process_ping_upload_response(string uuid, UploadResult result);
+    UploadTaskAction glean_process_ping_upload_response(string uuid, UploadResult result);
 };
 
 // The Glean configuration.
@@ -179,6 +179,19 @@ interface UploadResult {
     //
     // * code: The HTTP status code
     HttpStatus(i32 code);
+
+    // Signal that this uploader is done with work
+    // and won't accept new work.
+    Done(i8 unused);
+};
+
+// Communicating back whether the uploader loop should continue.
+enum UploadTaskAction {
+    // Instruct the caller to continue with work.
+    "Next",
+
+    // Instruct the caller to end work.
+    "End",
 };
 
 // The supported metrics' lifetimes.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -63,7 +63,7 @@ pub use crate::metrics::{
     StringListMetric, StringMetric, TextMetric, TimeUnit, TimerId, TimespanMetric,
     TimingDistributionMetric, UrlMetric, UuidMetric,
 };
-pub use crate::upload::{PingRequest, PingUploadTask, UploadResult};
+pub use crate::upload::{PingRequest, PingUploadTask, UploadResult, UploadTaskAction};
 
 const GLEAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 const GLEAN_SCHEMA_VERSION: u32 = 1;
@@ -851,7 +851,7 @@ pub fn glean_get_upload_task() -> PingUploadTask {
 }
 
 /// Processes the response from an attempt to upload a ping.
-pub fn glean_process_ping_upload_response(uuid: String, result: UploadResult) {
+pub fn glean_process_ping_upload_response(uuid: String, result: UploadResult) -> UploadTaskAction {
     core::with_glean(|glean| glean.process_ping_upload_response(&uuid, result))
 }
 

--- a/glean-core/src/upload/result.rs
+++ b/glean-core/src/upload/result.rs
@@ -32,6 +32,14 @@ pub enum UploadResult {
         /// The HTTP status code
         code: i32,
     },
+
+    /// Signal that this uploader is done with work
+    /// and won't accept new work.
+    Done {
+        #[doc(hidden)]
+        /// Unused field. Required because UniFFI can't handle variants without fields.
+        unused: i8,
+    },
 }
 
 impl UploadResult {
@@ -47,6 +55,7 @@ impl UploadResult {
             UploadResult::HttpStatus { .. } => Some("status_code_unknown"),
             UploadResult::UnrecoverableFailure { .. } => Some("unrecoverable"),
             UploadResult::RecoverableFailure { .. } => Some("recoverable"),
+            UploadResult::Done { .. } => None,
         }
     }
 
@@ -72,4 +81,18 @@ impl UploadResult {
     pub fn http_status(code: i32) -> Self {
         Self::HttpStatus { code }
     }
+
+    /// This uploader is done.
+    pub fn done() -> Self {
+        Self::Done { unused: 0 }
+    }
+}
+
+/// Communication back whether the uploader loop should continue.
+#[derive(Debug)]
+pub enum UploadTaskAction {
+    /// Instruct the caller to continue with work.
+    Next,
+    /// Instruct the caller to end work.
+    End,
 }


### PR DESCRIPTION
Putting this up so it's up.
I want to discuss this with chutten when he's back.

I'm not super happy with it because the `UploadResult::Done` needs to be handled on a different layer than all the other `UploadResult` variants.
(It's also only implemented for the RLB right now)