### PR TITLE
Bug 1786279 - fix broken "engineering practices & quality standards" link

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -82,7 +82,7 @@ When submitting a PR:
 ## Code Review
 
 This project is production Mozilla code and subject to our
-[engineering practices and quality standards](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Committing_Rules_and_Responsibilities).
+[engineering practices and quality standards](https://firefox-source-docs.mozilla.org/contributing/committing_rules_and_responsibilities.html).
 Every patch must be peer reviewed by a member of the Glean core team.
 
 Reviewers are defined in the [CODEOWNERS](https://github.com/mozilla/glean/blob/main/.github/CODEOWNERS) file


### PR DESCRIPTION
The [previous link was archived on MDN](https://github.com/mdn/content/pull/4599), so for now we will use this link until this section is rewritten.