### PR TITLE
Bug 1780410 - TC: Don't run Rust tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,14 +63,6 @@ commands:
           command: |
             export GLEAN_TEST_COVERAGE=$(realpath glean_coverage.txt)
             cargo test --verbose --jobs 6 -- --nocapture
-
-            # FIXME(bug 1786469): Tests are ignored to not cause TC failures.
-            # Explicitly run them here.
-            cargo test --verbose --jobs 6 -p glean --lib -- \
-              --test-threads 1 \
-              --ignored \
-              sending_deletion_ping_if_disabled_outside_of_run \
-              sending_of_foreground_background_pings
       - run:
           name: Install required Python dependencies
           command: |

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -148,7 +148,6 @@ fn test_experiments_recording_before_glean_inits() {
 }
 
 #[test]
-#[ignore = "Bug 1786469: Causing test timeouts on TaskCluster with Rust Beta"]
 fn sending_of_foreground_background_pings() {
     let _lock = lock_test();
 
@@ -598,7 +597,6 @@ fn core_metrics_should_be_cleared_and_restored_when_disabling_and_enabling_uploa
 }
 
 #[test]
-#[ignore = "Bug 1786469: Causing test timeouts on TaskCluster with Rust Beta"]
 fn sending_deletion_ping_if_disabled_outside_of_run() {
     let _lock = lock_test();
 

--- a/taskcluster/ci/rust/kind.yml
+++ b/taskcluster/ci/rust/kind.yml
@@ -24,6 +24,5 @@ jobs:
         - ['.', './taskcluster/scripts/rustup-setup.sh', 'beta']
         - ['rustup', 'component', 'add', 'clippy']
       commands:
-        - ['cargo', 'test', '--all', '--verbose', '--jobs', '6']
         - ['cargo', 'clippy', '--version']
         - ['cargo', 'clippy', '--verbose', '--all', '--all-targets', '--all-features', '--', '-D', 'warnings']


### PR DESCRIPTION
This reverts commit 01b1770

We still haven't figured out why some tests keep stalling.
This only happens on the TaskCluster instances and is so far not
reproducible in any other environment, including a local Docker run.

I'm out of options here.

---

I've now run the tests hundred of times in my local Docker on a Linux machine, limiting it to 2 vCPUs and 4 G of RAM, same as the taskcluster instance has, with no success to make them fail in the same way.