### PR TITLE
Fix incorrect method name in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Android
   * Set the target Android SDK to version 34 ([#2709](https://github.com/mozilla/glean/pull/2709))
-
+  * Fixed an incorrectly named method. The method is now correctly named `setExperimentationId`.
+  
 # v56.1.0 (2024-01-16)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v56.0.0...v56.1.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -362,7 +362,7 @@ open class GleanInternalAPI internal constructor() {
      *
      * @param experimentationId the id to set for experimentation purposes
      */
-    fun testGetExperimentationId(experimentationId: String) {
+    fun setExperimentationId(experimentationId: String) {
         gleanSetExperimentationId(experimentationId)
     }
 


### PR DESCRIPTION
Fixes an incorrect method name that slipped through review.