### PR TITLE
bug 1796258 - Introduce cargo feature `preinit_million_queue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v51.5.0...main)
 
+* Rust
+  * Add cargo feature `preinit_million_queue` to up the preinit queue length from 10^3 to 10^6 ([bug 1796258](https://bugzilla.mozilla.org/show_bug.cgi?id=1796258))
+
 # v51.5.0 (2022-10-18)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v51.4.0...v51.5.0)

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -61,3 +61,7 @@ ctor = "0.1.12"
 
 [build-dependencies]
 uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }
+
+[features]
+# Increases the preinit queue limit to 10^6
+preinit_million_queue = []

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -42,3 +42,6 @@ env_logger = { version = "0.9.0", default-features = false, features = ["termcol
 tempfile = "3.1.0"
 jsonschema-valid = "0.5.0"
 flate2 = "1.0.19"
+
+[features]
+preinit_million_queue = ["glean-core/preinit_million_queue"]

--- a/glean-core/src/dispatcher/global.rs
+++ b/glean-core/src/dispatcher/global.rs
@@ -8,7 +8,11 @@ use std::sync::RwLock;
 
 use super::{DispatchError, DispatchGuard, Dispatcher};
 
+#[cfg(feature = "preinit_million_queue")]
+pub const GLOBAL_DISPATCHER_LIMIT: usize = 1000000;
+#[cfg(not(feature = "preinit_million_queue"))]
 pub const GLOBAL_DISPATCHER_LIMIT: usize = 1000;
+
 static GLOBAL_DISPATCHER: Lazy<RwLock<Option<Dispatcher>>> =
     Lazy::new(|| RwLock::new(Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT))));
 pub static TESTING_MODE: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
Firefox Desktop appears confident in its ability to always init Glean _eventually_, and is willing to bet a few MB to that end.