### PR TITLE
Bug 1797934 - Pull up label limits to the recording API docs

### DIFF
--- a/docs/user/_includes/label-errors.md
+++ b/docs/user/_includes/label-errors.md
@@ -1,0 +1,3 @@
+* [`invalid_label`](../../user/metrics/error-reporting.md):
+  * If the label contains invalid characters. Data is still recorded to the special label `__other__`.
+  * If the label exceeds the maximum number of allowed characters. Data is still recorded to the special label `__other__`.

--- a/docs/user/_includes/label-limits.md
+++ b/docs/user/_includes/label-limits.md
@@ -1,0 +1,7 @@
+* Labels must conform to the [label formatting regular expression](index.md#label-format).
+* Each label must have a maximum of 60 bytes, when encoded as UTF-8.
+* The list of labels is limited to:
+  * 16 different dynamic labels if no static labels are defined.
+    Additional labels will all record to the special label `__other__`.
+  * 100 labels if specified as static labels in `metrics.yaml`, see [Labels](#labels).
+    Unknown labels will be recorded under the special label `__other__`.

--- a/docs/user/_includes/labels-parameter.md
+++ b/docs/user/_includes/labels-parameter.md
@@ -4,9 +4,7 @@ Labeled metrics may have an optional `labels` parameter, containing a list of kn
 The labels in this list must match the following requirements:
 
 * Conform to the [label formatting regular expression](index.md#label-format).
-
 * Each label must have a maximum of 60 bytes, when encoded as UTF-8.
-
 * This list itself is limited to 100 labels.
 
 {{#include ../../shared/blockquote-warning.html}}

--- a/docs/user/reference/metrics/labeled_booleans.md
+++ b/docs/user/reference/metrics/labeled_booleans.md
@@ -90,10 +90,12 @@ Glean.accessibility.features["high_contrast"].set(false);
 
 #### Recorded Errors
 
-* [`invalid_label`](../../user/metrics/error-reporting.md):
-  * If the label contains invalid characters. Data is still recorded to the special label `__other__`.
-  * If the label exceeds the maximum number of allowed characters. Data is still recorded to the special label `__other__`.
 * [`invalid_type`](../../user/metrics/error-reporting.md): if a non-boolean value is given.
+{{#include ../../_includes/label-errors.md}}
+
+#### Limits
+
+{{#include ../../_includes/label-limits.md}}
 
 ## Testing API
 

--- a/docs/user/reference/metrics/labeled_counters.md
+++ b/docs/user/reference/metrics/labeled_counters.md
@@ -97,18 +97,17 @@ Glean.stability.crashCount["native_code_crash"].add(3);
 
 {{#include ../../../shared/tab_footer.md}}
 
-#### Errors recorded
+#### Recorded Errors
 
 * [`invalid_value`](../../user/metrics/error-reporting.md): if the counter is incremented by `0` or a negative value.
-* [`invalid_label`](../../user/metrics/error-reporting.md):
-  * If the label contains invalid characters. Data is still recorded to the special label `__other__`.
-  * If the label exceeds the maximum number of allowed characters. Data is still recorded to the special label `__other__`.
 * [`invalid_type`](../../user/metrics/error-reporting.md): if a floating point or non-number value is given.
+{{#include ../../_includes/label-errors.md}}
 
 #### Limits
 
-* Only increments;
+* Only increments
 * Saturates at the largest value that can be represented as a 32-bit signed integer.
+{{#include ../../_includes/label-limits.md}}
 
 ## Testing API
 

--- a/docs/user/reference/metrics/labeled_strings.md
+++ b/docs/user/reference/metrics/labeled_strings.md
@@ -80,17 +80,16 @@ Glean.login.errorsByStage["server_auth"].set("Invalid password");
 
 {{#include ../../../shared/tab_footer.md}}
 
+#### Recorded Errors
+
+* [`invalid_overflow`](../../user/metrics/error-reporting.md): if the string is too long, see [limits below](#limits).
+* [`invalid_type`](../../user/metrics/error-reporting.md): if a non-string value is given.
+{{#include ../../_includes/label-errors.md}}
+
 #### Limits
 
 * Fixed maximum string length: 100. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
-
-#### Recorded Errors
-
-* [`invalid_overflow`](../../user/metrics/error-reporting.md): if the string is too long. (Prior to Glean 31.5.0, this recorded an `invalid_value`).
-* [`invalid_label`](../../user/metrics/error-reporting.md):
-  * If the label contains invalid characters. Data is still recorded to the special label `__other__`.
-  * If the label exceeds the maximum number of allowed characters. Data is still recorded to the special label `__other__`.
-* [`invalid_type`](../../user/metrics/error-reporting.md): if a non-string value is given.
+{{#include ../../_includes/label-limits.md}}
 
 ## Testing API
 

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -127,6 +127,13 @@ impl PingType {
         }
 
         let ping = &self.0;
+
+        // Allowing `clippy::manual_filter`.
+        // This causes a false positive.
+        // We have a side-effect in the `else` branch,
+        // so shouldn't delete it.
+        #[allow(unknown_lints)]
+        #[allow(clippy::manual_filter)]
         let corrected_reason = match reason {
             Some(reason) => {
                 if ping.reason_codes.contains(&reason.to_string()) {

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -1280,7 +1280,7 @@ mod test {
                 .unwrap()
         );
         assert_eq!(
-            n as i32,
+            n,
             upload_manager
                 .upload_metrics
                 .pending_pings

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -373,7 +373,7 @@ fn seen_labels_get_reloaded_from_disk() {
         // Set the maximum number of labels
         for i in 1..=16 {
             let label = format!("label{}", i);
-            labeled.get(&label).add_sync(&glean, i);
+            labeled.get(label).add_sync(&glean, i);
         }
 
         let snapshot = StorageManager
@@ -439,7 +439,7 @@ fn caching_metrics_with_dynamic_labels() {
     let metrics = (1..=20)
         .map(|i| {
             let label = format!("label{}", i);
-            labeled.get(&label)
+            labeled.get(label)
         })
         .collect::<Vec<_>>();
 
@@ -473,7 +473,7 @@ fn caching_metrics_with_dynamic_labels_across_pings() {
     let metrics = (1..=20)
         .map(|i| {
             let label = format!("label{}", i);
-            labeled.get(&label)
+            labeled.get(label)
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
These docs are relevant for the set/add methods, so better to call them out there and then.
To reduce copy-pasta I pulled that info out into includes.

[doc only]