### PR TITLE
Bug 1781823 - Handle that Glean might be uninitalized when an upload task is requested

### DIFF
--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -53,6 +53,9 @@ pub fn setup_glean(glean: Glean) -> Result<()> {
     Ok(())
 }
 
+/// Execute `f` passing the global Glean object.
+///
+/// Panics if the global Glean object has not been set.
 pub fn with_glean<F, R>(f: F) -> R
 where
     F: FnOnce(&Glean) -> R,
@@ -62,6 +65,9 @@ where
     f(&lock)
 }
 
+/// Execute `f` passing the global Glean object mutable.
+///
+/// Panics if the global Glean object has not been set.
 pub fn with_glean_mut<F, R>(f: F) -> R
 where
     F: FnOnce(&mut Glean) -> R,
@@ -69,6 +75,19 @@ where
     let glean = global_glean().expect("Global Glean object not initialized");
     let mut lock = glean.lock().unwrap();
     f(&mut lock)
+}
+
+/// Execute `f` passing the global Glean object if it has been set.
+///
+/// Returns `None` if the global Glean object has not been set.
+/// Returns `Some(T)` otherwise.
+pub fn with_opt_glean<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&Glean) -> R,
+{
+    let glean = global_glean()?;
+    let lock = glean.lock().unwrap();
+    Some(f(&lock))
 }
 
 /// The object holding meta information about a Glean instance.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -847,7 +847,7 @@ pub fn glean_test_destroy_glean(clear_stores: bool) {
 
 /// Get the next upload task
 pub fn glean_get_upload_task() -> PingUploadTask {
-    core::with_glean(|glean| glean.get_upload_task())
+    core::with_opt_glean(|glean| glean.get_upload_task()).unwrap_or_else(PingUploadTask::done)
 }
 
 /// Processes the response from an attempt to upload a ping.

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -174,7 +174,7 @@ impl PingUploadTask {
         matches!(self, PingUploadTask::Wait { .. })
     }
 
-    fn done() -> Self {
+    pub(crate) fn done() -> Self {
         PingUploadTask::Done { unused: 0 }
     }
 }


### PR DESCRIPTION
If Glean is uninitalized a `Done` task is returned, instructing the
uploader to not request further upload tasks and finish.
Uploads might now be delayed until the next ping is submitted (or the app restarted),
but that was kinda already the case if this crashed anyway.

---

While I still don't know the actualy root cause of the crashes we've been seeing, this should mitigate it.