### PR TITLE
Python: Use specific MarkupSafe version for development

### DIFF
--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -8,6 +8,7 @@ mypy==1.3.0; python_version > '3.6'
 pdoc3==0.10.0
 pip
 pytest-localserver==0.7.1
+MarkupSafe==2.0.1
 pytest-runner==5.3.1
 pytest==7.0.1
 semver==2.13.0


### PR DESCRIPTION
This is the most recent version we support (in glean_parser), but other dependencies pulled in a newer version, which under the wrong circumstances lead to a failure installing and building all the dependencies.

---

Yes, this broke for me locally from one day to another.
No, I have no clue what exactly changed (tbf I have a bit of a special setup and `python` comes from nix and so some things are a bit weird).
In any case this makes it work for me locally and also on my other machine.