### PR TITLE
Update to UniFFI 0.23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,13 +69,11 @@ commands:
             sudo apt update
             sudo apt install --yes --no-install-recommends \
               python3-pip \
-              python3.8-venv
+              python3.10-venv
       - run:
           name: Run Rust sample
           command: |
-            if rustc --version | grep -q 'rustc 1.6'; then
-              cargo run -p sample
-            fi
+            cargo run -p sample
       - run:
           name: Upload coverage report
           command: |
@@ -159,8 +157,7 @@ commands:
   build-windows-i686-wheel:
     steps:
       - install-rustup
-      - setup-rust-toolchain:
-          rust-version: "1.58.0"
+      - setup-rust-toolchain
       - install-mingw
       - run:
           name: Install Python development tools for host
@@ -244,7 +241,7 @@ jobs:
 
   License check:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - checkout
       - run:
@@ -264,7 +261,7 @@ jobs:
 
   Check vendored schema:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - checkout
       - run:
@@ -294,7 +291,7 @@ jobs:
 
   Check Rust formatting:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - checkout
       - run: rustup component add rustfmt
@@ -303,7 +300,7 @@ jobs:
 
   Lint Rust with clippy:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - checkout
       - run: rustup component add clippy
@@ -313,36 +310,36 @@ jobs:
           command: |
             sudo apt update
             sudo apt install --yes --no-install-recommends \
-              python3.8-venv
+              python3.10-venv
       - run:
           name: Clippy
           command: make lint-rust
 
   Rust tests - stable:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     resource_class: "medium+"
     steps:
       - test-rust
 
   Rust tests - beta:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - test-rust:
           rust-version: "beta"
 
   Rust tests - minimum version:
     docker:
-      - image: cimg/rust:1.58
+      - image: cimg/rust:1.67
     resource_class: "medium+"
     steps:
       - test-rust:
-          rust-version: "1.58.0"
+          rust-version: "1.60.0"
 
   Generate Rust documentation:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - checkout
       - run:
@@ -374,7 +371,7 @@ jobs:
 
   Publish Rust crates:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - checkout
       - run:
@@ -656,7 +653,7 @@ jobs:
 
   glean-swift release:
     docker:
-      - image: cimg/rust:1.61
+      - image: cimg/rust:1.67
     steps:
       - checkout
       - attach_workspace:
@@ -717,9 +714,6 @@ jobs:
     steps:
       - checkout
       - test-python
-      - persist_to_workspace:
-          root: glean-core/python/
-          paths: .venv3.8
 
   Python 3_9 tests:
     docker:
@@ -759,6 +753,9 @@ jobs:
     steps:
       - checkout
       - test-python
+      - persist_to_workspace:
+          root: glean-core/python/
+          paths: .venv3.10
 
   Python Windows x86_64 tests:
     docker:
@@ -812,14 +809,14 @@ jobs:
 
   Generate Python documentation:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     steps:
       - checkout
       - attach_workspace:
           at: glean-core/python/
       - run:
           name: Generate Python docs
-          command: glean-core/python/.venv3.8/bin/python3 -m pdoc --html glean --force -o build/docs/python
+          command: glean-core/python/.venv3.10/bin/python3 -m pdoc --html glean --force -o build/docs/python
       - persist_to_workspace:
           root: build/
           paths: docs/python
@@ -978,7 +975,7 @@ jobs:
 
   Docs internal metrics check:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:
@@ -1101,7 +1098,7 @@ workflows:
             - docs-spellcheck
       - Generate Python documentation:
           requires:
-            - Python 3_8 tests
+            - Python 3_10 tests
       - docs-linkcheck:
           requires:
             - Generate Rust documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,8 +372,6 @@ dependencies = [
  "thiserror",
  "time",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "uuid",
  "zeitstempel",
 ]
