### PR TITLE
Proposal: Make Swift debug APIs public as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Rust
   * Timing distribution traits now expose `accumulate_samples` and `accumulate_raw_samples_nanos`. This is a breaking change for consumers that make use of the trait as they will need to implement the new functions ([Bug 1829745](https://bugzilla.mozilla.org/show_bug.cgi?id=1829745))
+* Swift
+  * Make debugging APIs available on Swift ([#2470](https://github.com/mozilla/glean/pull/2470))
 
 # v52.7.0 (2023-05-10)
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -328,7 +328,7 @@ public class Glean {
     ///
     /// - parameters:
     ///     * value: The value of the tag, which must be a valid HTTP header value.
-    func setDebugViewTag(_ tag: String) -> Bool {
+    public func setDebugViewTag(_ tag: String) -> Bool {
         return gleanSetDebugViewTag(tag)
     }
 
@@ -337,7 +337,7 @@ public class Glean {
     ///
     /// - parameters:
     ///     * value: The value of the option.
-    func setLogPings(_ value: Bool) {
+    public func setLogPings(_ value: Bool) {
         gleanSetLogPings(value)
     }
 


### PR DESCRIPTION
I forgot to ask for Swift changes on https://bugzilla.mozilla.org/show_bug.cgi?id=1830937. Can we get this change as well? 🥺