### PR TITLE
Bug 1811253 - Invert remote metric config logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * General
   * On Rkv detecting a corrupted database delete the old RKV, create a new one and log the error ([#2425](https://github.com/mozilla/glean/pull/2425))
   * Add the Date header as late as possible before the uploader acts ([#2436](https://github.com/mozilla/glean/pull/2436))
+  * The logic of the Server Knobs API has been flipped. Instead of applying a list of metrics and their _disabled_ state, the API now accepts a list of metrics and their _enabled_ state ([bug 1811253](https://bugzilla.mozilla.org/show_bug.cgi?id=1811253))
 * Kotlin
   * Adds the ability to record metrics on a non-main process. This is enabled by setting a `dataPath` in the Glean configuration ([bug 1815233](https://bugzilla.mozilla.org/show_bug.cgi?id=1815233))
 * iOS

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -439,13 +439,15 @@ open class GleanInternalAPI internal constructor() {
     }
 
     /**
-     * Set configuration for metrics' disabled property, typically from a remote_settings
+     * [DEPRECATED] Set configuration for metrics' disabled property, typically from a remote_settings
      * experiment or rollout.
      *
      * @param json Stringified JSON map of metrics and their associated `disabled` property.
      */
+     @DEPRECATED
     fun setMetricsDisabledConfig(json: String) {
-        // Stub intentionally left empty to avoid breaking changes
+        // Let's convert this to the new API for backwards compatibility
+        val jsonData: JSON = JSONObject(json)
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -447,6 +447,11 @@ open class GleanInternalAPI internal constructor() {
      */
     fun setMetricsDisabledConfig(json: String) {
         // Let's convert this to the new API for backwards compatibility
+        // In order to convert to the new API we need to flip all of the boolean values that
+        // are contained in the map contained in the supplied JSON string. We do this by
+        // parsing the string and then iterating through the keys to create a new object with
+        // the boolean values inverted. Finally, we turn this back into a string to pass into
+        // the `setMetricsEnabledConfig` function.
         val jsonData = JSONObject(json)
         var invertedJsonData = JSONObject()
         jsonData.keys().forEach {

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -25,6 +25,7 @@ import mozilla.telemetry.glean.utils.ThreadUtils
 import mozilla.telemetry.glean.utils.calendarToDatetime
 import mozilla.telemetry.glean.utils.canWriteToDatabasePath
 import mozilla.telemetry.glean.utils.getLocaleTag
+import org.json.JSONObject
 import java.io.File
 import java.util.Calendar
 
@@ -439,15 +440,19 @@ open class GleanInternalAPI internal constructor() {
     }
 
     /**
-     * [DEPRECATED] Set configuration for metrics' disabled property, typically from a remote_settings
+     * Set configuration for metrics' disabled property, typically from a remote_settings
      * experiment or rollout.
      *
      * @param json Stringified JSON map of metrics and their associated `disabled` property.
      */
-     @DEPRECATED
     fun setMetricsDisabledConfig(json: String) {
         // Let's convert this to the new API for backwards compatibility
-        val jsonData: JSON = JSONObject(json)
+        val jsonData = JSONObject(json)
+        var invertedJsonData = JSONObject()
+        jsonData.keys().forEach {
+            invertedJsonData.put(it, !jsonData.getBoolean(it))
+        }
+        setMetricsEnabledConfig(invertedJsonData.toString())
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -445,7 +445,17 @@ open class GleanInternalAPI internal constructor() {
      * @param json Stringified JSON map of metrics and their associated `disabled` property.
      */
     fun setMetricsDisabledConfig(json: String) {
-        gleanSetMetricsDisabledConfig(json)
+        // Stub intentionally left empty to avoid breaking changes
+    }
+
+    /**
+     * Set configuration to override metrics' enabled/disabled state, typically from a remote_settings
+     * experiment or rollout.
+     *
+     * @param json Stringified JSON map of metrics and their associated `disabled` property.
+     */
+    fun setMetricsEnabledConfig(json: String) {
+        gleanSetMetricsEnabledConfig(json)
     }
 
     /**

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -358,7 +358,17 @@ public class Glean {
     /// - parameters:
     ///    * json: Stringified JSON map of metrics and their associated `disabled` property.
     public func setMetricsDisabledConfig(_ json: String) {
-        gleanSetMetricsDisabledConfig(json)
+        // Stubbed on purpose to prevent breaking changes
+    }
+
+    /// Set configuration to override metrics' default enabled/disabled state, typically from
+    /// a remote_settings experiment or rollout.
+    ///
+    /// - parameters:
+    ///    * json: Stringified JSON map of metric identifiers (category.name) to a boolean
+    ///            representing wether they are enabled
+    public func setMetricsEnabledConfig(_ json: String) {
+        gleanSetMetricsEnabledConfig(json)
     }
 
     /// When applications are launched using the custom URL scheme, this helper function will process

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -358,7 +358,24 @@ public class Glean {
     /// - parameters:
     ///    * json: Stringified JSON map of metrics and their associated `disabled` property.
     public func setMetricsDisabledConfig(_ json: String) {
-        // Stubbed on purpose to prevent breaking changes
+        // Let's convert this to the new API for backwards compatibility
+        if let jsonData = json.data(using: .utf8, allowLossyConversion: false) {
+            if let json = try? JSONSerialization.jsonObject(with: jsonData) {
+                if let jsonDict = json as? [String: Bool] {
+                    var newDict = [String: Bool]()
+                    jsonDict.forEach { k, v in
+                        newDict[k] = !v
+                    }
+                    if let newJsonData = try? JSONSerialization.data(
+                        withJSONObject: jsonDict,
+                        options: []) {
+                        if let newJsonString = String(data: newJsonData, encoding: .utf8) {
+                            setMetricsEnabledConfig(newJsonString)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Set configuration to override metrics' default enabled/disabled state, typically from

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -359,6 +359,11 @@ public class Glean {
     ///    * json: Stringified JSON map of metrics and their associated `disabled` property.
     public func setMetricsDisabledConfig(_ json: String) {
         // Let's convert this to the new API for backwards compatibility
+        // In order to convert to the new API we need to flip all of the boolean values that
+        // are contained in the map contained in the supplied JSON string. We do this by
+        // parsing the string and then iterating through the keys to create a new object with
+        // the boolean values inverted. Finally, we turn this back into a string to pass into
+        // the `setMetricsEnabledConfig` function.
         if let jsonData = json.data(using: .utf8, allowLossyConversion: false) {
             if let json = try? JSONSerialization.jsonObject(with: jsonData) {
                 if let jsonDict = json as? [String: Bool] {

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -270,6 +270,55 @@ class GleanTests: XCTestCase {
         }
     }
 
+    func testSettingRemoteMetricConfiguration() {
+        let counter = CounterMetricType(CommonMetricData(
+            category: "telemetry",
+            name: "counter_metric",
+            sendInPings: ["custom"],
+            lifetime: .application,
+            disabled: true
+        ))
+
+        // Set a metric configuration that enables telemetry.counter_metric
+        let metricConfigStringifiedJson =
+"""
+{
+  "telemetry.counter_metric": true
+}
+"""
+        Glean.shared.setMetricsEnabledConfig(metricConfigStringifiedJson)
+
+        // Attempt to add to the counter, this should succeed.
+        counter.add(1)
+        if let value = counter.testGetValue() {
+            XCTAssertEqual(1, value)
+        } else {
+            XCTAssert(false, "Failed to set metric config to enable counter")
+        }
+
+        // Set a metric configuration that disables the telemetry.counter_metric
+        // again, this time using the old API to ensure backwards compatibility.
+        // The old API was inverted and mapped directly to the metrics.yaml property
+        // for each metric named 'disabled'. So in this case `true` means the metric
+        // is disabled.
+        let metricConfigBackwardsCompatible =
+"""
+{
+  "telemetry.counter_metric": false
+}
+"""
+        Glean.shared.setMetricsDisabledConfig(metricConfigBackwardsCompatible)
+
+        // Attempt to add to the counter, this should not record so the value should
+        // remain at 1
+        counter.add(1)
+        if let value = counter.testGetValue() {
+            XCTAssertEqual(1, value)
+        } else {
+            XCTAssert(false, "Failed to set metric config to enable counter")
+        }
+    }
+
     func testForegroundCounter() {
         // Glean is started by the test framework.
         // That already triggers the first foreground event.

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -170,9 +170,9 @@ pub fn set_experiment_inactive(experiment_id: String) {
 
 /// Set the remote configuration values for the metrics' disabled property
 ///
-/// See [`glean_core::Glean::set_metrics_disabled_config`].
-pub fn glean_set_metrics_disabled_config(json: String) {
-    glean_core::glean_set_metrics_disabled_config(json)
+/// See [`glean_core::Glean::set_metrics_enabled_config`].
+pub fn glean_set_metrics_enabled_config(json: String) {
+    glean_core::glean_set_metrics_enabled_config(json)
 }
 
 /// Performs the collection/cleanup operations required by becoming active.

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -12,7 +12,7 @@ use crate::event_database::EventDatabase;
 use crate::internal_metrics::{AdditionalMetrics, CoreMetrics, DatabaseMetrics};
 use crate::internal_pings::InternalPings;
 use crate::metrics::{
-    self, ExperimentMetric, Metric, MetricType, MetricsDisabledConfig, PingType, RecordedExperiment,
+    self, ExperimentMetric, Metric, MetricType, MetricsEnabledConfig, PingType, RecordedExperiment,
 };
 use crate::ping::PingMaker;
 use crate::storage::{StorageManager, INTERNAL_STORAGE};
@@ -153,7 +153,7 @@ pub struct Glean {
     pub(crate) app_build: String,
     pub(crate) schedule_metrics_pings: bool,
     pub(crate) remote_settings_epoch: AtomicU8,
-    pub(crate) remote_settings_metrics_config: Arc<Mutex<MetricsDisabledConfig>>,
+    pub(crate) remote_settings_metrics_config: Arc<Mutex<MetricsEnabledConfig>>,
 }
 
 impl Glean {
@@ -207,7 +207,7 @@ impl Glean {
             // Subprocess doesn't use "metrics" pings so has no need for a scheduler.
             schedule_metrics_pings: false,
             remote_settings_epoch: AtomicU8::new(0),
-            remote_settings_metrics_config: Arc::new(Mutex::new(MetricsDisabledConfig::new())),
+            remote_settings_metrics_config: Arc::new(Mutex::new(MetricsEnabledConfig::new())),
         };
 
         // Ensuring these pings are registered.
@@ -703,14 +703,14 @@ impl Glean {
         metric.test_get_value(self)
     }
 
-    /// Set configuration for metrics' disabled property, typically from a remote_settings experiment
-    /// or rollout
+    /// Set configuration to override the default metric enabled/disabled state, typically from a
+    /// remote_settings experiment or rollout
     ///
     /// # Arguments
     ///
-    /// * `json` - The stringified JSON representation of a `MetricsDisabledConfig` object
-    pub fn set_metrics_disabled_config(&self, cfg: MetricsDisabledConfig) {
-        // Set the current MetricsDisabledConfig, keeping the lock until the epoch is
+    /// * `json` - The stringified JSON representation of a `MetricsEnabledConfig` object
+    pub fn set_metrics_enabled_config(&self, cfg: MetricsEnabledConfig) {
+        // Set the current MetricsEnabledConfig, keeping the lock until the epoch is
         // updated to prevent against reading a "new" config but an "old" epoch
         let mut lock = self.remote_settings_metrics_config.lock().unwrap();
         *lock = cfg;

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -30,7 +30,7 @@ namespace glean {
     RecordedExperiment? glean_test_get_experiment_data(string experiment_id);
 
     // Server Knobs API
-    void glean_set_metrics_disabled_config(string json);
+    void glean_set_metrics_enabled_config(string json);
 
     boolean glean_set_debug_view_tag(string tag);
     boolean glean_set_source_tags(sequence<string> tags);

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -28,7 +28,7 @@ use crossbeam_channel::unbounded;
 use once_cell::sync::{Lazy, OnceCell};
 use uuid::Uuid;
 
-use metrics::MetricsDisabledConfig;
+use metrics::MetricsEnabledConfig;
 
 mod common_metric_data;
 mod core;
@@ -773,13 +773,14 @@ pub fn glean_test_get_experiment_data(experiment_id: String) -> Option<RecordedE
     core::with_glean(|glean| glean.test_get_experiment_data(experiment_id.to_owned()))
 }
 
-/// Sets a remote configuration for the metrics' disabled property
+/// Sets a remote configuration to override metrics' default enabled/disabled
+/// state
 ///
-/// See [`core::Glean::set_metrics_disabled_config`].
-pub fn glean_set_metrics_disabled_config(json: String) {
-    match MetricsDisabledConfig::try_from(json) {
+/// See [`core::Glean::set_metrics_enabled_config`].
+pub fn glean_set_metrics_enabled_config(json: String) {
+    match MetricsEnabledConfig::try_from(json) {
         Ok(cfg) => launch_with_glean(|glean| {
-            glean.set_metrics_disabled_config(cfg);
+            glean.set_metrics_enabled_config(cfg);
         }),
         Err(e) => {
             log::error!("Error setting metrics feature config: {:?}", e);

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -852,15 +852,15 @@ fn test_set_metrics_disabled() {
     );
 
     // 2. Set a configuration to disable the metrics
-    let mut metrics_disabled_config = json!(
+    let mut metrics_enabled_config = json!(
         {
-            "category.string_metric": true,
-            "category.labeled_string_metric": true,
+            "category.string_metric": false,
+            "category.labeled_string_metric": false,
         }
     )
     .to_string();
-    glean.set_metrics_disabled_config(
-        MetricsDisabledConfig::try_from(metrics_disabled_config).unwrap(),
+    glean.set_metrics_enabled_config(
+        MetricsEnabledConfig::try_from(metrics_enabled_config).unwrap(),
     );
 
     // 3. Since the metrics were disabled, setting a new value will be ignored
@@ -883,9 +883,9 @@ fn test_set_metrics_disabled() {
     );
 
     // 4. Set a new configuration where the metrics are enabled
-    metrics_disabled_config = json!({}).to_string();
-    glean.set_metrics_disabled_config(
-        MetricsDisabledConfig::try_from(metrics_disabled_config).unwrap(),
+    metrics_enabled_config = json!({}).to_string();
+    glean.set_metrics_enabled_config(
+        MetricsEnabledConfig::try_from(metrics_enabled_config).unwrap(),
     );
 
     // 5. Since the metrics are now enabled, setting a new value should work
@@ -917,14 +917,14 @@ fn test_remote_settings_epoch() {
     assert_eq!(0u8, current_epoch, "Current epoch must start at 0");
 
     // 2. Set a configuration which will trigger incrementing the epoch
-    let metrics_disabled_config = json!(
+    let metrics_enabled_config = json!(
         {
-            "category.string_metric": true
+            "category.string_metric": false
         }
     )
     .to_string();
-    glean.set_metrics_disabled_config(
-        MetricsDisabledConfig::try_from(metrics_disabled_config).unwrap(),
+    glean.set_metrics_enabled_config(
+        MetricsEnabledConfig::try_from(metrics_enabled_config).unwrap(),
     );
 
     // 3. Ensure the epoch updated
@@ -951,14 +951,14 @@ fn test_remote_settings_epoch_updates_in_metric() {
     );
 
     // 2. Set a configuration to disable the `category.string_metric`
-    let metrics_disabled_config = json!(
+    let metrics_enabled_config = json!(
         {
-            "category.string_metric": true
+            "category.string_metric": false
         }
     )
     .to_string();
-    glean.set_metrics_disabled_config(
-        MetricsDisabledConfig::try_from(metrics_disabled_config).unwrap(),
+    glean.set_metrics_enabled_config(
+        MetricsEnabledConfig::try_from(metrics_enabled_config).unwrap(),
     );
 
     // 3. Ensure the epoch was updated

--- a/glean-core/src/metrics/metrics_enabled_config.rs
+++ b/glean-core/src/metrics/metrics_enabled_config.rs
@@ -6,31 +6,35 @@ use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-/// Represents a list of metrics and their associated `disabled` property from the
-/// remote-settings configuration store. The expected format of this data is stringified
-/// JSON in the following format:
+/// Represents a list of metrics and an associated boolean property
+/// indicating if the metric is enabledfrom the remote-settings
+/// configuration store. The expected format of this data is stringified JSON
+/// in the following format:
 /// ```json
 /// {
 ///     "category.metric_name": true
 /// }
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct MetricsDisabledConfig {
+pub struct MetricsEnabledConfig {
     /// This is a `HashMap` consisting of base_identifiers as keys
     /// and bool values representing an override for the `disabled`
-    /// property of the metric
+    /// property of the metric, only inverted to reduce confusion.
+    /// If a particular metric has a value of `true` here, it means
+    /// the default of the metric will be overriden and set to the
+    /// enabled state.
     #[serde(flatten)]
-    pub metrics_disabled: HashMap<String, bool>,
+    pub metrics_enabled: HashMap<String, bool>,
 }
 
-impl MetricsDisabledConfig {
-    /// Creates a new MetricsDisabledConfig
+impl MetricsEnabledConfig {
+    /// Creates a new MetricsEnabledConfig
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-impl TryFrom<String> for MetricsDisabledConfig {
+impl TryFrom<String> for MetricsEnabledConfig {
     type Error = crate::ErrorKind;
 
     fn try_from(json: String) -> Result<Self, Self::Error> {


### PR DESCRIPTION
This is in order to simplify the understanding of how the API works to a more natural form.