### PR TITLE
Apply clippy lint: Avoid potential infinite loop

### DIFF
--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -238,7 +238,7 @@ impl EventDatabase {
                 db.insert(
                     store_name,
                     file.lines()
-                        .filter_map(|line| line.ok())
+                        .map_while(Result::ok)
                         .filter_map(|line| serde_json::from_str::<StoredEvent>(&line).ok())
                         .collect(),
                 );


### PR DESCRIPTION
Detailed explanation in https://rust-lang.github.io/rust-clippy/master/index.html#lines_filter_map_ok We're unlikely to hit this, because `entry` is a file and thus continued read errors are unlikely.
But better be safe than sorry.