### PR TITLE
Handle that Glean might be uninitalized when an upload task is requested [backport]

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 50.1.3
+libraryVersion: 50.1.4
 groupId: org.mozilla.telemetry
 projects:
   glean:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v50.1.3...main)
+[Full changelog](https://github.com/mozilla/glean/compare/v50.1.4...main)
+
+# v50.1.4 (2022-08-01)
+
+[Full changelog](https://github.com/mozilla/glean/compare/v50.1.3...v50.1.4)
+
+* General
+  * BUGFIX: Handle that Glean might be uninitialized when an upload task is requested ([#2131](https://github.com/mozilla/glean/pull/2131))
 
 # v50.1.3 (2022-07-26)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "glean"
-version = "50.1.3"
+version = "50.1.4"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "50.1.3"
+version = "50.1.4"
 dependencies = [
  "android_logger",
  "bincode",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4955,8 +4955,8 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 The following text applies to code linked from these dependencies:
 
-* [glean 50.1.3]( https://github.com/mozilla/glean )
-* [glean-core 50.1.3]( https://github.com/mozilla/glean )
+* [glean 50.1.4]( https://github.com/mozilla/glean )
+* [glean-core 50.1.4]( https://github.com/mozilla/glean )
 * [zeitstempel 0.1.1]( https://github.com/badboy/zeitstempel )
 
 

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "50.1.3"
+version = "50.1.4"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -56,7 +56,7 @@ with (SRC_ROOT / "CHANGELOG.md").open() as history_file:
     history = history_file.read()
 
 # glean version. Automatically updated by the bin/prepare_release.sh script
-version = "50.1.3"
+version = "50.1.4"
 
 requirements = [
     "cffi>=1.13.0",

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean"
-version = "50.1.3"
+version = "50.1.4"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "Glean SDK Rust language bindings"
 repository = "https://github.com/mozilla/glean"
@@ -22,7 +22,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies.glean-core]
 path = ".."
-version = "50.1.3"
+version = "50.1.4"
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -53,6 +53,9 @@ pub fn setup_glean(glean: Glean) -> Result<()> {
     Ok(())
 }
 
+/// Execute `f` passing the global Glean object.
+///
+/// Panics if the global Glean object has not been set.
 pub fn with_glean<F, R>(f: F) -> R
 where
     F: FnOnce(&Glean) -> R,
@@ -62,6 +65,9 @@ where
     f(&lock)
 }
 
+/// Execute `f` passing the global Glean object mutable.
+///
+/// Panics if the global Glean object has not been set.
 pub fn with_glean_mut<F, R>(f: F) -> R
 where
     F: FnOnce(&mut Glean) -> R,
@@ -69,6 +75,19 @@ where
     let glean = global_glean().expect("Global Glean object not initialized");
     let mut lock = glean.lock().unwrap();
     f(&mut lock)
+}
+
+/// Execute `f` passing the global Glean object if it has been set.
+///
+/// Returns `None` if the global Glean object has not been set.
+/// Returns `Some(T)` otherwise.
+pub fn with_opt_glean<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&Glean) -> R,
+{
+    let glean = global_glean()?;
+    let lock = glean.lock().unwrap();
+    Some(f(&lock))
 }
 
 /// The object holding meta information about a Glean instance.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -847,7 +847,7 @@ pub fn glean_test_destroy_glean(clear_stores: bool) {
 
 /// Get the next upload task
 pub fn glean_get_upload_task() -> PingUploadTask {
-    core::with_glean(|glean| glean.get_upload_task())
+    core::with_opt_glean(|glean| glean.get_upload_task()).unwrap_or_else(PingUploadTask::done)
 }
 
 /// Processes the response from an attempt to upload a ping.

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -174,7 +174,7 @@ impl PingUploadTask {
         matches!(self, PingUploadTask::Wait { .. })
     }
 
-    fn done() -> Self {
+    pub(crate) fn done() -> Self {
         PingUploadTask::Done { unused: 0 }
     }
 }

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -529,7 +529,7 @@ except:
     void apply(Project project) {
         isOffline = project.gradle.startParameter.offline
 
-        project.ext.glean_version = "50.1.3"
+        project.ext.glean_version = "50.1.4"
         def parserVersion = gleanParserVersion(project)
 
         // Print the required glean_parser version to the console. This is


### PR DESCRIPTION
If Glean is uninitalized a `Done` task is returned, instructing the
uploader to not request further upload tasks and finish.
Uploads might now be delayed until the next ping is submitted (or the app restarted),
but that was kinda already the case if this crashed anyway.

---

Cherry-picked on top of v50.1.3
Original: https://github.com/mozilla/glean/pull/2131