### PR TITLE
Bug 1808586 - Kotlin: GleanDebugActivity can run without Glean being initialized 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.0.0...main)
 
+* Android
+  * The `GleanDebugActivity` can run without Glean being initialized ([#2336](https://github.com/mozilla/glean/pull/2336))
+
 # v52.0.0 (2022-12-13)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v51.8.3...v52.0.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/debug/GleanDebugActivity.kt
@@ -76,16 +76,6 @@ class GleanDebugActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (!Glean.isInitialized()) {
-            Log.e(
-                LOG_TAG,
-                "Glean is not initialized. " +
-                    "It may be disabled by the application."
-            )
-            finish()
-            return
-        }
-
         if (intent.extras == null) {
             Log.e(LOG_TAG, "No debugging option was provided, doing nothing.")
             finish()

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/scheduler/MetricsPingScheduler.kt
@@ -49,7 +49,6 @@ internal class MetricsPingScheduler(
     }
 
     init {
-        Log.i(LOG_TAG, "New MetricsPingSched")
         // In testing mode, set the "last seen version" as the same as this one.
         // Otherwise, all we will ever send is pings for the "upgrade" reason.
         if (Glean.testingMode) {
@@ -210,7 +209,6 @@ internal class MetricsPingScheduler(
      * collection.
      */
     fun schedule(): Boolean {
-        Log.i(LOG_TAG, "MetricsPingSched.schedule")
         val now = getCalendarInstance()
 
         // If the version of the app is different from the last time we ran the app,


### PR DESCRIPTION
I tried testing this with the instructions from https://bugzilla.mozilla.org/show_bug.cgi?id=1808231#c29
but wasn't able to reproduce the issue to begin with.

However I was able to trigger the behavior by just running the debug activity myself a couple of times with Fenix closed before:

```
adb shell am start -n org.mozilla.fenix/mozilla.telemetry.glean.debug.GleanDebugActivity --ez logPings true --es debugViewTag jer-fenix --es sendPing metrics
```

That eventually gave me the log message.
With this PR applied everything still seems to work and it sends pings as expected once Glean is initialized.