### PR TITLE
Bug 1842821 - Python: Export the `shutdown` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Rust
   * The Ping Rate Limit type is now accessible in the Rust Language Binding ([#2528](https://github.com/mozilla/glean/pull/2528))
   * `locale` now exposed through the RLB so it can be set by consumers ([2527](https://github.com/mozilla/glean/pull/2527))
+* Python
+  * Added the shutdown API for Python to ensure orderly shutdown and waiting for uploader processes ([#2538](https://github.com/mozilla/glean/pull/2538))
 
 # v53.1.0 (2023-06-28)
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -427,5 +427,16 @@ class Glean:
         """
         _uniffi.glean_handle_client_inactive()
 
+    @classmethod
+    def shutdown(cls):
+        """
+        Shuts down Glean in an orderly fashion.
+        """
+        _uniffi.glean_shutdown()
+
+        # On top of the Glean shutdown
+        # we also wait for the process dispatcher to finish.
+        ProcessDispatcher._wait_for_last_process()
+
 
 __all__ = ["Glean"]


### PR DESCRIPTION
I manually tested it, using a sample app (maybe I should commit the sample app...)