### PR TITLE
Use Python's modern `build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ build-apk: build-kotlin ## Build an apk of the Glean sample app
 	./gradlew glean-sample-app:build glean-sample-app:assembleAndroidTest
 
 build-python: setup-python ## Build the Python bindings
-	$(GLEAN_PYENV)/bin/python3 glean-core/python/setup.py build install
+	$(GLEAN_PYENV)/bin/python3 -m build
+	$(GLEAN_PYENV)/bin/python3 -m pip install -e glean-core/python
 
 build-xcframework:
 	./bin/build-xcframework.sh

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build-apk: build-kotlin ## Build an apk of the Glean sample app
 	./gradlew glean-sample-app:build glean-sample-app:assembleAndroidTest
 
 build-python: setup-python ## Build the Python bindings
-	$(GLEAN_PYENV)/bin/python3 -m build
+	$(GLEAN_PYENV)/bin/python3 -m build --no-isolation
 	$(GLEAN_PYENV)/bin/python3 -m pip install -e glean-core/python
 
 build-xcframework:

--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -16,3 +16,4 @@ setuptools-git==1.2
 twine==3.8.0
 types-pkg_resources==0.1.3
 wheel==0.40.0; python_version > '3.6'
+build==0.10.0


### PR DESCRIPTION
I seem to continuously run into trouble with the old way ([and here's why](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)), though it does not seem to be an issue on CI yet? Anyway, this then usually fixes it, though it's slightly more heavy-handed because it rebuilds the Rust code base over and over on `make build-python`.

But maybe a stop-gap until we land #2345