### PR TITLE
Suppress Swift warnings

### DIFF
--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -329,7 +329,7 @@ public class Glean {
     ///
     /// - parameters:
     ///     * value: The value of the tag, which must be a valid HTTP header value.
-    public func setDebugViewTag(_ tag: String) -> Bool {
+    @discardableResult public func setDebugViewTag(_ tag: String) -> Bool {
         return gleanSetDebugViewTag(tag)
     }
 

--- a/glean-core/ios/Glean/Metrics/UuidMetric.swift
+++ b/glean-core/ios/Glean/Metrics/UuidMetric.swift
@@ -22,7 +22,7 @@ public class UuidMetricType {
     /// Generate a new UUID and set it in the metric store.
     ///
     /// - returns: The `UUID` that was generated or `nil` if disabled.
-    public func generateAndSet() -> UUID {
+    @discardableResult public func generateAndSet() -> UUID {
         let uuid = inner.generateAndSet()
         return UUID(uuidString: uuid)!
     }


### PR DESCRIPTION
Frequently, we don't want to use the return of a UUID metric's `generateAndSet` function, or the result from `setDebugViewTag`.

However, this leaves warnings in Xcode and at build time:
<img width="782" alt="Screenshot 41" src="https://github.com/mozilla/glean/assets/9295855/a72ce407-2c72-4c2d-bfff-72cfebfaa79a">

[Swift has](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#discardableResult) the `discardableResult` attribute to suppress these warnings, commonly used for functions whose return will often be unused - like these two.