### PR TITLE
Possible fix for start up ping inconsistency

### DIFF
--- a/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
+++ b/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
@@ -23,9 +23,11 @@ class GleanLifecycleObserver {
             object: nil
         )
 
-        // We handle init the same as an foreground event,
+        // We handle init the same as an foreground event if the app is in the foreground,
         // as we won't get the enter-foreground notification.
-        Glean.shared.handleForegroundEvent()
+        if UIApplication.shared.applicationState == .active {
+            Glean.shared.handleForegroundEvent()
+        }
     }
 
     @objc func appWillEnterForeground(notification _: NSNotification) {


### PR DESCRIPTION
This is a potential fix for the start up ping issue on iOS.

The current theory is that the app is launching while in the background and then getting shut down without the user ever bringing the app into the foreground (and therefore never triggering the background event). There are two places this could be happening that were added in v113, one is a background task is scheduled to run after 4 hours and the other is a local notification that fires after 2 days. Both use cases would relaunch the app if it was terminated while keeping it in the background and if the user doesn't use the app soon after then the app would be terminated in the background resulting in Glean firing an active ping without a corresponding inactive ping.

We are working to gather more evidence to confirm this theory but in the mean time I wanted to get feedback if a solution like this would be acceptable or to start the conversation about how this might be solved otherwise as the use cases on the iOS side that are causing this are valid ones that we can't remove.

I'm also unable to run locally so I have no idea if this even runs or breaks tests 🙈 