### PR TITLE
Bug 1848201 (v2) - Add an API to set an experimentation ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * General
   * Experimental: Add configuration to add a wall clock timestamp to all events ([#2513](https://github.com/mozilla/glean/issues/2513))
-  * Add an API to set an Experimentation ID that will be annotated to all pings ([#2606](https://github.com/mozilla/glean/pull/2606))
+  * Add an API to set an Experimentation ID that will be annotated to all pings ([Bug 1848201](https://bugzilla.mozilla.org/show_bug.cgi?id=1848201))
 * Python
   * Switched the build system to maturin. This should not have any effect on consumers. ([#2345](https://github.com/mozilla/glean/pull/2345))
   * BREAKING CHANGE: Dropped support for Python 3.6 ([#2345](https://github.com/mozilla/glean/pull/2345))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Experimental: Add configuration to add a wall clock timestamp to all events ([#2513](https://github.com/mozilla/glean/issues/2513))
+  * Add an API to set an Experimentation ID that will be annotated to all pings ([#2606](https://github.com/mozilla/glean/pull/2606))
 * Python
   * Switched the build system to maturin. This should not have any effect on consumers. ([#2345](https://github.com/mozilla/glean/pull/2345))
   * BREAKING CHANGE: Dropped support for Python 3.6 ([#2345](https://github.com/mozilla/glean/pull/2345))

--- a/docs/user/reference/general/experiments-api.md
+++ b/docs/user/reference/general/experiments-api.md
@@ -185,6 +185,20 @@ FOG.setExperimentInactive("blue-button-effective");
 
 {{#include ../../../shared/tab_footer.md}}
 
+### Set an experimentation identifier
+
+An experimentation enrollment identifier that is derived and provided by the application can be set through the configuration object passed into the `initialize` function. See the section on [Initializing Glean](initializing.md) for more information on how to set this within the `Configuration` object.
+
+This identifier will be set during initialization and sent along with all pings sent by Glean, unless that ping is has opted out of sending the client_id. This identifier is not persisted by Glean and must be persisted by the application if necessary for it to remain consistent between runs.
+
+#### Limits
+
+The experimentation ID is subject to the same limitations as a `StringMetricType`.
+
+#### Recorded errors
+
+The experimentation ID will produce the same errors as a `StringMetricType`.
+
 ## Testing API
 
 ### `testIsExperimentActive`
@@ -305,8 +319,61 @@ Assert.equals(
 
 {{#include ../../../shared/tab_footer.md}}
 
+### `testGetExperimentationId`
+
+Returns the current Experimentation ID, if any.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+assertEquals("alpha-beta-gamma-delta", Glean.testGetExperimentationId())
+```
+</div>
+
+<div data-lang="Java" class="tab"></div>
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+XCTAssertEqual(
+  "alpha-beta-gamma-delta",
+  Glean.shared.testGetExperimentationId()!,
+  "Experimenatation ids must match"
+)
+```
+</div>
+
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import Glean
+
+assert "alpha-beta-gamma-delta" == Glean.test_get_experimentation_id()
+```
+</div>
+
+<div data-lang="JavaScript" class="tab" data-bug="1850323"></div>
+
+<div data-lang="Rust" class="tab">
+
+```Rust
+assert_eq!(
+  "alpha-beta-gamma-delta".to_string(),
+  glean_test_get_experimentation_id(),
+  "Experimentation id must match"
+);
+```
+</div>
+
+<div data-lang="Firefox Desktop" class="tab" data-bug="1850479"></div>
+
+{{#include ../../../shared/tab_footer.md}}
+
 ## Reference
 
 * [Swift API docs](../../../swift/Classes/QuantityMetricType.html)
 * [Python API docs](../../../python/glean/metrics/quantity.html)
 * [Rust API docs](../../../docs/glean/private/quantity/struct.QuantityMetric.html)
+* [String Metric Type](../metrics/string.md)

--- a/docs/user/reference/general/experiments-api.md
+++ b/docs/user/reference/general/experiments-api.md
@@ -193,11 +193,11 @@ This identifier will be set during initialization and sent along with all pings 
 
 #### Limits
 
-The experimentation ID is subject to the same limitations as a `StringMetricType`.
+The experimentation ID is subject to the same limitations as a [string metric type](../metrics/string.md#limits).
 
 #### Recorded errors
 
-The experimentation ID will produce the same errors as a `StringMetricType`.
+The experimentation ID will produce the same errors as a [string metric type](../metrics/string.md#recorded-errors).
 
 ## Testing API
 
@@ -373,7 +373,6 @@ assert_eq!(
 
 ## Reference
 
-* [Swift API docs](../../../swift/Classes/QuantityMetricType.html)
-* [Python API docs](../../../python/glean/metrics/quantity.html)
-* [Rust API docs](../../../docs/glean/private/quantity/struct.QuantityMetric.html)
-* [String Metric Type](../metrics/string.md)
+* [Swift API docs](../../../swift/Classes/Glean.html#/s:5GleanAAC19setExperimentActive_6branch5extraySS_SSSDyS2SGSgtF)
+* [Python API docs](../../../python/glean/index.html#glean.Glean.set_experiment_active)
+* [Rust API docs](../../../docs/glean/fn.set_experiment_active.html)

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -71,6 +71,7 @@ for more information on how and when the use this feature.
 - `rateLimit`: Optional.
   Specifies the maximum number of pings that can be uploaded per interval of a specified number of seconds.
   Default is to use the SDK default (presently 15 pings per 60s interval).
+- `experimentationId`: Optional identifier derived by the application to be sent in all pings for the purpose of experimentation. See the experiments API documentation for more information.
 
 To learn about SDK specific configuration options available, refer to the [Reference](#reference) section.
 

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -71,7 +71,7 @@ for more information on how and when the use this feature.
 - `rateLimit`: Optional.
   Specifies the maximum number of pings that can be uploaded per interval of a specified number of seconds.
   Default is to use the SDK default (presently 15 pings per 60s interval).
-- `experimentationId`: Optional identifier derived by the application to be sent in all pings for the purpose of experimentation. See the experiments API documentation for more information.
+- `experimentationId`: Optional. An identifier derived by the application to be sent in all pings for the purpose of experimentation. See the experiments API documentation for more information.
 
 To learn about SDK specific configuration options available, refer to the [Reference](#reference) section.
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -260,6 +260,7 @@ open class GleanInternalAPI internal constructor() {
                 logLevel = configuration.logLevel,
                 rateLimit = null,
                 enableEventTimestamps = configuration.enableEventTimestamps,
+                experimentationId = configuration.experimentationId,
             )
             val clientInfo = getClientInfo(configuration, buildInfo)
             val callbacks = OnGleanEventsImpl(this@GleanInternalAPI)
@@ -353,6 +354,17 @@ open class GleanInternalAPI internal constructor() {
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetExperimentData(experimentId: String): RecordedExperiment {
         return gleanTestGetExperimentData(experimentId) ?: throw NullPointerException("Experiment data is not set")
+    }
+
+    /**
+     * Returns the stored experimentation id, for testing purposes only.
+     *
+     * @return the [String] experimentation id
+     * @throws [NullPointerException] if no experimentation id is set.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetExperimentationId(): String {
+        return gleanTestGetExperimentationId() ?: throw NullPointerException("Experimentation Id is not set")
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -33,6 +33,7 @@ data class Configuration @JvmOverloads constructor(
     val dataPath: String? = null,
     val logLevel: LevelFilter? = null,
     val enableEventTimestamps: Boolean = false,
+    val experimentationId: String? = null,
 ) {
     companion object {
         /**

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -176,6 +176,12 @@ class GleanTest {
         assertFalse(Glean.testIsExperimentActive("experiment_preinit_disabled"))
     }
 
+    @Test
+    fun `test experimentation id recording`() {
+        resetGlean(config = Configuration(experimentationId = "alpha-beta-gamma-delta"))
+        assertEquals("alpha-beta-gamma-delta", Glean.testGetExperimentationId())
+    }
+
     // Suppressing our own deprecation before we move over to the new event recording API.
     @Test
     @Suppress("ComplexMethod", "LongMethod", "NestedBlockDepth", "DEPRECATION")

--- a/glean-core/ios/Glean/Config/Configuration.swift
+++ b/glean-core/ios/Glean/Config/Configuration.swift
@@ -11,6 +11,7 @@ public struct Configuration {
     let dataPath: String?
     let logLevel: LevelFilter?
     let enableEventTimestamps: Bool
+    let experimentationId: String?
 
     struct Constants {
         static let defaultTelemetryEndpoint = "https://incoming.telemetry.mozilla.org"
@@ -33,7 +34,8 @@ public struct Configuration {
         serverEndpoint: String? = nil,
         dataPath: String? = nil,
         logLevel: LevelFilter? = nil,
-        enableEventTimestamps: Bool = false
+        enableEventTimestamps: Bool = false,
+        experimentationId: String? = nil
     ) {
         self.serverEndpoint = serverEndpoint ?? Constants.defaultTelemetryEndpoint
         self.maxEvents = maxEvents
@@ -41,5 +43,6 @@ public struct Configuration {
         self.dataPath = dataPath
         self.logLevel = logLevel
         self.enableEventTimestamps = enableEventTimestamps
+        self.experimentationId = experimentationId
     }
 }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -193,7 +193,8 @@ public class Glean {
             trimDataToRegisteredPings: false,
             logLevel: configuration.logLevel,
             rateLimit: nil,
-            enableEventTimestamps: configuration.enableEventTimestamps
+            enableEventTimestamps: configuration.enableEventTimestamps,
+            experimentationId: configuration.experimentationId
         )
         let clientInfo = getClientInfo(configuration, buildInfo: buildInfo)
         let callbacks = OnGleanEventsImpl(glean: self)
@@ -274,6 +275,15 @@ public class Glean {
     /// - returns: `RecordedExperiment` if the experiment is active and reported in pings, `nil` otherwise.
     public func testGetExperimentData(_ experimentId: String) -> RecordedExperiment? {
         return gleanTestGetExperimentData(experimentId)
+    }
+
+    /// PUBLIC TEST ONLY FUNCTION.
+    ///
+    /// Returns the stored experimentation id, for testing purposes only.
+    ///
+    /// - returns: the 'String' experimentation id if set, and `nil` otherwise.
+    public func testGetExperimentationId() -> String? {
+        return gleanTestGetExperimentationId()
     }
 
     /// Returns true if the Glean SDK has been initialized.

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -103,6 +103,25 @@ class GleanTests: XCTestCase {
         )
     }
 
+    func testGleanExperimentationIdIsSet() {
+        Glean.shared.resetGlean(
+            configuration: Configuration(
+                maxEvents: nil,
+                channel: nil,
+                serverEndpoint: nil,
+                dataPath: nil,
+                logLevel: nil,
+                enableEventTimestamps: false,
+                experimentationId: "alpha-beta-gamma-delta"
+            ),
+            clearStores: true)
+        XCTAssertEqual(
+            "alpha-beta-gamma-delta",
+            Glean.shared.testGetExperimentationId()!,
+            "Experimenatation ids must match"
+        )
+    }
+
     func testGleanIsNotInitializedFromOtherProcesses() {
         // Check to see if Glean is initialized
         XCTAssert(Glean.shared.isInitialized())

--- a/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
+++ b/glean-core/ios/GleanTests/Net/DeletionRequestPingTests.swift
@@ -147,4 +147,24 @@ class DeletionRequestPingTests: XCTestCase {
         let clientId = clientInfo["client_id"] as! String
         XCTAssertEqual(clientId, "test-only")
     }
+
+    func testDeletionRequestPingsContainExperimentationId() {
+        let config = Configuration(experimentationId: "alpha-beta-gamma-delta")
+
+        Glean.shared.resetGlean(configuration: config, clearStores: true)
+
+        setupHttpResponseStub("deletion-request")
+        expectation = expectation(description: "Completed upload")
+
+        Glean.shared.setUploadEnabled(false)
+
+        waitForExpectations(timeout: 5.0) { error in
+            XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
+        }
+
+        let metrics = lastPingJson!["metrics"] as! [String: Any]
+        let strings = metrics["string"] as! [String: Any]
+        let experimentationId = strings["glean.client.annotation.experimentation_id"] as! String
+        XCTAssertEqual(experimentationId, "alpha-beta-gamma-delta")
+    }
 }

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -394,6 +394,25 @@ glean.internal.metrics:
       - glean-team@mozilla.com
     expires: never
 
+glean.client.annotation:
+  experimentation_id:
+    type: string
+    lifetime: application
+    send_in_pings:
+      - all-pings
+    description: |
+      An experimentation identifier derived and provided by the application
+      for the purpose of experimenation enrollment.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1848201
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1848201#c5
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+
 glean.error:
   invalid_value:
     type: labeled_counter

--- a/glean-core/python/glean/config.py
+++ b/glean-core/python/glean/config.py
@@ -34,6 +34,7 @@ class Configuration:
         ping_uploader: Optional[net.BaseUploader] = None,
         allow_multiprocessing: bool = True,
         enable_event_timestamps: bool = False,
+        experimentation_id: Optional[str] = None,
     ):
         """
         Args:
@@ -60,6 +61,7 @@ class Configuration:
         self._ping_uploader = ping_uploader
         self._allow_multiprocessing = allow_multiprocessing
         self._enable_event_timestamps = enable_event_timestamps
+        self._experimentation_id = experimentation_id
 
     @property
     def server_endpoint(self) -> str:
@@ -94,6 +96,11 @@ class Configuration:
     def enable_event_timestamps(self) -> bool:
         """(Experimental) Whether to add a wallclock timestamp to all events."""
         return self._enable_event_timestamps
+
+    @property
+    def experimentation_id(self) -> Optional[str]:
+        """An experimentation id that will be sent in all pings"""
+        return self._experimentation_id
 
     @property
     def ping_uploader(self) -> net.BaseUploader:

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -233,6 +233,7 @@ class Glean:
             log_level=None,
             rate_limit=None,
             enable_event_timestamps=configuration.enable_event_timestamps,
+            experimentation_id=configuration.experimentation_id,
         )
 
         _uniffi.glean_initialize(cfg, client_info, callbacks)
@@ -403,6 +404,20 @@ class Glean:
             return data
         else:
             raise RuntimeError("Experiment data is not set")
+
+    @classmethod
+    def test_get_experimentation_id(cls) -> str:
+        """
+        Returns the stored experimentation id, for testing purposes only.
+
+        Returns:
+            experimentation_id (str): The experimentation id set by the client.
+        """
+        experimentation_id = _uniffi.glean_test_get_experimentation_id()
+        if experimentation_id is not None:
+            return experimentation_id
+        else:
+            raise RuntimeError("Experimentation id is not set")
 
     @classmethod
     def handle_client_active(cls):

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -123,6 +123,7 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
             log_level=None,
             rate_limit=None,
             enable_event_timestamps=False,
+            experimentation_id=None,
         )
         if not glean_initialize_for_subprocess(cfg):
             log.error("Couldn't initialize Glean in subprocess")

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -619,6 +619,52 @@ def test_no_sending_deletion_ping_if_unchanged_outside_of_run(safe_httpserver, t
     assert 0 == len(safe_httpserver.requests)
 
 
+def test_deletion_request_ping_contains_experimentation_id(tmpdir, ping_schema_url):
+    info_path = Path(str(tmpdir)) / "info.txt"
+    data_dir = Path(str(tmpdir)) / "glean"
+
+    Glean._reset()
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=True,
+        data_dir=data_dir,
+        configuration=Configuration(
+            ping_uploader=_RecordingUploader(info_path),
+            experimentation_id="alpha-beta-gamma-delta",
+        ),
+    )
+
+    Glean._reset()
+
+    Glean.initialize(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=False,
+        data_dir=data_dir,
+        configuration=Configuration(
+            ping_uploader=_RecordingUploader(info_path),
+            experimentation_id="alpha-beta-gamma-delta",
+        ),
+    )
+
+    while not info_path.exists():
+        time.sleep(0.1)
+
+    with info_path.open("r") as fd:
+        url_path = fd.readline()
+        serialized_ping = fd.readline()
+
+    assert "deletion-request" == url_path.split("/")[3]
+
+    json_content = json.loads(serialized_ping)
+
+    assert {
+        "glean.client.annotation.experimentation_id": "alpha-beta-gamma-delta"
+    } == json_content["metrics"]["string"]
+
+
 def test_dont_allow_multiprocessing(monkeypatch, safe_httpserver):
     safe_httpserver.serve_content(b"", code=200)
 

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -177,6 +177,17 @@ def test_experiments_recording_before_glean_inits():
     assert not Glean.test_is_experiment_active("experiment_preinit_disabled")
 
 
+def test_exeperimentation_id_recording():
+    Glean._reset()
+    Glean._initialize_with_tempdir_for_testing(
+        application_id=GLEAN_APP_ID,
+        application_version=glean_version,
+        upload_enabled=True,
+        configuration=Configuration(experimentation_id="alpha-beta-gamma-delta"),
+    )
+    assert "alpha-beta-gamma-delta" == Glean.test_get_experimentation_id()
+
+
 @pytest.mark.skip
 def test_sending_of_background_pings():
     pass

--- a/glean-core/rlb/src/configuration.rs
+++ b/glean-core/rlb/src/configuration.rs
@@ -42,6 +42,10 @@ pub struct Configuration {
     pub rate_limit: Option<crate::PingRateLimit>,
     /// (Experimental) Whether to add a wallclock timestamp to all events.
     pub enable_event_timestamps: bool,
+    /// An experimentation identifier derived by the application to be sent with all pings, it should
+    /// be noted that this has an underlying StringMetric and so should conform to the limitations that
+    /// StringMetric places on length, etc.
+    pub experimentation_id: Option<String>,
 }
 
 /// Configuration builder.
@@ -84,6 +88,10 @@ pub struct Builder {
     pub rate_limit: Option<crate::PingRateLimit>,
     /// (Experimental) Whether to add a wallclock timestamp to all events.
     pub enable_event_timestamps: bool,
+    /// An experimentation identifier derived by the application to be sent with all pings, it should
+    /// be noted that this has an underlying StringMetric and so should conform to the limitations that
+    /// StringMetric places on length, etc.
+    pub experimentation_id: Option<String>,
 }
 
 impl Builder {
@@ -106,6 +114,7 @@ impl Builder {
             log_level: None,
             rate_limit: None,
             enable_event_timestamps: false,
+            experimentation_id: None,
         }
     }
 
@@ -124,6 +133,7 @@ impl Builder {
             log_level: self.log_level,
             rate_limit: self.rate_limit,
             enable_event_timestamps: self.enable_event_timestamps,
+            experimentation_id: self.experimentation_id,
         }
     }
 
@@ -166,6 +176,12 @@ impl Builder {
     /// Set whether to add a wallclock timestamp to all events (experimental).
     pub fn with_event_timestamps(mut self, value: bool) -> Self {
         self.enable_event_timestamps = value;
+        self
+    }
+
+    /// Set whether to add a wallclock timestamp to all events (experimental).
+    pub fn with_experimentation_id(mut self, value: String) -> Self {
+        self.experimentation_id = Some(value);
         self
     }
 }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -121,6 +121,7 @@ fn initialize_internal(cfg: Configuration, client_info: ClientInfoMetrics) -> Op
         log_level: cfg.log_level,
         rate_limit: cfg.rate_limit,
         enable_event_timestamps: cfg.enable_event_timestamps,
+        experimentation_id: cfg.experimentation_id,
     };
 
     glean_core::glean_initialize(core_cfg, client_info.into(), callbacks);
@@ -169,6 +170,12 @@ pub fn set_experiment_active(
 /// See [`glean_core::Glean::set_experiment_inactive`].
 pub fn set_experiment_inactive(experiment_id: String) {
     glean_core::glean_set_experiment_inactive(experiment_id)
+}
+
+/// TEST ONLY FUNCTION.
+/// Gets stored experimenation id.
+pub fn test_get_experimentation_id() -> Option<String> {
+    glean_core::glean_test_get_experimentation_id()
 }
 
 /// Set the remote configuration values for the metrics' disabled property

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -767,6 +767,74 @@ fn no_sending_of_deletion_ping_if_unchanged_outside_of_run() {
 }
 
 #[test]
+fn deletion_request_ping_contains_experimentation_id() {
+    let _lock = lock_test();
+
+    let (s, r) = crossbeam_channel::bounded::<JsonValue>(1);
+
+    // Define a fake uploader that reports back the submission URL
+    // using a crossbeam channel.
+    #[derive(Debug)]
+    pub struct FakeUploader {
+        sender: crossbeam_channel::Sender<JsonValue>,
+    }
+    impl net::PingUploader for FakeUploader {
+        fn upload(
+            &self,
+            _url: String,
+            body: Vec<u8>,
+            _headers: Vec<(String, String)>,
+        ) -> net::UploadResult {
+            let mut gzip_decoder = GzDecoder::new(&body[..]);
+            let mut body_str = String::with_capacity(body.len());
+            let data: JsonValue = gzip_decoder
+                .read_to_string(&mut body_str)
+                .ok()
+                .map(|_| &body_str[..])
+                .or_else(|| std::str::from_utf8(&body).ok())
+                .and_then(|payload| serde_json::from_str(payload).ok())
+                .unwrap();
+            self.sender.send(data).unwrap();
+            net::UploadResult::http_status(200)
+        }
+    }
+
+    // Create a custom configuration to use a fake uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().to_path_buf();
+
+    let cfg = ConfigurationBuilder::new(true, tmpname.clone(), GLOBAL_APPLICATION_ID)
+        .with_server_endpoint("invalid-test-host")
+        .with_experimentation_id("alpha-beta-gamma-delta".to_string())
+        .build();
+
+    let _t = new_glean(Some(cfg), true);
+
+    // Now reset Glean and disable upload: it should still send a deletion request
+    // ping even though we're just starting.
+    test_reset_glean(
+        ConfigurationBuilder::new(false, tmpname, GLOBAL_APPLICATION_ID)
+            .with_server_endpoint("invalid-test-host")
+            .with_uploader(FakeUploader { sender: s })
+            .with_experimentation_id("alpha-beta-gamma-delta".to_string())
+            .build(),
+        ClientInfoMetrics::unknown(),
+        false,
+    );
+
+    // Wait for the ping to arrive and check the experimentation id matches
+    let url = r.recv().unwrap();
+    let metrics = url.get("metrics").unwrap();
+    let strings = metrics.get("string").unwrap();
+    assert_eq!(
+        "alpha-beta-gamma-delta",
+        strings
+            .get("glean.client.annotation.experimentation_id")
+            .unwrap()
+    );
+}
+
+#[test]
 fn test_sending_of_startup_baseline_ping_with_application_lifetime_metric() {
     let _lock = lock_test();
 

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -115,6 +119,7 @@ where
 ///     log_level: None,
 ///     rate_limit: None,
 ///     enable_event_timestamps: false,
+///     experimentation_id: None,
 /// };
 /// let mut glean = Glean::new(cfg).unwrap();
 /// let ping = PingType::new("sample", true, false, vec![]);
@@ -243,6 +248,14 @@ impl Glean {
         let data_path = Path::new(&cfg.data_path);
         glean.data_store = Some(Database::new(data_path, cfg.delay_ping_lifetime_io)?);
 
+        // Set experimentation identifier (if any)
+        if let Some(experimentation_id) = &cfg.experimentation_id {
+            glean
+                .additional_metrics
+                .experimentation_id
+                .set_sync(&glean, experimentation_id.to_string());
+        }
+
         // The upload enabled flag may have changed since the last run, for
         // example by the changing of a config file.
         if cfg.upload_enabled {
@@ -306,6 +319,7 @@ impl Glean {
             log_level: None,
             rate_limit: None,
             enable_event_timestamps: false,
+            experimentation_id: None,
         };
 
         let mut glean = Self::new(cfg).unwrap();
@@ -718,6 +732,15 @@ impl Glean {
     pub fn test_get_experiment_data(&self, experiment_id: String) -> Option<RecordedExperiment> {
         let metric = ExperimentMetric::new(self, experiment_id);
         metric.test_get_value(self)
+    }
+
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Gets stored experimenation id annotation.
+    pub fn test_get_experimentation_id(&self) -> Option<String> {
+        self.additional_metrics
+            .experimentation_id
+            .get_value(self, None)
     }
 
     /// Set configuration to override the default metric enabled/disabled state, typically from a

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -32,6 +32,9 @@ namespace glean {
     void glean_set_experiment_inactive(string experiment_id);
     RecordedExperiment? glean_test_get_experiment_data(string experiment_id);
 
+    // Experimentation ID API
+    string? glean_test_get_experimentation_id();
+
     // Server Knobs API
     void glean_set_metrics_enabled_config(string json);
 
@@ -75,6 +78,7 @@ dictionary InternalConfiguration {
     LevelFilter? log_level;
     PingRateLimit? rate_limit;
     boolean enable_event_timestamps;
+    string? experimentation_id;
 };
 
 // How to specify the rate pings may be uploaded before they are throttled.

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -27,6 +27,10 @@ pub struct AdditionalMetrics {
 
     /// Time waited for the dispatcher to unblock during shutdown.
     pub shutdown_dispatcher_wait: TimingDistributionMetric,
+
+    /// An experimentation identifier derived and provided by the application
+    /// for the purpose of experimentation enrollment.
+    pub experimentation_id: StringMetric,
 }
 
 impl CoreMetrics {
@@ -112,6 +116,23 @@ impl AdditionalMetrics {
                 },
                 TimeUnit::Millisecond,
             ),
+
+            // This uses a `send_in_pings` that contains "all-ping".
+            // This works because all of our other current "all-pings" metrics
+            // have special handling internally and are not actually processed
+            // into a store quite like this identifier is.
+            //
+            // This could become an issue if we ever decide to start generating
+            // code from the internal Glean metrics.yaml (there aren't currently
+            // any plans for this).
+            experimentation_id: StringMetric::new(CommonMetricData {
+                name: "experimentation_id".into(),
+                category: "glean.client.annotation".into(),
+                send_in_pings: vec!["all-pings".into()],
+                lifetime: Lifetime::Application,
+                disabled: false,
+                dynamic_label: None,
+            }),
         }
     }
 }

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -132,6 +132,10 @@ pub struct InternalConfiguration {
     pub rate_limit: Option<PingRateLimit>,
     /// (Experimental) Whether to add a wallclock timestamp to all events.
     pub enable_event_timestamps: bool,
+    /// An experimentation identifier derived by the application to be sent with all pings, it should
+    /// be noted that this has an underlying StringMetric and so should conform to the limitations that
+    /// StringMetric places on length, etc.
+    pub experimentation_id: Option<String>,
 }
 
 /// How to specify the rate at which pings may be uploaded before they are throttled.
@@ -853,6 +857,13 @@ pub fn glean_set_experiment_inactive(experiment_id: String) {
 pub fn glean_test_get_experiment_data(experiment_id: String) -> Option<RecordedExperiment> {
     block_on_dispatcher();
     core::with_glean(|glean| glean.test_get_experiment_data(experiment_id.to_owned()))
+}
+
+/// TEST ONLY FUNCTION.
+/// Gets stored experimenation id annotation.
+pub fn glean_test_get_experimentation_id() -> Option<String> {
+    block_on_dispatcher();
+    core::with_glean(|glean| glean.test_get_experimentation_id())
 }
 
 /// Sets a remote configuration to override metrics' default enabled/disabled

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -178,6 +178,43 @@ fn experiments_status_is_correctly_toggled() {
 }
 
 #[test]
+fn experimentation_id_is_set_correctly() {
+    let t = tempfile::tempdir().unwrap();
+    let name = t.path().display().to_string();
+
+    // Define an experimentation id to test
+    let experimentation_id = "test-experimentation-id";
+
+    let glean = Glean::new(InternalConfiguration {
+        data_path: name,
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        language_binding_name: "Rust".into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        app_build: "Unknown".into(),
+        use_core_mps: false,
+        trim_data_to_registered_pings: false,
+        log_level: None,
+        rate_limit: None,
+        enable_event_timestamps: false,
+        experimentation_id: Some(experimentation_id.to_string()),
+    })
+    .unwrap();
+
+    // Check that the correct value was stored
+    if let Some(exp_id) = glean
+        .additional_metrics
+        .experimentation_id
+        .get_value(&glean, "all-pings")
+    {
+        assert_eq!(exp_id, experimentation_id, "Experimentation ids must match");
+    } else {
+        panic!("The experimentation id must not be `None`");
+    }
+}
+
+#[test]
 fn client_id_and_first_run_date_must_be_regenerated() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -100,7 +100,9 @@ impl StorageManager {
         storage.iter_store_from(Lifetime::User, store_name, None, &mut snapshotter);
 
         // Add send in all pings client.annotations
-        storage.iter_store_from(Lifetime::Application, "all-pings", None, snapshotter);
+        if store_name != "glean_client_info" {
+            storage.iter_store_from(Lifetime::Application, "all-pings", None, snapshotter);
+        }
 
         if clear_store {
             if let Err(e) = storage.clear_ping_lifetime_storage(store_name) {

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -99,6 +99,9 @@ impl StorageManager {
         storage.iter_store_from(Lifetime::Application, store_name, None, &mut snapshotter);
         storage.iter_store_from(Lifetime::User, store_name, None, &mut snapshotter);
 
+        // Add send in all pings client.annotations
+        storage.iter_store_from(Lifetime::Application, "all-pings", None, snapshotter);
+
         if clear_store {
             if let Err(e) = storage.clear_ping_lifetime_storage(store_name) {
                 log::warn!("Failed to clear lifetime storage: {:?}", e);

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -62,6 +62,7 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
         log_level: None,
         rate_limit: None,
         enable_event_timestamps: false,
+        experimentation_id: None,
     };
     let glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -470,7 +470,8 @@ fn with_event_timestamps() {
         trim_data_to_registered_pings: false,
         log_level: None,
         rate_limit: None,
-        enable_event_timestamps: true, // Enabling event timestamps
+        enable_event_timestamps: true,
+        experimentation_id: None, // Enabling event timestamps
     };
     let glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -125,6 +125,37 @@ fn test_metrics_must_report_experimentation_id() {
 }
 
 #[test]
+fn experimentation_id_is_removed_if_send_if_empty_is_false() {
+    // Initialize Glean with an experimentation id, it should be removed if the ping is empty
+    // and send_if_empty is false.
+    let (tempdir, _) = tempdir();
+    let mut glean = Glean::new(glean_core::InternalConfiguration {
+        data_path: tempdir.path().display().to_string(),
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        language_binding_name: "Rust".into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        app_build: "Unknown".into(),
+        use_core_mps: false,
+        trim_data_to_registered_pings: false,
+        log_level: None,
+        rate_limit: None,
+        enable_event_timestamps: false,
+        experimentation_id: Some("test-experimentation-id".to_string()),
+    })
+    .unwrap();
+    let ping_maker = PingMaker::new();
+
+    let unknown_ping_type = PingType::new("unknown", true, false, vec![]);
+    glean.register_ping_type(&unknown_ping_type);
+
+    assert!(ping_maker
+        .collect(&glean, &unknown_ping_type, None, "", "")
+        .is_none());
+}
+
+#[test]
 fn collect_must_report_none_when_no_data_is_stored() {
     // NOTE: This is a behavior change from glean-ac which returned an empty
     // string in this case. As this is an implementation detail and not part of

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -75,6 +75,56 @@ fn get_client_info_must_report_all_the_available_data() {
 }
 
 #[test]
+fn test_metrics_must_report_experimentation_id() {
+    let (tempdir, _) = tempdir();
+    let mut glean = Glean::new(glean_core::InternalConfiguration {
+        data_path: tempdir.path().display().to_string(),
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        language_binding_name: "Rust".into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: false,
+        app_build: "Unknown".into(),
+        use_core_mps: false,
+        trim_data_to_registered_pings: false,
+        log_level: None,
+        rate_limit: None,
+        enable_event_timestamps: false,
+        experimentation_id: Some("test-experimentation-id".to_string()),
+    })
+    .unwrap();
+    let ping_maker = PingMaker::new();
+    let ping_type = PingType::new("store1", true, false, vec![]);
+    glean.register_ping_type(&ping_type);
+
+    // Record something, so the ping will have data
+    let metric = BooleanMetric::new(CommonMetricData {
+        name: "boolean_metric".into(),
+        category: "telemetry".into(),
+        send_in_pings: vec!["store1".into()],
+        disabled: false,
+        lifetime: Lifetime::User,
+        ..Default::default()
+    });
+    metric.set_sync(&glean, true);
+
+    let ping = ping_maker
+        .collect(&glean, &ping_type, None, "", "")
+        .unwrap();
+    let metrics = ping.content["metrics"].as_object().unwrap();
+    println!("TLDEBUG Metrics:\n{:?}", metrics);
+
+    let strings = metrics["string"].as_object().unwrap();
+    assert_eq!(
+        strings["glean.client.annotation.experimentation_id"]
+            .as_str()
+            .unwrap(),
+        "test-experimentation-id",
+        "experimentation ids must match"
+    );
+}
+
+#[test]
 fn collect_must_report_none_when_no_data_is_stored() {
     // NOTE: This is a behavior change from glean-ac which returned an empty
     // string in this case. As this is an implementation detail and not part of

--- a/samples/rust/src/main.rs
+++ b/samples/rust/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
         log_level: None,
         rate_limit: None,
         enable_event_timestamps: false,
+        experimentation_id: None,
     };
 
     let client_info = ClientInfoMetrics {


### PR DESCRIPTION
This adds an experimentation ID that can be set through the Glean configuration object which is passed in during initialization.  There is also a test API to make retrieving the set value easier in tests.  This is a spin on #2606 using the configuration object rather than a `set` function.