### PR TITLE
CI: Pick the current Rust for the publish task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ jobs:
 
   Publish Rust crates:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.75
     steps:
       - checkout
       - run:


### PR DESCRIPTION
There's no `latest` tag.
For publishing we're good with a up-to-date Rust.
We have a separate task for testing our own MSRV (and have Cargo.lock committed for reproducible builds).

[docs only]

(not really docs, but doesn't change any CI related things other than release)