### PR TITLE
TC: Limit to 6 test jobs on the Rust Beta tests

### DIFF
--- a/taskcluster/ci/rust/kind.yml
+++ b/taskcluster/ci/rust/kind.yml
@@ -24,6 +24,6 @@ jobs:
         - ['.', './taskcluster/scripts/rustup-setup.sh', 'beta']
         - ['rustup', 'component', 'add', 'clippy']
       commands:
-        - ['cargo', 'test', '--all', '--verbose']
+        - ['cargo', 'test', '--all', '--verbose', '--jobs', '6']
         - ['cargo', 'clippy', '--version']
         - ['cargo', 'clippy', '--verbose', '--all', '--all-targets', '--all-features', '--', '-D', 'warnings']


### PR DESCRIPTION
Let's see if that fixes the issues we have.