### PR TITLE
Bug 1833381 - Add configuration merging for remote metric configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.7.0...main)
 
+* General
+  * The ability to merge remote metric configurations has been added. This will enable better sharing of Server Knobs between experiments and rollouts running at the same time. ([Bug 1833381](https://bugzilla.mozilla.org/show_bug.cgi?id=1833381))
 * Rust
   * Timing distribution traits now expose `accumulate_samples` and `accumulate_raw_samples_nanos`. This is a breaking change for consumers that make use of the trait as they will need to implement the new functions ([Bug 1829745](https://bugzilla.mozilla.org/show_bug.cgi?id=1829745))
 * Swift

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -458,7 +458,7 @@ open class GleanInternalAPI internal constructor() {
         jsonData.keys().forEach {
             invertedJsonData.put(it, !jsonData.getBoolean(it))
         }
-        setMetricsEnabledConfig(invertedJsonData.toString())
+        setMetricsEnabledConfig("glean", invertedJsonData.toString())
     }
 
     /**
@@ -467,8 +467,8 @@ open class GleanInternalAPI internal constructor() {
      *
      * @param json Stringified JSON map of metrics and their associated `disabled` property.
      */
-    fun setMetricsEnabledConfig(json: String) {
-        gleanSetMetricsEnabledConfig(json)
+    fun setMetricsEnabledConfig(featureId: String, json: String) {
+        gleanSetMetricsEnabledConfig(featureId, json)
     }
 
     /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -974,7 +974,7 @@ class GleanTest {
               "telemetry.string_metric": true
             }
         """.trimIndent()
-        Glean.setMetricsEnabledConfig(metricConfig)
+        Glean.setMetricsEnabledConfig("glean", metricConfig)
 
         // This should result in the metric being set to "foo"
         stringMetric.set("foo")

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -376,7 +376,7 @@ public class Glean {
                         withJSONObject: jsonDict,
                         options: []) {
                         if let newJsonString = String(data: newJsonData, encoding: .utf8) {
-                            setMetricsEnabledConfig(newJsonString)
+                            setMetricsEnabledConfig("glean", json: newJsonString)
                         }
                     }
                 }
@@ -390,8 +390,8 @@ public class Glean {
     /// - parameters:
     ///    * json: Stringified JSON map of metric identifiers (category.name) to a boolean
     ///            representing wether they are enabled
-    public func setMetricsEnabledConfig(_ json: String) {
-        gleanSetMetricsEnabledConfig(json)
+    public func setMetricsEnabledConfig(_ featureId: String, json: String) {
+        gleanSetMetricsEnabledConfig(featureId, json)
     }
 
     /// When applications are launched using the custom URL scheme, this helper function will process

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -286,7 +286,7 @@ class GleanTests: XCTestCase {
   "telemetry.counter_metric": true
 }
 """
-        Glean.shared.setMetricsEnabledConfig(metricConfigStringifiedJson)
+        Glean.shared.setMetricsEnabledConfig("glean", json: metricConfigStringifiedJson)
 
         // Attempt to add to the counter, this should succeed.
         counter.add(1)

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -172,8 +172,8 @@ pub fn set_experiment_inactive(experiment_id: String) {
 /// Set the remote configuration values for the metrics' disabled property
 ///
 /// See [`glean_core::Glean::set_metrics_enabled_config`].
-pub fn glean_set_metrics_enabled_config(json: String) {
-    glean_core::glean_set_metrics_enabled_config(json)
+pub fn glean_set_metrics_enabled_config(feature_id: String, json: String) {
+    glean_core::glean_set_metrics_enabled_config(feature_id, json)
 }
 
 /// Performs the collection/cleanup operations required by becoming active.

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -30,7 +30,7 @@ namespace glean {
     RecordedExperiment? glean_test_get_experiment_data(string experiment_id);
 
     // Server Knobs API
-    void glean_set_metrics_enabled_config(string json);
+    void glean_set_metrics_enabled_config(string feature_id, string json);
 
     boolean glean_set_debug_view_tag(string tag);
     boolean glean_set_source_tags(sequence<string> tags);

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -808,10 +808,10 @@ pub fn glean_test_get_experiment_data(experiment_id: String) -> Option<RecordedE
 /// state
 ///
 /// See [`core::Glean::set_metrics_enabled_config`].
-pub fn glean_set_metrics_enabled_config(json: String) {
+pub fn glean_set_metrics_enabled_config(feature_id: String, json: String) {
     match MetricsEnabledConfig::try_from(json) {
         Ok(cfg) => launch_with_glean(|glean| {
-            glean.set_metrics_enabled_config(cfg);
+            glean.set_metrics_enabled_config(feature_id, cfg);
         }),
         Err(e) => {
             log::error!("Error setting metrics feature config: {:?}", e);

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -69,7 +69,9 @@ pub use self::uuid::UuidMetric;
 pub use crate::histogram::HistogramType;
 pub use recorded_experiment::RecordedExperiment;
 
-pub use self::server_knobs::{FeatureMetricConfiguration, MetricsEnabledConfig};
+pub use self::server_knobs::{
+    FeatureConfigurationMap, FeatureMetricConfiguration, MetricsEnabledConfig,
+};
 
 /// A snapshot of all buckets and the accumulated sum of a distribution.
 //

--- a/glean-core/src/metrics/server_knobs.rs
+++ b/glean-core/src/metrics/server_knobs.rs
@@ -2,9 +2,25 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::{collections::HashMap, convert::TryFrom};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    sync::{atomic::AtomicU8, Arc, Mutex},
+};
 
 use serde::{Deserialize, Serialize};
+
+/// Represents a remote feature configuration and an "epoch" used to determine
+/// if the locally cached copy of the configuration is stale.
+#[derive(Debug)]
+pub struct FeatureMetricConfiguration {
+    /// An "epoch" used as a sequence number to ensure that the configuration
+    /// being applied is current.
+    pub epoch: AtomicU8,
+    /// The remote configuration that will be applied to the metrics for a given
+    /// feature_id.
+    pub config: Arc<Mutex<MetricsEnabledConfig>>,
+}
 
 /// Represents a list of metrics and an associated boolean property
 /// indicating if the metric is enabledfrom the remote-settings
@@ -17,7 +33,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MetricsEnabledConfig {
-    /// This is a `HashMap` consisting of base_identifiers as keys
+    /// This is a `HashMap` consisting of identifiers as keys
     /// and bool values representing an override for the `disabled`
     /// property of the metric, only inverted to reduce confusion.
     /// If a particular metric has a value of `true` here, it means

--- a/glean-core/src/metrics/server_knobs.rs
+++ b/glean-core/src/metrics/server_knobs.rs
@@ -10,6 +10,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+/// Represents a map of "feature-id" strings as keys to values that are of type
+/// [`FeatureMetricConfiguration`]
+pub type FeatureConfigurationMap = HashMap<String, FeatureMetricConfiguration>;
+
 /// Represents a remote feature configuration and an "epoch" used to determine
 /// if the locally cached copy of the configuration is stale.
 #[derive(Debug)]


### PR DESCRIPTION
This adds the ability to merge remote metric configurations by "feature-ids", which are used by Nimbus to identify a feature. This will allow for the functionality to be shared across multiple features and avoid Nimbus feature collisions/exclusion until better multi-feature rollout and experiment capabilities are available.