### PR TITLE
Disable env_logger features in glean-core

### DIFF
--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -52,7 +52,7 @@ android_logger = { version = "0.11.0", default-features = false }
 oslog = { version = "0.1.0", default-features = false, features = ["logger"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
+env_logger = { version = "0.9.0", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty", "humantime"] }


### PR DESCRIPTION
glean-core shouldn't be making this decision for its users.