### PR TITLE
Update ktlint to version 0.50.0 and fix new warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ configurations {
 }
 
 dependencies {
-    ktlint("com.pinterest:ktlint:0.49.1") {
+    ktlint("com.pinterest:ktlint:0.50.0") {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))
         }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package mozilla.telemetry.glean
 
 import android.app.ActivityManager
@@ -16,7 +18,7 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import mozilla.telemetry.glean.GleanMetrics.GleanValidation
 import mozilla.telemetry.glean.config.Configuration
-import mozilla.telemetry.glean.internal.* // ktlint-disable no-wildcard-imports
+import mozilla.telemetry.glean.internal.*
 import mozilla.telemetry.glean.net.BaseUploader
 import mozilla.telemetry.glean.scheduler.GleanLifecycleObserver
 import mozilla.telemetry.glean.scheduler.MetricsPingScheduler


### PR DESCRIPTION
Changelog: https://github.com/pinterest/ktlint/releases/tag/0.50.0

Nothing super interesting in this update other than getting more strict about how suppressions are declared.