### PR TITLE
Bug 1833381 - Add capability to merge remote metric configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v52.7.0...main)
 
+* General
+  * Adds the capability to merge remote metric configurations, enabling multiple Nimbus Features or components to share this functionality ([Bug 1833381](https://bugzilla.mozilla.org/show_bug.cgi?id=1833381))
 * Rust
   * Timing distribution traits now expose `accumulate_samples` and `accumulate_raw_samples_nanos`. This is a breaking change for consumers that make use of the trait as they will need to implement the new functions ([Bug 1829745](https://bugzilla.mozilla.org/show_bug.cgi?id=1829745))
 * Swift

--- a/docs/user/user/metrics/data-control-plane/advanced-topics.md
+++ b/docs/user/user/metrics/data-control-plane/advanced-topics.md
@@ -4,11 +4,7 @@
 
 Since each feature defined as a Nimbus Feature can independently provide a Glean configuration, these must be merged together into a cohesive configuration for the entire set of metrics collected by Glean.
 
-In order to accomplish this, Glean uses the same feature identifier used by Nimbus. Provide this id when calling the Glean API to set the configuration.
-
-This means that any existing configuration that is associated with a particular feature identifier will be overwritten if a new configuration is provided with the same identifier.
-
-Configurations from all identifiers will be merged together along with the default values in the metrics.yaml file and applied to the appropriate metrics.
+Configurations will be merged together along with the default values in the metrics.yaml file and applied to the appropriate metrics. Only the latest configuration provided for a given metric will be applied and any previously configured metrics that are omitted from the new configuration will not be changed.
 
 ### Example
 
@@ -132,6 +128,6 @@ In each case, Glean only updates the configuration associated with the feature t
 
 ### Merging Caveats
 
-Because there is currently nothing that ties a particular Nimbus Feature to a set of metrics, care must be taken to avoid feature overlap over a particular metric. If two different features supply  conflicting configurations for the same metric identifier, then whether or not the metric is enabled will likely come down to a race condition of whoever set the configuration last
+Because there is currently nothing that ties a particular Nimbus Feature to a set of metrics, care must be taken to avoid feature overlap over a particular metric. If two different features supply conflicting configurations for the same metric, then whether or not the metric is enabled will likely come down to a race condition of whoever set the configuration last.
 
 [Example Scenarios]: example-scenarios.md

--- a/docs/user/user/metrics/data-control-plane/faq.md
+++ b/docs/user/user/metrics/data-control-plane/faq.md
@@ -1,9 +1,9 @@
 # Frequently Asked Questions
 
-* how can I tell if a given client id has the metric X on?
+* How can I tell if a given client id has the metric X on?
 
+Once we have established the functionality behind the data control plane, a dashboard for monitoring this will be provided. Details are to be determined.
 
+* Why isn't some client id reporting the metric that should be enabled for all the clients for that channel? (e.g. Some fraction of population may get stuck on “default” config)
 
-* why isn't some client id reporting the metric that should be enabled for all the clients for that channel? (e.g. Some fraction of population may get stuck on “default” config)
-
-
+Nimbus must be able to both reach and supply a valid configuration to the audience. For some outliers this doesn't work and so may be "unreachable" at times.

--- a/docs/user/user/metrics/data-control-plane/product-integration.md
+++ b/docs/user/user/metrics/data-control-plane/product-integration.md
@@ -15,24 +15,23 @@ variables:
     "Glean metric configuration"
 ```
 
-This definition allows for configuration to be set in a Nimbus rollout or experiment and fetched by the client to be applied based on the enrollment. Once the Feature Variable has been defined, the final step is to fetch the configuration from Nimbus and supply it to the Glean API function along with the identifier for the feature. This can be done during initialization and again any time afterwards, such as in response to receiving an updated configuration from Nimbus. Only the latest configuration provided will be applied. An example call to set a configuration from the “urlbar” Nimbus Feature could look like this:
+This definition allows for configuration to be set in a Nimbus rollout or experiment and fetched by the client to be applied based on the enrollment. Once the Feature Variable has been defined, the final step is to fetch the configuration from Nimbus and supply it to the Glean API. This can be done during initialization and again any time afterwards, such as in response to receiving an updated configuration from Nimbus. Only the latest configuration provided will be applied and any previously configured metrics that are omitted from the new configuration will not be changed. An example call to set a configuration from the “urlbar” Nimbus Feature could look like this:
 
 ```JavaScript
-Services.fog.setMetricsFeatureConfig("urlbar",
-  JSON.stringify(
-    Lazy.NimbusFeatures.urlbar.getVariable("gleanMetricConfiguration")
-  )
+let cfg = lazy.NimbusFeatures.urlbar.getVariable(
+  "gleanMetricConfiguration"
 );
+Services.fog.setMetricsFeatureConfig(JSON.stringify(cfg));
 ```
 
 It is also recommended to register to listen for updates for the Nimbus Feature and apply new configurations as soon as possible. The following example illustrates how the “urlbar” Nimbus Feature might register and update the metric configuration:
 
 ```JavaScript
 lazy.NimbusFeatures.urlbar.onUpdate(() => {
-  let cfg = lazy.NimbusFeatures.glean.getVariable(
+  let cfg = lazy.NimbusFeatures.urlbar.getVariable(
     "gleanMetricConfiguration"
   );
-  Services.fog.setMetricsFeatureConfig("urlbar", JSON.stringify(cfg));
+  Services.fog.setMetricsFeatureConfig(JSON.stringify(cfg));
 });
 ```
 
@@ -54,7 +53,7 @@ features:
         default: "{}"
 ```
 
-Once the Feature Variable has been defined, the final step is to fetch the configuration from Nimbus and supply it to the Glean API function along with the identifier for the feature. This can be done during initialization and again any time afterwards, such as in response to receiving an updated configuration from Nimbus. Only the latest configuration provided will be applied. An example call to set a configuration from the “homescreen” Nimbus Feature could look like this:
+Once the Feature Variable has been defined, the final step is to fetch the configuration from Nimbus and supply it to the Glean API. This can be done during initialization and again any time afterwards, such as in response to receiving an updated configuration from Nimbus. Only the latest configuration provided will be applied and any previously configured metrics that are omitted from the new configuration will not be changed. An example call to set a configuration from the “homescreen” Nimbus Feature could look like this:
 
 ```Swift
 Glean.setMetricsEnabledConfig(FxNimbus.features.homescreen.value().metricsEnabled)

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -714,8 +714,10 @@ impl Glean {
     pub fn set_metrics_enabled_config(&self, cfg: MetricsEnabledConfig) {
         // Set the current MetricsEnabledConfig, keeping the lock until the epoch is
         // updated to prevent against reading a "new" config but an "old" epoch
-        let mut lock = self.remote_settings_metrics_config.lock().unwrap();
-        *lock = cfg;
+        let mut metric_config = self.remote_settings_metrics_config.lock().unwrap();
+
+        // Merge the exising configuration with the supplied one
+        metric_config.metrics_enabled.extend(cfg.metrics_enabled);
 
         // Update remote_settings epoch
         self.remote_settings_epoch.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
This merges configurations regardless of feature ID. A much simpler approach that basically offers the same protections as adding the additional feature-id stuff on top.