### PR TITLE
Bug 1814592 - Instrument the time needed for a successful/failure upload of a ping & upload shutdown in testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * General
   * Loosen label restrictions to "at most 71 characters of printable ASCII" ([bug 1672273](https://bugzilla.mozilla.org/show_bug.cgi?id=1672273))
   * Introduced 2 new Glean health metrics: `glean.upload.send_failure` and `glean.upload.send_success` to measure the time for sending a ping ([#2365](https://github.com/mozilla/glean/pull/2365))
+  * Introduced a new Glean metric: `glean.validation.shutdown_wait` to measure the time Glean waits for the uploader on shutdown ([#2365](https://github.com/mozilla/glean/pull/2365))
 * Rust
   * On shutdown wait up to 30s on the uploader to finish work ([#2232](https://github.com/mozilla/glean/pull/2332))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.2.0...main)
 
-* Rust
-  * On shutdown wait up to 30s on the uploader to finish work ([#2232](https://github.com/mozilla/glean/pull/2332))
 * General
   * Loosen label restrictions to "at most 71 characters of printable ASCII" ([bug 1672273](https://bugzilla.mozilla.org/show_bug.cgi?id=1672273))
+  * Introduced 2 new Glean health metrics: `glean.upload.send_failure` and `glean.upload.send_success` to measure the time for sending a ping ([#2365](https://github.com/mozilla/glean/pull/2365))
+* Rust
+  * On shutdown wait up to 30s on the uploader to finish work ([#2232](https://github.com/mozilla/glean/pull/2332))
 
 # v52.2.0 (2023-01-30)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -70,6 +70,10 @@ internal class OnGleanEventsImpl(val glean: GleanInternalAPI) : OnGleanEvents {
         // data after the upload has been disabled.
         PingUploadWorker.cancel(glean.applicationContext)
     }
+
+    override fun shutdown() {
+        // Android doesn't warn us about shutdown, so we don't try.
+    }
 }
 
 /**

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -44,6 +44,10 @@ class OnGleanEventsImpl: OnGleanEvents {
     func cancelUploads() {
         // intentionally left empty
     }
+
+    func shutdown() {
+        shutdownUploader()
+    }
 }
 
 public struct BuildInfo {
@@ -132,6 +136,8 @@ public class Glean {
             logger.error("Glean should not be initialized multiple times")
             return
         }
+
+        startUploader()
 
         self.buildInfo = buildInfo
         self.configuration = configuration

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -607,6 +607,38 @@ glean.upload:
     no_lint:
       - COMMON_PREFIX
 
+  send_success:
+    type: timing_distribution
+    time_unit: millisecond
+    description: |
+      Time needed for a successful send of a ping to the servers and getting a reply back
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1814592
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1814592#c3
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+      - jrediger@mozilla.com
+    expires: never
+
+  send_failure:
+    type: timing_distribution
+    time_unit: millisecond
+    description: |
+      Time needed for a failed send of a ping to the servers and getting a reply back.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1814592
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1814592#c3
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+      - jrediger@mozilla.com
+    expires: never
+
 glean.database:
   size:
     type: memory_distribution

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -696,6 +696,22 @@ glean.validation:
     expires:
       never
 
+  shutdown_wait:
+    type: timing_distribution
+    time_unit: millisecond
+    description: |
+      Time waited for the uploader at shutdown.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1814592
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1814592#c3
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+      - jrediger@mozilla.com
+    expires: never
+
 glean:
   restarted:
     type: event

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -90,8 +90,9 @@ impl glean_core::OnGleanEvents for GleanEvents {
         Ok(())
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self) -> Result<(), glean_core::CallbackError> {
         self.upload_manager.shutdown();
+        Ok(())
     }
 }
 

--- a/glean-core/rlb/tests/upload_timing.rs
+++ b/glean-core/rlb/tests/upload_timing.rs
@@ -205,10 +205,9 @@ fn upload_timings() {
         "One failed ping"
     );
 
-    glean::shutdown();
-
     // This is awkward, but it's what gets us very close to just starting a new process with a
     // fresh Glean.
+    // This also calls `glean::shutdown();` internally, waiting on the uploader.
     let data_path = Some(tmpname.display().to_string());
     glean_core::glean_test_destroy_glean(false, data_path);
 

--- a/glean-core/rlb/tests/upload_timing.rs
+++ b/glean-core/rlb/tests/upload_timing.rs
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This integration test should model how the RLB is used when embedded in another Rust application
+//! (e.g. FOG/Firefox Desktop).
+//!
+//! We write a single test scenario per file to avoid any state keeping across runs
+//! (different files run as different processes).
+
+mod common;
+
+use std::io::Read;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time;
+
+use crossbeam_channel::{bounded, Sender};
+use flate2::read::GzDecoder;
+use serde_json::Value as JsonValue;
+
+use glean::net;
+use glean::ConfigurationBuilder;
+
+pub mod metrics {
+    #![allow(non_upper_case_globals)]
+
+    use glean::{
+        private::BooleanMetric, private::TimingDistributionMetric, CommonMetricData, Lifetime,
+        TimeUnit,
+    };
+
+    pub static sample_boolean: once_cell::sync::Lazy<BooleanMetric> =
+        once_cell::sync::Lazy::new(|| {
+            BooleanMetric::new(CommonMetricData {
+                name: "sample_boolean".into(),
+                category: "test.metrics".into(),
+                send_in_pings: vec!["validation".into()],
+                disabled: false,
+                lifetime: Lifetime::Ping,
+                ..Default::default()
+            })
+        });
+
+    // The following are duplicated from `glean-core/src/internal_metrics.rs`
+    // so we can use the test APIs to query them.
+
+    pub static send_success: once_cell::sync::Lazy<TimingDistributionMetric> =
+        once_cell::sync::Lazy::new(|| {
+            TimingDistributionMetric::new(
+                CommonMetricData {
+                    name: "send_success".into(),
+                    category: "glean.upload".into(),
+                    send_in_pings: vec!["metrics".into()],
+                    lifetime: Lifetime::Ping,
+                    disabled: false,
+                    dynamic_label: None,
+                },
+                TimeUnit::Millisecond,
+            )
+        });
+
+    pub static send_failure: once_cell::sync::Lazy<TimingDistributionMetric> =
+        once_cell::sync::Lazy::new(|| {
+            TimingDistributionMetric::new(
+                CommonMetricData {
+                    name: "send_failure".into(),
+                    category: "glean.upload".into(),
+                    send_in_pings: vec!["metrics".into()],
+                    lifetime: Lifetime::Ping,
+                    disabled: false,
+                    dynamic_label: None,
+                },
+                TimeUnit::Millisecond,
+            )
+        });
+}
+
+mod pings {
+    use glean::private::PingType;
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static validation: Lazy<PingType> =
+        Lazy::new(|| glean::private::PingType::new("validation", true, true, vec![]));
+}
+
+// Define a fake uploader that sleeps.
+#[derive(Debug)]
+struct FakeUploader {
+    calls: AtomicUsize,
+    sender: Sender<JsonValue>,
+}
+
+impl net::PingUploader for FakeUploader {
+    fn upload(
+        &self,
+        _url: String,
+        body: Vec<u8>,
+        _headers: Vec<(String, String)>,
+    ) -> net::UploadResult {
+        let calls = self.calls.fetch_add(1, Ordering::SeqCst);
+        let decode = |body: Vec<u8>| {
+            let mut gzip_decoder = GzDecoder::new(&body[..]);
+            let mut s = String::with_capacity(body.len());
+
+            gzip_decoder
+                .read_to_string(&mut s)
+                .ok()
+                .map(|_| &s[..])
+                .or_else(|| std::str::from_utf8(&body).ok())
+                .and_then(|payload| serde_json::from_str(payload).ok())
+                .unwrap()
+        };
+
+        match calls {
+            // First goes through as is.
+            0 => net::UploadResult::http_status(200),
+            // Second briefly sleeps
+            1 => {
+                thread::sleep(time::Duration::from_millis(100));
+                net::UploadResult::http_status(200)
+            }
+            // Third one fails
+            2 => net::UploadResult::http_status(404),
+            // Fourth one fast again
+            3 => {
+                self.sender.send(decode(body)).unwrap();
+                net::UploadResult::http_status(200)
+            }
+            // Last one is the metrics ping, a-ok.
+            _ => {
+                self.sender.send(decode(body)).unwrap();
+                net::UploadResult::http_status(200)
+            }
+        }
+    }
+}
+
+/// Test scenario: Different timings for upload on success and failure.
+///
+/// The app is initialized, in turn Glean gets initialized without problems.
+/// A custom ping is submitted multiple times to trigger upload.
+/// A metrics ping is submitted to get the upload timing data.
+///
+/// And later the whole process is shutdown.
+#[test]
+fn upload_timings() {
+    common::enable_test_logging();
+
+    // Create a custom configuration to use a validating uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().to_path_buf();
+    let (tx, rx) = bounded(1);
+
+    let cfg = ConfigurationBuilder::new(true, tmpname, "glean-upload-timing")
+        .with_server_endpoint("invalid-test-host")
+        .with_use_core_mps(false)
+        .with_uploader(FakeUploader {
+            calls: AtomicUsize::new(0),
+            sender: tx,
+        })
+        .build();
+    common::initialize(cfg);
+
+    // Wait for init to finish,
+    // otherwise we might be to quick with calling `shutdown`.
+    let _ = metrics::sample_boolean.test_get_value(None);
+
+    // fast
+    pings::validation.submit(None);
+    // slow
+    pings::validation.submit(None);
+    // failed
+    pings::validation.submit(None);
+    // fast
+    pings::validation.submit(None);
+
+    // wait for the last ping
+    let _body = rx.recv().unwrap();
+
+    assert_eq!(
+        3,
+        metrics::send_success.test_get_value(None).unwrap().count,
+        "Successful pings: two fast, one slow"
+    );
+    assert_eq!(
+        1,
+        metrics::send_failure.test_get_value(None).unwrap().count,
+        "One failed ping"
+    );
+
+    glean::shutdown();
+}

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -123,6 +123,15 @@ callback interface OnGleanEvents {
     // Called when upload is disabled and uploads should be stopped
     [Throws=CallbackError]
     void cancel_uploads();
+
+    // Called on shutdown, before Glean is fully shutdown.
+    //
+    // * This MUST NOT put any new tasks on the dispatcher.
+    //   * New tasks will be ignored.
+    // * This SHOULD NOT block arbitrarily long.
+    //   * Shutdown waits for a maximum of 30 seconds.
+    [Throws=CallbackError]
+    void shutdown();
 };
 
 // Deserialized experiment data.

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -21,6 +21,9 @@ pub struct AdditionalMetrics {
 
     /// A count of the pings submitted, by ping type.
     pub pings_submitted: LabeledMetric<CounterMetric>,
+
+    /// Time waited for the uploader at shutdown.
+    pub shutdown_wait: TimingDistributionMetric,
 }
 
 impl CoreMetrics {
@@ -81,6 +84,18 @@ impl AdditionalMetrics {
                     dynamic_label: None,
                 },
                 None,
+            ),
+
+            shutdown_wait: TimingDistributionMetric::new(
+                CommonMetricData {
+                    name: "shutdown_wait".into(),
+                    category: "glean.validation".into(),
+                    send_in_pings: vec!["metrics".into()],
+                    lifetime: Lifetime::Ping,
+                    disabled: false,
+                    dynamic_label: None,
+                },
+                TimeUnit::Millisecond,
             ),
         }
     }

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -93,6 +93,8 @@ pub struct UploadMetrics {
     pub pending_pings_directory_size: MemoryDistributionMetric,
     pub deleted_pings_after_quota_hit: CounterMetric,
     pub pending_pings: CounterMetric,
+    pub send_success: TimingDistributionMetric,
+    pub send_failure: TimingDistributionMetric,
 }
 
 impl UploadMetrics {
@@ -157,6 +159,30 @@ impl UploadMetrics {
                 disabled: false,
                 dynamic_label: None,
             }),
+
+            send_success: TimingDistributionMetric::new(
+                CommonMetricData {
+                    name: "send_success".into(),
+                    category: "glean.upload".into(),
+                    send_in_pings: vec!["metrics".into()],
+                    lifetime: Lifetime::Ping,
+                    disabled: false,
+                    dynamic_label: None,
+                },
+                TimeUnit::Millisecond,
+            ),
+
+            send_failure: TimingDistributionMetric::new(
+                CommonMetricData {
+                    name: "send_failure".into(),
+                    category: "glean.upload".into(),
+                    send_in_pings: vec!["metrics".into()],
+                    lifetime: Lifetime::Ping,
+                    disabled: false,
+                    dynamic_label: None,
+                },
+                TimeUnit::Millisecond,
+            ),
         }
     }
 }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -957,7 +957,13 @@ pub fn glean_test_destroy_glean(clear_stores: bool, data_path: Option<String>) {
 
         dispatcher::reset_dispatcher();
 
-        uploader_shutdown();
+        // Only useful if Glean initialization finished successfully
+        // and set up the storage.
+        let has_storage =
+            core::with_opt_glean(|glean| glean.storage_opt().is_some()).unwrap_or(false);
+        if has_storage {
+            uploader_shutdown();
+        }
 
         if core::global_glean().is_some() {
             core::with_glean_mut(|glean| {

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -123,6 +123,14 @@ impl TimingDistributionMetric {
         id
     }
 
+    pub(crate) fn start_sync(&self) -> TimerId {
+        let start_time = time::precise_time_ns();
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst).into();
+        let metric = self.clone();
+        metric.set_start(id, start_time);
+        id
+    }
+
     /// **Test-only API (exported for testing purposes).**
     ///
     /// Set start time for this metric synchronously.
@@ -246,7 +254,7 @@ impl TimingDistributionMetric {
     }
 
     /// Aborts a previous [`start`](Self::start) call synchronously.
-    fn cancel_sync(&self, id: TimerId) {
+    pub(crate) fn cancel_sync(&self, id: TimerId) {
         let mut map = self.start_times.lock().expect("can't lock timings map");
         map.remove(&id);
     }

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -12,6 +12,7 @@
 //!   API to check the HTTP response from the ping upload and either delete the
 //!   corresponding ping from disk or re-enqueue it for sending.
 
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::path::PathBuf;
@@ -21,6 +22,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::error::ErrorKind;
+use crate::TimerId;
 use crate::{internal_metrics::UploadMetrics, Glean};
 use directory::{PingDirectoryManager, PingPayloadsByDirectory};
 use policy::Policy;
@@ -205,6 +207,8 @@ pub struct PingUploadManager {
     upload_metrics: UploadMetrics,
     /// Policies for ping storage, uploading and requests.
     policy: Policy,
+
+    in_flight: RwLock<HashMap<String, (TimerId, TimerId)>>,
 }
 
 impl PingUploadManager {
@@ -230,6 +234,7 @@ impl PingUploadManager {
             language_binding_name: language_binding_name.into(),
             upload_metrics: UploadMetrics::new(),
             policy: Policy::default(),
+            in_flight: RwLock::new(HashMap::default()),
         }
     }
 
@@ -575,6 +580,11 @@ impl PingUploadManager {
                     }
                 }
 
+                let mut lock = self.in_flight.write().unwrap();
+                let success_id = self.upload_metrics.send_success.start_sync();
+                let failure_id = self.upload_metrics.send_failure.start_sync();
+                lock.insert(request.document_id.clone(), (success_id, failure_id));
+
                 PingUploadTask::Upload {
                     request: queue.pop_front().unwrap(),
                 }
@@ -656,14 +666,30 @@ impl PingUploadManager {
     ) -> UploadTaskAction {
         use UploadResult::*;
 
+        let stop_time = time::precise_time_ns();
+
         if let Some(label) = status.get_label() {
             let metric = self.upload_metrics.ping_upload_failure.get(label);
             metric.add_sync(glean, 1);
         }
 
+        let mut lock = self.in_flight.write().unwrap();
+        let send_ids = lock.remove(document_id);
+
         match status {
             HttpStatus { code } if (200..=299).contains(&code) => {
                 log::info!("Ping {} successfully sent {}.", document_id, code);
+                if let Some((success_id, failure_id)) = send_ids {
+                    self.upload_metrics
+                        .send_success
+                        .set_stop_and_accumulate(glean, success_id, stop_time);
+                    self.upload_metrics.send_failure.cancel_sync(failure_id);
+                } else {
+                    // TODO(bug 1816400): Instrument missing IDs.
+                    // Should be done here and further below.
+                    // How did we remove the doc ID before we got here?
+                    // That's an inconsistency.
+                }
                 self.directory_manager.delete_file(document_id);
             }
 
@@ -673,6 +699,12 @@ impl PingUploadManager {
                     document_id,
                     status
                 );
+                if let Some((success_id, failure_id)) = send_ids {
+                    self.upload_metrics.send_success.cancel_sync(success_id);
+                    self.upload_metrics
+                        .send_failure
+                        .set_stop_and_accumulate(glean, failure_id, stop_time);
+                }
                 self.directory_manager.delete_file(document_id);
             }
 
@@ -682,6 +714,12 @@ impl PingUploadManager {
                     document_id,
                     status
                 );
+                if let Some((success_id, failure_id)) = send_ids {
+                    self.upload_metrics.send_success.cancel_sync(success_id);
+                    self.upload_metrics
+                        .send_failure
+                        .set_stop_and_accumulate(glean, failure_id, stop_time);
+                }
                 self.enqueue_ping_from_file(glean, document_id);
                 self.recoverable_failure_count
                     .fetch_add(1, Ordering::SeqCst);
@@ -689,6 +727,10 @@ impl PingUploadManager {
 
             Done { .. } => {
                 log::debug!("Uploader signaled Done. Exiting.");
+                if let Some((success_id, failure_id)) = send_ids {
+                    self.upload_metrics.send_success.cancel_sync(success_id);
+                    self.upload_metrics.send_failure.cancel_sync(failure_id);
+                }
                 return UploadTaskAction::End;
             }
         };


### PR DESCRIPTION
This PR does multiple things:

* Bring back #2365 -- that's the first 3 commits, cherry-picked unchanged (#2374 reverted them)
* Refactors the uploader shutdown to be used in test reset 
* Implement uploader shutdown in Swift
  * This is only used in test mode, because `glean::shutdown` is not called by the iOS bindings
  * Tries to be a bit more defensive for the newly introduced timing distributions done in the uploader.

Out of 20+ runs locally I had only 3 test failures ("No database found"). I don't fully understand why that still happens.
But hey, with only #2365 we had 7 tests fail basically every time. Improvement!

Especially the last part though bugs me. The iOS uploader still has some runs where it does some work after we told it to shut ~~up~~ down. And yet it happens in some tests.
Because Glean Swift _does not_ shut down in production use (it either runs or the embedding app is stopped/killed), this should not occur.
If it _does_ occur though this is strictly better by NOT crashing, but just logging an error now (but also: we only cover the known cases of metric types Glean collects there itself).

Time-wise: I'm still around on Monday, so we can have that reviewed and merged before.
I'd rather not have #2332 shipping without instrumentation, but it's also essentially desktop only for the time being in `main`, so it could.

I haven't (yet) tested this exact code on Desktop, but a prior version at least compiled in m-c just fine and ran tests.