### PR TITLE
Prototyping a Glean Event Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v56.1.0...main)
 
+* General
+  * Added an experimental event listener API ([#2719](https://github.com/mozilla/glean/pull/2719)) 
 * Android
   * BREAKING CHANGE: Update JNA to version 5.14.0. Projects using older JNA releases may encounter errors until they update. ([#2727](https://github.com/mozilla/glean/pull/2727))
   * Set the target Android SDK to version 34 ([#2709](https://github.com/mozilla/glean/pull/2709))

--- a/docs/user/SUMMARY.md
+++ b/docs/user/SUMMARY.md
@@ -49,6 +49,7 @@
     - [Annotating experiments](reference/general/experiments-api.md)
     - [Registering custom pings](reference/general/register-custom-pings.md)
     - [Shut down](reference/general/shutdown.md)
+    - [EXPERIMENTAL: Glean Event Listener](reference/general/glean-event-listener.md)
 - [Debugging](reference/debug/index.md)
     - [Log pings](reference/debug/logPings.md)
     - [Debug View Tag](reference/debug/debugViewTag.md)

--- a/docs/user/reference/general/glean-event-listener.md
+++ b/docs/user/reference/general/glean-event-listener.md
@@ -1,0 +1,67 @@
+# Glean Event Listener
+
+> **Note:** This API is currently experimental and subject to change or elimination. Please reach out to the Glean Team if you are planning on using this API in its experimental state.
+
+## Summary
+
+Glean provides an API to register a callback by which a consumer can be notified of all event metrics being recorded.
+
+## Usage
+
+Consumers can register a callback through this API which will be called with the base identifier of each event metric when it is recorded. The base identifier of the event consists of the category name and the event name with a dot separator:  
+
+`<event_category>.<event_name>`
+
+Glean will execute the registered callbacks on a background thread independent of the thread in which the event is being recorded in order to not interfere with the collection of the event.
+
+Glean will ensure that event recordings are reported to listeners in the same order that they are recorded by using the same dispatching mechanisms used to ensure events are recorded in the order they are received.  
+
+## Examples
+
+<div data-lang="Kotlin" class="tab">
+
+```kotlin
+class TestEventListener : GleanEventListener {
+    val listenerTag: String = "TestEventListener"
+    var lastSeenId: String = ""
+    var count: Int = 0
+
+    override fun onEventRecorded(id: String) {
+        this.lastSeenId = id
+        this.count += 1
+    }
+}
+
+val listener = TestEventListener()
+Glean.registerEventListener(listener.listenerTag, listener)
+
+// If necessary to unregister the listener:
+Glean.unregisterEventListener(listener.listenerTag)
+```
+
+</div>
+
+<div data-lang="Swift" class="tab">
+
+```Swift
+class TestEventListener: GleanEventListener {
+    let listenerTag: String = "TestEventListener"
+    var lastSeenId: String = ""
+    var count: Int64 = 0
+
+    func onEventRecorded(_ id: String) {
+        self.lastSeenId = id
+        self.count += 1
+    }
+}
+
+let listener = TestEventListener()
+Glean.shared.registerEventListener(tag: listener.listenerTag, listener: listener)
+
+// If necessary to unregister the listener:
+Glean.shared.unregisterEventListener(listener.listenerTag)
+```
+
+</div>
+
+{{#include ../../../shared/tab_footer.md}}

--- a/docs/user/reference/general/index.md
+++ b/docs/user/reference/general/index.md
@@ -24,3 +24,4 @@ The Glean SDKs provide a general API that supports the following operations. See
 | `registerPings` | Register custom pings generated from `pings.yaml`. | [Custom pings][custom-pings] |
 | `setExperimentActive` | Indicate that an experiment is running. | [Using the Experiments API][experiments-api] |
 | `setExperimentInactive` | Indicate that an experiment is no longer running.. | [Using the Experiments API][experiments-api] |
+| `registerEventListener` | Register a callback by which a consumer can be notified of all event metrics being recorded. | [Glean Event Listener](./glean-event-listener.md) |

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -378,6 +378,28 @@ open class GleanInternalAPI internal constructor() {
     }
 
     /**
+     * EXPERIMENTAL: Register a listener to receive event recording notifications
+     *
+     * NOTE: Only one listener may be registered for a given tag. Each subsequent registration with
+     * that same tag replaces the currently registered listener.
+     *
+     * @param tag a tag to use when unregistering the listener
+     * @param listener implements the `GleanEventListener` interface
+     */
+    fun registerEventListener(tag: String, listener: GleanEventListener) {
+        gleanRegisterEventListener(tag, listener)
+    }
+
+    /**
+     * Unregister an event listener
+     *
+     * @param tag the tag used when registering the listener to be unregistered
+     */
+    fun unregisterEventListener(tag: String) {
+        gleanUnregisterEventListener(tag)
+    }
+
+    /**
      * Initialize the core metrics internally managed by Glean (e.g. client id).
      */
     internal fun getClientInfo(configuration: Configuration, buildInfo: BuildInfo): ClientInfoMetrics {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DateUtilsTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/utils/DateUtilsTest.kt
@@ -15,8 +15,7 @@ import org.junit.runner.RunWith
 class DateUtilsTest {
     @Test
     fun `test roundtripping ISO date formats`() {
-        for (
-        timeUnit in listOf(
+        for (timeUnit in listOf(
             TimeUnit.NANOSECOND,
             TimeUnit.MICROSECOND,
             TimeUnit.MILLISECOND,
@@ -24,8 +23,7 @@ class DateUtilsTest {
             TimeUnit.MINUTE,
             TimeUnit.HOUR,
             TimeUnit.DAY,
-        )
-        ) {
+        )) {
             val dateString = getISOTimeString(truncateTo = timeUnit)
             val parsedDate = parseISOTimeString(dateString)!!
             val regenDateString = getISOTimeString(parsedDate, truncateTo = timeUnit)

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -405,6 +405,23 @@ public class Glean {
         }
     }
 
+    /// EXPERIMENTAL: Register a listener to receive notification of event recordings
+    ///
+    /// - parameters:
+    ///     * tag: String used to identify the listener when unregistering it
+    ///     * listener: Implements `GleanEventListener` protocol
+    public func registerEventListener(tag: String, listener: GleanEventListener) {
+        gleanRegisterEventListener(tag, listener)
+    }
+
+    /// EXPERIMENTAL: Unregister a listener to receive notification of event recordings
+    ///
+    /// - parameters:
+    ///     * tag: String used to identify the listener when it was registered
+    public func unregisterEventListener(tag: String) {
+        gleanUnregisterEventListener(tag)
+    }
+
     /// Set configuration to override metrics' default enabled/disabled state, typically from
     /// a remote_settings experiment or rollout.
     ///

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -341,8 +341,9 @@ class GleanTests: XCTestCase {
     }
 
     func testForegroundCounter() {
-        // Glean is started by the test framework.
-        // That already triggers the first foreground event.
+        // Reset Glean to ensure that this isn't affected by concurrent tests
+        // This will trigger the initial "foreground" event
+        resetGleanDiscardingInitialPings(testCase: self, tag: "GleanTests")
 
         // Put it in the background
         Glean.shared.handleBackgroundEvent()

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -36,6 +36,16 @@ namespace glean {
     void glean_set_experimentation_id(string experimentation_id);
     string? glean_test_get_experimentation_id();
 
+    // EXPERIMENTAL: Register a listener to receive notification of event recordings
+    //
+    // tag: String value used later to unregister the listener
+    // listener: An object which implements the GleanEventListener interface
+    void glean_register_event_listener(string tag, GleanEventListener listener);
+    // EXPERIMENTAL: Unregister a previously registered event listener
+    //
+    // tag: The tag used when registering the listener
+    void glean_unregister_event_listener(string tag);
+
     // Server Knobs API
     void glean_set_metrics_enabled_config(string json);
 
@@ -162,6 +172,12 @@ callback interface OnGleanEvents {
     //   * Shutdown waits for a maximum of 30 seconds.
     [Throws=CallbackError]
     void shutdown();
+};
+
+// A callback handler that receives the IDs of recorded events
+callback interface GleanEventListener {
+    // Called when an event is recorded, indicating the id of the event
+    void on_event_recorded(string id);
 };
 
 // Deserialized experiment data.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -229,6 +229,25 @@ fn setup_state(state: State) {
     }
 }
 
+/// A global singleton that stores listener callbacks registered with Glean
+/// to receive event recording notifications.
+static EVENT_LISTENERS: OnceCell<Mutex<HashMap<String, Box<dyn GleanEventListener>>>> =
+    OnceCell::new();
+
+fn event_listeners() -> &'static Mutex<HashMap<String, Box<dyn GleanEventListener>>> {
+    EVENT_LISTENERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_event_listener(tag: String, listener: Box<dyn GleanEventListener>) {
+    let mut lock = event_listeners().lock().unwrap();
+    lock.insert(tag, listener);
+}
+
+fn unregister_event_listener(tag: String) {
+    let mut lock = event_listeners().lock().unwrap();
+    lock.remove(&tag);
+}
+
 /// An error returned from callbacks.
 #[derive(Debug)]
 pub enum CallbackError {
@@ -283,6 +302,13 @@ pub trait OnGleanEvents: Send {
         // empty by default
         Ok(())
     }
+}
+
+/// A callback handler that receives the base identifier of recorded events
+/// The identifier is in the format: <category>.<name>
+pub trait GleanEventListener: Send {
+    /// Called when an event is recorded, indicating the id of the event
+    fn on_event_recorded(&self, id: String);
 }
 
 /// Initializes Glean.
@@ -1064,6 +1090,27 @@ pub fn glean_submit_ping_by_name_sync(ping_name: String, reason: Option<String>)
     }
 
     core::with_glean(|glean| glean.submit_ping_by_name(&ping_name, reason.as_deref()))
+}
+
+/// EXPERIMENTAL: Register a listener object to recieve notifications of event recordings.
+///
+/// # Arguments
+///
+/// * `tag` - A string identifier used to later unregister the listener
+/// * `listener` - Implements the `GleanEventListener` trait
+pub fn glean_register_event_listener(tag: String, listener: Box<dyn GleanEventListener>) {
+    register_event_listener(tag, listener);
+}
+
+/// Unregister an event listener from recieving notifications.
+///
+/// Does not panic if the listener doesn't exist.
+///
+/// # Arguments
+///
+/// * `tag` - The tag used when registering the listener to be unregistered
+pub fn glean_unregister_event_listener(tag: String) {
+    unregister_event_listener(tag);
 }
 
 /// **TEST-ONLY Method**

--- a/glean-core/src/metrics/event.rs
+++ b/glean-core/src/metrics/event.rs
@@ -84,6 +84,14 @@ impl EventMetric {
                 }
             }
         });
+
+        let id = self.meta().base_identifier();
+        crate::launch_with_glean(move |_| {
+            let event_listeners = crate::event_listeners().lock().unwrap();
+            event_listeners
+                .iter()
+                .for_each(|(_, listener)| listener.on_event_recorded(id.clone()));
+        });
     }
 
     /// Validate that extras are empty or all extra keys are allowed.


### PR DESCRIPTION
This adds a method for a consuming application to register an event listener to receive notifications when events are recorded.