### PR TITLE
Bug 1716847 - Fix for Glean internal metric `baseline.duration` InvalidState errors

### DIFF
--- a/glean-core/ios/GleanTests/Net/BaselinePingTests.swift
+++ b/glean-core/ios/GleanTests/Net/BaselinePingTests.swift
@@ -58,7 +58,9 @@ final class BaselinePingTests: XCTestCase {
         Glean.shared.metricsPingScheduler!.updateSentDate(now)
 
         // Resetting Glean doesn't trigger lifecycle events in tests so we must call the method
-        // invoked by the lifecycle observer directly.
+        // invoked by the lifecycle observer directly. We must also reset the `isActive` flag in
+        // order to have the correct state to test.
+        Glean.shared.isActive = false
         Glean.shared.handleForegroundEvent()
         waitForExpectations(timeout: 5.0) { error in
             XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")


### PR DESCRIPTION
This puts an interlock on calling `glean_handle_active` to ensure it is only called once until `glean_handle_inactive` is called.