### PR TITLE
Swift: Remove super long-running test

### DIFF
--- a/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
@@ -213,38 +213,4 @@ class LabeledMetricTypeTests: XCTestCase {
             XCTAssertEqual(error as! String, "Can not create a labeled version of this metric type")
         }
     }
-
-    func testRapidlyRecreatingLabeledMetricsDoesNotCrash() {
-        // Regression test for bug 1733757.
-        // The underlying map implementation has an upper limit of entries it can handle,
-        // currently set to (1<<15)-1 = 32767.
-        // We used to create a new object every time a label was referenced,
-        // leading to exhausting the available storage in that map, which finally results in a panic.
-
-        let counterMetric = CounterMetricType(CommonMetricData(
-            category: "telemetry",
-            name: "labeled_nocrash_counter",
-            sendInPings: ["metrics"],
-            lifetime: .application,
-            disabled: false
-        ))
-
-        let labeledCounterMetric = try! LabeledMetricType<CounterMetricType>(
-            category: "telemetry",
-            name: "labeled_nocrash",
-            sendInPings: ["metrics"],
-            lifetime: .application,
-            disabled: false,
-            subMetric: counterMetric,
-            labels: ["foo"]
-        )
-
-        // We go higher than the maximum of `(1<<15)-1 = 32767`.
-        let maxAttempts = Int32(1 << 16)
-        for _ in 1 ... maxAttempts {
-            labeledCounterMetric["foo"].add(1)
-        }
-
-        XCTAssertEqual(maxAttempts, labeledCounterMetric["foo"].testGetValue())
-    }
 }

--- a/glean-core/ios/GleanTests/Metrics/PingTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/PingTests.swift
@@ -131,7 +131,7 @@ class PingTests: XCTestCase {
         Glean.shared.submitPingByName("unknown")
 
         // We wait for a timeout to happen, as we don't expect any data to be sent.
-        waitForExpectations(timeout: 5.0) { _ in
+        waitForExpectations(timeout: 2.0) { _ in
             XCTAssert(true, "Test didn't time out when it should")
         }
     }

--- a/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
+++ b/glean-core/ios/GleanTests/Scheduler/MetricsPingSchedulerTests.swift
@@ -341,12 +341,12 @@ class MetricsPingSchedulerTests: XCTestCase {
         let fakeNow = Calendar.current.date(
             bySettingHour: MetricsPingScheduler.Constants.dueHourOfTheDay - 1,
             minute: 59,
-            second: 55,
+            second: 58,
             of: now
         )!
 
         // Calling `schedulePingCollection` with our `fakeNow` should cause the timer to
-        // be set to fire in @ 5 seconds
+        // be set to fire in 2 seconds.
         mps.schedulePingCollection(
             fakeNow,
             sendTheNextCalendarDay: false,


### PR DESCRIPTION
This test takes up to 40s on a dev machine and closer to 70s on CI.
The underlying implementation has changed since the regression.
We also still have tests for this in Kotlin and Python (Python takes ~7s),
so we can keep those only.

Second commit reduces timeouts just a tiny bit.
Both commits can be reviewed on each own and also separate landed.