### PR TITLE
Remove some direct dependencies from RLB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,6 @@ dependencies = [
 name = "glean"
 version = "56.1.0"
 dependencies = [
- "chrono",
  "crossbeam-channel",
  "env_logger",
  "flate2",
@@ -328,12 +327,8 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "serde",
  "serde_json",
  "tempfile",
- "thiserror",
- "time",
- "uuid",
  "whatsys",
 ]
 

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -26,24 +26,19 @@ path = ".."
 version = "56.1.0"
 
 [dependencies]
-crossbeam-channel = "0.5"
 inherent = "1"
 log = "0.4.8"
 once_cell = "1.18.0"
-thiserror = "1.0.4"
-serde_json = "1.0.44"
-serde = { version = "1.0.104", features = ["derive"] }
-uuid = { version = "1.0", features = ["v4"] }
-chrono = { version = "0.4.10", features = ["serde"] }
-time = "0.1.40"
 whatsys = "0.3.0"
 
 [dev-dependencies]
+crossbeam-channel = "0.5"
 env_logger = { version = "0.10.0", default-features = false, features = ["humantime"] }
-tempfile = "3.1.0"
-jsonschema-valid = "0.5.0"
 flate2 = "1.0.19"
+jsonschema-valid = "0.5.0"
 libc = "0.2"
+serde_json = "1.0.44"
+tempfile = "3.1.0"
 
 [features]
 preinit_million_queue = ["glean-core/preinit_million_queue"]


### PR DESCRIPTION
These are unused or only used in tests.

---

`cargo clippy -- -D unused_crate_dependencies` uncovered these.