### PR TITLE
Set the target Android SDK to version 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v56.1.0...main)
 
+* Android
+  * Set the target Android SDK to version 34 ([#2709](https://github.com/mozilla/glean/pull/2709))
+
 # v56.1.0 (2024-01-16)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v56.0.0...v56.1.0)

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     ext.build = [
         ndkVersion: "25.2.9519653", // Keep it in sync in TC Dockerfile.
         compileSdkVersion: 34,
-        targetSdkVersion: 33,
+        targetSdkVersion: 34,
         minSdkVersion: 21,
         jvmTargetCompatibility: 17,
     ]


### PR DESCRIPTION
Just seeing how CI likes this right now. Need to coordinate merging with the Android team as getting Fenix bumped to API34 is high-priority.