### PR TITLE
Install setuptools in Builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
 name = "glean-build"
 version = "10.0.0"
 dependencies = [
+ "tempfile",
  "xshell-venv",
 ]
 

--- a/glean-core/build/Cargo.toml
+++ b/glean-core/build/Cargo.toml
@@ -17,3 +17,6 @@ rust-version = "1.63"
 
 [dependencies]
 xshell-venv = "1.1.0"
+
+[dev-dependencies]
+tempfile = "3.8.0"

--- a/glean-core/build/src/lib.rs
+++ b/glean-core/build/src/lib.rs
@@ -110,6 +110,7 @@ impl Builder {
         let venv = VirtualEnv::new(&sh, "py3-glean_parser")?;
 
         let glean_parser = format!("glean_parser~={GLEAN_PARSER_VERSION}");
+        // TODO: Remove after we switched glean_parser away from legacy setup.py
         venv.pip_install("setuptools")?;
         venv.pip_install(&glean_parser)?;
 


### PR DESCRIPTION
This is needed for Python 3.12 (https://github.com/python/cpython/issues/95299)

(I hit this after upgrading to Fedora 39 and trying to build app-services)