### PR TITLE
Bug 1780410 - RLB: Ignore two tests by default, run them on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,14 @@ commands:
           command: |
             export GLEAN_TEST_COVERAGE=$(realpath glean_coverage.txt)
             cargo test --verbose --jobs 6 -- --nocapture
+
+            # FIXME(bug 1786469): Tests are ignored to not cause TC failures.
+            # Explicitly run them here.
+            cargo test --verbose --jobs 6 -p glean --lib -- \
+              --test-threads 1 \
+              --ignored \
+              sending_deletion_ping_if_disabled_outside_of_run \
+              sending_of_foreground_background_pings
       - run:
           name: Install required Python dependencies
           command: |

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -148,6 +148,7 @@ fn test_experiments_recording_before_glean_inits() {
 }
 
 #[test]
+#[ignore = "Bug 1786469: Causing test timeouts on TaskCluster with Rust Beta"]
 fn sending_of_foreground_background_pings() {
     let _lock = lock_test();
 
@@ -597,6 +598,7 @@ fn core_metrics_should_be_cleared_and_restored_when_disabling_and_enabling_uploa
 }
 
 #[test]
+#[ignore = "Bug 1786469: Causing test timeouts on TaskCluster with Rust Beta"]
 fn sending_deletion_ping_if_disabled_outside_of_run() {
     let _lock = lock_test();
 


### PR DESCRIPTION
These tests cause test timeouts on TaskCluster with Rust Beta.
We don't know yet why, they run fine on CircleCI/Rust Stable.

We ignore them for the time being, but explicitly run them on CI.