### PR TITLE
Add a wildcard audit for jsonschema-valido

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,13 @@
 
 # cargo-vet audits file
 
+[[wildcard-audits.jsonschema-valid]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-run"
+user-id = 48 # Jan-Erik Rediger (badboy)
+start = "2020-02-26"
+end = "2024-11-10"
+
 [[wildcard-audits.uniffi]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -230,12 +237,6 @@ criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2022-01-22"
 end = "2024-10-19"
-
-[[trusted.jsonschema-valid]]
-criteria = "safe-to-run"
-user-id = 48 # Jan-Erik Rediger (badboy)
-start = "2020-02-26"
-end = "2024-11-08"
 
 [[trusted.linux-raw-sys]]
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -372,12 +372,6 @@ version = "0.3.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.textwrap]]
-who = "ChromeOS"
-criteria = "safe-to-run"
-version = "0.15.2"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.textwrap]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "0.16.0"


### PR DESCRIPTION
I publish this crate, so a wildcard is more appropriate than a trusted marker.

[doc only]