### PR TITLE
Bug 1782194 - Gradle plugin: Remove the version conflict check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * BUGFIX: Handle that Glean might be uninitialized when an upload task is requested ([#2131](https://github.com/mozilla/glean/pull/2131))
 * Kotlin
   * BUGFIX: When setting a local endpoint in testing check for testing mode, not initialization ([#2145](https://github.com/mozilla/glean/pull/2145/))
+  * Gradle plugin: Remove the version conflict check. Now the consuming module need to ensure it uses a single version across all dependencies ([#2143](https://github.com/mozilla/glean/pull/2143))
 
 # v51.0.1 (2022-07-26)
 

--- a/gradle-plugin/bin/main/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/bin/main/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -556,16 +556,6 @@ except:
                 }
                 because 'use GeckoView Glean instead of standalone Glean'
             }
-
-            incoming.afterResolve {
-                resolutionResult.allComponents {
-                    if (selectionReason.conflictResolution && moduleVersion != null) {
-                        if (moduleVersion.group.contains("org.mozilla.telemetry") && moduleVersion.name.contains("glean")) {
-                            throw new AssertionError("Cannot have a conflict on Glean ${selectionReason}")
-                        }
-                    }
-                }
-            }
         }
 
         if (project.android.hasProperty('applicationVariants')) {


### PR DESCRIPTION
This check didn't work out as expected,
and caused more problems for us when updating Glean than it caught issues.

Now the consuming module need to ensure it uses a single version across all dependencies.