### PR TITLE
Rust testing: Always keep a handle to the temporary directory

### DIFF
--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -27,7 +27,7 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
 
 #[test]
 fn path_is_constructed_from_data() {
-    let (glean, _) = new_glean(None);
+    let (glean, _t) = new_glean(None);
 
     assert_eq!(
         "/submit/org-mozilla-glean-test-app/baseline/1/this-is-a-docid",
@@ -241,7 +241,7 @@ fn basic_metrics_should_be_cleared_when_uploading_is_disabled() {
 
 #[test]
 fn first_run_date_is_managed_correctly_when_toggling_uploading() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
 
     let original_first_run_date = glean
         .core_metrics
@@ -269,7 +269,7 @@ fn first_run_date_is_managed_correctly_when_toggling_uploading() {
 
 #[test]
 fn client_id_is_managed_correctly_when_toggling_uploading() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
 
     let original_client_id = glean
         .core_metrics
@@ -611,7 +611,7 @@ fn test_dirty_bit() {
 fn test_change_metric_type_runtime() {
     let dir = tempfile::tempdir().unwrap();
 
-    let (glean, _) = new_glean(Some(dir));
+    let (glean, _t) = new_glean(Some(dir));
 
     // We attempt to create two metrics: one with a 'string' type and the other
     // with a 'timespan' type, both being sent in the same pings and having the
@@ -670,7 +670,7 @@ fn test_change_metric_type_runtime() {
 fn timing_distribution_truncation() {
     let dir = tempfile::tempdir().unwrap();
 
-    let (glean, _) = new_glean(Some(dir));
+    let (glean, _t) = new_glean(Some(dir));
     let max_sample_time = 1000 * 1000 * 1000 * 60 * 10;
 
     for (unit, expected_keys) in &[
@@ -744,7 +744,7 @@ fn timing_distribution_truncation() {
 fn timing_distribution_truncation_accumulate() {
     let dir = tempfile::tempdir().unwrap();
 
-    let (glean, _) = new_glean(Some(dir));
+    let (glean, _t) = new_glean(Some(dir));
     let max_sample_time = 1000 * 1000 * 1000 * 60 * 10;
 
     for &unit in &[
@@ -790,7 +790,7 @@ fn timing_distribution_truncation_accumulate() {
 fn test_setting_debug_view_tag() {
     let dir = tempfile::tempdir().unwrap();
 
-    let (mut glean, _) = new_glean(Some(dir));
+    let (mut glean, _t) = new_glean(Some(dir));
 
     let valid_tag = "valid-tag";
     assert!(glean.set_debug_view_tag(valid_tag));
@@ -805,7 +805,7 @@ fn test_setting_debug_view_tag() {
 fn test_setting_log_pings() {
     let dir = tempfile::tempdir().unwrap();
 
-    let (mut glean, _) = new_glean(Some(dir));
+    let (mut glean, _t) = new_glean(Some(dir));
     assert!(!glean.log_pings());
 
     glean.set_log_pings(true);
@@ -1064,7 +1064,7 @@ fn test_activity_api() {
     let _ = env_logger::builder().is_test(true).try_init();
 
     let dir = tempfile::tempdir().unwrap();
-    let (mut glean, _) = new_glean(Some(dir));
+    let (mut glean, _t) = new_glean(Some(dir));
 
     // Signal that the client was active.
     glean.handle_client_active();

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -150,7 +150,7 @@ mod test {
 
     #[test]
     fn setting_a_long_string_records_an_error() {
-        let (glean, _) = new_glean(None);
+        let (glean, _t) = new_glean(None);
 
         let metric = StringMetric::new(CommonMetricData {
             name: "string_metric".into(),

--- a/glean-core/src/metrics/text.rs
+++ b/glean-core/src/metrics/text.rs
@@ -154,7 +154,7 @@ mod test {
 
     #[test]
     fn setting_a_long_string_records_an_error() {
-        let (glean, _) = new_glean(None);
+        let (glean, _t) = new_glean(None);
 
         let metric = TextMetric::new(CommonMetricData {
             name: "text_metric".into(),

--- a/glean-core/src/metrics/url.rs
+++ b/glean-core/src/metrics/url.rs
@@ -168,7 +168,7 @@ mod test {
 
     #[test]
     fn payload_is_correct() {
-        let (glean, _) = new_glean(None);
+        let (glean, _t) = new_glean(None);
 
         let metric = UrlMetric::new(CommonMetricData {
             name: "url_metric".into(),
@@ -186,7 +186,7 @@ mod test {
 
     #[test]
     fn does_not_record_url_exceeding_maximum_length() {
-        let (glean, _) = new_glean(None);
+        let (glean, _t) = new_glean(None);
 
         let metric = UrlMetric::new(CommonMetricData {
             name: "url_metric".into(),
@@ -224,7 +224,7 @@ mod test {
 
     #[test]
     fn does_not_record_data_urls() {
-        let (glean, _) = new_glean(None);
+        let (glean, _t) = new_glean(None);
 
         let metric = UrlMetric::new(CommonMetricData {
             name: "url_metric".into(),
@@ -248,7 +248,7 @@ mod test {
 
     #[test]
     fn url_validation_works_and_records_errors() {
-        let (glean, _) = new_glean(None);
+        let (glean, _t) = new_glean(None);
 
         let metric = UrlMetric::new(CommonMetricData {
             name: "url_metric".into(),

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -374,7 +374,7 @@ mod test {
 
     #[test]
     fn sequence_numbers_should_be_reset_when_toggling_uploading() {
-        let (mut glean, _) = new_glean(None);
+        let (mut glean, _t) = new_glean(None);
         let ping_maker = PingMaker::new();
 
         assert_eq!(0, ping_maker.get_ping_seq(&glean, "custom"));

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -778,7 +778,7 @@ mod test {
 
     #[test]
     fn doesnt_error_when_there_are_no_pending_pings() {
-        let (glean, _) = new_glean(None);
+        let (glean, _t) = new_glean(None);
 
         // Try and get the next request.
         // Verify request was not returned
@@ -885,7 +885,7 @@ mod test {
 
     #[test]
     fn clearing_the_queue_doesnt_clear_deletion_request_pings() {
-        let (mut glean, _) = new_glean(None);
+        let (mut glean, _t) = new_glean(None);
 
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
@@ -1007,7 +1007,7 @@ mod test {
 
     #[test]
     fn processes_correctly_server_error_upload_response() {
-        let (mut glean, _) = new_glean(None);
+        let (mut glean, _t) = new_glean(None);
 
         // Register a ping for testing
         let ping_type = PingType::new("test", true, /* send_if_empty */ true, vec![]);
@@ -1125,7 +1125,7 @@ mod test {
 
     #[test]
     fn adds_debug_view_header_to_requests_when_tag_is_set() {
-        let (mut glean, _) = new_glean(None);
+        let (mut glean, _t) = new_glean(None);
 
         glean.set_debug_view_tag("valid-tag");
 

--- a/glean-core/tests/custom_distribution.rs
+++ b/glean-core/tests/custom_distribution.rs
@@ -52,7 +52,7 @@ mod linear {
         // Make a new Glean instance here, which should force reloading of the data from disk
         // so we can ensure it persisted, because it has User lifetime
         {
-            let (glean, _) = new_glean(Some(tempdir));
+            let (glean, _t) = new_glean(Some(tempdir));
             let snapshot = StorageManager
                 .snapshot_as_json(glean.storage(), "store1", true)
                 .unwrap();
@@ -254,7 +254,7 @@ mod exponential {
         // Make a new Glean instance here, which should force reloading of the data from disk
         // so we can ensure it persisted, because it has User lifetime
         {
-            let (glean, _) = new_glean(Some(tempdir));
+            let (glean, _t) = new_glean(Some(tempdir));
             let snapshot = StorageManager
                 .snapshot_as_json(glean.storage(), "store1", true)
                 .unwrap();

--- a/glean-core/tests/datetime.rs
+++ b/glean-core/tests/datetime.rs
@@ -56,7 +56,7 @@ fn datetime_serializer_should_correctly_serialize_datetime() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/labeled.rs
+++ b/glean-core/tests/labeled.rs
@@ -394,7 +394,7 @@ fn seen_labels_get_reloaded_from_disk() {
 
     // Force a reload
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
 
         // Try to store another label
         labeled.get("new_label").add_sync(&glean, 40);

--- a/glean-core/tests/memory_distribution.rs
+++ b/glean-core/tests/memory_distribution.rs
@@ -49,7 +49,7 @@ fn serializer_should_correctly_serialize_memory_distribution() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -34,7 +34,7 @@ fn write_ping_to_disk() {
 
 #[test]
 fn disabling_upload_clears_pending_pings() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
 
     let ping = PingType::new("metrics", true, false, vec![]);
     glean.register_ping_type(&ping);
@@ -77,7 +77,7 @@ fn disabling_upload_clears_pending_pings() {
 
 #[test]
 fn deletion_request_only_when_toggled_from_on_to_off() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
 
     // Disabling upload generates a deletion ping
     glean.set_upload_enabled(false);
@@ -103,7 +103,7 @@ fn deletion_request_only_when_toggled_from_on_to_off() {
 
 #[test]
 fn empty_pings_with_flag_are_sent() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
 
     let ping1 = PingType::new("custom-ping1", true, true, vec![]);
     glean.register_ping_type(&ping1);
@@ -216,7 +216,7 @@ fn test_pings_submitted_metric() {
 
 #[test]
 fn events_ping_with_metric_but_no_events_is_not_sent() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
 
     let events_ping = PingType::new("events", true, true, vec![]);
     glean.register_ping_type(&events_ping);

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -161,7 +161,7 @@ fn seq_number_must_be_sequential() {
 
 #[test]
 fn clear_pending_pings() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
     let ping_maker = PingMaker::new();
     let ping_type = PingType::new("store1", true, false, vec![]);
     glean.register_ping_type(&ping_type);
@@ -190,7 +190,7 @@ fn clear_pending_pings() {
 fn no_pings_submitted_if_upload_disabled() {
     // Regression test, bug 1603571
 
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
     let ping_type = PingType::new("store1", true, true, vec![]);
     glean.register_ping_type(&ping_type);
 
@@ -207,7 +207,7 @@ fn no_pings_submitted_if_upload_disabled() {
 
 #[test]
 fn metadata_is_correctly_added_when_necessary() {
-    let (mut glean, _) = new_glean(None);
+    let (mut glean, _t) = new_glean(None);
     glean.set_debug_view_tag("valid-tag");
     let ping_type = PingType::new("store1", true, true, vec![]);
     glean.register_ping_type(&ping_type);

--- a/glean-core/tests/quantity.rs
+++ b/glean-core/tests/quantity.rs
@@ -50,7 +50,7 @@ fn quantity_serializer_should_correctly_serialize_quantities() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/string.rs
+++ b/glean-core/tests/string.rs
@@ -48,7 +48,7 @@ fn string_serializer_should_correctly_serialize_strings() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -63,7 +63,7 @@ fn stringlist_serializer_should_correctly_serialize_stringlists() {
     }
 
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
 
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)

--- a/glean-core/tests/text.rs
+++ b/glean-core/tests/text.rs
@@ -45,7 +45,7 @@ fn text_serializer_should_correctly_serialize_strings() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -52,7 +52,7 @@ fn serializer_should_correctly_serialize_timespans() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -54,7 +54,7 @@ fn serializer_should_correctly_serialize_timing_distribution() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();

--- a/glean-core/tests/uuid.rs
+++ b/glean-core/tests/uuid.rs
@@ -72,7 +72,7 @@ fn uuid_serializer_should_correctly_serialize_uuids() {
     // Make a new Glean instance here, which should force reloading of the data from disk
     // so we can ensure it persisted, because it has User lifetime
     {
-        let (glean, _) = new_glean(Some(tempdir));
+        let (glean, _t) = new_glean(Some(tempdir));
         let snapshot = StorageManager
             .snapshot_as_json(glean.storage(), "store1", true)
             .unwrap();


### PR DESCRIPTION
Binding to `_` _immediately_ drops the value.
This causes the temp directory to be removed, which in turn causes errors when writing into the database.
Surprisingly enough things keep working for tests to still work*!

* Because we have all data in-memory anyway.