### PR TITLE
Correctly remove the version conflict check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Relax `glean_parser` version requirement. All "compatible releases" are now allowed ([#2086](https://github.com/mozilla/glean/pull/2086))
 * Kotlin
   * BUGFIX: Re-enable correctly connecting `glean.validation.foreground_count` again ([#2153](https://github.com/mozilla/glean/pull/2153))
+  * BUGFIX: Gradle plugin: Correctly remove the version conflict check. Now the consuming module need to ensure it uses a single version across all dependencies ([#2155](https://github.com/mozilla/glean/pull/2155))
 
 # v51.1.0 (2022-08-08)
 

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -579,16 +579,6 @@ except:
                 }
                 because 'use GeckoView Glean instead of standalone Glean'
             }
-
-            incoming.afterResolve {
-                resolutionResult.allComponents {
-                    if (selectionReason.conflictResolution && moduleVersion != null) {
-                        if (moduleVersion.group.contains("org.mozilla.telemetry") && moduleVersion.name.contains("glean")) {
-                            throw new AssertionError("Cannot have a conflict on Glean ${selectionReason}")
-                        }
-                    }
-                }
-            }
         }
 
         if (project.android.hasProperty('applicationVariants')) {


### PR DESCRIPTION
This was broken in the last release.
ec61a9ddf662cf2c574e9d195d861729a7bf2bff modified the wrong file.