### PR TITLE
Replace once_cell usage with libstd's OnceLock

### DIFF
--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, FixedOffset};
-use once_cell::sync::OnceCell;
 
 use crate::database::Database;
 use crate::debug::DebugOptions;
@@ -23,7 +23,7 @@ use crate::{
     DEFAULT_MAX_EVENTS, GLEAN_SCHEMA_VERSION, GLEAN_VERSION, KNOWN_CLIENT_ID,
 };
 
-static GLEAN: OnceCell<Mutex<Glean>> = OnceCell::new();
+static GLEAN: OnceLock<Mutex<Glean>> = OnceLock::new();
 
 pub fn global_glean() -> Option<&'static Mutex<Glean>> {
     GLEAN.get()
@@ -31,7 +31,7 @@ pub fn global_glean() -> Option<&'static Mutex<Glean>> {
 
 /// Sets or replaces the global Glean object.
 pub fn setup_glean(glean: Glean) -> Result<()> {
-    // The `OnceCell` type wrapping our Glean is thread-safe and can only be set once.
+    // The `OnceLock` type wrapping our Glean is thread-safe and can only be set once.
     // Therefore even if our check for it being empty succeeds, setting it could fail if a
     // concurrent thread is quicker in setting it.
     // However this will not cause a bigger problem, as the second `set` operation will just fail.

--- a/glean-core/src/histogram/exponential.rs
+++ b/glean-core/src/histogram/exponential.rs
@@ -3,8 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
 use super::{Bucketing, Histogram};
@@ -61,7 +61,7 @@ pub struct PrecomputedExponential {
     // Don't serialize the (potentially large) array of ranges, instead compute them on first
     // access.
     #[serde(skip)]
-    bucket_ranges: OnceCell<Vec<u64>>,
+    bucket_ranges: OnceLock<Vec<u64>>,
     min: u64,
     max: u64,
     bucket_count: usize,
@@ -102,7 +102,7 @@ impl Histogram<PrecomputedExponential> {
             count: 0,
             sum: 0,
             bucketing: PrecomputedExponential {
-                bucket_ranges: OnceCell::new(),
+                bucket_ranges: OnceLock::new(),
                 min,
                 max,
                 bucket_count,

--- a/glean-core/src/histogram/linear.rs
+++ b/glean-core/src/histogram/linear.rs
@@ -4,8 +4,8 @@
 
 use std::cmp;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
 use super::{Bucketing, Histogram};
@@ -41,7 +41,7 @@ pub struct PrecomputedLinear {
     // Don't serialize the (potentially large) array of ranges, instead compute them on first
     // access.
     #[serde(skip)]
-    bucket_ranges: OnceCell<Vec<u64>>,
+    bucket_ranges: OnceLock<Vec<u64>>,
     min: u64,
     max: u64,
     bucket_count: usize,
@@ -78,7 +78,7 @@ impl Histogram<PrecomputedLinear> {
             count: 0,
             sum: 0,
             bucketing: PrecomputedLinear {
-                bucket_ranges: OnceCell::new(),
+                bucket_ranges: OnceLock::new(),
                 min,
                 max,
                 bucket_count,


### PR DESCRIPTION
Rust 1.70.0 stabilized OnceCell and OnceLock[1].
No more need for `once_cell`!

Note that:

* Only since 1.70, which is far ahead of our current MSRV.
* `LazyCell` and `LazyLock` are not yet stabilized, so we can't abandon the `once_cell` crate
* `glean_parser` generates references to `once_cell`'s `OnceCell`, so we would also need to update our generators when we land this.

[1]: https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html

---

Opening this mostly for @travis79 to see when he's back. Once seen we can close this, it's not actionable yet until we raise our MSRV anyway.