### PR TITLE
Release v51.4.0

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 51.3.0
+libraryVersion: 51.4.0
 groupId: org.mozilla.telemetry
 projects:
   glean:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v51.3.0...main)
+[Full changelog](https://github.com/mozilla/glean/compare/v51.4.0...main)
+
+# v51.4.0 (2022-10-04)
+
+[Full changelog](https://github.com/mozilla/glean/compare/v51.3.0...v51.4.0)
 
 * Kotlin
   * Update Kotlin and Android Gradle Plugin to the latest releases ([#2211](https://github.com/mozilla/glean/pull/2211))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "glean"
-version = "51.3.0"
+version = "51.4.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "51.3.0"
+version = "51.4.0"
 dependencies = [
  "android_logger",
  "bincode",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -5252,9 +5252,9 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 The following text applies to code linked from these dependencies:
 
-* [glean 51.3.0]( https://github.com/mozilla/glean )
+* [glean 51.4.0]( https://github.com/mozilla/glean )
 * [glean-build 6.1.2]( https://github.com/mozilla/glean )
-* [glean-core 51.3.0]( https://github.com/mozilla/glean )
+* [glean-core 51.4.0]( https://github.com/mozilla/glean )
 * [zeitstempel 0.1.1]( https://github.com/badboy/zeitstempel )
 
 ```

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "51.3.0"
+version = "51.4.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/python/setup.py
+++ b/glean-core/python/setup.py
@@ -56,7 +56,7 @@ with (SRC_ROOT / "CHANGELOG.md").open() as history_file:
     history = history_file.read()
 
 # glean version. Automatically updated by the bin/prepare_release.sh script
-version = "51.3.0"
+version = "51.4.0"
 
 requirements = [
     "semver>=2.13.0",

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean"
-version = "51.3.0"
+version = "51.4.0"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "Glean SDK Rust language bindings"
 repository = "https://github.com/mozilla/glean"
@@ -22,7 +22,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies.glean-core]
 path = ".."
-version = "51.3.0"
+version = "51.4.0"
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -555,7 +555,7 @@ except:
     void apply(Project project) {
         isOffline = project.gradle.startParameter.offline
 
-        project.ext.glean_version = "51.3.0"
+        project.ext.glean_version = "51.4.0"
         def parserVersion = gleanParserVersion(project)
 
         // Print the required glean_parser version to the console. This is


### PR DESCRIPTION
New release branch PR

# v51.4.0 (2022-10-04)

[Full changelog](https://github.com/mozilla/glean/compare/v51.3.0...v51.4.0)

* Kotlin
  * Update Kotlin and Android Gradle Plugin to the latest releases ([#2211](https://github.com/mozilla/glean/pull/2211))

* Swift
  * Fix for iOS startup crash caused by Glean ([#2206](https://github.com/mozilla/glean/pull/2206))