### PR TITLE
Swift (testing): Use a string as the json object

### DIFF
--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -160,9 +160,9 @@ class GleanTests: XCTestCase {
             }
 
             return HTTPStubsResponse(
-                jsonObject: [],
+                data: Data("OK".utf8),
                 statusCode: 200,
-                headers: ["Content-Type": "application/json"]
+                headers: nil
             )
         }
 
@@ -198,9 +198,9 @@ class GleanTests: XCTestCase {
             }
 
             return HTTPStubsResponse(
-                jsonObject: [],
+                data: Data("OK".utf8),
                 statusCode: 200,
-                headers: ["Content-Type": "application/json"]
+                headers: nil
             )
         }
 

--- a/glean-core/ios/GleanTests/TestUtils.swift
+++ b/glean-core/ios/GleanTests/TestUtils.swift
@@ -37,9 +37,9 @@ func stubServerReceive(callback: @escaping (String, [String: Any]?) -> Void) {
         callback(pingType, payload)
 
         return HTTPStubsResponse(
-            jsonObject: [],
+            data: Data("OK".utf8),
             statusCode: 200,
-            headers: ["Content-Type": "application/json"]
+            headers: nil
         )
     }
 }


### PR DESCRIPTION
This ensures it's a known type and avoids the warning

"empty collection literal requires an explicit type"