### PR TITLE
Proposal: Make Glean Swift logs public by default

### DIFF
--- a/glean-core/ios/Glean/Utils/Logger.swift
+++ b/glean-core/ios/Glean/Utils/Logger.swift
@@ -49,6 +49,6 @@ class Logger {
     ///     * message: The message to log
     ///     * level: The `LogLevel` at which to output the message
     private func log(_ message: String, type: OSLogType) {
-        os_log("%@", log: self.log, type: type, message)
+        os_log("%{public}@", log: self.log, type: type, message)
     }
 }


### PR DESCRIPTION
Ok so, when I try to see Glean logs from an iOS device using `log` I just get `<private>` for all Glean messages. According to [this Stack Overflow](https://stackoverflow.com/questions/45908875/apple-iphone-debugging-with-console-private) that is because all dynamic strings are by default private. I made this change locally and I can now see the messages, would it be possible to get this merged? Thanks!