### PR TITLE
Bug 1828528 - add TextMetric entry to private mod.rs

### DIFF
--- a/glean-core/rlb/src/private/mod.rs
+++ b/glean-core/rlb/src/private/mod.rs
@@ -19,6 +19,7 @@ pub use glean_core::RateMetric;
 pub use glean_core::RecordedExperiment;
 pub use glean_core::StringListMetric;
 pub use glean_core::StringMetric;
+pub use glean_core::TextMetric;
 pub use glean_core::TimespanMetric;
 pub use glean_core::TimingDistributionMetric;
 pub use glean_core::UrlMetric;


### PR DESCRIPTION
I added a test just to make sure the private version of TextMetric was being used. 

Do we have a canonical string for long entries? I'm not sure movie quotes are appropriate here