### PR TITLE
Bug 1848201 - Introduce API to allow setting an experimentation ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Experimental: Add configuration to add a wall clock timestamp to all events ([#2513](https://github.com/mozilla/glean/issues/2513))
+  * Add an API to set an Experimentation ID that will be annotated to all pings ([#2606](https://github.com/mozilla/glean/pull/2606))
 * Python
   * Switched the build system to maturin. This should not have any effect on consumers. ([#2345](https://github.com/mozilla/glean/pull/2345))
   * BREAKING CHANGE: Dropped support for Python 3.6 ([#2345](https://github.com/mozilla/glean/pull/2345))

--- a/docs/user/reference/general/experiments-api.md
+++ b/docs/user/reference/general/experiments-api.md
@@ -185,6 +185,59 @@ FOG.setExperimentInactive("blue-button-effective");
 
 {{#include ../../../shared/tab_footer.md}}
 
+### `setExperimentationId`
+
+Set an experimentation enrollment identifier that is derived and provided by the application.
+This can be useful for the purpose unification of telemetry across a client/server experiment.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+Glean.setExperimentationId("alpha-beta-gamma-delta")
+```
+</div>
+
+<div data-lang="Java" class="tab"></div>
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+Glean.shared.setExperimentationId(experimentationId: "alpha-beta-gamma-delta")
+```
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import Glean
+
+Glean.set_experimentation_id("alpha-beta-gamma-delta")
+```
+</div>
+
+<div data-lang="JavaScript" class="tab" data-bug="1850323"></div>
+
+<div data-lang="Rust" class="tab">
+
+```Rust
+glean_set_experimentation_id("alpha-beta-gamma-delta".to_string());
+```
+</div>
+
+<div data-lang="Firefox Desktop" class="tab" data-bug="1850479"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
+#### Limits
+
+The experimentation ID is subject to the same limitations as a `StringMetricType`.
+
+#### Recorded errors
+
+The experimentation ID will produce the same errors as a `StringMetricType`.
+
 ## Testing API
 
 ### `testIsExperimentActive`
@@ -305,8 +358,61 @@ Assert.equals(
 
 {{#include ../../../shared/tab_footer.md}}
 
+### `testGetExperimentationId`
+
+Returns the current Experimentation ID, if any.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+assertEquals("alpha-beta-gamma-delta", Glean.testGetExperimentationId())
+```
+</div>
+
+<div data-lang="Java" class="tab"></div>
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+XCTAssertEqual(
+  "alpha-beta-gamma-delta",
+  Glean.shared.testGetExperimentationId()!,
+  "Experimenatation ids must match"
+)
+```
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import Glean
+
+assert "alpha-beta-gamma-delta" == Glean.test_get_experimentation_id()
+```
+</div>
+
+<div data-lang="JavaScript" class="tab" data-bug="1850323"></div>
+
+<div data-lang="Rust" class="tab">
+
+```Rust
+assert_eq!(
+  "alpha-beta-gamma-delta".to_string(),
+  glean_test_get_experimentation_id(),
+  "Experimentation id must match"
+);
+```
+</div>
+
+<div data-lang="Firefox Desktop" class="tab" data-bug="1850479"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
 ## Reference
 
 * [Swift API docs](../../../swift/Classes/QuantityMetricType.html)
 * [Python API docs](../../../python/glean/metrics/quantity.html)
 * [Rust API docs](../../../docs/glean/private/quantity/struct.QuantityMetric.html)
+* [String Metric Type](../metrics/string.md)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -356,6 +356,31 @@ open class GleanInternalAPI internal constructor() {
     }
 
     /**
+     * Set an experimentation identifier derived and provided by the application
+     * for the purpose of enrollment and unification of telemetry across a
+     * client/server experiment.
+     *
+     * Note: Glean will add this experimentation id annotation to all pings that
+     * are sent, and the experimentation id is not persisted between runs.
+     *
+     * @param experimentationId the experimentation id annotation to set.
+     */
+    fun setExperimentationId(experimentationId: String) {
+        return gleanSetExperimentationId(experimentationId)
+    }
+
+    /**
+     * Returns the stored experimentation id, for testing purposes only.
+     *
+     * @return the [String] experimentation id
+     * @throws [NullPointerException] if no experimentation id is set.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetExperimentationId(): String {
+        return gleanTestGetExperimentationId() ?: throw NullPointerException("Experimentation Id is not set")
+    }
+
+    /**
      * Initialize the core metrics internally managed by Glean (e.g. client id).
      */
     internal fun getClientInfo(configuration: Configuration, buildInfo: BuildInfo): ClientInfoMetrics {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -176,6 +176,12 @@ class GleanTest {
         assertFalse(Glean.testIsExperimentActive("experiment_preinit_disabled"))
     }
 
+    @Test
+    fun `test experimentation id recording`() {
+        Glean.setExperimentationId("alpha-beta-gamma-delta")
+        assertEquals("alpha-beta-gamma-delta", Glean.testGetExperimentationId())
+    }
+
     // Suppressing our own deprecation before we move over to the new event recording API.
     @Test
     @Suppress("ComplexMethod", "LongMethod", "NestedBlockDepth", "DEPRECATION")

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/DeletionPingTest.kt
@@ -13,6 +13,8 @@ import mozilla.telemetry.glean.getWorkerStatus
 import mozilla.telemetry.glean.resetGlean
 import mozilla.telemetry.glean.testing.GleanTestRule
 import mozilla.telemetry.glean.triggerWorkManager
+import mozilla.telemetry.glean.utils.decompressGZIP
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -162,5 +164,40 @@ class DeletionPingTest {
 
         // 'baseline' ping is removed from disk.
         assertEquals(0, pendingPingDir.listFiles()?.size)
+    }
+
+    @Test
+    fun `deletion-request pings include experimentation id`() {
+        val server = getMockWebServer()
+        val context = getContext()
+
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            ),
+            clearStores = true,
+            uploadEnabled = true,
+        )
+
+        Glean.setExperimentationId("alpha-beta-gamma-delta")
+
+        // Disabling upload generates a deletion ping
+        Glean.setUploadEnabled(false)
+        triggerWorkManager(context)
+
+        val request = server.takeRequest(2L, TimeUnit.SECONDS)!!
+        val docType = request.path!!.split("/")[3]
+        assertEquals("deletion-request", docType)
+
+        val body = decompressGZIP(request.body.readByteArray())
+
+        // Parse the body back into JSON
+        val deletionPing = JSONObject(body)
+        val metrics = deletionPing.getJSONObject("metrics")
+        val strings = metrics.getJSONObject("string")
+        val experimentationId = strings.getString("glean.client.annotation.experimentation_id")
+
+        assertEquals("Experimentation ids must match", "alpha-beta-gamma-delta", experimentationId)
     }
 }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -276,6 +276,28 @@ public class Glean {
         return gleanTestGetExperimentData(experimentId)
     }
 
+    /// Set an experimentation identifier derived and provided by the application
+    /// for the purpose of enrollment and unification of telemetry across a
+    /// client/server experiment.
+    ///
+    /// Note: Glean will add this experimentation id annotation to all pings that
+    /// are sent, and the experimentation id is not persisted between runs.
+    ///
+    /// - parameters:
+    ///     * experimentationId: the experimentation id annotation to set.
+    public func setExperimentationId(experimentationId: String) {
+        return gleanSetExperimentationId(experimentationId)
+    }
+
+    /// PUBLIC TEST ONLY FUNCTION.
+    ///
+    /// Returns the stored experimentation id, for testing purposes only.
+    ///
+    /// - returns: the 'String' experimentation id if set, and `nil` otherwise.
+    public func testGetExperimentationId() -> String? {
+        return gleanTestGetExperimentationId()
+    }
+
     /// Returns true if the Glean SDK has been initialized.
     func isInitialized() -> Bool {
         return self.initialized

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -276,15 +276,13 @@ public class Glean {
         return gleanTestGetExperimentData(experimentId)
     }
 
-    /// Set an experimentation identifier derived and provided by the application
-    /// for the purpose of enrollment and unification of telemetry across a
-    /// client/server experiment.
+    /// Set an experimentation identifier.
     ///
-    /// Note: Glean will add this experimentation id annotation to all pings that
-    /// are sent, and the experimentation id is not persisted between runs.
+    /// Note: Glean will add this experimentation id to all pings that are sent,
+    /// and the experimentation id is not persisted between runs.
     ///
     /// - parameters:
-    ///     * experimentationId: the experimentation id annotation to set.
+    ///     * experimentationId: the experimentation id to set.
     public func setExperimentationId(experimentationId: String) {
         return gleanSetExperimentationId(experimentationId)
     }

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -103,6 +103,15 @@ class GleanTests: XCTestCase {
         )
     }
 
+    func testGleanExperimentationIdIsSet() {
+        Glean.shared.setExperimentationId(experimentationId: "alpha-beta-gamma-delta")
+        XCTAssertEqual(
+            "alpha-beta-gamma-delta",
+            Glean.shared.testGetExperimentationId()!,
+            "Experimenatation ids must match"
+        )
+    }
+
     func testGleanIsNotInitializedFromOtherProcesses() {
         // Check to see if Glean is initialized
         XCTAssert(Glean.shared.isInitialized())

--- a/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
+++ b/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
@@ -147,4 +147,24 @@ class DeletionRequestPingTests: XCTestCase {
         let clientId = clientInfo["client_id"] as! String
         XCTAssertEqual(clientId, "test-only")
     }
+
+    func testDeletionRequestPingsContainExperimentationId() {
+        Glean.shared.resetGlean(clearStores: true)
+
+        setupHttpResponseStub("deletion-request")
+        expectation = expectation(description: "Completed upload")
+
+        Glean.shared.setExperimentationId(experimentationId: "alpha-beta-gamma-delta")
+
+        Glean.shared.setUploadEnabled(false)
+
+        waitForExpectations(timeout: 5.0) { error in
+            XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
+        }
+
+        let metrics = lastPingJson!["metrics"] as! [String: Any]
+        let strings = metrics["string"] as! [String: Any]
+        let experimentationId = strings["glean.client.annotation.experimentation_id"] as! String
+        XCTAssertEqual(experimentationId, "alpha-beta-gamma-delta")
+    }
 }

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -406,7 +406,7 @@ client.annotation:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1848201
     data_reviews:
-      - TBD
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1848201#c5
     data_sensitivity:
       - technical
     notification_emails:

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -394,7 +394,7 @@ glean.internal.metrics:
       - glean-team@mozilla.com
     expires: never
 
-client.annotation:
+glean.client.annotation:
   experimentation_id:
     type: string
     lifetime: application

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -394,6 +394,25 @@ glean.internal.metrics:
       - glean-team@mozilla.com
     expires: never
 
+client.annotation:
+  experimentation_id:
+    type: string
+    lifetime: application
+    send_in_pings:
+      - all-pings
+    description: |
+      An experimentation identifier derived and provided by the application
+      for the purpose of experimenation enrollment.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1848201
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+
 glean.error:
   invalid_value:
     type: labeled_counter

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -407,15 +407,13 @@ class Glean:
     @classmethod
     def set_experimentation_id(cls, experimentation_id: str) -> None:
         """
-        Set an experimentation identifier derived and provided by the application
-        for the purpose of enrollment and unification of telemetry across a
-        client/server experiment.
+        Set an experimentation identifier.
 
-        Note: Glean will add this experimentation id annotation to all pings that
-        are sent, and the experimentation id is not persisted between runs.
+        Note: Glean will add this experimentation id to all pings that are sent,
+        and the experimentation id is not persisted between runs.
 
         Args:
-            experimentation_id (str): The experimentation id to annotate all pings with.
+            experimentation_id (str): The experimentation id to set.
         """
         _uniffi.glean_set_experimentation_id(experimentation_id)
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -405,6 +405,35 @@ class Glean:
             raise RuntimeError("Experiment data is not set")
 
     @classmethod
+    def set_experimentation_id(cls, experimentation_id: str) -> None:
+        """
+        Set an experimentation identifier derived and provided by the application
+        for the purpose of enrollment and unification of telemetry across a
+        client/server experiment.
+
+        Note: Glean will add this experimentation id annotation to all pings that
+        are sent, and the experimentation id is not persisted between runs.
+
+        Args:
+            experimentation_id (str): The experimentation id to annotate all pings with.
+        """
+        _uniffi.glean_set_experimentation_id(experimentation_id)
+
+    @classmethod
+    def test_get_experimentation_id(cls) -> str:
+        """
+        Returns the stored experimentation id, for testing purposes only.
+
+        Returns:
+            experimentation_id (str): The experimentation id set by the client.
+        """
+        experimentation_id = _uniffi.glean_test_get_experimentation_id()
+        if experimentation_id is not None:
+            return experimentation_id
+        else:
+            raise RuntimeError("Experimentation id is not set")
+
+    @classmethod
     def handle_client_active(cls):
         """
         Performs the collection/cleanup operations required by becoming active.

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -177,6 +177,11 @@ def test_experiments_recording_before_glean_inits():
     assert not Glean.test_is_experiment_active("experiment_preinit_disabled")
 
 
+def test_exeperimentation_id_recording():
+    Glean.set_experimentation_id("alpha-beta-gamma-delta")
+    assert "alpha-beta-gamma-delta" == Glean.test_get_experimentation_id()
+
+
 @pytest.mark.skip
 def test_sending_of_background_pings():
     pass

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -171,6 +171,24 @@ pub fn set_experiment_inactive(experiment_id: String) {
     glean_core::glean_set_experiment_inactive(experiment_id)
 }
 
+/// An experimentation identifier derived and provided by the application
+/// for the purpose of enrollment and unification of telemetry across a
+/// client/server application.
+///
+/// Glean will add this experimentation id annotation to along with all pings
+/// that are sent. This information is not persisted between runs.
+///
+/// See [`glean_core::Glean::set_experimentation_id`].
+pub fn set_experimenation_id(experimentation_id: String) {
+    glean_core::glean_set_experimentation_id(experimentation_id)
+}
+
+/// TEST ONLY FUNCTION.
+/// Gets stored experimenation id annotation.
+pub fn test_get_experimentation_id() -> Option<String> {
+    glean_core::glean_test_get_experimentation_id()
+}
+
 /// Set the remote configuration values for the metrics' disabled property
 ///
 /// See [`glean_core::Glean::set_metrics_enabled_config`].

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use crossbeam_channel::RecvTimeoutError;
 use flate2::read::GzDecoder;
+use glean_core::{glean_set_experimentation_id, glean_test_get_experimentation_id};
 use serde_json::Value as JsonValue;
 
 use crate::private::PingType;
@@ -140,6 +141,24 @@ fn test_experiments_recording_before_glean_inits() {
     assert!(!test_is_experiment_active(
         "experiment_preinit_disabled".to_string()
     ));
+}
+
+#[test]
+fn test_experimentation_id_recording() {
+    let _lock = lock_test();
+    let _t = new_glean(None, true);
+
+    glean_set_experimentation_id("alpha-beta-gamma-delta".into());
+
+    if let Some(exp_id) = glean_test_get_experimentation_id() {
+        assert_eq!(
+            "alpha-beta-gamma-delta".to_string(),
+            exp_id,
+            "Experimentation id must match"
+        );
+    } else {
+        panic!("Experimentation id must not be None");
+    }
 }
 
 #[test]

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -150,15 +150,12 @@ fn test_experimentation_id_recording() {
 
     glean_set_experimentation_id("alpha-beta-gamma-delta".into());
 
-    if let Some(exp_id) = glean_test_get_experimentation_id() {
-        assert_eq!(
-            "alpha-beta-gamma-delta".to_string(),
-            exp_id,
-            "Experimentation id must match"
-        );
-    } else {
-        panic!("Experimentation id must not be None");
-    }
+    let exp_id = glean_test_get_experimentation_id().expect("Experimentation id must not be None");
+    assert_eq!(
+        "alpha-beta-gamma-delta".to_string(),
+        exp_id,
+        "Experimentation id must match"
+    );
 }
 
 #[test]

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -718,6 +722,31 @@ impl Glean {
     pub fn test_get_experiment_data(&self, experiment_id: String) -> Option<RecordedExperiment> {
         let metric = ExperimentMetric::new(self, experiment_id);
         metric.test_get_value(self)
+    }
+
+    /// Set an experimentation identifier derived and provided by the application
+    /// for the purpose of enrollment and unification of telemetry across a
+    /// client/server application.
+    ///
+    /// Glean will add this experimentation id annotation to along with all pings
+    /// that are sent. This information is not persisted between runs.
+    ///
+    /// # Arguments
+    ///
+    /// * `experimentation_id` - The experimentation id annotation.
+    pub fn set_experimentation_id(&self, experimentation_id: String) {
+        self.additional_metrics
+            .experimentation_id
+            .set_sync(self, experimentation_id);
+    }
+
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Gets stored experimenation id annotation.
+    pub fn test_get_experimentation_id(&self) -> Option<String> {
+        self.additional_metrics
+            .experimentation_id
+            .get_value(self, None)
     }
 
     /// Set configuration to override the default metric enabled/disabled state, typically from a

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -32,6 +32,10 @@ namespace glean {
     void glean_set_experiment_inactive(string experiment_id);
     RecordedExperiment? glean_test_get_experiment_data(string experiment_id);
 
+    // Experimentation ID API
+    void glean_set_experimentation_id(string experimentation_id);
+    string? glean_test_get_experimentation_id();
+
     // Server Knobs API
     void glean_set_metrics_enabled_config(string json);
 

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -117,9 +117,17 @@ impl AdditionalMetrics {
                 TimeUnit::Millisecond,
             ),
 
+            // This uses a `send_in_pings` that contains "all-ping".
+            // This works because all of our other current "all-pings" metrics
+            // have special handling internally and are not actually processed
+            // into a store quite like this identifier is.
+            //
+            // This could become an issue if we ever decide to start generating
+            // code from the internal Glean metrics.yaml (there aren't currently
+            // any plans for this).
             experimentation_id: StringMetric::new(CommonMetricData {
                 name: "experimentation_id".into(),
-                category: "client.annotation".into(),
+                category: "glean.client.annotation".into(),
                 send_in_pings: vec!["all-pings".into()],
                 lifetime: Lifetime::Application,
                 disabled: false,

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -27,6 +27,10 @@ pub struct AdditionalMetrics {
 
     /// Time waited for the dispatcher to unblock during shutdown.
     pub shutdown_dispatcher_wait: TimingDistributionMetric,
+
+    /// An experimentation identifier derived and provided by the application
+    /// for the purpose of experimentation enrollment.
+    pub experimentation_id: StringMetric,
 }
 
 impl CoreMetrics {
@@ -112,6 +116,15 @@ impl AdditionalMetrics {
                 },
                 TimeUnit::Millisecond,
             ),
+
+            experimentation_id: StringMetric::new(CommonMetricData {
+                name: "experimentation_id".into(),
+                category: "client.annotation".into(),
+                send_in_pings: vec!["all-pings".into()],
+                lifetime: Lifetime::Application,
+                disabled: false,
+                dynamic_label: None,
+            }),
         }
     }
 }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -855,6 +855,25 @@ pub fn glean_test_get_experiment_data(experiment_id: String) -> Option<RecordedE
     core::with_glean(|glean| glean.test_get_experiment_data(experiment_id.to_owned()))
 }
 
+/// An experimentation identifier derived and provided by the application
+/// for the purpose of enrollment and unification of telemetry across a
+/// client/server application.
+///
+/// Glean will add this experimentation id annotation to along with all pings
+/// that are sent. This information is not persisted between runs.
+///
+/// See [`core::Glean::set_experimentation_id`].
+pub fn glean_set_experimentation_id(experimentation_id: String) {
+    launch_with_glean(|glean| glean.set_experimentation_id(experimentation_id))
+}
+
+/// TEST ONLY FUNCTION.
+/// Gets stored experimenation id annotation.
+pub fn glean_test_get_experimentation_id() -> Option<String> {
+    block_on_dispatcher();
+    core::with_glean(|glean| glean.test_get_experimentation_id())
+}
+
 /// Sets a remote configuration to override metrics' default enabled/disabled
 /// state
 ///

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -178,6 +178,30 @@ fn experiments_status_is_correctly_toggled() {
 }
 
 #[test]
+fn experimentation_id_is_set_correctly() {
+    let t = tempfile::tempdir().unwrap();
+    let name = t.path().display().to_string();
+    let glean = Glean::with_options(&name, "org.mozilla.glean.tests", true);
+
+    // Define an experimentation id to test
+    let experimentation_id = "test-experimentation-id";
+
+    // Set the experimentation identifier
+    glean.set_experimentation_id(experimentation_id.into());
+
+    // Check that the correct value was stored
+    if let Some(exp_id) = glean
+        .additional_metrics
+        .experimentation_id
+        .get_value(&glean, "all-pings")
+    {
+        assert_eq!(exp_id, experimentation_id, "Experimentation ids must match");
+    } else {
+        panic!("The experimentation id must not be `None`");
+    }
+}
+
+#[test]
 fn client_id_and_first_run_date_must_be_regenerated() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -99,6 +99,9 @@ impl StorageManager {
         storage.iter_store_from(Lifetime::Application, store_name, None, &mut snapshotter);
         storage.iter_store_from(Lifetime::User, store_name, None, &mut snapshotter);
 
+        // Add send in all pings client.annotations
+        storage.iter_store_from(Lifetime::Application, "all-pings", None, snapshotter);
+
         if clear_store {
             if let Err(e) = storage.clear_ping_lifetime_storage(store_name) {
                 log::warn!("Failed to clear lifetime storage: {:?}", e);

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -87,7 +87,7 @@ fn test_metrics_must_report_experimentation_id() {
     let metrics = ping.content["metrics"].as_object().unwrap();
     let strings = metrics["string"].as_object().unwrap();
     assert_eq!(
-        strings["client.annotation.experimentation_id"]
+        strings["glean.client.annotation.experimentation_id"]
             .as_str()
             .unwrap(),
         "test-experimentation-id",

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -75,6 +75,27 @@ fn get_client_info_must_report_all_the_available_data() {
 }
 
 #[test]
+fn test_metrics_must_report_experimentation_id() {
+    let (glean, ping_maker, ping_type, _t) = set_up_basic_ping();
+
+    // Set an expermentation id annotation
+    glean.set_experimentation_id("test-experimentation-id".to_string());
+
+    let ping = ping_maker
+        .collect(&glean, &ping_type, None, "", "")
+        .unwrap();
+    let metrics = ping.content["metrics"].as_object().unwrap();
+    let strings = metrics["string"].as_object().unwrap();
+    assert_eq!(
+        strings["client.annotation.experimentation_id"]
+            .as_str()
+            .unwrap(),
+        "test-experimentation-id",
+        "experimentation ids must match"
+    );
+}
+
+#[test]
 fn collect_must_report_none_when_no_data_is_stored() {
     // NOTE: This is a behavior change from glean-ac which returned an empty
     // string in this case. As this is an implementation detail and not part of


### PR DESCRIPTION
This adds an API to allow consumers of Glean to set an "experimentation identifier" which is then sent along with all pings. This is particularly useful for client/server applications using Cirrus (Nimbus) in a client/server architecture so the experimentation id can be used to unify experiment telemetry across both the client and the server.