### PR TITLE
Update debugViewTag.md

### DIFF
--- a/docs/user/reference/debug/debugViewTag.md
+++ b/docs/user/reference/debug/debugViewTag.md
@@ -31,6 +31,8 @@ The tag will be applied upon initialization in this case.
 import Glean
 
 Glean.shared.setDebugViewTag("my-tag")
+```
+</div>
 <div data-lang="Python" class="tab"></div>
 <div data-lang="Rust" class="tab">
 

--- a/docs/user/reference/debug/debugViewTag.md
+++ b/docs/user/reference/debug/debugViewTag.md
@@ -32,6 +32,7 @@ import Glean
 
 Glean.shared.setDebugViewTag("my-tag")
 ```
+
 </div>
 <div data-lang="Python" class="tab"></div>
 <div data-lang="Rust" class="tab">


### PR DESCRIPTION
Second commit on https://github.com/mozilla/glean/pull/2602/ ended up with an unclosed tag, causing some unexpected formatting: https://mozilla.github.io/glean/book/reference/debug/debugViewTag.html#debug-view-tag