### PR TITLE
Bug 1818361 -  Prevent another test-only issue: The storage going away when the uploader reports back its status

### DIFF
--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -527,6 +527,7 @@ impl Glean {
     }
 
     /// Gets a handle to the database.
+    #[track_caller] // If this fails we're interested in the caller.
     pub fn storage(&self) -> &Database {
         self.data_store.as_ref().expect("No database found")
     }


### PR DESCRIPTION
The "No database found" message is unique, so we _always_ know that it
happens in exactly that line.
That's not helpful during debugging though. We want to know which part
requested storage.

`track_caller` does that.
See https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute

---

This is more of a workaround than a fix and we should eventually follow this up with properly addressing this in a more holistic way