### PR TITLE
Bug 1820792 - handle rkv DatabaseCorrupted error by creating a new rkv

### DIFF
--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -52,6 +52,12 @@ pub fn rkv_new(path: &Path) -> std::result::Result<Rkv, rkv::StoreError> {
             // Now try again, we only handle that error once.
             Rkv::new::<rkv::backend::SafeMode>(path)
         }
+        Err(rkv::StoreError::DatabaseCorrupted) => {
+            let safebin = path.join("data.safe.bin");
+            fs::remove_file(safebin).map_err(|_| rkv::StoreError::DatabaseCorrupted)?;
+            // Try again, only allowing the error once.
+            Rkv::new::<rkv::backend::SafeMode>(path)
+        }
         other => other,
     }
 }


### PR DESCRIPTION
As discussed, this change only covers having this log in case of a DatabaseError.

I could find no tests around InvalidFile so I have not included any new ones.

This change is small enough that I wasn't sure a changelog entry was justified, especially given this isn't a change external folks should ever notice.