### PR TITLE
Python: Avoid variable shadowing to avoid type confusion

### DIFF
--- a/glean-core/python/glean/metrics/datetime.py
+++ b/glean-core/python/glean/metrics/datetime.py
@@ -99,19 +99,19 @@ class DatetimeMetricType:
         Returns:
             value (datetime.datetime): value of the stored metric.
         """
-        dt = self._inner.test_get_value(ping_name)
-        if not dt:
+        value = self._inner.test_get_value(ping_name)
+        if not value:
             return None
 
-        tz = tzoffset(dt.offset_seconds)
+        tz = tzoffset(value.offset_seconds)
         dt = datetime.datetime(
-            year=dt.year,
-            month=dt.month,
-            day=dt.day,
-            hour=dt.hour,
-            minute=dt.minute,
-            second=dt.second,
-            microsecond=round(dt.nanosecond / 1000),
+            year=value.year,
+            month=value.month,
+            day=value.day,
+            hour=value.hour,
+            minute=value.minute,
+            second=value.second,
+            microsecond=round(value.nanosecond / 1000),
             tzinfo=tz,
         )
         return dt


### PR DESCRIPTION
mypy found this for me.

```
glean-core/python/glean/metrics/datetime.py:107: error: Incompatible types in assignment (expression has type "datetime", variable has type "Optional[Datetime]")  [assignment]
glean-core/python/glean/metrics/datetime.py:117: error: Incompatible return value type (got "Datetime", expected "Optional[datetime]")  [return-value]
```