### PR TITLE
bug 1839433 - Try blocking shutdown 10s for init to complete

### DIFF
--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -473,6 +473,10 @@ fn initialize_inner(
             });
 
             // Signal Dispatcher that init is complete
+            // bug 1839433: It is important that this happens after any init tasks
+            // that shutdown() depends on. At time of writing that's only setting up
+            // the global Glean, but it is probably best to flush the preinit queue
+            // as late as possible in the glean.init thread.
             match dispatcher::flush_init() {
                 Ok(task_count) if task_count > 0 => {
                     core::with_glean(|glean| {
@@ -562,19 +566,45 @@ fn uploader_shutdown() {
 
 /// Shuts down Glean in an orderly fashion.
 pub fn shutdown() {
-    // Either init was never called or Glean was not fully initialized
-    // (e.g. due to an error).
-    // There's the potential that Glean is not initialized _yet_,
-    // but in progress. That's fine, we shutdown either way before doing any work.
-    if !was_initialize_called() || core::global_glean().is_none() {
+    // Shutdown might have been called
+    // 1) Before init was called
+    //    * (data loss, oh well. Not enough time to do squat)
+    // 2) After init was called, but before it completed
+    //    * (we're willing to wait a little bit for init to complete)
+    // 3) After init completed
+    //    * (we can shut down immediately)
+
+    // Case 1: "Before init was called"
+    if !was_initialize_called() {
         log::warn!("Shutdown called before Glean is initialized");
         if let Err(e) = dispatcher::kill() {
             log::error!("Can't kill dispatcher thread: {:?}", e);
         }
-
         return;
     }
 
+    // Case 2: "After init was called, but before it completed"
+    if core::global_glean().is_none() {
+        log::warn!("Shutdown called before Glean is initialized. Waiting.");
+        // We can't join on the `glean.init` thread because there's no (easy) way
+        // to do that with a timeout. Instead, we wait for the preinit queue to
+        // empty, which is the last meaningful thing we do on that thread.
+
+        // TODO: Make the timeout configurable?
+        // We don't need the return value, as we're less interested in whether
+        // this times out than we are in whether there's a Global Glean at the end.
+        let _ = dispatcher::block_on_queue_timeout(Duration::from_secs(10));
+    }
+    // We can't shut down Glean if there's no Glean to shut down.
+    if core::global_glean().is_none() {
+        log::warn!("Waiting for Glean initialization timed out. Exiting.");
+        if let Err(e) = dispatcher::kill() {
+            log::error!("Can't kill dispatcher thread: {:?}", e);
+        }
+        return;
+    }
+
+    // Case 3: "After init completed"
     crate::launch_with_glean_mut(|glean| {
         glean.cancel_metrics_ping_scheduler();
         glean.set_dirty_flag(false);


### PR DESCRIPTION
Tested manually by running exceedingly short ( under 1s ) sessions on a self-built Firefox. A broad-spectrum tryrun is underway to ensure we haven't regressed anything we specifically care about: https://treeherder.mozilla.org/jobs?repo=try&revision=1f4ee9d8392cc0db1000c59b1c38eb573cfb2c6e