### PR TITLE
Bug 1832324 - Add a way to await ping submission in iOS 

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 261 utf-8
+personal_ws-1.1 en 262 utf-8
 AAR
 AARs
 ABI
@@ -92,6 +92,7 @@ Unbreak
 Underflowing
 UniFFI
 Uploaders
+VPN
 Wasm
 WebRender
 Webpack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Timing distribution traits now expose `accumulate_samples` and `accumulate_raw_samples_nanos`. This is a breaking change for consumers that make use of the trait as they will need to implement the new functions ([Bug 1829745](https://bugzilla.mozilla.org/show_bug.cgi?id=1829745))
 * Swift
   * Make debugging APIs available on Swift ([#2470](https://github.com/mozilla/glean/pull/2470))
+  * Added a shutdown API for Swift. This should only be necessary for when Glean is running in a process other than the main process (like in the VPN daemon, for instance)([Bug 1832324](https://bugzilla.mozilla.org/show_bug.cgi?id=1832324))
 
 # v52.7.0 (2023-05-10)
 

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -394,6 +394,11 @@ public class Glean {
         gleanSetMetricsEnabledConfig(json)
     }
 
+    /// Shuts down Glean in an orderly fashion
+    public func shutdown() {
+        gleanShutdown()
+    }
+
     /// When applications are launched using the custom URL scheme, this helper function will process
     /// the URL and parse the debug commands
     ///

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 private typealias GleanInternalMetrics = GleanMetrics.GleanInternalMetrics
 
+// swiftlint:disable type_body_length
 class GleanTests: XCTestCase {
     var expectation: XCTestExpectation?
 
@@ -367,4 +368,63 @@ class GleanTests: XCTestCase {
         Glean.shared.initialize(uploadEnabled: true, buildInfo: stubBuildInfo())
         XCTAssertFalse(Glean.shared.isCustomDataPath)
     }
+
+    func testShutdown() {
+        // This test relies on Glean not being initialized
+        Glean.shared.testDestroyGleanHandle()
+
+        // We expect 10 pings later
+        stubServerReceive { pingType, _ in
+            if pingType == "baseline" {
+                // Ignore initial "active" baseline ping
+                return
+            }
+
+            XCTAssertEqual("custom", pingType)
+
+            // Fulfill test's expectation once we parsed the incoming data.
+            DispatchQueue.main.async {
+                // Let the response get processed before we mark the expectation fulfilled
+                self.expectation?.fulfill()
+            }
+        }
+
+        let customPing = Ping<NoReasonCodes>(
+            name: "custom",
+            includeClientId: true,
+            sendIfEmpty: false,
+            reasonCodes: []
+        )
+
+        let counter = CounterMetricType(CommonMetricData(
+            category: "telemetry",
+            name: "counter_metric",
+            sendInPings: ["custom"],
+            lifetime: .application,
+            disabled: false
+        ))
+
+        expectation = expectation(description: "Completed upload")
+        expectation?.expectedFulfillmentCount = 10
+
+        // Set the last time the "metrics" ping was sent to now. This is required for us to not
+        // send a metrics pings the first time we initialize Glean and to keep it from interfering
+        // with these tests.
+        let now = Date()
+        MetricsPingScheduler(true).updateSentDate(now)
+        // Restart glean
+        Glean.shared.resetGlean(clearStores: false)
+
+        // Set data and try to submit a custom ping 10x.
+        for _ in (0..<10) {
+            counter.add(1)
+            customPing.submit()
+        }
+
+        Glean.shared.shutdown()
+        waitForExpectations(timeout: 5.0) { error in
+            XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
+        }
+    }
 }
+// swiftlint:enable type_body_length

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -13,6 +13,9 @@ namespace glean {
     // It will return immediately.
     void glean_initialize(InternalConfiguration cfg, ClientInfoMetrics client_info, OnGleanEvents callbacks);
 
+    /// Shuts down Glean in an orderly fashion.
+    void glean_shutdown();
+
     // Creates and initializes a new Glean object for use in a subprocess.
     //
     // Importantly, this will not send any pings at startup, since that

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -274,6 +274,11 @@ pub fn glean_initialize(
     initialize_inner(cfg, client_info, callbacks);
 }
 
+/// Shuts down Glean in an orderly fashion.
+pub fn glean_shutdown() {
+    shutdown();
+}
+
 /// Creates and initializes a new Glean object for use in a subprocess.
 ///
 /// Importantly, this will not send any pings at startup, since that


### PR DESCRIPTION
This simply awaits the internal dispatcher which is where the pings are submitted from.