### PR TITLE
Bug 1826973 - Add Data Control Plane user documentation

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 257 utf-8
+personal_ws-1.1 en 261 utf-8
 AAR
 AARs
 ABI
@@ -157,11 +157,13 @@ gradle
 grcov
 gzip
 gzipped
+homescreen
 hotfix
 html
 illumos
 init
 inlined
+instrumentations
 integrations
 io
 ios
@@ -209,6 +211,7 @@ rethrow
 rfloor
 rkv
 rkv's
+rollout
 rollouts
 runtime
 runtimes
@@ -247,6 +250,7 @@ uniffi
 unminified
 uploader
 uploaders
+urlbar
 vendored
 vendoring
 webextension

--- a/docs/user/user/metrics/data-control-plane/advanced-topics.md
+++ b/docs/user/user/metrics/data-control-plane/advanced-topics.md
@@ -1,0 +1,137 @@
+# Advanced Topics
+
+## Merging of Configurations from Multiple Features
+
+Since each feature defined as a Nimbus Feature can independently provide a Glean configuration, these must be merged together into a cohesive configuration for the entire set of metrics collected by Glean.
+
+In order to accomplish this, Glean uses the same feature identifier used by Nimbus. Provide this id when calling the Glean API to set the configuration.
+
+This means that any existing configuration that is associated with a particular feature identifier will be overwritten if a new configuration is provided with the same identifier.
+
+Configurations from all identifiers will be merged together along with the default values in the metrics.yaml file and applied to the appropriate metrics.
+
+### Example
+
+Imagine a situation where we have 3 features (`A`, `B`, `C`). Each of these features has an event (`A.event`, `B.event`, `C.event`) and these events all default to disabled from their definition in the metrics.yaml file.
+
+Let’s walk through an example of changing configurations for these features that illustrates how the merging will work:
+
+#### _Initial State_
+
+This is what the initial state of the events looks like with no configurations applied. All of the events are falling back to the defaults from the metrics.yaml file. This is the starting point for Scenario 1 in the [Example Scenarios].
+
+- Feature A
+  - No config, default used
+  - A.event is disabled
+- Feature B
+  - No config, default used
+  - B.event is disabled
+- Feature C
+  - No config, default used
+  - C.event is disabled
+
+#### _Second State_
+
+In this state, let’s create two rollouts which will provide configurations for features A and B that will enable the events associated with each. The first rollout selects Feature A in experimenter and provides the indicated configuration in the Branch setup page. The second rollout does the same thing, only for Feature B.
+
+- Feature A
+  - Configuration:
+    - ```json
+        {
+            // Other variable configs
+
+            // Glean metric config
+            "gleanMetricConfiguration": {
+                "A.event": true
+            }
+        }
+        ```
+  - A.event is enabled
+- Feature B
+  - Configuration:
+    - ```json
+        {
+            // Other variable configs
+
+            // Glean metric config
+            "gleanMetricConfiguration": {
+                "B.event": true
+            }
+        }
+        ```
+  - B.event is enabled
+- Feature C
+  - No config, default used
+  - C.event is disabled
+
+As you can see, the A.event and B.event are enabled by the configurations while C.event remains disabled because there is no rollout for it.
+
+#### _Third State_
+
+In this state, let’s end the rollout for Feature B, start a rollout for Feature C, and launch an experiment for Feature A. Because experiments take precedence over rollouts, this should supersede our configuration from the rollout for Feature A.
+
+- Feature A
+  - Configuration:
+    - ```json
+        {
+            // Other variable configs
+
+            // Glean metric config
+            "gleanMetricConfiguration": {
+                "A.event": false
+            }
+        }
+        ```
+  - A.event is disabled
+- Feature B
+  - No config, default used
+  - B.event is disabled
+- Feature C
+  - Configuration:
+    - ```json
+        {
+            // Other variable configs
+
+            // Glean metric config
+            "gleanMetricConfiguration": {
+                "C.event": true
+            }
+        }
+        ```
+  - C.event is enabled
+
+After the new changes to the currently running rollouts and experiments, this client is now enrolled in the experiment for Feature A and the configuration is suppressing the A.event. Feature B is no longer sending B.event because it is reverting back to the defaults from the metrics.yaml file. And finally, Feature C is sending C.event with the rollout configuration applied.
+
+#### _Fourth State_
+
+Finally, in this state, let’s end the rollout for Feature C along with the experiment for Feature A. This should stop the sending of the B.event and C.event and resume sending of the A.event as the rollout configuration will again be applied since the experiment configuration is no longer available.
+
+- Feature A
+  - Configuration
+    -  ```json
+        {
+            // Other variable configs
+
+            // Glean metric config
+            "gleanMetricConfiguration": {
+                "A.event": true
+            }
+        }
+        ```
+  - A.event is enabled
+- Feature B
+  - No config, default used
+  - B.event is disabled
+- Feature C
+  - No config, default used
+  - C.event is disabled
+
+After the new changes to the currently running rollouts and experiments, this client is now enrolled in the experiment for Feature A and the configuration is suppressing the A.event. Feature B is no longer sending B.event because it is reverting back to the defaults from the metrics.yaml file. And finally, Feature C is sending C.event with the rollout configuration applied.
+
+In each case, Glean only updates the configuration associated with the feature that provided it. Nimbus’ feature exclusion would prevent a client from being enrolled in multiple rollouts or experiments for a given feature, so no more than one configuration would be applied per feature for a given client.
+
+### Merging Caveats
+
+Because there is currently nothing that ties a particular Nimbus Feature to a set of metrics, care must be taken to avoid feature overlap over a particular metric. If two different features supply  conflicting configurations for the same metric identifier, then whether or not the metric is enabled will likely come down to a race condition of whoever set the configuration last
+
+[Example Scenarios]: example-scenarios.md

