### PR TITLE
Bug 1826132 - CI: Switch to gen2 macos builders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,6 +479,7 @@ jobs:
   Check Swift formatting:
     macos:
       xcode: "14.0"
+    resource_class: "macos.x86.medium.gen2"
     steps:
       - checkout
       - run:
@@ -497,6 +498,7 @@ jobs:
   iOS build and test:
     macos:
       xcode: "13.4.1"
+    resource_class: "macos.x86.medium.gen2"
     steps:
       - checkout
       - run:
@@ -603,6 +605,7 @@ jobs:
   iOS integration test:
     macos:
       xcode: "13.4.1"
+    resource_class: "macos.x86.medium.gen2"
     steps:
       - checkout
       - skip-if-doc-only
@@ -660,6 +663,7 @@ jobs:
   iOS Framework release:
     macos:
       xcode: "13.4.1"
+    resource_class: "macos.x86.medium.gen2"
     steps:
       - checkout
       - attach_workspace:
@@ -901,6 +905,7 @@ jobs:
   pypi-macos-release:
     macos:
       xcode: "13.4.1"
+    resource_class: "macos.x86.medium.gen2"
     steps:
       - install-rustup
       - setup-rust-toolchain


### PR DESCRIPTION
The default, `medium`, is gen1 and will be deprecated completely in October.

---

Let's try this out and see how much faster it is.