### PR TITLE
Revert "Dependabot: Group all Python package updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,3 @@ updates:
     ignore:
       # Updated in lockstep across all implementations
       - dependency-name: "glean_parser"
-    groups:
-      python-packages:
-        patterns:
-          - "*"


### PR DESCRIPTION
This reverts commit cbe5ef9be06359a7b218c008834c3bae145b88c9

---

The bundling didn't play out as I hoped it would.
The PR titles are now less descriptive ("Bump the python-packages group in /glean-core/python with 1 update") and still mostly contain only a single dependency update.
Feels like reverting this thus is better.