### PR TITLE
Update to rkv 0.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v51.8.2...main)
 
+* General
+  * Upgrade to rkv 0.18.3. This comes with a bug fix that ensures that interrupted database writes don't corrupt/truncate the database file ([#2288](https://github.com/mozilla/glean/pull/2288))
 * iOS
   * Avoid building a dynamic library ([#2285](https://github.com/mozilla/glean/pull/2285)).
     Note: v51.8.1 and 51.8.2 are **not** working on iOS and will break the build due to accidentally including a link to a dynamic library.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "rkv"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3b196786090b5b57c9bb0f4afca6ac6a5bfb6182c0161ef32f1ecade43ac47"
+checksum = "0622ddc1a429e180a92d9fb8abbc2e01ab5f1b8d403a44197bbe714c07951f67"
 dependencies = [
  "arrayref",
  "bincode",

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -29,7 +29,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.44"
-rkv = { version = "0.18.2", default-features = false, features = ["lmdb"] }
+rkv = { version = "0.18.3", default-features = false, features = ["lmdb"] }
 bincode = "1.2.1"
 log = "0.4.8"
 uuid = { version = "0.8.1", features = ["v4"] }


### PR DESCRIPTION
This contains an important bug fix: Data is now written to a temporary file before being moved to the final database file location. This avoids truncated database files in case the write gets interrupted.