### PR TITLE
Bug 1723090 - Add note to `glean.restarted` docs about leading/trailing event omission

### DIFF
--- a/docs/user/user/pings/custom.md
+++ b/docs/user/user/pings/custom.md
@@ -71,6 +71,8 @@ If this metric should also be sent in the default ping for the given metric type
 For custom pings that contain event metrics, the `glean.restarted` event is injected by Glean
 on every application restart that may happen during the pings measurement window.
 
+**Note**: All leading and trailing `glean.restarted` events are omitted from each ping.
+
 {{#include ../../../shared/blockquote-warning.html}}
 
 ### Only applies to the Glean JavaScript SDK


### PR DESCRIPTION
Updating docs as a part of https://github.com/mozilla/glean.js/pull/1452