@@ -968,25 +966,21 @@ dependencies = [
 
 [[package]]
 name = "uniffi"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7057bad60ea5f6e2c2df43dbc8143880d19daca2d9bb0ef81131b37ef42cc9"
+checksum = "f71cc01459bc34cfe43fabf32b39f1228709bc6db1b3a664a92940af3d062376"
 dependencies = [
  "anyhow",
- "bytes",
- "camino",
- "log",
- "once_cell",
- "paste",
- "static_assertions",
+ "uniffi_build",
+ "uniffi_core",
  "uniffi_macros",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d84dea610e893f4043354c71e4361386475365e6e2834aded4c8cebf940311"
+checksum = "dbbba5103051c18f10b22f80a74439ddf7100273f217a547005d2735b2498994"
 dependencies = [
  "anyhow",
  "askama",
@@ -1008,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db116cd55ae857fd40d5780d47c76d3f6aa68c242458fb57bc24cb130a3e920"
+checksum = "0ee1a28368ff3d83717e3d3e2e15a66269c43488c3f036914131bb68892f29fb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1019,19 +1013,35 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55105cc7e1ac83ca1eb29587e3b7f65737f9142dc65d54b63502c2589c9d6a5"
+checksum = "03de61393a42b4ad4984a3763c0600594ac3e57e5aaa1d05cede933958987c03"
 dependencies = [
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "uniffi_macros"
-version = "0.22.0"
+name = "uniffi_core"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72d962296f794d962888484c8a2129174976fb2d7c566eca52892d373e0234"
+checksum = "7a2b4852d638d74ca2d70e450475efb6d91fe6d54a7cd8d6bd80ad2ee6cd7daa"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "cargo_metadata",
+ "log",
+ "once_cell",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa03394de21e759e0022f1ea8d992d2e39290d735b9ed52b1f74b20a684f794e"
 dependencies = [
  "bincode",
  "camino",
@@ -1048,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f819a2d6f98e2e9758604f3f541c8200166868525d0329e232ce188f19eeeb4"
+checksum = "66fdab2c436aed7a6391bec64204ec33948bfed9b11b303235740771f85c4ea6"
 dependencies = [
  "serde",
  "siphasher",
@@ -1059,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd68c90ec2ab35abc868eae85eedd92b7cede34d38a57e356fce96b8f99d4ef"
+checksum = "92b0570953ec41d97ce23e3b92161ac18231670a1f97523258a6d2ab76d7f76c"
 dependencies = [
  "anyhow",
  "camino",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The code in this repository is organized as follows:
 * [./glean-core/ios](glean-core/ios) contains the Swift bindings for use by iOS applications.
 * [./glean-core/python](glean-core/python) contains Python bindings.
 
-**Note: The Glean SDK requires at least [Rust 1.58.0](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html). Older versions are untested.**
+**Note: The Glean SDK requires at least [Rust 1.60.0](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html). Older versions are untested.**
 
 ## Contact
 

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -18,7 +18,7 @@ include = [
   "/uniffi.toml",
   "/build.rs",
 ]
-rust-version = "1.58"
+rust-version = "1.60"
 
 [package.metadata.glean]
 glean-parser = "7.0.0"

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -40,8 +40,7 @@ flate2 = "1.0.19"
 zeitstempel = "0.1.0"
 crossbeam-channel = "0.5"
 thiserror = "1.0.4"
-uniffi = "0.22.0"
-uniffi_macros = "0.22.0"
+uniffi = { version = "0.23.0", default-features = false }
 time = "0.1.40"
 remove_dir_all = "0.5.3"
 env_logger = { version = "0.9.0", default-features = false, optional = true }
@@ -59,7 +58,7 @@ iso8601 = "0.4"
 ctor = "0.1.12"
 
 [build-dependencies]
-uniffi_build = { version = "0.22.0", features = ["builtin-bindgen"] }
+uniffi = { version = "0.23.0", default-features = false, features = ["build"] }
 
 [features]
 # Increases the preinit queue limit to 10^6

--- a/glean-core/build.rs
+++ b/glean-core/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    uniffi_build::generate_scaffolding("./src/glean.udl").unwrap();
+    uniffi::generate_scaffolding("./src/glean.udl").unwrap();
 }

--- a/glean-core/build/Cargo.toml
+++ b/glean-core/build/Cargo.toml
@@ -13,7 +13,7 @@ include = [
   "/src",
   "/Cargo.toml",
 ]
-rust-version = "1.59"
+rust-version = "1.60"
 
 [dependencies]
 xshell-venv = "1.1.0"

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -15,7 +15,7 @@ include = [
   "/tests",
   "/Cargo.toml",
 ]
-rust-version = "1.58"
+rust-version = "1.60"
 
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "main" }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -978,7 +978,7 @@ pub fn glean_enable_logging_to_fd(_fd: u64) {
 #[allow(missing_docs)]
 mod ffi {
     use super::*;
-    uniffi_macros::include_scaffolding!("glean");
+    uniffi::include_scaffolding!("glean");
 
     type CowString = Cow<'static, str>;
 

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -9,4 +9,5 @@ publish = false
 [dependencies]
 anyhow = "1"
 camino = "1.1.1"
-uniffi_bindgen = { version = "0.22.0", default-features = false }
+# TODO: Depend on `uniffi`, but avoid the clap dependency.
+uniffi_bindgen = { version = "0.23.0", default-features = false }


### PR DESCRIPTION
This adopts the new crate layout and only directly depends on the `uniffi` crate.
Everything else is a transitive dependency. This hopefully reduces the amount of churn and coordination needed when uniffi_* crates are updated.

---

~~v0.23 is not yet released. This currently uses it from the git repository.~~