### PR TITLE
Update baseline ping description to reflect reasons

### DIFF
--- a/glean-core/pings.yaml
+++ b/glean-core/pings.yaml
@@ -14,8 +14,9 @@ baseline:
     This ping is intended to provide metrics that are managed by the library
     itself, and not explicitly set by the application or included in the
     application's `metrics.yaml` file.
-    The `baseline` ping is automatically sent when the application is moved to
-    the background.
+    The `baseline` ping is automatically sent when the application becomes
+    inactive and when the application becomes active again (including
+    application start). Please see the Reasons section for more information.
   include_client_id: true
   send_if_empty: true
   bugs:


### PR DESCRIPTION
Hi team! 👋🏻 

I am currently investigating client ID regeneration. In documentation that I've created, I mention when the `baseline` ping is sent based on what I've read in the description at https://dictionary.telemetry.mozilla.org/apps/fenix/pings/baseline.

@travis79 kindly pointed out a slight inaccuracy: The `baseline` ping is **also** sent when the app becomes active (moved to the foreground). This pull request updates the ping description to be in sync with the reasons.

It's been a while since I've contributed to this repo. 😅 

Please let me know if there's anything I need to do before we can merge this.