--- a/docs/user/user/metrics/data-control-plane/example-scenarios.md
+++ b/docs/user/user/metrics/data-control-plane/example-scenarios.md
@@ -1,0 +1,40 @@
+# Example Scenarios
+
+## Scenario 1
+
+> *Landing a metric that is disabled by default and then enabling it for some segment of the population*
+
+This scenario can be expected in cases such as when instrumenting high-traffic areas of the browser. These are instrumentations that would normally generate a lot of data because they are recorded frequently for every user.
+
+In this case, the telemetry which has the potential to be high-volume would land with the “disabled” property of the metric set to “true”. This will ensure that it does not record data by default.
+
+An example metric definition with this property set would look something like this:
+
+```yaml
+urlbar:
+  impression:
+    disabled: true
+    type: event
+    description: Recorded when urlbar results are shown to the user.
+  ...
+```
+
+Once the instrumentation is landed, it can now be enabled for a subset of the population through a Nimbus rollout or experiment without further code changes.
+
+Through [Nimbus], we have the ability to sample the population by setting the audience size to a certain percentage of the eligible population. Nimbus also provides the ability to target clients based on the available targeting parameters for a particular application (for instance, Firefox Desktop’s available targeting parameters).
+
+This can be used to slowly roll out instrumentations to the population in order to validate the data we are collecting before measuring the entire population and potentially avoiding costs and  overhead by collecting data that isn’t useful.
+
+## Scenario 2
+
+> *Landing a metric that is enabled by default and then disabling it for a segment of the population*
+
+This is effectively the inverse of [Scenario 1](#scenario-1), instead of landing the metrics disabled by default, they are landed as enabled so that they are normally collecting data from the entire population.
+
+Similar to the first scenario, a [Nimbus] rollout or experiment can then be launched to configure the metrics as disabled for a subset of the population.
+
+This provides a mechanism by which we can disable the sending of telemetry from an audience that we do not wish to collect telemetry data from.
+
+For instance, this could be useful in tuning out telemetry data coming from automation sources or bad actors. In addition, it provides a way to disable broken, incorrect, or unexpectedly noisy instrumentations as an operational safety mechanism to directly control the volume of the data we collect and ingest.
+
+[Nimbus]: https://experimenter.info

--- a/docs/user/user/metrics/data-control-plane/experimenter-configuration.md
+++ b/docs/user/user/metrics/data-control-plane/experimenter-configuration.md
@@ -1,0 +1,21 @@
+# Experimenter Configuration
+
+The structure of this configuration is a key-value collection with the full metric identification of the Glean metric serving as the key in the format <metric_category.metric_name>.
+
+The values of the key-value pair are booleans which represent whether the metric is enabled (`true`) or not (`false`).
+
+In the example below `gleanMetricConfiguration` is the name of the variable defined in the Nimbus feature.
+
+This configuration would be what is entered into the branch configuration setup in Experimenter when defining an experiment or rollout.
+
+## Example Configuration:
+
+```json
+{
+  "gleanMetricConfiguration": {
+    "urlbar.abandonment": true,
+    "urlbar.engagement": true,
+    "urlbar.impression": true
+  }
+}
+```

--- a/docs/user/user/metrics/data-control-plane/faq.md
+++ b/docs/user/user/metrics/data-control-plane/faq.md
@@ -1,0 +1,9 @@
+# Frequently Asked Questions
+
+* how can I tell if a given client id has the metric X on?
+
+
+
+* why isn't some client id reporting the metric that should be enabled for all the clients for that channel? (e.g. Some fraction of population may get stuck on “default” config)
+
+

--- a/docs/user/user/metrics/data-control-plane/index.md
+++ b/docs/user/user/metrics/data-control-plane/index.md
@@ -1,0 +1,21 @@
+# Data Control Plane (a.k.a. Server Knobs)
+
+Glean provides a Data [Control Plane] through which metrics can be enabled, disabled or throttled through a [Nimbus] rollout or experiment.
+
+Products can use this capability to control "data-traffic", similar to how a network control plane controls "network-traffic".
+
+This provides the ability to do the following:
+
+- Allow runtime changes to data collection without needing to land code and ride release trains.
+- Eliminate the need for manual creation and maintenance of feature flags specific to data collection.
+- Sampling of measurements from a subset of the population so that we do not collect or ingest more data than is necessary from high traffic areas of an application instrumented with Glean metrics.
+- Operational safety through being able to react to high-volume or unwanted data.
+- Visibility into sampling and sampling rates for remotely configured metrics.
+
+## Contents
+- [Example Scenarios](example-scenarios.md)
+- [Product Integration](product-integration.md)
+- [Experimenter Configuration](experimenter-configuration.md)
+
+[Control Plane]: https://en.wikipedia.org/wiki/Control_plane
+[Nimbus]: https://experimenter.info

--- a/docs/user/user/metrics/data-control-plane/product-integration.md
+++ b/docs/user/user/metrics/data-control-plane/product-integration.md
@@ -1,0 +1,66 @@
+# Product Integration
+
+In order to enable sharing of this functionality between multiple Nimbus Features, the implementation is not defined as part of the stand-alone Glean feature defined in the Nimbus Feature Manifest, but instead is intended to be added as a feature variable to other Nimbus Feature definitions for them to make use of.
+
+## Desktop Feature Integration
+
+In order to make use of the remote metric configuration in a Firefox Desktop component, the component must first be defined as a Nimbus Feature. The instructions for defining your component as a feature (or multiple features) can be found in the Nimbus documentation specific to the [Nimbus Desktop Feature API]. Once you have defined a feature, you simply need to add a Feature Variable to represent the piece of the Glean configuration that will be provided by this Nimbus Feature. For example:
+
+```yaml
+variables:
+  ... // Definitions of other feature variables
+  gleanMetricConfiguration:
+    type: json
+    description: >-
+    "Glean metric configuration"
+```
+
+This definition allows for configuration to be set in a Nimbus rollout or experiment and fetched by the client to be applied based on the enrollment. Once the Feature Variable has been defined, the final step is to fetch the configuration from Nimbus and supply it to the Glean API function along with the identifier for the feature. This can be done during initialization and again any time afterwards, such as in response to receiving an updated configuration from Nimbus. Only the latest configuration provided will be applied. An example call to set a configuration from the “urlbar” Nimbus Feature could look like this:
+
+```JavaScript
+Services.fog.setMetricsFeatureConfig("urlbar",
+  JSON.stringify(
+    Lazy.NimbusFeatures.urlbar.getVariable("gleanMetricConfiguration")
+  )
+);
+```
+
+It is also recommended to register to listen for updates for the Nimbus Feature and apply new configurations as soon as possible. The following example illustrates how the “urlbar” Nimbus Feature might register and update the metric configuration:
+
+```JavaScript
+lazy.NimbusFeatures.urlbar.onUpdate(() => {
+  let cfg = lazy.NimbusFeatures.glean.getVariable(
+    "gleanMetricConfiguration"
+  );
+  Services.fog.setMetricsFeatureConfig("urlbar", JSON.stringify(cfg));
+});
+```
+
+## Mobile Feature Integration
+
+In order to make use of the remote metric configuration in a Firefox Mobile application, you must first define a Nimbus Feature or add a variable to an existing Nimbus Feature. The instructions for defining your component as a feature (or multiple features) can be found in the Nimbus documentation specific to the Nimbus Mobile Feature API. Once you have defined a feature, you simply need to add a Feature Variable to represent the piece of the Glean configuration that will be provided by this Nimbus Feature. For example:
+
+```yaml
+features:
+  homescreen:
+    description: |
+      The homescreen that the user goes to when they press home or new    
+      tab.
+    variables:
+      ... // Other homescreen variables
+      gleanMetricConfiguration:
+        description: Glean metric configuration
+        type: String
+        default: "{}"
+```
+
+Once the Feature Variable has been defined, the final step is to fetch the configuration from Nimbus and supply it to the Glean API function along with the identifier for the feature. This can be done during initialization and again any time afterwards, such as in response to receiving an updated configuration from Nimbus. Only the latest configuration provided will be applied. An example call to set a configuration from the “homescreen” Nimbus Feature could look like this:
+
+```Swift
+Glean.setMetricsEnabledConfig(FxNimbus.features.homescreen.value().metricsEnabled)
+```
+
+Since mobile experiments only update on initialization of the application, it isn't necessary to register to listen for notifications for experiment updates.
+
+[Nimbus]: https://experimenter.info
+[Nimbus Desktop Feature API]: https://experimenter.info/desktop-feature-api


### PR DESCRIPTION
This adds documentation about the Glean Data Control Plane functionality (a.k.a. Server Knobs).