### PR TITLE
Switch to Android SDK 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * BREAKING CHANGE: Dropped support for Python 3.6 ([#2345](https://github.com/mozilla/glean/pull/2345))
 * Kotlin
   * Update to Gradle v8.2.1 ([#2516](https://github.com/mozilla/glean/pull/2516))
+  * Increase Android compile SDK to version 34 ([#2614](https://github.com/mozilla/glean/pull/2614))
 
 # v53.2.0 (2023-08-02)
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
 
     ext.build = [
         ndkVersion: "25.2.9519653", // Keep it in sync in TC Dockerfile.
-        compileSdkVersion: 33,
+        compileSdkVersion: 34,
         targetSdkVersion: 33,
         minSdkVersion: 21,
         jvmTargetCompatibility: 17,


### PR DESCRIPTION
Not changing the target SDK yet as 33 is still the target for AC, but we need to use SDK34 for compatibility with some newer dependencies.