### PR TITLE
Bug 1870048 - Replace whenTaskAdded with configureEach to avoid unnecesary configuration.

### DIFF
--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -489,7 +489,7 @@ except:
                 condaBootstrapDir,
                 "Miniconda3"
             )
-            project.tasks.whenTaskAdded { task ->
+            project.tasks.configureEach { task ->
                 if (task.name.startsWith('Bootstrap_CONDA')) {
                     task.dependsOn(createBuildDir)
 


### PR DESCRIPTION
Tested locally and this seems to be enough for moving forward with https://bugzilla.mozilla.org/show_bug.cgi?id=1870050.
Also, before going even further https://github.com/mozilla/glean/pull/2680 IMO this would be a good test to see if moving to Task Configuration Avoidance would be smooth.
