### PR TITLE
Bug 1804632 - Include `env_logger` only in debug builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,9 @@ ext.cargoProfile = "debug"
 // Additionally, we require `--locked` in CI, but not for local builds.
 // Unlike the above, this can't be overridden by `local.properties` (mainly
 // because doing so seems pointless, not for any security reason)
-ext.extraCargoBuildArguments = []
+// For debug builds we also enable the `env_logger`,
+// so that local testing can get some output
+ext.extraCargoBuildArguments = ["--features=enable_env_logger"]
 
 if (System.getenv("CI")) {
     // Note: CI can still override this (and does for PRs), this

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -44,15 +44,13 @@ uniffi = "0.21.0"
 uniffi_macros = "0.21.0"
 time = "0.1.40"
 remove_dir_all = "0.5.3"
+env_logger = { version = "0.9.0", default-features = false, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = { version = "0.11.0", default-features = false }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 oslog = { version = "0.1.0", default-features = false, features = ["logger"] }
-
-[target.'cfg(not(target_os = "android"))'.dependencies]
-env_logger = { version = "0.9.0", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
@@ -66,3 +64,5 @@ uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }
 [features]
 # Increases the preinit queue limit to 10^6
 preinit_million_queue = []
+# Enable `env_logger`. Only works on non-Android non-iOS targets.
+enable_env_logger = ["env_logger"]

--- a/glean-core/bundle-android/Cargo.toml
+++ b/glean-core/bundle-android/Cargo.toml
@@ -23,3 +23,6 @@ path = "../bundle/src/lib.rs"
 [dependencies.glean-core]
 # No version specified, we build against what's available here.
 path = ".."
+
+[features]
+enable_env_logger = ["glean-core/enable_env_logger"]

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -601,10 +601,14 @@ pub extern "C" fn glean_enable_logging() {
         };
     }
 
-    // Make sure logging does something on non Android platforms as well.
+    // When specifically requested make sure logging does something on non-Android platforms as well.
     // Use the RUST_LOG environment variable to set the desired log level,
     // e.g. setting RUST_LOG=debug sets the log level to debug.
-    #[cfg(all(not(target_os = "android"), not(target_os = "ios")))]
+    #[cfg(all(
+        not(target_os = "android"),
+        not(target_os = "ios"),
+        feature = "enable_env_logger"
+    ))]
     {
         match env_logger::try_init() {
             Ok(_) => log::trace!("stdout logging should be hooked up!"),


### PR DESCRIPTION
This has no immediate effect on any other usage.
It's still in use as a dev-dependency in Rust (and thus can be enabled for tests).
It also is active for local builds of Glean for Android for testing.