### PR TITLE
Bug 1799852 - Document `time_unit` and `memory_unit` as optional parameters

### DIFF
--- a/docs/user/reference/metrics/datetime.md
+++ b/docs/user/reference/metrics/datetime.md
@@ -393,11 +393,12 @@ refer to the [metrics YAML registry format](../yaml/metrics.md) reference page.
 
 #### `time_unit`
 
-Datetimes have a required `time_unit` parameter to specify the smallest unit of resolution that the metric will record. The allowed values for `time_unit` are:
+Datetimes have an optional `time_unit` parameter to specify the smallest unit of resolution that the metric will record.
+The allowed values for `time_unit` are:
 
 * `nanosecond`
 * `microsecond`
-* `millisecond`
+* `millisecond` (default)
 * `second`
 * `minute`
 * `hour`

--- a/docs/user/reference/metrics/memory_distribution.md
+++ b/docs/user/reference/metrics/memory_distribution.md
@@ -360,14 +360,13 @@ memory:
 
 #### `memory_unit`
 
-Memory distributions have a required `memory_unit` parameter,
-which specifies the unit the incoming memory size values are recorded in.
-The allowed values for `time_unit` are:
+Memory distributions have an optional `memory_unit` parameter, which specifies the unit the incoming memory size values are recorded in.
+The allowed values for `memory_unit` are:
 
-- `byte`
-- `kilobyte` (`= 2^10 = 1,024 bytes`)
-- `megabyte` (`= 2^20 = 1,048,576 bytes`)
-- `gigabyte` (`= 2^30 = 1,073,741,824 bytes`)
+* `byte` (default)
+* `kilobyte` (`= 2^10 = 1,024 bytes`)
+* `megabyte` (`= 2^20 = 1,048,576 bytes`)
+* `gigabyte` (`= 2^30 = 1,073,741,824 bytes`)
 
 ## Limits
 

--- a/docs/user/reference/metrics/timespan.md
+++ b/docs/user/reference/metrics/timespan.md
@@ -653,17 +653,16 @@ refer to the [metrics YAML registry format](../yaml/metrics.md) reference page.
 
 #### `time_unit`
 
-Timespans have a required
-`time_unit` parameter to specify the smallest unit of resolution that the timespan will record.
+Timespans have an optional `time_unit` parameter to specify the smallest unit of resolution that the timespan will record.
 The allowed values for `time_unit` are:
 
-   - `nanosecond`
-   - `microsecond`
-   - `millisecond`
-   - `second`
-   - `minute`
-   - `hour`
-   - `day`
+* `nanosecond`
+* `microsecond`
+* `millisecond` (default)
+* `second`
+* `minute`
+* `hour`
+* `day`
 
 Consider the resolution that is required by your metric,
 and use the largest possible value that will provide useful information so as to not leak too much fine-grained information from the client.

--- a/docs/user/reference/metrics/timing_distribution.md
+++ b/docs/user/reference/metrics/timing_distribution.md
@@ -620,16 +620,16 @@ pages:
 
 #### `time_unit`
 
-Timing distributions have a required `time_unit` parameter to specify the smallest unit of resolution that the timespan will record.
+Timing distributions have an optional `time_unit` parameter to specify the smallest unit of resolution that the timespan will record.
 The allowed values for `time_unit` are:
 
-- `nanosecond`
-- `microsecond`
-- `millisecond`
-- `second`
-- `minute`
-- `hour`
-- `day`
+* `nanosecond` (default)
+* `microsecond`
+* `millisecond`
+* `second`
+* `minute`
+* `hour`
+* `day`
 
 ## Limits
 


### PR DESCRIPTION
[doc only]