### PR TITLE
Bug 1815233 - allow custom data path on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Kotlin
   * Adds the ability to record metrics on a non-main process. This is enabled by setting a `dataPath` in the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
 * iOS
-  * Adds the ability to record metrics on a non-main process. This is enabled by passing a `dataPath` to the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
+  * Adds the ability to record metrics on a non-main process. This is enabled by setting a `dataPath` in the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
 
 # v52.4.3 (2023-03-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * General
   * On Rkv detecting a corrupted database delete the old RKV, create a new one and log the error ([#2425](https://github.com/mozilla/glean/pull/2425))
   * Add the Date header as late as possible before the uploader acts ([#2436](https://github.com/mozilla/glean/pull/2436))
+* Kotlin
+  * Adds the ability to record metrics on a non-main process. This is enabled by passing a `dataPath` to the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
+* iOS
+  * Adds the ability to record metrics on a non-main process. This is enabled by passing a `dataPath` to the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
 
 # v52.4.3 (2023-03-24)
 
@@ -48,11 +52,6 @@
 
 * General
   * No functional change from v52.3.0, just CI updates.
-
-* Kotlin
-  * Allow the user to specify a custom data path when calling `initialize`.
-* iOS
-  * Allow the user to specify a custom data path when calling `initialize`.
 
 # v52.3.0 (2023-02-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
 * General
   * No functional change from v52.3.0, just CI updates.
 
+* Kotlin
+  * Allow the user to specify a custom data path when calling `initialize`.
+* iOS
+  * Allow the user to specify a custom data path when calling `initialize`.
+
 # v52.3.0 (2023-02-23)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.2.0...v52.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   * On Rkv detecting a corrupted database delete the old RKV, create a new one and log the error ([#2425](https://github.com/mozilla/glean/pull/2425))
   * Add the Date header as late as possible before the uploader acts ([#2436](https://github.com/mozilla/glean/pull/2436))
 * Kotlin
-  * Adds the ability to record metrics on a non-main process. This is enabled by passing a `dataPath` to the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
+  * Adds the ability to record metrics on a non-main process. This is enabled by setting a `dataPath` in the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
 * iOS
   * Adds the ability to record metrics on a non-main process. This is enabled by passing a `dataPath` to the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
 

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -117,7 +117,7 @@ The Glean Kotlin SDK supports use across multiple processes. This is enabled by 
 
 Requirements for a non-main process
 - `Glean.initialize` must be called with the `dataPath` value set in the `Glean.Configuration`.
-- The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
+- The default `dataPath` for Glean is `{context.applicationInfo.dataDir}/glean_data`. If you try to use this path, `Glean.initialize` will fail and throw an error.
 
 **Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled [baseline](../../user/pings/baseline.md) or [metrics](../../user/pings/metrics.md) pings.
 
@@ -182,7 +182,7 @@ The Glean Swift SDK supports use across multiple processes. This is enabled by s
 
 Requirements for a non-main process 
 - `Glean.initialize` must be called with the `dataPath` value set in the `Glean.Configuration`.
-- The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
+- On iOS devices, Glean stores data in the Application Support directory. The default `dataPath` Glean uses is `{FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]}/glean_data`. If you try to use this path, `Glean.initialize` will fail and throw an error.
 
 **Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled [baseline](../../user/pings/baseline.md) or [metrics](../../user/pings/metrics.md) pings.
 

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -113,13 +113,13 @@ class SampleApplication : Application() {
 }
 ```
 
-The Glean Kotlin SDK supports use across multiple processes. To configure this you call `initialize` as usual from your main process. From the secondary process you can call `initialize` again with the `dataPath` parameter. This allows you to store data locally in a separate location for the secondary process.
+The Glean Kotlin SDK supports use across multiple processes. This is enabled by adding a `dataPath` value to the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to pass a `dataPath` for your main process. This configuration should only be used by a non-main process.
 
-Requirements for a secondary process
-- `initialize` must be called from the main thread
-- The reserved data path `glean_data` cannot be used
+Requirements for a non-main process
+- `Glean.initialize` must be called from the main thread.
+- The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
 
-**Note**: When initializing from a secondary process with a specified data path, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
+**Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
 
 ### Consuming Glean through Android Components
 
@@ -178,13 +178,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 ```
 
-The Glean Swift SDK supports use across multiple processes. To configure this you call `initialize` as usual from your main process. From the secondary process you can call `initialize` again with the `dataPath` parameter. This allows you to store data locally in a separate location for the secondary process.
+The Glean Swift SDK supports use across multiple processes. This is enabled by adding a `dataPath` value to the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to pass a `dataPath` for your main process. This configuration should only be used by a non-main process.
 
-Requirements for a secondary process
-- `initialize` must be called from the main thread
-- The reserved data path `glean_data` cannot be used
+Requirements for a non-main process 
+- `Glean.initialize` must be called from the main thread.
+- The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
 
-**Note**: When initializing from a secondary process with a specified data path, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
+**Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
 
 </div>
 

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -113,7 +113,7 @@ class SampleApplication : Application() {
 }
 ```
 
-The Glean Kotlin SDK supports use across multiple processes. This is enabled by adding a `dataPath` value to the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to pass a `dataPath` for your main process. This configuration should only be used by a non-main process.
+The Glean Kotlin SDK supports use across multiple processes. This is enabled by setting a `dataPath` value in the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to set a `dataPath` for your main process. This configuration should only be used by a non-main process.
 
 Requirements for a non-main process
 - `Glean.initialize` must be called from the main thread.

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -181,7 +181,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 The Glean Swift SDK supports use across multiple processes. This is enabled by setting a `dataPath` value in the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to set a `dataPath` for your main process. This configuration should only be used by a non-main process.
 
 Requirements for a non-main process 
-- `Glean.initialize` must be called from the main thread.
+- `Glean.initialize` must be called with the `dataPath` value set in the `Glean.Configuration`.
 - The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
 
 **Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -116,7 +116,7 @@ class SampleApplication : Application() {
 The Glean Kotlin SDK supports use across multiple processes. This is enabled by setting a `dataPath` value in the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to set a `dataPath` for your main process. This configuration should only be used by a non-main process.
 
 Requirements for a non-main process
-- `Glean.initialize` must be called from the main thread.
+- `Glean.initialize` must be called with a `dataPath` set in the `Glean.Configuration`
 - The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
 
 **Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -116,10 +116,10 @@ class SampleApplication : Application() {
 The Glean Kotlin SDK supports use across multiple processes. This is enabled by setting a `dataPath` value in the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to set a `dataPath` for your main process. This configuration should only be used by a non-main process.
 
 Requirements for a non-main process
-- `Glean.initialize` must be called with a `dataPath` set in the `Glean.Configuration`
+- `Glean.initialize` must be called with the `dataPath` value set in the `Glean.Configuration`.
 - The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
 
-**Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
+**Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled [baseline](../../user/pings/baseline.md) or [metrics](../../user/pings/metrics.md) pings.
 
 ### Consuming Glean through Android Components
 
@@ -184,7 +184,7 @@ Requirements for a non-main process
 - `Glean.initialize` must be called with the `dataPath` value set in the `Glean.Configuration`.
 - The default `dataPath` for Glean is `glean_data`. If you try and use `glean_data`, `Glean.initialize` will fail and throw an error.
 
-**Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
+**Note**: When initializing from a non-main process with a specified `dataPath`, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled [baseline](../../user/pings/baseline.md) or [metrics](../../user/pings/metrics.md) pings.
 
 </div>
 

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -178,7 +178,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 ```
 
-The Glean Swift SDK supports use across multiple processes. This is enabled by adding a `dataPath` value to the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to pass a `dataPath` for your main process. This configuration should only be used by a non-main process.
+The Glean Swift SDK supports use across multiple processes. This is enabled by setting a `dataPath` value in the `Glean.Configuration` object passed to `Glean.initialize`. You **do not** need to set a `dataPath` for your main process. This configuration should only be used by a non-main process.
 
 Requirements for a non-main process 
 - `Glean.initialize` must be called from the main thread.

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -113,9 +113,13 @@ class SampleApplication : Application() {
 }
 ```
 
-The Glean Kotlin SDK does not support use across multiple processes, and must only be initialized on the application's main process. Initializing in other processes is a no-op.
+The Glean Kotlin SDK supports use across multiple processes. To configure this you call `initialize` as usual from your main process. From the secondary process you can call `initialize` again with the `dataPath` parameter. This allows you to store data locally in a separate location for the secondary process.
 
-Additionally, Glean must be initialized on the main (UI) thread of the applications main process. Failure to do so will throw an `IllegalThreadStateException`.
+Requirements for a secondary process
+- `initialize` must be called from the main thread
+- The reserved data path `glean_data` cannot be used
+
+**Note**: When initializing from a secondary process with a specified data path, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
 
 ### Consuming Glean through Android Components
 
@@ -174,8 +178,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 ```
 
-The Glean Swift SDK does not support use across multiple processes,
-and must only be initialized on the application's main process.
+The Glean Swift SDK supports use across multiple processes. To configure this you call `initialize` as usual from your main process. From the secondary process you can call `initialize` again with the `dataPath` parameter. This allows you to store data locally in a separate location for the secondary process.
+
+Requirements for a secondary process
+- `initialize` must be called from the main thread
+- The reserved data path `glean_data` cannot be used
+
+**Note**: When initializing from a secondary process with a specified data path, the lifecycle observers will not be set up. This means you will not receive otherwise scheduled baseline or metrics pings.
 
 </div>
 

--- a/docs/user/user/pings/ping-schedules-and-timings.md
+++ b/docs/user/user/pings/ping-schedules-and-timings.md
@@ -19,3 +19,5 @@ The `submission_timestamp` is the time the ping was received at the telemetry en
 The "Baseline 4" ping illustrates an important corner case. When "Session 2" ended, the OS also shut down the entire process, and the Glean SDK did not have an opportunity to send a `baseline` ping immediately.  In this case, it is sent at the next available opportunity when the application starts up again in "Run 2".  This `baseline` ping is annotated with the reason code `dirty_startup`.
 
 The "Metrics 2" ping likewise illustrates another important corner case. "Metrics 1" was able to be sent at the target time of 04:00 (local device time) because the application was currently running.  However, the next time 04:00 came around, the application was not active, so the Glean SDK was unable to send a `metrics` ping.  It is sent at the next available opportunity, when the application starts up again in "Run 2".  This `metrics` ping is annotated with the reason code `overdue`.
+
+**NOTE**: If you are running Glean on a secondary process where to pass a custom `dataPath` to the `initialize` call for either the Kotlin or Swift SDKs, **these life-cycles will not be set up**.

--- a/docs/user/user/pings/ping-schedules-and-timings.md
+++ b/docs/user/user/pings/ping-schedules-and-timings.md
@@ -20,4 +20,4 @@ The "Baseline 4" ping illustrates an important corner case. When "Session 2" end
 
 The "Metrics 2" ping likewise illustrates another important corner case. "Metrics 1" was able to be sent at the target time of 04:00 (local device time) because the application was currently running.  However, the next time 04:00 came around, the application was not active, so the Glean SDK was unable to send a `metrics` ping.  It is sent at the next available opportunity, when the application starts up again in "Run 2".  This `metrics` ping is annotated with the reason code `overdue`.
 
-**NOTE**: If you are running Glean on a secondary process where to pass a custom `dataPath` to the `initialize` call for either the Kotlin or Swift SDKs, **these life-cycles will not be set up**.
+**NOTE**: Ping scheduling and other application lifecycle dependent activities are not set up when Glean is used in a non-main process. See [initializing](../../reference/general/initializing.html#gleaninitializeconfiguration)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -42,7 +42,7 @@ internal class OnGleanEventsImpl(val glean: GleanInternalAPI) : OnGleanEvents {
     override fun initializeFinished() {
         // Only set up the lifecycle observers if we don't provide a custom
         // data path.
-        if (glean.getIsCustomDataPath() != null && glean.getIsCustomDataPath() == false) {
+        if (!glean.isCustomDataPath) {
             MainScope().launch {
                 ProcessLifecycleOwner.get().lifecycle.addObserver(glean.gleanLifecycleObserver)
             }
@@ -64,7 +64,7 @@ internal class OnGleanEventsImpl(val glean: GleanInternalAPI) : OnGleanEvents {
     override fun startMetricsPingScheduler(): Boolean {
         // If we pass a custom data path, the metrics ping schedule should not
         // be setup.
-        if (glean.getIsCustomDataPath() == true) {
+        if (glean.isCustomDataPath) {
             glean.metricsPingScheduler?.cancel()
             return false
         }
@@ -137,7 +137,7 @@ open class GleanInternalAPI internal constructor() {
     // Store the build information provided by the application.
     internal lateinit var buildInfo: BuildInfo
 
-    private var isCustomDataPath: Boolean? = null
+    internal var isCustomDataPath: Boolean = false
 
     init {
         gleanEnableLogging()
@@ -610,13 +610,6 @@ open class GleanInternalAPI internal constructor() {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun isMainThread(): Boolean {
         return Looper.getMainLooper().thread == Thread.currentThread()
-    }
-
-    /**
-     * Returns true if the Glean instance is using a custom data path.
-     */
-    internal fun getIsCustomDataPath(): Boolean? {
-        return this.isCustomDataPath
     }
 }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -16,6 +16,8 @@ import mozilla.telemetry.glean.net.PingUploader
  * @property httpClient The HTTP client implementation to use for uploading pings.
  * @property channel the release channel the application is on, if known. This will be
  *           sent along with all the pings, in the `client_info` section.
+ * @property dataPath An optional [String] that specifies where to store data locally on the device.
+ *           This should ONLY be used when setting up Glean on a non-main process.
  */
 data class Configuration @JvmOverloads constructor(
     val serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
@@ -24,7 +26,8 @@ data class Configuration @JvmOverloads constructor(
     // NOTE: since only simple object or strings can be made `const val`s, if the
     // default values for the lines below are ever changed, they are required
     // to change in the public constructor below.
-    val httpClient: PingUploader = HttpURLConnectionUploader()
+    val httpClient: PingUploader = HttpURLConnectionUploader(),
+    val dataPath: String? = null
 ) {
     companion object {
         /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
@@ -1,0 +1,55 @@
+package mozilla.telemetry.glean.utils
+
+import mozilla.telemetry.glean.GleanInternalAPI
+import java.io.File
+
+/**
+ * Takes a base data directory and a custom data path and creates
+ * the data storage location on the device.
+ *
+ * @param dataDir A [String] that specifies the base directory where we will
+ *     store data.
+ * @param customDataPath An optional [String] provided by the user to specify
+ *     the specific path to store data.
+ */
+fun generateGleanStoragePath(dataDir: String, customDataPath: String?): File {
+    val file: File = if (customDataPath == null) {
+        File(
+            dataDir,
+            GleanInternalAPI.GLEAN_DATA_DIR
+        )
+    } else {
+        File(dataDir, customDataPath)
+    }
+
+    return file
+}
+
+/**
+ * Check if the data path provided is valid and writable.
+ *
+ * @param dataDir A [String] that specifies the base directory where we will
+ *     store data.
+ * @param customDataPath An optional [String] provided by the user to specify
+ *     the specific path to store data.
+ */
+fun canWriteToDatabasePath(dataDir: String, customDataPath: String? = ""): Boolean {
+    // Do not allow empty strings or strings with leading or trailing spaces.
+    if (customDataPath == "" || customDataPath!!.startsWith(" ") || customDataPath.endsWith(" ")) {
+        return false
+    }
+
+    // Generate the full path that we want to write to using our custom data path.
+    val fullFilePath = generateGleanStoragePath(dataDir, customDataPath).absolutePath
+
+    // If the file exists we need to ensure we can write to it.
+    val file = File(fullFilePath)
+    if (file.exists()) {
+        if (!file.canWrite()) {
+            return false
+        }
+    }
+
+    // The database path is valid and writable.
+    return true
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
@@ -30,12 +30,11 @@ fun generateGleanStoragePath(dataDir: String, customDataPath: String?): File {
  *
  * @param dataDir A [String] that specifies the base directory where we will
  *     store data.
- * @param customDataPath An optional [String] provided by the user to specify
- *     the specific path to store data.
+ * @param customDataPath A [String] provided by the user to specify the path to store data.
  */
-fun canWriteToDatabasePath(dataDir: String, customDataPath: String? = ""): Boolean {
+fun canWriteToDatabasePath(dataDir: String, customDataPath: String): Boolean {
     // Do not allow empty strings or strings with leading or trailing spaces.
-    if (customDataPath == "" || customDataPath!!.startsWith(" ") || customDataPath.endsWith(" ")) {
+    if (customDataPath == "" || customDataPath.startsWith(" ") || customDataPath.endsWith(" ")) {
         return false
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
@@ -13,15 +13,14 @@ import java.io.File
  *     the specific path to store data.
  */
 fun generateGleanStoragePath(dataDir: String, customDataPath: String?): File {
-    val file: File = if (customDataPath == null) {
+    val file: File = customDataPath?.let { safeDataPath ->
+        File(dataDir, safeDataPath)
+    } ?: run {
         File(
             dataDir,
             GleanInternalAPI.GLEAN_DATA_DIR
         )
-    } else {
-        File(dataDir, customDataPath)
     }
-
     return file
 }
 
@@ -34,7 +33,7 @@ fun generateGleanStoragePath(dataDir: String, customDataPath: String?): File {
  */
 fun canWriteToDatabasePath(dataDir: String, customDataPath: String): Boolean {
     // Do not allow empty strings.
-    if (customDataPath == "") {
+    if (customDataPath.isEmpty()) {
         return false
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
@@ -1,47 +1,21 @@
 package mozilla.telemetry.glean.utils
 
-import mozilla.telemetry.glean.GleanInternalAPI
 import java.io.File
-
-/**
- * Takes a base data directory and a custom data path and creates
- * the data storage location on the device.
- *
- * @param dataDir A [String] that specifies the base directory where we will
- *     store data.
- * @param customDataPath An optional [String] provided by the user to specify
- *     the specific path to store data.
- */
-fun generateGleanStoragePath(dataDir: String, customDataPath: String?): File {
-    val file: File = customDataPath?.let { safeDataPath ->
-        File(dataDir, safeDataPath)
-    } ?: run {
-        File(
-            dataDir,
-            GleanInternalAPI.GLEAN_DATA_DIR
-        )
-    }
-    return file
-}
 
 /**
  * Check if the data path provided is valid and writable.
  *
- * @param dataDir A [String] that specifies the base directory where we will
- *     store data.
- * @param customDataPath A [String] provided by the user to specify the path to store data.
+ * @param dataPath A [String] provided by the user to specify the path to store data.
+ * @return True if the database path is valid and writable.
  */
-fun canWriteToDatabasePath(dataDir: String, customDataPath: String): Boolean {
+fun canWriteToDatabasePath(dataPath: String): Boolean {
     // Do not allow empty strings.
-    if (customDataPath.isEmpty()) {
+    if (dataPath.isEmpty()) {
         return false
     }
 
-    // Generate the full path that we want to write to using our custom data path.
-    val fullFilePath = generateGleanStoragePath(dataDir, customDataPath).absolutePath
-
     // If the file exists we need to ensure we can write to it.
-    val file = File(fullFilePath)
+    val file = File(dataPath)
     if (file.exists()) {
         if (!file.canWrite()) {
             return false

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/utils/DataPathUtils.kt
@@ -33,8 +33,8 @@ fun generateGleanStoragePath(dataDir: String, customDataPath: String?): File {
  * @param customDataPath A [String] provided by the user to specify the path to store data.
  */
 fun canWriteToDatabasePath(dataDir: String, customDataPath: String): Boolean {
-    // Do not allow empty strings or strings with leading or trailing spaces.
-    if (customDataPath == "" || customDataPath.startsWith(" ") || customDataPath.endsWith(" ")) {
+    // Do not allow empty strings.
+    if (customDataPath == "") {
         return false
     }
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -887,7 +887,7 @@ class GleanTest {
     }
 
     @Test
-    fun `Date header is set on actualy HTTP POST`() {
+    fun `Date header is set on actually HTTP POST`() {
         delayMetricsPing(context)
         val server = getMockWebServer()
         resetGlean(
@@ -926,5 +926,31 @@ class GleanTest {
         // we're still below that sleep time.
         assertTrue("Difference should be more than 0 seconds, was $diff", diff > 0)
         assertTrue("Difference should be less than 2 seconds, was $diff", diff < 2000)
+    }
+
+    @Test
+    fun `test glean is custom data path is set correctly`() {
+        // Initialize with a custom data path and ensure `getIsCustomDataPath` is true.
+        Glean.testDestroyGleanHandle()
+        Glean.initialize(context, true, buildInfo = GleanBuildInfo.buildInfo, dataPath = "glean_test")
+        assertNotNull(Glean.getIsCustomDataPath())
+        assertTrue(Glean.getIsCustomDataPath()!!)
+
+        // Initialize without a custom data path and ensure `getIsCustomDataPath` is false.
+        Glean.testDestroyGleanHandle()
+        Glean.initialize(context, true, buildInfo = GleanBuildInfo.buildInfo)
+        assertNotNull(Glean.getIsCustomDataPath())
+        assertFalse(Glean.getIsCustomDataPath()!!)
+    }
+
+    @Test
+    fun `test glean does not initialize with invalid DB path`() {
+        Glean.testDestroyGleanHandle()
+
+        // The path provided here is invalid because of the leading and trailing spaces.
+        Glean.initialize(context, true, buildInfo = GleanBuildInfo.buildInfo, dataPath = " invalid db path ")
+
+        // Since the path is invalid, Glean should not properly initialize.
+        assertFalse(Glean.initialized)
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -929,7 +929,7 @@ class GleanTest {
     }
 
     @Test
-    fun `test glean is custom data path is set correctly`() {
+    fun `test glean with custom data path is set correctly`() {
         // Initialize with a custom data path and ensure `isCustomDataPath` is true.
         Glean.testDestroyGleanHandle()
         val cfg = Configuration(dataPath = "glean_test")

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -929,7 +929,7 @@ class GleanTest {
     }
 
     @Test
-    fun `test glean with custom data path is set correctly`() {
+    fun `Glean accepts a custom data path`() {
         // Initialize with a custom data path and ensure `isCustomDataPath` is true.
         Glean.testDestroyGleanHandle()
         val cfg = Configuration(dataPath = "glean_test")

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -929,10 +929,12 @@ class GleanTest {
     }
 
     @Test
-    fun `Glean accepts a custom data path`() {
+    fun `Initialization succeeds with valid DB path`() {
         // Initialize with a custom data path and ensure `isCustomDataPath` is true.
         Glean.testDestroyGleanHandle()
-        val cfg = Configuration(dataPath = "glean_test")
+        val cfg = Configuration(
+            dataPath = File(context.applicationInfo.dataDir, "glean_test").absolutePath
+        )
         Glean.initialize(context, true, cfg, buildInfo = GleanBuildInfo.buildInfo)
         assertTrue(Glean.isCustomDataPath)
 
@@ -943,7 +945,7 @@ class GleanTest {
     }
 
     @Test
-    fun `test glean does not initialize with invalid DB path`() {
+    fun `Initialization fails with invalid DB path`() {
         Glean.testDestroyGleanHandle()
 
         // The path provided here is invalid because it is an empty string.

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -887,7 +887,7 @@ class GleanTest {
     }
 
     @Test
-    fun `Date header is set on actually HTTP POST`() {
+    fun `Date header is set on actual HTTP POST`() {
         delayMetricsPing(context)
         val server = getMockWebServer()
         resetGlean(

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -930,17 +930,15 @@ class GleanTest {
 
     @Test
     fun `test glean is custom data path is set correctly`() {
-        // Initialize with a custom data path and ensure `getIsCustomDataPath` is true.
+        // Initialize with a custom data path and ensure `isCustomDataPath` is true.
         Glean.testDestroyGleanHandle()
         Glean.initialize(context, true, buildInfo = GleanBuildInfo.buildInfo, dataPath = "glean_test")
-        assertNotNull(Glean.getIsCustomDataPath())
-        assertTrue(Glean.getIsCustomDataPath()!!)
+        assertTrue(Glean.isCustomDataPath)
 
-        // Initialize without a custom data path and ensure `getIsCustomDataPath` is false.
+        // Initialize without a custom data path and ensure `isCustomDataPath` is false.
         Glean.testDestroyGleanHandle()
         Glean.initialize(context, true, buildInfo = GleanBuildInfo.buildInfo)
-        assertNotNull(Glean.getIsCustomDataPath())
-        assertFalse(Glean.getIsCustomDataPath()!!)
+        assertFalse(Glean.isCustomDataPath)
     }
 
     @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -932,7 +932,8 @@ class GleanTest {
     fun `test glean is custom data path is set correctly`() {
         // Initialize with a custom data path and ensure `isCustomDataPath` is true.
         Glean.testDestroyGleanHandle()
-        Glean.initialize(context, true, buildInfo = GleanBuildInfo.buildInfo, dataPath = "glean_test")
+        val cfg = Configuration(dataPath = "glean_test")
+        Glean.initialize(context, true, cfg, buildInfo = GleanBuildInfo.buildInfo)
         assertTrue(Glean.isCustomDataPath)
 
         // Initialize without a custom data path and ensure `isCustomDataPath` is false.
@@ -946,7 +947,8 @@ class GleanTest {
         Glean.testDestroyGleanHandle()
 
         // The path provided here is invalid because of the leading and trailing spaces.
-        Glean.initialize(context, true, buildInfo = GleanBuildInfo.buildInfo, dataPath = " invalid db path ")
+        val cfg = Configuration(dataPath = " invalid db path ")
+        Glean.initialize(context, true, cfg, buildInfo = GleanBuildInfo.buildInfo)
 
         // Since the path is invalid, Glean should not properly initialize.
         assertFalse(Glean.initialized)

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -946,8 +946,8 @@ class GleanTest {
     fun `test glean does not initialize with invalid DB path`() {
         Glean.testDestroyGleanHandle()
 
-        // The path provided here is invalid because of the leading and trailing spaces.
-        val cfg = Configuration(dataPath = " invalid db path ")
+        // The path provided here is invalid because it is an empty string.
+        val cfg = Configuration(dataPath = "")
         Glean.initialize(context, true, cfg, buildInfo = GleanBuildInfo.buildInfo)
 
         // Since the path is invalid, Glean should not properly initialize.

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DataPathUtilsTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DataPathUtilsTest.kt
@@ -18,7 +18,7 @@ class DataPathUtilsTest {
 
     @Test
     fun `test can write to database path invalid path`() {
-        val customDataPath = " invalid db path "
+        val customDataPath = ""
         assertFalse(canWriteToDatabasePath(mockDataDir, customDataPath))
     }
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DataPathUtilsTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DataPathUtilsTest.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.telemetry.glean.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DataPathUtilsTest {
+    private val mockDataDir = "mock_dataDir_path"
+
+    @Test
+    fun `test can write to database path invalid path`() {
+        val customDataPath = " invalid db path "
+        assertFalse(canWriteToDatabasePath(mockDataDir, customDataPath))
+    }
+
+    fun `test can write to database path valid path`() {
+        val customDataPath = "valid_db_path"
+        assertTrue(canWriteToDatabasePath(mockDataDir, customDataPath))
+    }
+
+    fun `test generate glean storage path has correct slug`() {
+        val customDataPath = "test_glean_data"
+        val path = generateGleanStoragePath(mockDataDir, customDataPath)
+        assertEquals(path.absolutePath.substringAfterLast("/"), customDataPath)
+    }
+}

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DataPathUtilsTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DataPathUtilsTest.kt
@@ -5,8 +5,9 @@
 
 package mozilla.telemetry.glean.utils
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -14,22 +15,18 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class DataPathUtilsTest {
-    private val mockDataDir = "mock_dataDir_path"
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
 
     @Test
-    fun `test can write to database path invalid path`() {
+    fun `Cannot write to invalid database path`() {
         val customDataPath = ""
-        assertFalse(canWriteToDatabasePath(mockDataDir, customDataPath))
+        assertFalse(canWriteToDatabasePath(customDataPath))
     }
 
-    fun `test can write to database path valid path`() {
-        val customDataPath = "valid_db_path"
-        assertTrue(canWriteToDatabasePath(mockDataDir, customDataPath))
-    }
-
-    fun `test generate glean storage path has correct slug`() {
-        val customDataPath = "test_glean_data"
-        val path = generateGleanStoragePath(mockDataDir, customDataPath)
-        assertEquals(path.absolutePath.substringAfterLast("/"), customDataPath)
+    @Test
+    fun `Can write to valid database path`() {
+        val dataPath = context.applicationInfo.dataDir + "/valid_db_path"
+        assertTrue(canWriteToDatabasePath(dataPath))
     }
 }

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		BFFE18382350A5F50068D97B /* TimingDistributionMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE18372350A5F50068D97B /* TimingDistributionMetric.swift */; };
 		BFFE183A2350A61F0068D97B /* TimingDistributionMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE18392350A61F0068D97B /* TimingDistributionMetricTests.swift */; };
 		BFFE33AB232927C3005348FE /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE33AA232927C3005348FE /* Utils.swift */; };
+		C27E756329D4A67800C6AADD /* DataPathUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27E756229D4A67800C6AADD /* DataPathUtilsTests.swift */; };
 		CD062129284110970006370D /* TextMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD062128284110970006370D /* TextMetric.swift */; };
 		CD0CADA427E216810015A997 /* glean.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD08C8527E21104007C8400 /* glean.swift */; };
 		CD0F7CC026F0F27900EDA6A4 /* UrlMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0F7CBF26F0F27900EDA6A4 /* UrlMetric.swift */; };
@@ -136,6 +137,7 @@
 		BFFE18372350A5F50068D97B /* TimingDistributionMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingDistributionMetric.swift; sourceTree = "<group>"; };
 		BFFE18392350A61F0068D97B /* TimingDistributionMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingDistributionMetricTests.swift; sourceTree = "<group>"; };
 		BFFE33AA232927C3005348FE /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		C27E756229D4A67800C6AADD /* DataPathUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPathUtilsTests.swift; sourceTree = "<group>"; };
 		CD062128284110970006370D /* TextMetric.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextMetric.swift; sourceTree = "<group>"; };
 		CD0F7CBF26F0F27900EDA6A4 /* UrlMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlMetric.swift; sourceTree = "<group>"; };
 		CD0F7CC126F0F28900EDA6A4 /* UrlMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlMetricTests.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 		BF3DE39E2243A2F20018E23F /* GleanTests */ = {
 			isa = PBXGroup;
 			children = (
+				C27E756429D4B56500C6AADD /* Utils */,
 				60691AEA28DD0BF200BDF31A /* BaselinePingTests.swift */,
 				1F39E7B1239F0741009B13B3 /* Debug */,
 				1FB8F8392326EBA500618E47 /* Config */,
@@ -367,6 +370,14 @@
 				BF80AA5A2399301200A8B172 /* HttpPingUploaderTests.swift */,
 			);
 			name = Net;
+			sourceTree = "<group>";
+		};
+		C27E756429D4B56500C6AADD /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				C27E756229D4A67800C6AADD /* DataPathUtilsTests.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		CDD08C8227E21069007C8400 /* uniffi */ = {
@@ -630,6 +641,7 @@
 				1F6A8FF2233C068A007837D5 /* BooleanMetricTypeTest.swift in Sources */,
 				BFE1CDC6233B6B6D0019EE47 /* LabeledMetricTests.swift in Sources */,
 				BF30FDC6233260C400840607 /* TimespanMetricTests.swift in Sources */,
+				C27E756329D4A67800C6AADD /* DataPathUtilsTests.swift in Sources */,
 				BF80AA5F2399305200A8B172 /* DeletionRequestPingTests.swift in Sources */,
 				BFFE183A2350A61F0068D97B /* TimingDistributionMetricTests.swift in Sources */,
 				BF3DE3A02243A2F20018E23F /* GleanTests.swift in Sources */,

--- a/glean-core/ios/Glean/Config/Configuration.swift
+++ b/glean-core/ios/Glean/Config/Configuration.swift
@@ -8,6 +8,7 @@ public struct Configuration {
     let serverEndpoint: String
     let maxEvents: Int32?
     let channel: String?
+    let dataPath: String?
 
     struct Constants {
         static let defaultTelemetryEndpoint = "https://incoming.telemetry.mozilla.org"
@@ -18,14 +19,19 @@ public struct Configuration {
     /// - parameters:
     ///   * maxEvents the number of events to store before the events ping is sent.
     ///   * channel the release channel the application is on, if known.
-    ///     This will be sent along with all the pings, in the `client_info` section.
+    ///   This will be sent along with all the pings, in the `client_info` section.
+    ///   * serverEndpoint the server endpoint Glean should send data to
+    ///   * dataPath an optional String that specifies where to store data locally on the device.
+    ///   This should ONLY be used when setting up Glean on a non-main process.
     public init(
         maxEvents: Int32? = nil,
         channel: String? = nil,
-        serverEndpoint: String? = nil
+        serverEndpoint: String? = nil,
+        dataPath: String? = nil
     ) {
         self.serverEndpoint = serverEndpoint ?? Constants.defaultTelemetryEndpoint
         self.maxEvents = maxEvents
         self.channel = channel
+        self.dataPath = dataPath
     }
 }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -21,8 +21,7 @@ class OnGleanEventsImpl: OnGleanEvents {
     }
 
     func initializeFinished() {
-        // Only set up the lifecycle observer if we don't provide a custom
-        // data path.
+        // Only set up the lifecycle observer if no dataPath is specified.
         if !self.glean.isCustomDataPath {
             // Run this off the main thread,
             // as it will trigger a ping submission,
@@ -257,7 +256,7 @@ public class Glean {
         gleanSetExperimentInactive(experimentId)
     }
 
-    /// Tests wheter an experiment is active, for testing purposes only.
+    /// Tests whether an experiment is active, for testing purposes only.
     ///
     /// - parameters:
     ///     * experimentId: The id of the experiment to look for.
@@ -381,7 +380,7 @@ public class Glean {
     ///
     /// The structure of the custom URL uses the following format:
     ///
-    /// `<protocol>://glean?<command 1>=<paramter 1>&<command 2>=<parameter 2> ...`
+    /// `<protocol>://glean?<command 1>=<parameter 1>&<command 2>=<parameter 2> ...`
     ///
     /// Where:
     ///
@@ -393,7 +392,7 @@ public class Glean {
     /// There are a few things to consider when creating the custom URL:
     ///
     /// - Invalid commands will trigger an error and be ignored.
-    /// - Not all commands are requred to be encoded in the URL, you can mix and match the commands that you need.
+    /// - Not all commands are required to be encoded in the URL, you can mix and match the commands that you need.
     /// - Special characters should be properly URL encoded and escaped since this needs to represent a valid URL.
     public func handleCustomUrl(url: URL) {
         GleanDebugUtility.handleCustomUrl(url: url)

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -23,7 +23,7 @@ class OnGleanEventsImpl: OnGleanEvents {
     func initializeFinished() {
         // Only set up the lifecycle observer if we don't provide a custom
         // data path.
-        if self.glean.getIsCustomDataPath() != nil && self.glean.getIsCustomDataPath() == false {
+        if !self.glean.isCustomDataPath {
             // Run this off the main thread,
             // as it will trigger a ping submission,
             // which itself will trigger `triggerUpload()` on this class.
@@ -43,7 +43,7 @@ class OnGleanEventsImpl: OnGleanEvents {
     func startMetricsPingScheduler() -> Bool {
         // If we pass a custom data path, the metrics ping schedule should not
         // be setup.
-        if self.glean.getIsCustomDataPath() == true {
+        if self.glean.isCustomDataPath {
             self.glean.metricsPingScheduler = nil
             return false
         }
@@ -92,7 +92,7 @@ public class Glean {
     private var buildInfo: BuildInfo?
     fileprivate var observer: GleanLifecycleObserver?
     private var gleanDataPath: String?
-    private var isCustomDataPath: Bool?
+    var isCustomDataPath: Bool = false
 
     // This struct is used for organizational purposes to keep the class constants in a single place
     struct Constants {
@@ -422,11 +422,6 @@ public class Glean {
         }
 
         return isMainProcess!
-    }
-
-    /// Returns true if the Glean instance is using a custom data path.
-    public func getIsCustomDataPath() -> Bool? {
-        return self.isCustomDataPath
     }
 
     /// Test-only method to destroy the owned glean-core handle.

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -153,14 +153,8 @@ public class Glean {
             self.isCustomDataPath = false
         } else {
             // When the `dataPath` is provided, we need to make sure:
-            //   1. The call happens on the main thread of the non main process.
-            //   2. The database path provided is not `glean_data`.
-            //   3. The database path is valid and writeable.
-
-            if !Thread.isMainThread {
-                logger.error("Attempted to initialize Glean on a thread other than the main thread")
-                return
-            }
+            //   1. The database path provided is not `glean_data`.
+            //   2. The database path is valid and writeable.
 
             if configuration.dataPath == "glean_data" {
                 logger.error("Attempted to initialize Glean with an invalid database path \"glean_data\" is reserved")

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -168,7 +168,7 @@ public class Glean {
             }
 
             // Check that the database path we are trying to write to is valid and writable.
-            if !canWriteToDatabasePath(configuration.dataPath) {
+            if !canWriteToDatabasePath(configuration.dataPath!) {
                 logger.error("Attempted to initialize Glean with an invalid database path")
                 return
             }

--- a/glean-core/ios/Glean/Utils/Utils.swift
+++ b/glean-core/ios/Glean/Utils/Utils.swift
@@ -111,7 +111,7 @@ func generateGleanStoragePath(_ customDataPath: String? = nil) -> URL {
 ///     * customDataPath: An override for manually setting the data directory.
 func canWriteToDatabasePath(_ customDataPath: String) -> Bool {
     // Do not allow empty strings.
-    if customDataPath == "" {
+    if customDataPath.isEmpty {
         return false
     }
 

--- a/glean-core/ios/Glean/Utils/Utils.swift
+++ b/glean-core/ios/Glean/Utils/Utils.swift
@@ -109,9 +109,9 @@ func generateGleanStoragePath(_ customDataPath: String? = nil) -> URL {
 ///
 /// - parameters
 ///     * customDataPath: An override for manually setting the data directory.
-func canWriteToDatabasePath(_ customDataPath: String? = "") -> Bool {
+func canWriteToDatabasePath(_ customDataPath: String) -> Bool {
     // Do not allow empty strings or strings with leading or trailing spaces.
-    if customDataPath == "" || customDataPath!.hasPrefix(" ") || customDataPath!.hasSuffix(" ") {
+    if customDataPath == "" || customDataPath.hasPrefix(" ") || customDataPath.hasSuffix(" ") {
         return false
     }
 

--- a/glean-core/ios/Glean/Utils/Utils.swift
+++ b/glean-core/ios/Glean/Utils/Utils.swift
@@ -84,25 +84,13 @@ extension Date {
     }
 }
 
-/// Creates the path for persistent file storage using a custom data path or
-/// the default path (`glean_data`).
-///
-/// - parameters
-///     * customDataPath: An override for manually setting the data directory.
+/// Helper function to retrieve the application's Application Support directory for persistent file storage.
 ///
 /// - returns: `URL` of the Application Support directory
-func generateGleanStoragePath(_ customDataPath: String? = nil) -> URL {
+func getGleanDirectory() -> URL {
     let paths = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
     let documentsDirectory = paths[0]
-
-    let dataPath: String
-    if customDataPath == nil {
-        dataPath = "glean_data"
-    } else {
-        dataPath = customDataPath!
-    }
-
-    return documentsDirectory.appendingPathComponent(dataPath)
+    return documentsDirectory.appendingPathComponent("glean_data")
 }
 
 /// Check if the data path provided is valid and writable.
@@ -115,12 +103,9 @@ func canWriteToDatabasePath(_ customDataPath: String) -> Bool {
         return false
     }
 
-    // Generate the full path that we want to write to using our custom data path.
-    let fullFilePath = generateGleanStoragePath(customDataPath).path
-
     // If the file exists we need to ensure we can write to it.
-    if FileManager.default.fileExists(atPath: fullFilePath) {
-        if !FileManager.default.isWritableFile(atPath: fullFilePath) {
+    if FileManager.default.fileExists(atPath: customDataPath) {
+        if !FileManager.default.isWritableFile(atPath: customDataPath) {
             return false
         }
     }

--- a/glean-core/ios/Glean/Utils/Utils.swift
+++ b/glean-core/ios/Glean/Utils/Utils.swift
@@ -110,8 +110,8 @@ func generateGleanStoragePath(_ customDataPath: String? = nil) -> URL {
 /// - parameters
 ///     * customDataPath: An override for manually setting the data directory.
 func canWriteToDatabasePath(_ customDataPath: String) -> Bool {
-    // Do not allow empty strings or strings with leading or trailing spaces.
-    if customDataPath == "" || customDataPath.hasPrefix(" ") || customDataPath.hasSuffix(" ") {
+    // Do not allow empty strings.
+    if customDataPath == "" {
         return false
     }
 

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -306,16 +306,14 @@ class GleanTests: XCTestCase {
     }
 
     func testGleanIsCustomDataPathIsSetCorrectly() {
-        // Initialize with a custom data path and ensure `getIsCustomDataPath` is true.
+        // Initialize with a custom data path and ensure `isCustomDataPath` is true.
         Glean.shared.testDestroyGleanHandle()
         Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo(), dataPath: "glean_test")
-        XCTAssertNotNil(Glean.shared.getIsCustomDataPath())
-        XCTAssertTrue(Glean.shared.getIsCustomDataPath()!)
+        XCTAssertTrue(Glean.shared.isCustomDataPath)
 
-        // Initialize without a custom data path and ensure `getIsCustomDataPath` is false.
+        // Initialize without a custom data path and ensure `isCustomDataPath` is false.
         Glean.shared.testDestroyGleanHandle()
         Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo())
-        XCTAssertNotNil(Glean.shared.getIsCustomDataPath())
-        XCTAssertFalse(Glean.shared.getIsCustomDataPath()!)
+        XCTAssertFalse(Glean.shared.isCustomDataPath)
     }
 }

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -299,7 +299,8 @@ class GleanTests: XCTestCase {
         Glean.shared.testDestroyGleanHandle()
 
         // The path provided here is invalid because of the leading and trailing spaces.
-        Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo(), dataPath: " invalid db path ")
+        let cfg = Configuration(dataPath: " invalid db path ")
+        Glean.shared.initialize(uploadEnabled: true, configuration: cfg, buildInfo: stubBuildInfo())
 
         // Since the path is invalid, Glean should not propertly initialize.
         XCTAssertFalse(Glean.shared.isInitialized())
@@ -308,7 +309,8 @@ class GleanTests: XCTestCase {
     func testGleanIsCustomDataPathIsSetCorrectly() {
         // Initialize with a custom data path and ensure `isCustomDataPath` is true.
         Glean.shared.testDestroyGleanHandle()
-        Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo(), dataPath: "glean_test")
+        let cfg = Configuration(dataPath: "glean_test")
+        Glean.shared.initialize(uploadEnabled: true, configuration: cfg, buildInfo: stubBuildInfo())
         XCTAssertTrue(Glean.shared.isCustomDataPath)
 
         // Initialize without a custom data path and ensure `isCustomDataPath` is false.

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -298,8 +298,8 @@ class GleanTests: XCTestCase {
     func testGleanDoesNotInitializeWithInvalidDbPath() {
         Glean.shared.testDestroyGleanHandle()
 
-        // The path provided here is invalid because of the leading and trailing spaces.
-        let cfg = Configuration(dataPath: " invalid db path ")
+        // The path provided here is invalid because it is an empty string.
+        let cfg = Configuration(dataPath: "")
         Glean.shared.initialize(uploadEnabled: true, configuration: cfg, buildInfo: stubBuildInfo())
 
         // Since the path is invalid, Glean should not properly initialize.

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -302,7 +302,7 @@ class GleanTests: XCTestCase {
         let cfg = Configuration(dataPath: " invalid db path ")
         Glean.shared.initialize(uploadEnabled: true, configuration: cfg, buildInfo: stubBuildInfo())
 
-        // Since the path is invalid, Glean should not propertly initialize.
+        // Since the path is invalid, Glean should not properly initialize.
         XCTAssertFalse(Glean.shared.isInitialized())
     }
 

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -294,4 +294,28 @@ class GleanTests: XCTestCase {
             GleanInternalMetrics.buildDate.testGetValue()
         )
     }
+
+    func testGleanDoesNotInitializeWithInvalidDbPath() {
+        Glean.shared.testDestroyGleanHandle()
+
+        // The path provided here is invalid because of the leading and trailing spaces.
+        Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo(), dataPath: " invalid db path ")
+
+        // Since the path is invalid, Glean should not propertly initialize.
+        XCTAssertFalse(Glean.shared.isInitialized())
+    }
+
+    func testGleanIsCustomDataPathIsSetCorrectly() {
+        // Initialize with a custom data path and ensure `getIsCustomDataPath` is true.
+        Glean.shared.testDestroyGleanHandle()
+        Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo(), dataPath: "glean_test")
+        XCTAssertNotNil(Glean.shared.getIsCustomDataPath())
+        XCTAssertTrue(Glean.shared.getIsCustomDataPath()!)
+
+        // Initialize without a custom data path and ensure `getIsCustomDataPath` is false.
+        Glean.shared.testDestroyGleanHandle()
+        Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo())
+        XCTAssertNotNil(Glean.shared.getIsCustomDataPath())
+        XCTAssertFalse(Glean.shared.getIsCustomDataPath()!)
+    }
 }

--- a/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
+++ b/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
@@ -113,7 +113,7 @@ class DeletionRequestPingTests: XCTestCase {
         glean.enableTestingMode()
 
         // Create directory for pending deletion-request pings
-        let pendingDeletionRequestDir = generateGleanStoragePath().appendingPathComponent("deletion_request")
+        let pendingDeletionRequestDir = getGleanDirectory().appendingPathComponent("deletion_request")
         try! FileManager.default.createDirectory(
             atPath: pendingDeletionRequestDir.path,
             withIntermediateDirectories: true,

--- a/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
+++ b/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
@@ -113,7 +113,7 @@ class DeletionRequestPingTests: XCTestCase {
         glean.enableTestingMode()
 
         // Create directory for pending deletion-request pings
-        let pendingDeletionRequestDir = getGleanDirectory().appendingPathComponent("deletion_request")
+        let pendingDeletionRequestDir = generateGleanStoragePath().appendingPathComponent("deletion_request")
         try! FileManager.default.createDirectory(
             atPath: pendingDeletionRequestDir.path,
             withIntermediateDirectories: true,

--- a/glean-core/ios/GleanTests/Utils/DataPathUtilsTests.swift
+++ b/glean-core/ios/GleanTests/Utils/DataPathUtilsTests.swift
@@ -10,19 +10,15 @@ class DataPathMetricTests: XCTestCase {
         resetGleanDiscardingInitialPings(testCase: self, tag: "PingTests")
     }
 
-    func testCanWriteToDatabasePathInvalidPath() {
+    func testCannotWriteToInvalidDatabasePath() {
         let customDataPath = ""
         XCTAssertFalse(canWriteToDatabasePath(customDataPath))
     }
 
-    func testCanWriteToDatabasePathValidPath() {
-        let customDataPath = "valid_db_path"
-        XCTAssertTrue(canWriteToDatabasePath(customDataPath))
-    }
-
-    func testGenerateGleanStoragePathHasCorrectSlug() {
-        let customDataPath = "test_glean_data"
-        let url = generateGleanStoragePath(customDataPath)
-        XCTAssertEqual(customDataPath, url.lastPathComponent)
+    func testCanWriteToValidDatabasePath() {
+        let paths = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        let documentsDirectory = paths[0]
+        let dataPath = documentsDirectory.appendingPathComponent("valid_db_path").relativePath
+        XCTAssertTrue(canWriteToDatabasePath(dataPath))
     }
 }

--- a/glean-core/ios/GleanTests/Utils/DataPathUtilsTests.swift
+++ b/glean-core/ios/GleanTests/Utils/DataPathUtilsTests.swift
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Glean
+import XCTest
+
+class DataPathMetricTests: XCTestCase {
+    override func setUp() {
+        resetGleanDiscardingInitialPings(testCase: self, tag: "PingTests")
+    }
+
+    func testCanWriteToDatabasePathInvalidPath() {
+        let customDataPath = " invalid db path "
+        XCTAssertFalse(canWriteToDatabasePath(customDataPath))
+    }
+
+    func testCanWriteToDatabasePathValidPath() {
+        let customDataPath = "valid_db_path"
+        XCTAssertTrue(canWriteToDatabasePath(customDataPath))
+    }
+
+    func testGenerateGleanStoragePathHasCorrectSlug() {
+        let customDataPath = "test_glean_data"
+        let url = generateGleanStoragePath(customDataPath)
+        XCTAssertEqual(customDataPath, url.lastPathComponent)
+    }
+}

--- a/glean-core/ios/GleanTests/Utils/DataPathUtilsTests.swift
+++ b/glean-core/ios/GleanTests/Utils/DataPathUtilsTests.swift
@@ -11,7 +11,7 @@ class DataPathMetricTests: XCTestCase {
     }
 
     func testCanWriteToDatabasePathInvalidPath() {
-        let customDataPath = " invalid db path "
+        let customDataPath = ""
         XCTAssertFalse(canWriteToDatabasePath(customDataPath))
     }
 


### PR DESCRIPTION
For both iOS and Android we add a new parameter to `initialize` to let the user specify the specific data path they want to write to. When the user registers a custom data path, the app lifecycle observers are not setup.

