### PR TITLE
Use the sparse protocol everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ commands:
           command: |
             echo "export RUST_BACKTRACE=1" >> $BASH_ENV
             echo "export RUST_LOG=glean_core=debug" >> $BASH_ENV
+            echo "export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $BASH_ENV
+            echo "export CARGO_INCREMENTAL=0" >> $BASH_ENV
       - run:
           name: Setup Rust toolchain
           command: |

--- a/taskcluster/scripts/rustup-setup.sh
+++ b/taskcluster/scripts/rustup-setup.sh
@@ -11,6 +11,7 @@ export RUSTFLAGS='-Dwarnings'
 export CARGO_INCREMENTAL='0'
 export CI='1'
 export RUST_LOG='glean_core=debug,glean_ffi=debug'
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Rust
 RUSTUP_PLATFORM='x86_64-unknown-linux-gnu'
@@ -36,10 +37,6 @@ else
     echo "Installing Rust ${TOOLCHAIN}"
     rustup toolchain add "${TOOLCHAIN}" --profile minimal
     rustup default "${TOOLCHAIN}"
-
-    # Testing new index protocol
-    # https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
-    export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 fi
 
 set +eu


### PR DESCRIPTION
It became available in Rust 1.68.0
Additionally lets avoid incremental builds on CI.
That's just extra work which we don't need there.