### PR TITLE
Try to avoid a crash by not invalidating upload sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Kotlin
   * Increase to Android target/compile SDK version 33 ([#2246](https://github.com/mozilla/glean/pull/2246))
+* iOS
+  * Try to avoid a crash by not invalidating upload sessions ([#2254](https://github.com/mozilla/glean/pull/2254))
 
 # v51.7.0 (2022-10-25)
 

--- a/glean-core/ios/Glean/Net/HttpPingUploader.swift
+++ b/glean-core/ios/Glean/Net/HttpPingUploader.swift
@@ -196,7 +196,5 @@ private class SessionResponseDelegate: NSObject, URLSessionTaskDelegate {
             // HTTP status codes are handled on the Rust side
             callback(.httpStatus(code: statusCode))
         }
-
-        session.finishTasksAndInvalidate()
     }
 }


### PR DESCRIPTION
If I understood the documentation right the worst that should happen here is that we leak memory until the application quits. Now if our assumption is right and the crashes happen when the app gets backgrounded it eventually quits anyway and we should be fine.