### PR TITLE
Bug 1830937 - Make `setLogPings` and `setDebugViewTag` public for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Allow user to configure how verbose the internal logging is ([#2459](https://github.com/mozilla/glean/pull/2459))
 * Kotlin
   * Update Kotlin to version 1.8.21 ([#2462](https://github.com/mozilla/glean/pull/2462))
+  * Make debugging APIs available on Android ([Bug 1830937](https://bugzilla.mozilla.org/show_bug.cgi?id=1830937))
 
 # v52.6.0 (2023-04-20)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -422,7 +422,7 @@ open class GleanInternalAPI internal constructor() {
      *
      * @param value The value of the tag, which must be a valid HTTP header value.
      */
-    internal fun setDebugViewTag(value: String): Boolean {
+    fun setDebugViewTag(value: String): Boolean {
         return gleanSetDebugViewTag(value)
     }
 
@@ -479,7 +479,7 @@ open class GleanInternalAPI internal constructor() {
      *
      * @param value The value of the option.
      */
-    internal fun setLogPings(value: Boolean) {
+    fun setLogPings(value: Boolean) {
         gleanSetLogPings(value)
     }
 


### PR DESCRIPTION
This changes `setLogPings` and `setDebugViewTag` from internal to public access. This _doesn't_ make `sendPingsByName` public as that API is a bit trickier to use directly.