### PR TITLE
properly invoke the windows buildid function from whatsys

### DIFF
--- a/glean-core/rlb/src/system.rs
+++ b/glean-core/rlb/src/system.rs
@@ -76,7 +76,7 @@ pub fn get_os_version() -> String {
 #[cfg(target_os = "windows")]
 /// Returns the Windows build number, e.g. 22000
 pub fn get_windows_build_number() -> Option<i64> {
-    match whatsys::get_windows_build_number() {
+    match whatsys::windows_build_number() {
         // Cast to i64 to work with QuantityMetric type
         Some(i) => Some(i as i64),
         _ => None,


### PR DESCRIPTION
Due to this code being off the execution path in Mac/Linux, the prior PR managed to pass tests even though it was not invoking this function correctly.

This rectifies that.