### PR TITLE
Rename 'job' -> 'task' in Taskgraph's multi_dep loader

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -16,7 +16,7 @@ kind-dependencies:
 primary-dependency: module-build
 group-by: component
 
-job-template:
+task-template:
   run-on-tasks-for: [github-release]
   description: 'Publish release module {}'
   worker-type: beetmover

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -15,7 +15,7 @@ kind-dependencies:
 primary-dependency: module-build
 group-by: component
 
-job-template:
+task-template:
   run-on-tasks-for: [github-release]
   description: 'Sign release module {}'
   worker-type: signing

--- a/taskcluster/glean_taskgraph/loader/build_config.py
+++ b/taskcluster/glean_taskgraph/loader/build_config.py
@@ -15,7 +15,7 @@ from ..build_config import get_components
 
 
 def loader(kind, path, config, params, loaded_tasks):
-    config['jobs'] = jobs = {
+    config['tasks'] = {
         component['name']: {
             'attributes': {
                 'buildconfig': component

--- a/taskcluster/glean_taskgraph/loader/multi_dep.py
+++ b/taskcluster/glean_taskgraph/loader/multi_dep.py
@@ -32,10 +32,10 @@ def loader(kind, path, config, params, loaded_tasks):
     collapsed by platform with `platform`
     Optional ``primary-dependency`` (ordered list or string) is used to determine
     which upstream kind to inherit attrs from. See ``get_primary_dep``.
-    Optional ``job-template`` kind configuration value, if specified, will be used to
+    Optional ``task-template`` kind configuration value, if specified, will be used to
     pass configuration down to the specified transforms used.
     """
-    job_template = config.get('job-template')
+    task_template = config.get('task-template')
 
     for dep_tasks in group_tasks(config, loaded_tasks):
         kinds = [dep.kind for dep in dep_tasks]
@@ -45,12 +45,12 @@ def loader(kind, path, config, params, loaded_tasks):
 
         dep_tasks_per_kind = {dep.kind: dep for dep in dep_tasks}
 
-        job = {'dependent-tasks': dep_tasks_per_kind,
+        task = {'dependent-tasks': dep_tasks_per_kind,
                'primary-dependency': get_primary_dep(config, dep_tasks_per_kind)}
-        if job_template:
-            job.update(copy.deepcopy(job_template))
+        if task_template:
+            task.update(copy.deepcopy(task_template))
 
-        yield job
+        yield task
 
 
 def assert_unique_members(kinds, error_msg=None):


### PR DESCRIPTION
This fixes a couple places I neglected to convert when upgrading Taskgraph.

Issue: #2388