### PR TITLE
1783739 sleep causing intermittent

### DIFF
--- a/glean-core/python/tests/metrics/test_timing_distribution.py
+++ b/glean-core/python/tests/metrics/test_timing_distribution.py
@@ -162,13 +162,20 @@ def test_measure():
     )
 
     with metric.measure():
-        time.sleep(0.1)
+        iteration_guard = 10**8  # this guard should be
+        # about 100 times as long as the loop
+        iterations = 0
+        end_time = time.perf_counter() + 0.1
+        while time.perf_counter() < end_time:
+            if iterations > iteration_guard:
+                raise Exception("Loop to accrue time exceeded guard")
+            iterations += 1
 
     snapshot = metric.test_get_value()
     # more than 0.1s = 100ms = 10^8 nanoseconds
     # less than 0.2s = 200ms = 2*10^8 nanoseconds
-    assert 10**8 < snapshot.sum
-    assert 2 * 10**8 > snapshot.sum
+    assert snapshot.sum > 10**8, "Measured value below minimum time"
+    assert snapshot.sum < 2 * 10**8, "Measured value above maximum time"
 
 
 def test_measure_exception():


### PR DESCRIPTION
Hmm, not sure about the readme. Will fix tomorrow.

Anyway, here is the strategy I've cooked up (thanks stackoverflow!). It uses a guarded while loop (so, max number of iterations)

Here are the test results I did up quickly. Average over 100 loops for how much deviation there is from the desired time. While this doesn't perfectly mirror the test env or guarantee the problem is fixed, it should make that error far less likely.

I also tried using a small value for sleep and looping and checking but this was... not good lol

```
(base) pmcmanis@MacBook-Pro scratch % python time_loop_tests.py
sleep test average deviation 3.47556ms
sleep loop test average deviation 28.14823ms
perf counter test average deviation 0.0032599999999979447ms
guarded perf counter test average deviation 0.003129999999996755ms
```