### PR TITLE
TC: Don't hide which tasks are executed anymore.

### DIFF
--- a/taskcluster/scripts/rustup-setup.sh
+++ b/taskcluster/scripts/rustup-setup.sh
@@ -38,4 +38,4 @@ else
     rustup default "${TOOLCHAIN}"
 fi
 
-set +eux
+set +eu


### PR DESCRIPTION
We set `set -x` early on, thus seeing all commands from rustup-setup.sh,
but then disable that afterwards.
The log then only shows the output, making it harder to understand what
output is from what command.
Now we just leave the `set -x` and it will apply to all the following
commands.