### PR TITLE
Dependabot: Group all Python package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     ignore:
       # Updated in lockstep across all implementations
       - dependency-name: "glean_parser"
+    groups:
+      python-packages:
+        patterns:
+          - "*"


### PR DESCRIPTION
This will reduce individual PRs in favor of a single PR updating multiple dependencies.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

[doc only]