### PR TITLE
Ensure the baseline ping is sent when empty

### DIFF
--- a/glean-core/src/internal_pings.rs
+++ b/glean-core/src/internal_pings.rs
@@ -24,7 +24,7 @@ impl InternalPings {
             baseline: PingType::new(
                 "baseline",
                 true,
-                false,
+                true,
                 vec![
                     "active".to_string(),
                     "dirty_startup".to_string(),


### PR DESCRIPTION
This is already defined in the `metrics.yaml`, but was not adjusted in the code.
Luckily right now there's always a metric in there (`first_run_hour`), so it was never empty to begin with.