### PR TITLE
Bug 1800640 - Use a Cow<'static, str> for labels to reduce heap allocation when use…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * `test_reset_glean` will remove all previous data if asked to clear stores, even if Glean never has been initialized ([#2294](https://github.com/mozilla/glean/pull/2294))
   * Upgrade to `glean_parser` v6.5.0, with support for `Cow` in Rust code ([#2300](https://github.com/mozilla/glean/issues/2300))
   * API REMOVED: The deprecated-since-v38 `event` metric `record(map)` API has been removed ([bug 1802550](https://bugzilla.mozilla.org/show_bug.cgi?id=1802550))
+* Rust
+  * Static labels for labeled metrics are now `Cow<'static, str>` to reduce heap allocations ([#2272](https://github.com/mozilla/glean/pull/2272))
 
 # v51.8.3 (2022-11-25)
 

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -48,6 +48,10 @@ namespace glean {
     UploadTaskAction glean_process_ping_upload_response(string uuid, UploadResult result);
 };
 
+// A `Cow<'static, str>`, but really it's always the owned part.
+[Custom]
+typedef string CowString;
+
 // The Glean configuration.
 //
 // This exposes all configurable parameters to the SDK side.
@@ -321,7 +325,7 @@ interface StringMetric {
 };
 
 interface LabeledCounter {
-    constructor(CommonMetricData meta, sequence<string>? labels);
+    constructor(CommonMetricData meta, sequence<CowString>? labels);
 
     CounterMetric get(string label);
 
@@ -329,7 +333,7 @@ interface LabeledCounter {
 };
 
 interface LabeledBoolean {
-    constructor(CommonMetricData meta, sequence<string>? labels);
+    constructor(CommonMetricData meta, sequence<CowString>? labels);
 
     BooleanMetric get(string label);
 
@@ -337,7 +341,7 @@ interface LabeledBoolean {
 };
 
 interface LabeledString {
-    constructor(CommonMetricData meta, sequence<string>? labels);
+    constructor(CommonMetricData meta, sequence<CowString>? labels);
 
     StringMetric get(string label);
 

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::borrow::Cow;
+
 use super::{metrics::*, CommonMetricData, Lifetime};
 
 #[derive(Debug)]
@@ -106,11 +108,11 @@ impl UploadMetrics {
                     dynamic_label: None,
                 },
                 Some(vec![
-                    "status_code_4xx".into(),
-                    "status_code_5xx".into(),
-                    "status_code_unknown".into(),
-                    "unrecoverable".into(),
-                    "recoverable".into(),
+                    Cow::from("status_code_4xx"),
+                    Cow::from("status_code_5xx"),
+                    Cow::from("status_code_unknown"),
+                    Cow::from("unrecoverable"),
+                    Cow::from("recoverable"),
                 ]),
             ),
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -14,6 +14,7 @@
 //!
 //! ## [The Glean SDK Book](https://mozilla.github.io/glean)
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -946,6 +947,20 @@ pub fn glean_enable_logging_to_fd(_fd: u64) {
 mod ffi {
     use super::*;
     uniffi_macros::include_scaffolding!("glean");
+
+    type CowString = Cow<'static, str>;
+
+    impl UniffiCustomTypeConverter for CowString {
+        type Builtin = String;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(Cow::from(val))
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.into_owned()
+        }
+    }
 }
 pub use ffi::*;
 

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::borrow::Cow;
 use std::collections::{hash_map::Entry, HashMap};
 use std::sync::{Arc, Mutex};
 
@@ -88,7 +89,7 @@ fn matches_label_regex(value: &str) -> bool {
 /// Labeled metrics allow to record multiple sub-metrics of the same type under different string labels.
 #[derive(Debug)]
 pub struct LabeledMetric<T> {
-    labels: Option<Vec<String>>,
+    labels: Option<Vec<Cow<'static, str>>>,
     /// Type of the underlying metric
     /// We hold on to an instance of it, which is cloned to create new modified instances.
     submetric: T,
@@ -159,12 +160,12 @@ where
     /// Creates a new labeled metric from the given metric instance and optional list of labels.
     ///
     /// See [`get`](LabeledMetric::get) for information on how static or dynamic labels are handled.
-    pub fn new(meta: CommonMetricData, labels: Option<Vec<String>>) -> LabeledMetric<T> {
+    pub fn new(meta: CommonMetricData, labels: Option<Vec<Cow<'static, str>>>) -> LabeledMetric<T> {
         let submetric = T::new_labeled(meta);
         LabeledMetric::new_inner(submetric, labels)
     }
 
-    fn new_inner(submetric: T, labels: Option<Vec<String>>) -> LabeledMetric<T> {
+    fn new_inner(submetric: T, labels: Option<Vec<Cow<'static, str>>>) -> LabeledMetric<T> {
         let label_map = Default::default();
         LabeledMetric {
             labels,


### PR DESCRIPTION
…d with static labels in Rust

---

This will require changes to the code generator in FOG (and probably glean_parser).