### PR TITLE
Enable edit this page on our documentation

### DIFF
--- a/docs/dev/book.toml
+++ b/docs/dev/book.toml
@@ -11,6 +11,7 @@ create-missing = false
 additional-css = ["../shared/glean.css", "../shared/mermaid.css"]
 additional-js = ["../shared/tabs.js", "../shared/mermaid.min.js", "../shared/mermaid-init.js"]
 git-repository-url = "https://github.com/mozilla/glean"
+edit-url-template = "https://github.com/mozilla/glean/edit/main/docs/dev/{path}"
 git-branch = "main"
 mathjax-support = true
 

--- a/docs/user/book.toml
+++ b/docs/user/book.toml
@@ -11,6 +11,7 @@ create-missing = false
 additional-css = ["../shared/glean.css", "../shared/mermaid.css"]
 additional-js = ["../shared/tabs.js", "../shared/mermaid.min.js", "../shared/mermaid-init.js", "chart.min.js", "chart-distributions.js", "chart-distributions-ui.js"]
 git-repository-url = "https://github.com/mozilla/glean"
+edit-url-template = "https://github.com/mozilla/glean/edit/main/docs/user/{path}"
 git-branch = "main"
 mathjax-support = true
 


### PR DESCRIPTION
This should enable a button to edit the current page via github, as documented [in the mdbook docs](https://rust-lang.github.io/mdBook/format/configuration/renderers.html)