### PR TITLE
Bug 1749510 - RLB: Wait for uploader on shutdown using new shutdown mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,10 @@ commands:
           command: |
             cargo run -p sample
       - run:
+          name: Run Rust RLB test
+          command: |
+            glean-core/rlb/tests/test-shutdown-blocking.sh
+      - run:
           name: Upload coverage report
           command: |
             pip3 install glean_parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.2.0...main)
 
+* Rust
+  * On shutdown wait up to 30s on the uploader to finish work ([#2232](https://github.com/mozilla/glean/pull/2332))
+
 # v52.2.0 (2023-01-30)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.1.1...v52.2.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -37,7 +37,7 @@ typealias GleanTimerId = mozilla.telemetry.glean.internal.TimerId
 data class BuildInfo(val versionCode: String, val versionName: String, val buildDate: Calendar)
 
 internal class OnGleanEventsImpl(val glean: GleanInternalAPI) : OnGleanEvents {
-    override fun onInitializeFinished() {
+    override fun initializeFinished() {
         // At this point, all metrics and events can be recorded.
         // This should only be called from the main thread. This is enforced by
         // the @MainThread decorator and the `assertOnUiThread` call.

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -20,7 +20,7 @@ class OnGleanEventsImpl: OnGleanEvents {
         self.glean = glean
     }
 
-    func onInitializeFinished() {
+    func initializeFinished() {
         // Run this off the main thread,
         // as it will trigger a ping submission,
         // which itself will trigger `triggerUpload()` on this class.

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -49,7 +49,7 @@ class OnGleanEventsImpl(_uniffi.OnGleanEvents):
     def __init__(self, glean):
         self.glean = glean
 
-    def on_initialize_finished(self):
+    def initialize_finished(self):
         log.debug("OnGleanEventsImpl.on_initialize_finished")
         self.glean._init_finished = True
 

--- a/glean-core/rlb/examples/long-running.rs
+++ b/glean-core/rlb/examples/long-running.rs
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::env;
+use std::path::PathBuf;
+use std::{thread, time};
+
+use once_cell::sync::Lazy;
+
+use glean::net;
+use glean::{private::PingType, ClientInfoMetrics, ConfigurationBuilder};
+
+pub mod glean_metrics {
+    use glean::{private::BooleanMetric, CommonMetricData, Lifetime};
+
+    #[allow(non_upper_case_globals)]
+    pub static sample_boolean: once_cell::sync::Lazy<BooleanMetric> =
+        once_cell::sync::Lazy::new(|| {
+            BooleanMetric::new(CommonMetricData {
+                name: "sample_boolean".into(),
+                category: "test.metrics".into(),
+                send_in_pings: vec!["prototype".into()],
+                disabled: false,
+                lifetime: Lifetime::Ping,
+                ..Default::default()
+            })
+        });
+}
+
+// Define a fake uploader that sleeps.
+#[derive(Debug)]
+struct FakeUploader;
+
+impl net::PingUploader for FakeUploader {
+    fn upload(
+        &self,
+        _url: String,
+        _body: Vec<u8>,
+        _headers: Vec<(String, String)>,
+    ) -> net::UploadResult {
+        thread::sleep(time::Duration::from_millis(100));
+        net::UploadResult::http_status(200)
+    }
+}
+
+#[allow(non_upper_case_globals)]
+pub static PrototypePing: Lazy<PingType> =
+    Lazy::new(|| PingType::new("prototype", true, true, vec![]));
+
+fn main() {
+    env_logger::init();
+
+    let mut args = env::args().skip(1);
+
+    let data_path = PathBuf::from(args.next().expect("need data path"));
+
+    let cfg = ConfigurationBuilder::new(true, data_path, "glean.longrunning")
+        .with_server_endpoint("invalid-test-host")
+        .with_use_core_mps(false)
+        .with_uploader(FakeUploader)
+        .build();
+
+    let client_info = ClientInfoMetrics {
+        app_build: env!("CARGO_PKG_VERSION").to_string(),
+        app_display_version: env!("CARGO_PKG_VERSION").to_string(),
+        channel: None,
+    };
+
+    glean::initialize(cfg, client_info);
+
+    // Wait for init to finish,
+    // otherwise we might be to quick with calling `shutdown`.
+    let _ = glean_metrics::sample_boolean.test_get_value(None);
+
+    glean_metrics::sample_boolean.set(true);
+
+    log::info!("submitting PrototypePing");
+    PrototypePing.submit(None);
+
+    glean::shutdown();
+}

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -70,7 +70,7 @@ struct GleanEvents {
 }
 
 impl glean_core::OnGleanEvents for GleanEvents {
-    fn on_initialize_finished(&self) {
+    fn initialize_finished(&self) {
         // intentionally left empty
     }
 

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -89,6 +89,10 @@ impl glean_core::OnGleanEvents for GleanEvents {
         // intentionally left empty
         Ok(())
     }
+
+    fn shutdown(&self) {
+        self.upload_manager.shutdown();
+    }
 }
 
 fn initialize_internal(cfg: Configuration, client_info: ClientInfoMetrics) -> Option<()> {

--- a/glean-core/rlb/tests/test-shutdown-blocking.sh
+++ b/glean-core/rlb/tests/test-shutdown-blocking.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Test harness for testing the RLB processes from the outside.
+#
+# Some behavior can only be observed when properly exiting the process running Glean,
+# e.g. when an uploader runs in another thread.
+# On exit the threads will be killed, regardless of their state.
+
+# Remove the temporary data path on all exit conditions
+cleanup() {
+  if [ -n "$datapath" ]; then
+    rm -r "$datapath"
+  fi
+}
+trap cleanup INT ABRT TERM EXIT
+
+tmp="${TMPDIR:-/tmp}"
+datapath=$(mktemp -d "${tmp}/glean_long_running.XXXX")
+
+cargo run --example long-running -- "$datapath"
+count=$(ls -1q "$datapath/pending_pings" | wc -l)
+
+if [[ "$count" -eq 0 ]]; then
+  echo "test result: ok."
+  exit 0
+else
+  echo "test result: FAILED."
+  exit 101
+fi

--- a/glean-core/src/dispatcher/global.rs
+++ b/glean-core/src/dispatcher/global.rs
@@ -5,6 +5,7 @@
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::RwLock;
+use std::thread;
 
 use super::{DispatchError, DispatchGuard, Dispatcher};
 
@@ -45,6 +46,11 @@ fn guard() -> DispatchGuard {
 ///
 /// [`flush_init`]: fn.flush_init.html
 pub fn launch(task: impl FnOnce() + Send + 'static) {
+    let current_thread = thread::current();
+    if let Some("glean.shutdown") = current_thread.name() {
+        log::error!("Tried to launch a task from the shutdown thread. That is forbidden.");
+    }
+
     let guard = guard();
     match guard.launch(task) {
         Ok(_) => {}

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -102,7 +102,7 @@ callback interface OnGleanEvents {
     // The language SDK can do additional things from within the same initializer thread,
     // e.g. starting to observe application events for foreground/background behavior.
     // The observer then needs to call the respective client activity API.
-    void on_initialize_finished();
+    void initialize_finished();
 
     // Trigger the uploader whenever a ping was submitted.
     //

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -224,7 +224,7 @@ pub trait OnGleanEvents: Send {
     /// The language SDK can do additional things from within the same initializer thread,
     /// e.g. starting to observe application events for foreground/background behavior.
     /// The observer then needs to call the respective client activity API.
-    fn on_initialize_finished(&self);
+    fn initialize_finished(&self);
 
     /// Trigger the uploader whenever a ping was submitted.
     ///
@@ -446,7 +446,7 @@ fn initialize_inner(
             }
 
             let state = global_state().lock().unwrap();
-            state.callbacks.on_initialize_finished();
+            state.callbacks.initialize_finished();
         })
         .expect("Failed to spawn Glean's init thread");
 


### PR DESCRIPTION
RLB: Wait for uploader on shutdown using new `shutdown` mechanism

On shutdown we now wait up to 30s for the upload thread to finish.
This gets done just after we drain and shut down the dispatcher,
but before Glean is considered fully shutdown.

The callback MUST NOT put any new tasks on the dispatcher.
The callback SHOULD NOT block arbitrarily long.

The RLB implementation of that callback instructs a potential uploader
thread to end operation after it finished one upload.
It also blocks any new upload thread from getting started.
This means an in-flight upload can finish as usual, but no new one
is launched.
If the upload thread is currently sleeping, it gets one more upload.

This also adds a new test.
The only way to reliably test this is from the outside,
so the test invokes an example implementation and checks that the
`pending_pings` directory is empty after the program ends.
The uploader inside sleeps for a short period of time.
Without waiting for this uploader the main thread would end and kill the
uploader thread before it wakes up.
With waiting the uploader finishes correctly before the main thread
exits.