### PR TITLE
Bug 1789615 - Always store a UUID hyphenated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   * BUGFIX: Correctly set `os_version` and `architecture` again ([#2174](https://github.com/mozilla/glean/pull/2174))
 * iOS
   * BUGFIX: Correctly set `os_version` and `architecture` again ([#2174](https://github.com/mozilla/glean/pull/2174))
+* Python
+  * BUGFIX: Correctly handle every string that represents a UUID, including non-hyphenated random 32-character strings ([#2182](https://github.com/mozilla/glean/pull/2182))
 
 # v51.1.0 (2022-08-08)
 

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -58,8 +58,8 @@ impl UuidMetric {
 
         let value = value.into();
 
-        if uuid::Uuid::parse_str(&value).is_ok() {
-            let value = Metric::Uuid(value);
+        if let Ok(uuid) = uuid::Uuid::parse_str(&value) {
+            let value = Metric::Uuid(uuid.to_hyphenated().to_string());
             glean.storage().record(glean, &self.meta, &value)
         } else {
             let msg = format!("Unexpected UUID value '{}'", value);


### PR DESCRIPTION
This fixes a regression in the Glean Python SDK.
We used to do this, but failed to correctly encode UUIDs since v50.

The Glean ping schema expects UUIDs in a hyphenated form a la `060f830d-3bcc-4a6a-b4b1-7336271a2b34`. However we passed the user data through without re-encoding, thus leading to non-hyphenated strings landing in the JSON payload of a ping and then getting rejected by the pipeline.

This is only an issue for Python, because for Kotlin and Swift we don't accept plain strings, but only `UUID` types, which serialize to hyphenated strings.