### PR TITLE
Use single-quote to ensure code is valid when executed on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v51.2.0...main)
 
+* Kotlin
+  * Gradle plugin: Fix quoting issue in Python wrapper code ([#2193](https://github.com/mozilla/glean/pull/2193))
+
 # v51.2.0 (2022-09-08)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v51.1.0...v51.2.0)

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -104,9 +104,9 @@ else:
         sys.exit(1)
     else:
         # We check MAJOR.MINOR only
-        expected_ver = expected_version.split(".")
+        expected_ver = expected_version.split('.')
         expected_maj, expected_min = int(expected_ver[0]), int(expected_ver[1])
-        current_ver = found_version.split(".")
+        current_ver = found_version.split('.')
         current_maj, current_min = int(current_ver[0]), int(current_ver[1])
 
         if current_maj > expected_maj or current_maj < expected_maj or (current_maj == expected_maj and current_min < expected_min):


### PR DESCRIPTION
Should fix https://github.com/mozilla-mobile/fenix/issues/27053

Fixes #2192