### PR TITLE
Bug 1838174 - Glean plugin: Try newer accessor name for exec result

### DIFF
--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -267,7 +267,14 @@ except:
                 standardOutput = new ByteArrayOutputStream()
                 errorOutput = standardOutput
                 doLast {
-                    if (execResult.exitValue != 0) {
+                    def exitValue
+                    // Gradle 8 renamed it to `executionResult`. We handle both cases.
+                    if (hasProperty("executionResult")) {
+                        exitValue = executionResult.exitValue
+                    } else {
+                        exitValue = execResult.exitValue
+                    }
+                    if (exitValue != 0) {
                         throw new GradleException("Glean code generation failed.\n\n${standardOutput.toString()}")
                     }
                 }


### PR DESCRIPTION
This makes it possible to run with both Gradle <8 & 8+

---

I haven't verified that this actually works with Gradle 8.