### PR TITLE
Bug 1844533 - Fixes Glean ping uploading from background services in Kotlin

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 267 utf-8
+personal_ws-1.1 en 268 utf-8
 AAR
 AARs
 ABI
@@ -98,6 +98,7 @@ VPN
 Wasm
 WebRender
 Webpack
+WorkManager
 XCFramework
 Xcode
 YAML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * `locale` now exposed through the RLB so it can be set by consumers ([2527](https://github.com/mozilla/glean/pull/2527))
 * Python
   * Added the shutdown API for Python to ensure orderly shutdown and waiting for uploader processes ([#2538](https://github.com/mozilla/glean/pull/2538))
+* Kotlin
+  * Move running of upload task when Glean is running in a background service to use the internal Glean Dispatchers rather than WorkManager. [Bug 1844533](https://bugzilla.mozilla.org/show_bug.cgi?id=1844533)
 
 # v53.1.0 (2023-06-28)
 

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$rootProject.versions.androidx_appcompat"
     implementation "androidx.browser:browser:$rootProject.versions.androidx_browser"
+    implementation "androidx.work:work-runtime-ktx:$rootProject.versions.androidx_browser"
+
 
     androidTestImplementation "androidx.test:core-ktx:$rootProject.versions.androidx_test"
     androidTestImplementation "androidx.test:runner:$rootProject.versions.androidx_test"

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -41,7 +41,6 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$rootProject.versions.androidx_appcompat"
     implementation "androidx.browser:browser:$rootProject.versions.androidx_browser"
-    implementation "androidx.work:work-runtime-ktx:$rootProject.versions.androidx_browser"
 
 
     androidTestImplementation "androidx.test:core-ktx:$rootProject.versions.androidx_test"

--- a/samples/android/app/metrics.yaml
+++ b/samples/android/app/metrics.yaml
@@ -148,6 +148,20 @@ custom:
     notification_emails:
       - CHANGE-ME@test-only.com
     expires: 2
+  bg_counter:
+    type: counter
+    description: |
+      A custom counter incremented in background process
+    lifetime: ping
+    send_in_pings:
+      - background
+    bugs:
+      - https://bugzilla.mozilla.org/1547330
+    data_reviews:
+      - N/A
+    notification_emails:
+      - CHANGE-ME@test-only.com
+    expires: 2
 
 legacy_ids:
   client_id:

--- a/samples/android/app/pings.yaml
+++ b/samples/android/app/pings.yaml
@@ -20,3 +20,13 @@ sample:
     - N/A
   notification_emails:
     - CHANGE-ME@example.com
+background:
+  description: |
+    A sample custom ping sent from the background process.
+  include_client_id: true
+  bugs:
+    - https://bugzilla.mozilla.org/123456789
+  data_reviews:
+    - N/A
+  notification_emails:
+    - CHANGE-ME@example.com

--- a/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BackgroundPingTest.kt
+++ b/samples/android/app/src/androidTest/java/org/mozilla/samples/gleancore/pings/BackgroundPingTest.kt
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.gleancore.pings
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ServiceTestRule
+import mozilla.telemetry.glean.testing.GleanTestLocalServer
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.samples.gleancore.SampleBackgroundProcess
+
+// Note that this is ignored because for some reason the mock server
+// doesn't seem to be able to catch the background ping when it is
+// sent, despite the logs clearly stating that the ping is being sent
+// and from testing with the Glean Debug View also clearly showing
+// that the ping is being sent. See Bug 1846518 filed as a follow-up
+// to this to try and fix this.
+@RunWith(AndroidJUnit4::class)
+@Ignore
+class BackgroundPingTest {
+    private val server = createMockWebServer()
+
+    @get:Rule
+    val serviceRule: ServiceTestRule = ServiceTestRule()
+
+    @get:Rule
+    val gleanRule = GleanTestLocalServer(context, server.port)
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun validateBackgroundPing() {
+        val serviceIntent = Intent(
+            context,
+            SampleBackgroundProcess::class.java,
+        )
+        serviceRule.startService(serviceIntent)
+
+        val backgroundPing = waitForPingContent("background", "started", server)
+        assertNotNull(backgroundPing)
+
+        val metrics = backgroundPing?.getJSONObject("metrics")
+
+        val counters = metrics?.getJSONObject("counter")
+        assertTrue(counters?.getJSONObject("custom.bg_counter")?.getLong("value") == 1L)
+
+        // Make sure there's no errors.
+        val errors = metrics?.optJSONObject("labeled_counter")?.keys()
+        errors?.forEach {
+            assertFalse(it.startsWith("glean.error."))
+        }
+    }
+}

--- a/samples/android/app/src/main/AndroidManifest.xml
+++ b/samples/android/app/src/main/AndroidManifest.xml
@@ -47,5 +47,28 @@
             android:targetActivity=".MainActivity"
             android:exported="true">
         </activity-alias>
+
+        <!--
+          Define a background service to test running Glean from off the main process
+        -->
+        <service android:name=".SampleBackgroundProcess"
+            android:process=":sampleBackgroundProcess" />
+
+        <!--
+          Disable default WorkManager initialization so we can use a custom
+          provider in order to test background service operation
+        -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <!-- If you are using androidx.startup to initialize other components -->
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 </manifest>

--- a/samples/android/app/src/main/AndroidManifest.xml
+++ b/samples/android/app/src/main/AndroidManifest.xml
@@ -53,22 +53,5 @@
         -->
         <service android:name=".SampleBackgroundProcess"
             android:process=":sampleBackgroundProcess" />
-
-        <!--
-          Disable default WorkManager initialization so we can use a custom
-          provider in order to test background service operation
-        -->
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-            <!-- If you are using androidx.startup to initialize other components -->
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-        </provider>
-
     </application>
 </manifest>

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/GleanApplication.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/GleanApplication.kt
@@ -6,7 +6,6 @@ package org.mozilla.samples.gleancore
 
 import android.app.Application
 import android.util.Log
-import androidx.work.Configuration
 import mozilla.telemetry.glean.Glean
 import org.mozilla.samples.gleancore.GleanMetrics.Basic
 import org.mozilla.samples.gleancore.GleanMetrics.Custom
@@ -18,21 +17,7 @@ import java.util.UUID
 
 private const val TAG = "Glean"
 
-class GleanApplication : Application(), Configuration.Provider {
-
-    /**
-     * Override for providing a default WorkManager configuration for the background service to
-     * use. This sets the default process to the main process, otherwise the background service
-     * WorkManager doesn't function.
-     */
-    override fun getWorkManagerConfiguration(): Configuration {
-        return Configuration.Builder()
-            // This is required for Glean to be able to enqueue the PingUploadWorker
-            // from both the daemon and the main app.
-            .setDefaultProcessName(packageName)
-            .setMinimumLoggingLevel(Log.INFO)
-            .build()
-    }
+class GleanApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/GleanApplication.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/GleanApplication.kt
@@ -6,6 +6,7 @@ package org.mozilla.samples.gleancore
 
 import android.app.Application
 import android.util.Log
+import androidx.work.Configuration
 import mozilla.telemetry.glean.Glean
 import org.mozilla.samples.gleancore.GleanMetrics.Basic
 import org.mozilla.samples.gleancore.GleanMetrics.Custom
@@ -17,7 +18,21 @@ import java.util.UUID
 
 private const val TAG = "Glean"
 
-class GleanApplication : Application() {
+class GleanApplication : Application(), Configuration.Provider {
+
+    /**
+     * Override for providing a default WorkManager configuration for the background service to
+     * use. This sets the default process to the main process, otherwise the background service
+     * WorkManager doesn't function.
+     */
+    override fun getWorkManagerConfiguration(): Configuration {
+        return Configuration.Builder()
+            // This is required for Glean to be able to enqueue the PingUploadWorker
+            // from both the daemon and the main app.
+            .setDefaultProcessName(packageName)
+            .setMinimumLoggingLevel(Log.INFO)
+            .build()
+    }
 
     override fun onCreate() {
         super.onCreate()

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/MainActivity.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/MainActivity.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.samples.gleancore
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -19,6 +20,12 @@ open class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
+
+        // Start the background service to test recording metrics and sending pings in from off
+        // the main process
+        startService(
+            Intent(this, SampleBackgroundProcess::class.java),
+        )
 
         setContentView(binding.root)
 

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/MainActivity.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/MainActivity.kt
@@ -16,16 +16,16 @@ import org.mozilla.samples.gleancore.databinding.ActivityMainBinding
 
 open class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
+    private lateinit var serviceIntent: Intent
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
+        serviceIntent = Intent(this, SampleBackgroundProcess::class.java)
 
         // Start the background service to test recording metrics and sending pings in from off
         // the main process
-        startService(
-            Intent(this, SampleBackgroundProcess::class.java),
-        )
+        startService(serviceIntent)
 
         setContentView(binding.root)
 
@@ -79,5 +79,10 @@ open class MainActivity : AppCompatActivity() {
         }
 
         Test.timespan.stop()
+    }
+
+    override fun onDestroy() {
+        stopService(serviceIntent)
+        super.onDestroy()
     }
 }

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/SampleBackgroundProcess.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/SampleBackgroundProcess.kt
@@ -1,0 +1,83 @@
+package org.mozilla.samples.gleancore
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import android.util.Log
+import mozilla.telemetry.glean.BuildInfo
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.config.Configuration
+import org.mozilla.samples.gleancore.GleanMetrics.Custom
+import org.mozilla.samples.gleancore.GleanMetrics.Pings
+import java.io.File
+import java.util.Calendar
+
+/**
+ * A simple sample background service for the purpose of testing Glean running in a background
+ * process. This service records a counter and then submits a ping as it starts.
+ */
+class SampleBackgroundProcess : Service() {
+    private var mBinder: Binder = Binder()
+
+    /**
+     * Required override, don't need to do anything here so we
+     * just return a default Binder
+     */
+    override fun onBind(p0: Intent?): IBinder? {
+        return mBinder
+    }
+
+    /**
+     * Entry point when the Service gets started by ServiceIntent
+     */
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(TAG, "Service Started by Intent")
+
+        initializeGlean()
+
+        Custom.bgCounter.add()
+        Pings.background.submit()
+
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    /**
+     * Initialize Glean for the background process with a custom data path
+     */
+    private fun initializeGlean() {
+        val customDataPath = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR).path
+        Log.i(TAG, "Initializing Glean on background process with path: $customDataPath")
+
+        Glean.registerPings(Pings)
+        Glean.initialize(
+            applicationContext = this.applicationContext,
+            uploadEnabled = true,
+            // GleanBuildInfo can only be generated for application,
+            // We are in a library so we have to build it ourselves.
+            buildInfo =
+            BuildInfo(
+                "0.0.1",
+                "0.0.1",
+                Calendar.getInstance(),
+            ),
+            configuration =
+            Configuration(
+                channel = "sample",
+                // When initializing Glean from outside the main process,
+                // we need to provide it with a dataPath manually.
+                dataPath = customDataPath,
+            ),
+        )
+
+        Log.i(TAG, "Initialized Glean in background service")
+    }
+
+    companion object {
+        // A custom data path to use for the background service
+        internal const val GLEAN_DATA_DIR: String = "sample_background_service"
+
+        // A log tag for background service log messages
+        internal const val TAG: String = "sample_bg_service"
+    }
+}

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/SampleBackgroundProcess.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/SampleBackgroundProcess.kt
@@ -18,14 +18,12 @@ import java.util.Calendar
  * process. This service records a counter and then submits a ping as it starts.
  */
 class SampleBackgroundProcess : Service() {
-    private var mBinder: Binder = Binder()
-
     /**
      * Required override, don't need to do anything here so we
      * just return a default Binder
      */
-    override fun onBind(p0: Intent?): IBinder? {
-        return mBinder
+    override fun onBind(intent: Intent?): IBinder {
+        return Binder()
     }
 
     /**


### PR DESCRIPTION
When Glean attempted to schedule an upload task on the WorkManager from a background process
it would get the main-process Glean when the task was executed. Since the main-process Glean
didn't have the data directory from the background process, it would not find the ping to be
able to upload it. This changes the uploader to run on the internal Glean Dispatcher when it
is being run from a background service or process and continues to rely on WorkManager for
the main process execution.