### PR TITLE
Bug 1829745 - Expose accumulate samples APIs for TimingDistribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.7.0...main)
 
+* Rust
+  * Timing distribution traits now expose `accumulate_samples` and `accumulate_raw_samples_nanos`. This is a breaking change for consumers that make use of the trait as they will need to implement the new functions ([Bug 1829745](https://bugzilla.mozilla.org/show_bug.cgi?id=1829745))
+
 # v52.7.0 (2023-05-10)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.6.0...v52.7.0)

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -43,6 +43,41 @@ pub trait TimingDistribution {
     ///   same timing distribution metric.
     fn cancel(&self, id: TimerId);
 
+    /// Accumulates the provided signed samples in the metric.
+    ///
+    /// This is required so that the platform-specific code can provide us with
+    /// 64 bit signed integers if no `u64` comparable type is available. This
+    /// will take care of filtering and reporting errors for any provided negative
+    /// sample.
+    ///
+    /// Please note that this assumes that the provided samples are already in
+    /// the "unit" declared by the instance of the metric type (e.g. if the
+    /// instance this method was called on is using [`crate::TimeUnit::Second`], then
+    /// `samples` are assumed to be in that unit).
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - The vector holding the samples to be recorded by the metric.
+    ///
+    /// ## Notes
+    ///
+    /// Discards any negative value in `samples` and report an [`ErrorType::InvalidValue`]
+    /// for each of them. Reports an [`ErrorType::InvalidOverflow`] error for samples that
+    /// are longer than `MAX_SAMPLE_TIME`.
+    fn accumulate_samples(&self, samples: Vec<i64>);
+
+    /// Accumulates the provided samples in the metric.
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - A list of samples recorded by the metric.
+    ///               Samples must be in nanoseconds.
+    /// ## Notes
+    ///
+    /// Reports an [`ErrorType::InvalidOverflow`] error for samples that
+    /// are longer than `MAX_SAMPLE_TIME`.
+    fn accumulate_raw_samples_nanos(&self, samples: Vec<u64>);
+
     /// **Exported for test purposes.**
     ///
     /// Gets the currently stored value of the metric.


### PR DESCRIPTION
This exposes `accumulate_samples` and `accumulate_raw_samples_nanos` in the TimingDistribution traits