### PR TITLE
iOS: Handle `didBecomeActiveNotification` to track first active state of an app

### DIFF
--- a/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
+++ b/glean-core/ios/Glean/Scheduler/GleanLifecycleObserver.swift
@@ -11,6 +11,12 @@ class GleanLifecycleObserver {
     init() {
         NotificationCenter.default.addObserver(
             self,
+            selector: #selector(GleanLifecycleObserver.appDidBecomeActive(notification:)),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
             selector: #selector(GleanLifecycleObserver.appWillEnterForeground(notification:)),
             name: UIApplication.willEnterForegroundNotification,
             object: nil
@@ -22,9 +28,14 @@ class GleanLifecycleObserver {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
+    }
 
-        // We handle init the same as an foreground event,
-        // as we won't get the enter-foreground notification.
+    @objc func appDidBecomeActive(notification _: NSNotification) {
+        // `didBecomeActiveNotification` is also triggered after the user
+        // leaves an overlay (popup, notification),
+        // but that's okay in our case:
+        // `handleForegroundEvent` keeps track of the `active` status,
+        // but the above cases don't trigger `didEnterBackgroundNotification`!
         Glean.shared.handleForegroundEvent()
     }
 

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -321,8 +321,7 @@ class GleanTests: XCTestCase {
     }
 
     func testForegroundCounter() {
-        // Glean is started by the test framework.
-        // That already triggers the first foreground event.
+        Glean.shared.handleForegroundEvent()
 
         // Put it in the background
         Glean.shared.handleBackgroundEvent()


### PR DESCRIPTION
We used to always call `handleForegroundEvent` after initialize, when setting up the lifecycle observer.
Howerver there are cases where the app starts up but is NOT made active.

The only way to really capture that is to listen to `didBecomeActiveNotification`. Now `didBecomeActiveNotification` is also triggered after the user leaves an overlay (popup, notification), but that's okay in our case: `handleForegroundEvent` keeps track of the `active` status, but the above cases don't trigger `didEnterBackgroundNotification`!

---

Alternative to #2587 probably