### PR TITLE
Bug 1822482 - Switch from chrono to time 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.45",
  "winapi",
 ]
 
@@ -333,7 +333,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "time",
+ "time 0.1.45",
  "uuid",
  "whatsys",
 ]
@@ -379,7 +379,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "time",
+ "time 0.3.20",
  "uniffi",
  "uuid",
  "zeitstempel",
@@ -661,6 +661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -949,6 +958,35 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -41,8 +41,8 @@ zeitstempel = "0.1.0"
 crossbeam-channel = "0.5"
 thiserror = "1.0.4"
 uniffi = { version = "0.23.0", default-features = false }
-time = "0.1.40"
 env_logger = { version = "0.10.0", default-features = false, optional = true }
+time = { version = "0.3.20", features = ["local-offset", "serde", "formatting", "parsing", "macros"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = { version = "0.12.0", default-features = false }

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, FixedOffset};
 use once_cell::sync::OnceCell;
+use time::OffsetDateTime;
 
 use crate::database::Database;
 use crate::debug::DebugOptions;
@@ -145,7 +146,7 @@ pub struct Glean {
     data_path: PathBuf,
     application_id: String,
     ping_registry: HashMap<String, PingType>,
-    start_time: DateTime<FixedOffset>,
+    start_time: OffsetDateTime,
     max_events: u32,
     is_first_run: bool,
     pub(crate) upload_manager: PingUploadManager,
@@ -656,7 +657,7 @@ impl Glean {
     }
 
     /// Get create time of the Glean object.
-    pub(crate) fn start_time(&self) -> DateTime<FixedOffset> {
+    pub(crate) fn start_time(&self) -> OffsetDateTime {
         self.start_time
     }
 

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 use chrono::{DateTime, FixedOffset};
+use time::OffsetDateTime;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
@@ -357,7 +358,7 @@ impl EventDatabase {
         glean: &Glean,
         store_name: &str,
         store: &mut Vec<StoredEvent>,
-        glean_start_time: DateTime<FixedOffset>,
+        glean_start_time: OffsetDateTime,
     ) {
         let is_glean_restarted =
             |event: &RecordedEvent| event.category == "glean" && event.name == "restarted";
@@ -424,7 +425,7 @@ impl EventDatabase {
                     .as_mut()
                     .and_then(|extra| {
                         extra.remove("glean.startup.date").and_then(|date_str| {
-                            DateTime::parse_from_str(&date_str, TimeUnit::Minute.format_pattern())
+                            OffsetDateTime::parse(&date_str, TimeUnit::Minute.format_pattern())
                                 .map_err(|_| {
                                     record_error(
                                         glean,
@@ -461,7 +462,7 @@ impl EventDatabase {
                     .get_value(glean, INTERNAL_STORAGE)
                     .unwrap_or(glean_start_time);
                 let time_from_ping_start_to_glean_restarted =
-                    (glean_startup_date - ping_start).num_milliseconds();
+                    (glean_startup_date - ping_start).whole_milliseconds();
                 intra_group_offset = event.event.timestamp;
                 inter_group_offset =
                     u64::try_from(time_from_ping_start_to_glean_restarted).unwrap_or(0);

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crossbeam_channel::unbounded;
 use once_cell::sync::{Lazy, OnceCell};
@@ -521,7 +521,7 @@ fn uploader_shutdown() {
     //   * We don't know how long uploads take until we get data from bug 1814592.
     let result = rx.recv_timeout(Duration::from_secs(30));
 
-    let stop_time = time::precise_time_ns();
+    let stop_time = Instant::now();
     core::with_glean(|glean| {
         glean
             .additional_metrics

--- a/glean-core/src/metrics/time_unit.rs
+++ b/glean-core/src/metrics/time_unit.rs
@@ -6,6 +6,8 @@ use std::convert::TryFrom;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use time::macros::format_description;
+use time::format_description::FormatItem;
 
 use crate::error::{Error, ErrorKind};
 
@@ -33,16 +35,16 @@ pub enum TimeUnit {
 
 impl TimeUnit {
     /// Formats the given time unit, truncating the time if needed.
-    pub fn format_pattern(self) -> &'static str {
+    pub fn format_pattern(self) -> &'static [FormatItem<'static>] {
         use TimeUnit::*;
         match self {
-            Nanosecond => "%Y-%m-%dT%H:%M:%S%.f%:z",
-            Microsecond => "%Y-%m-%dT%H:%M:%S%.6f%:z",
-            Millisecond => "%Y-%m-%dT%H:%M:%S%.3f%:z",
-            Second => "%Y-%m-%dT%H:%M:%S%:z",
-            Minute => "%Y-%m-%dT%H:%M%:z",
-            Hour => "%Y-%m-%dT%H%:z",
-            Day => "%Y-%m-%d%:z",
+            Nanosecond => format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[[subsecond][offset_hour sign:mandatory]:[offset_minute]"),
+            Microsecond => format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[[subsecond][offset_hour sign:mandatory]:[offset_minute]"),
+            Millisecond => format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[[subsecond][offset_hour sign:mandatory]:[offset_minute]"),
+            Second => format_description!("[year]-[month]-[day]T[hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"),
+            Minute => format_description!("[year]-[month]-[day]T[hour]:[minute][offset_hour sign:mandatory]:[offset_minute]"),
+            Hour => format_description!("[year]-[month]-[day]T[hour][offset_hour sign:mandatory]:[offset_minute]"),
+            Day => format_description!("[year]-[month]-[day][offset_hour sign:mandatory]:[offset_minute]"),
         }
     }
 

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -686,7 +686,7 @@ impl PingUploadManager {
     ) -> UploadTaskAction {
         use UploadResult::*;
 
-        let stop_time = time::precise_time_ns();
+        let stop_time = Instant::now();
 
         if let Some(label) = status.get_label() {
             let metric = self.upload_metrics.ping_upload_failure.get(label);


### PR DESCRIPTION
This is a frist try at migrating from chrono to time. This compiles, but with warnings.
Tests don't compile, as they still largely make use of chrono.

Things that would need to be tested:

* Do we handle timezones correctly?
* Are we handling time measurement correctly?
  * This switched from `time::precise_time_ns()` to libstd's `Instant`. We need to verify the guarantees.
* Are we correctly (de)serializing data?
  * Datetimes are stored in the database. We need to handle the old data transparently. `DatetimeWrapper` should do that, but will require more testing.
* Truncation/Formatting
  * We use `TimeUnit` for the date/time related metrics to truncate. As this switches formatting we need to verify it's correct (especially at the nano-/micro-/millisecond level)