### PR TITLE
Bug 1873911 - Update rkv to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,9 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "byteorder"
@@ -547,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -727,13 +730,13 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rkv"
-version = "0.18.4"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0ea3af1393b22f8fe25615b6fa5d13072b7b622e66acffc8b12b2baa0342b1"
+checksum = "2c6d906922d99c677624d2042a93f89b2b7df0f6411032237d5d99a602c2487c"
 dependencies = [
  "arrayref",
  "bincode",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "byteorder",
  "id-arena",
  "lazy_static",

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -30,7 +30,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.44"
-rkv = { version = "0.18.4", default-features = false, features = ["lmdb"] }
+rkv = { version = "0.19.0", default-features = false, features = ["lmdb"] }
 bincode = "1.2.1"
 log = "0.4.8"
 uuid = { version = "1.0", features = ["v4"] }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -291,6 +291,12 @@ criteria = "safe-to-deploy"
 delta = "0.4.17 -> 0.4.18"
 notes = "One dependency removed, others updated (which we don't rely on), some APIs (which we don't use) changed."
 
+[[audits.log]]
+who = "Kagami Sascha Rosylight <krosylight@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.18 -> 0.4.20"
+notes = "Only cfg attribute and internal macro changes and module refactorings"
+
 [[audits.oneshot-uniffi]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -325,6 +331,12 @@ notes = "Minimal changes and removal of the build.rs"
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.16 -> 0.3.5"
+
+[[audits.rkv]]
+who = "Kagami Sascha Rosylight <krosylight@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.18.4 -> 0.19.0"
+notes = "Maintained by Mozilla, no addition of unsafe blocks"
 
 [[audits.rustversion]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"


### PR DESCRIPTION
I see a couple of failures locally on Windows:

* database::test::safe_mode::migration_doesnt_overwrite
* database::test::safe_mode::migration_ignores_empty_database

But these two fail even without the update, so 🤷