### PR TITLE
Rust: Remove `OnceCell`s around Mutexes

### DIFF
--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -91,12 +91,12 @@ pub(crate) const DELETION_REQUEST_PINGS_DIRECTORY: &str = "deletion_request";
 static INITIALIZE_CALLED: AtomicBool = AtomicBool::new(false);
 
 /// Keep track of the debug features before Glean is initialized.
-static PRE_INIT_DEBUG_VIEW_TAG: OnceCell<Mutex<String>> = OnceCell::new();
+static PRE_INIT_DEBUG_VIEW_TAG: Mutex<String> = Mutex::new(String::new());
 static PRE_INIT_LOG_PINGS: AtomicBool = AtomicBool::new(false);
-static PRE_INIT_SOURCE_TAGS: OnceCell<Mutex<Vec<String>>> = OnceCell::new();
+static PRE_INIT_SOURCE_TAGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
 /// Keep track of pings registered before Glean is initialized.
-static PRE_INIT_PING_REGISTRATION: OnceCell<Mutex<Vec<metrics::PingType>>> = OnceCell::new();
+static PRE_INIT_PING_REGISTRATION: Mutex<Vec<metrics::PingType>> = Mutex::new(Vec::new());
 
 /// Global singleton of the handles of the glean.init threads.
 /// For joining. For tests.
@@ -370,11 +370,9 @@ fn initialize_inner(
             core::with_glean_mut(|glean| {
                 // The debug view tag might have been set before initialize,
                 // get the cached value and set it.
-                if let Some(tag) = PRE_INIT_DEBUG_VIEW_TAG.get() {
-                    let lock = tag.try_lock();
-                    if let Ok(ref debug_tag) = lock {
-                        glean.set_debug_view_tag(debug_tag);
-                    }
+                let debug_tag = PRE_INIT_DEBUG_VIEW_TAG.lock().unwrap();
+                if debug_tag.len() > 0 {
+                    glean.set_debug_view_tag(&debug_tag);
                 }
 
                 // The log pings debug option might have been set before initialize,
@@ -386,11 +384,9 @@ fn initialize_inner(
 
                 // The source tags might have been set before initialize,
                 // get the cached value and set them.
-                if let Some(tags) = PRE_INIT_SOURCE_TAGS.get() {
-                    let lock = tags.try_lock();
-                    if let Ok(ref source_tags) = lock {
-                        glean.set_source_tags(source_tags.to_vec());
-                    }
+                let source_tags = PRE_INIT_SOURCE_TAGS.lock().unwrap();
+                if source_tags.len() > 0 {
+                    glean.set_source_tags(source_tags.to_vec());
                 }
 
                 // Get the current value of the dirty flag so we know whether to
@@ -402,13 +398,9 @@ fn initialize_inner(
 
                 // Perform registration of pings that were attempted to be
                 // registered before init.
-                if let Some(tags) = PRE_INIT_PING_REGISTRATION.get() {
-                    let lock = tags.try_lock();
-                    if let Ok(pings) = lock {
-                        for ping in &*pings {
-                            glean.register_ping_type(ping);
-                        }
-                    }
+                let pings = PRE_INIT_PING_REGISTRATION.lock().unwrap();
+                for ping in pings.iter() {
+                    glean.register_ping_type(ping);
                 }
 
                 // If this is the first time ever the Glean SDK runs, make sure to set
@@ -835,7 +827,7 @@ pub(crate) fn register_ping_type(ping: &PingType) {
         // if ping registration is attempted before Glean initializes.
         // This state is kept across Glean resets, which should only ever happen in test mode.
         // It's a set and keeping them around forever should not have much of an impact.
-        let m = PRE_INIT_PING_REGISTRATION.get_or_init(Default::default);
+        let m = &PRE_INIT_PING_REGISTRATION;
         let mut lock = m.lock().unwrap();
         lock.push(ping.clone());
     }
@@ -930,7 +922,7 @@ pub fn glean_set_debug_view_tag(tag: String) -> bool {
         true
     } else {
         // Glean has not been initialized yet. Cache the provided tag value.
-        let m = PRE_INIT_DEBUG_VIEW_TAG.get_or_init(Default::default);
+        let m = &PRE_INIT_DEBUG_VIEW_TAG;
         let mut lock = m.lock().unwrap();
         *lock = tag;
         // When setting the debug view tag before initialization,
@@ -958,7 +950,7 @@ pub fn glean_set_source_tags(tags: Vec<String>) -> bool {
         true
     } else {
         // Glean has not been initialized yet. Cache the provided source tags.
-        let m = PRE_INIT_SOURCE_TAGS.get_or_init(Default::default);
+        let m = &PRE_INIT_SOURCE_TAGS;
         let mut lock = m.lock().unwrap();
         *lock = tags;
         // When setting the source tags before initialization,


### PR DESCRIPTION
Now that Mutex, Vec and String have const `new` methods, we don't need the OnceCell anymore and can just use the statics directly.

This should still be safe:
* Everything still behind a Mutex, and thus thread-safe
* We previously didn't reset those values, and we still don't other than setting the Mutex-locked wrapped value

---

This is the followup I promised in #2719 comments