### PR TITLE
Bug 1716954 - Update timing_distribution metric docs

### DIFF
--- a/docs/user/reference/metrics/timing_distribution.md
+++ b/docs/user/reference/metrics/timing_distribution.md
@@ -111,7 +111,18 @@ fn on_page_start() {
 ```
 
 </div>
-<div data-lang="JavaScript" class="tab" data-bug="1716954"></div>
+<div data-lang="JavaScript" class="tab">
+
+```Javascript
+import * as timing from "./path/to/generated/files/timing.js";
+
+function onPageStart() {
+    // store this ID, you will need it later to stop or cancel your timer
+    const timerId = timing.start();
+}
+```
+
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -197,7 +208,17 @@ fn on_page_loaded() {
 ```
 
 </div>
-<div data-lang="JavaScript" class="tab" data-bug="1716954"></div>
+<div data-lang="JavaScript" class="tab">
+
+```Javascript
+import * as timing from "./path/to/generated/files/timing.js";
+
+function onPageLoaded() {
+    timing.stopAndAccumulate(timerId);
+}
+```
+
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -265,7 +286,7 @@ with metrics.pages.page_load.measure():
 
 </div>
 <div data-lang="Rust" class="tab"></div>
-<div data-lang="JavaScript" class="tab" data-bug="1716954"></div>
+<div data-lang="JavaScript" class="tab"></div>
 <div data-lang="Firefox Desktop" class="tab"></div>
 
 {{#include ../../../shared/tab_footer.md}}
@@ -333,7 +354,17 @@ fn on_page_error() {
 ```
 
 </div>
-<div data-lang="JavaScript" class="tab"></div>
+<div data-lang="JavaScript" class="tab">
+
+```Javascript
+import * as timing from "./path/to/generated/files/timing.js";
+
+function onPageError() {
+    timing.cancel(timerId);
+}
+```
+
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -435,7 +466,19 @@ assert_eq!(1, snapshot.values.len());
 
 
 </div>
-<div data-lang="JavaScript" class="tab" data-bug="1716954"></div>
+<div data-lang="JavaScript" class="tab">
+
+```Javascript
+import * as timing from "./path/to/generated/files/timing.js";
+
+const snapshot = await timing.testGetValue("<yourPingName>");
+
+// Usually you don't know the exact timing values,
+// but how many should have been recorded.
+assert.equal(1, snapshot.count);
+```
+
+</div>
 <div data-lang="Firefox Desktop" class="tab">
 
 **C++**
@@ -524,7 +567,16 @@ assert_eq!(
 ```
 
 </div>
-<div data-lang="JavaScript" class="tab" data-bug="1716954"></div>
+<div data-lang="JavaScript" class="tab">
+
+```Javascript
+import * as timing from "./path/to/generated/files/timing.js";
+import { ErrorType } from "@mozilla/glean/<platform>";
+
+assert.equal(1, await metric.testGetNumRecordedErrors(ErrorType.InvalidValue));
+```
+
+</div>
 <div data-lang="Firefox Desktop" class="tab"></div>
 
 {{#include ../../../shared/tab_footer.md}}

--- a/docs/user/reference/metrics/timing_distribution.md
+++ b/docs/user/reference/metrics/timing_distribution.md
@@ -114,11 +114,11 @@ fn on_page_start() {
 <div data-lang="JavaScript" class="tab">
 
 ```Javascript
-import * as timing from "./path/to/generated/files/timing.js";
+import * as pages from "./path/to/generated/files/pages.js";
 
 function onPageStart() {
     // store this ID, you will need it later to stop or cancel your timer
-    const timerId = timing.start();
+    const timerId = pages.pageLoad.start();
 }
 ```
 
@@ -211,10 +211,10 @@ fn on_page_loaded() {
 <div data-lang="JavaScript" class="tab">
 
 ```Javascript
-import * as timing from "./path/to/generated/files/timing.js";
+import * as pages from "./path/to/generated/files/pages.js";
 
 function onPageLoaded() {
-    timing.stopAndAccumulate(timerId);
+    pages.pageLoad.stopAndAccumulate(timerId);
 }
 ```
 
@@ -357,10 +357,10 @@ fn on_page_error() {
 <div data-lang="JavaScript" class="tab">
 
 ```Javascript
-import * as timing from "./path/to/generated/files/timing.js";
+import * as pages from "./path/to/generated/files/pages.js";
 
 function onPageError() {
-    timing.cancel(timerId);
+    pages.pageLoad.cancel(timerId);
 }
 ```
 
@@ -469,9 +469,9 @@ assert_eq!(1, snapshot.values.len());
 <div data-lang="JavaScript" class="tab">
 
 ```Javascript
-import * as timing from "./path/to/generated/files/timing.js";
+import * as pages from "./path/to/generated/files/pages.js";
 
-const snapshot = await timing.testGetValue("<yourPingName>");
+const snapshot = await pages.pageLoad.testGetValue();
 
 // Usually you don't know the exact timing values,
 // but how many should have been recorded.
@@ -570,10 +570,10 @@ assert_eq!(
 <div data-lang="JavaScript" class="tab">
 
 ```Javascript
-import * as timing from "./path/to/generated/files/timing.js";
+import * as pages from "./path/to/generated/files/pages.js";
 import { ErrorType } from "@mozilla/glean/<platform>";
 
-assert.equal(1, await metric.testGetNumRecordedErrors(ErrorType.InvalidValue));
+assert.equal(1, await pages.pageLoad.testGetNumRecordedErrors(ErrorType.InvalidValue));
 ```
 
 </div>


### PR DESCRIPTION
Now that timing_distribution is being implemented in Glean.js, we no longer need to say that the API is not available.

Glean.js PR - https://github.com/mozilla/glean.js/pull/1475