### PR TITLE
Bug 1833870 - Increase StringList metric type limits

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 262 utf-8
+personal_ws-1.1 en 263 utf-8
 AAR
 AARs
 ABI
@@ -76,6 +76,7 @@ SDKs
 SRE
 Solaris
 Sourcegraph
+StringList
 TLDs
 TODO
 TSan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Adds the capability to merge remote metric configurations, enabling multiple Nimbus Features or components to share this functionality ([Bug 1833381](https://bugzilla.mozilla.org/show_bug.cgi?id=1833381))
+  * StringList metric type limits have been increased. The length of strings allowed has been increased from 50 to 100 to match the String metric type, and the list length has been increased from 20 to 100 ([Bug 1833870](https://bugzilla.mozilla.org/show_bug.cgi?id=1833870))
 * Rust
   * Timing distribution traits now expose `accumulate_samples` and `accumulate_raw_samples_nanos`. This is a breaking change for consumers that make use of the trait as they will need to implement the new functions ([Bug 1829745](https://bugzilla.mozilla.org/show_bug.cgi?id=1829745))
 * Swift

--- a/docs/user/reference/metrics/string_list.md
+++ b/docs/user/reference/metrics/string_list.md
@@ -101,8 +101,8 @@ Glean.search.engines.add("duck duck go");
 
 #### Limits
 
-* Fixed maximum string length: 50. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
-* Fixed maximum list length: 20 items. Additional strings are dropped.
+* Fixed maximum string length: 100. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
+* Fixed maximum list length: 100 items. Additional strings are dropped.
 
 ### `set`
 
@@ -188,8 +188,8 @@ Glean.search.engines.set(["wikipedia", "duck duck go"]);
 
 #### Limits
 
-* Fixed maximum string length: 50. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
-* Fixed maximum list length: 20 items. Additional strings are dropped.
+* Fixed maximum string length: 100. Longer strings are truncated. This is measured in the number of bytes when the string is encoded in UTF-8.
+* Fixed maximum list length: 100 items. Additional strings are dropped.
 
 ## Testing API
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringListMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/StringListMetricTypeTest.kt
@@ -188,12 +188,12 @@ class StringListMetricTypeTest {
             )
         )
 
-        for (x in 0..20) {
+        for (x in 0..100) {
             stringListMetric.add("value$x")
         }
 
         val snapshot = stringListMetric.testGetValue("store1")!!
-        assertEquals(20, snapshot.size)
+        assertEquals(100, snapshot.size)
 
         assertEquals(1, stringListMetric.testGetNumRecordedErrors(ErrorType.INVALID_VALUE))
     }

--- a/glean-core/ios/GleanTests/Metrics/StringListMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/StringListMetricTests.swift
@@ -141,11 +141,11 @@ class StringListMetricTests: XCTestCase {
             disabled: false
         ))
 
-        for n in 0 ... 20 {
+        for n in 0 ... 100 {
             stringListMetric.add(String(format: "value%02d", n))
         }
 
-        XCTAssertEqual(20, stringListMetric.testGetValue()!.count)
+        XCTAssertEqual(100, stringListMetric.testGetValue()!.count)
         XCTAssertEqual(1, stringListMetric.testGetNumRecordedErrors(.invalidValue))
     }
 }

--- a/glean-core/python/tests/metrics/test_string_list.py
+++ b/glean-core/python/tests/metrics/test_string_list.py
@@ -128,10 +128,10 @@ def test_long_string_lists_are_truncated():
         )
     )
 
-    for i in range(21):
+    for i in range(101):
         metric.add(f"value{i}")
 
     snapshot = metric.test_get_value()
-    assert 20 == len(snapshot)
+    assert 100 == len(snapshot)
 
     assert 1 == metric.test_get_num_recorded_errors(testing.ErrorType.INVALID_VALUE)

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -14,9 +14,9 @@ use crate::CommonMetricData;
 use crate::Glean;
 
 // Maximum length of any list
-const MAX_LIST_LENGTH: usize = 20;
+const MAX_LIST_LENGTH: usize = 100;
 // Maximum length of any string in the list
-const MAX_STRING_LENGTH: usize = 50;
+const MAX_STRING_LENGTH: usize = 100;
 
 /// A string list metric.
 ///

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -121,7 +121,7 @@ fn long_string_values_are_truncated() {
 
     // Ensure the string was truncated to the proper length.
     assert_eq!(
-        vec![test_string[..50].to_string()],
+        vec![test_string[..100].to_string()],
         metric.get_value(&glean, "store1").unwrap()
     );
 
@@ -135,7 +135,7 @@ fn long_string_values_are_truncated() {
 
     // Ensure the string was truncated to the proper length.
     assert_eq!(
-        vec![test_string[..50].to_string()],
+        vec![test_string[..100].to_string()],
         metric.get_value(&glean, "store1").unwrap()
     );
 
@@ -186,18 +186,18 @@ fn string_lists_dont_exceed_max_items() {
         ..Default::default()
     });
 
-    for _n in 1..21 {
+    for _n in 1..101 {
         metric.add_sync(&glean, "test_string");
     }
 
     let expected: Vec<String> = "test_string "
-        .repeat(20)
+        .repeat(100)
         .split_whitespace()
         .map(|s| s.to_string())
         .collect();
     assert_eq!(expected, metric.get_value(&glean, "store1").unwrap());
 
-    // Ensure the 21st string wasn't added.
+    // Ensure the 101st string wasn't added.
     metric.add_sync(&glean, "test_string");
     assert_eq!(expected, metric.get_value(&glean, "store1").unwrap());
 
@@ -207,9 +207,9 @@ fn string_lists_dont_exceed_max_items() {
         test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue)
     );
 
-    // Try to set it to a list that's too long. Ensure it cuts off at 20 elements.
+    // Try to set it to a list that's too long. Ensure it cuts off at 100 elements.
     let too_many: Vec<String> = "test_string "
-        .repeat(21)
+        .repeat(101)
         .split_whitespace()
         .map(|s| s.to_string())
         .collect();


### PR DESCRIPTION
This increases the length of strings allowed in the list from 50 to 100 utf8 bytes to match the `StringMetric` type, as well as increasing the total number of strings allowed in the list from 20 to 100.