### PR TITLE
Rust: Rename API to to reflect that it takes in a string, not a refer…

### DIFF
--- a/glean-core/rlb/src/private/object.rs
+++ b/glean-core/rlb/src/private/object.rs
@@ -55,7 +55,7 @@ impl<K: traits::ObjectSerialize> ObjectMetric<K> {
     /// # Arguments
     ///
     /// * `object` - JSON representation of the object to set.
-    pub fn set_str(&self, object: String) {
+    pub fn set_string(&self, object: String) {
         let data = match K::from_str(&object) {
             Ok(data) => data,
             Err(_) => {
@@ -165,6 +165,28 @@ mod test {
             { "colour": "red", "diameter": 5 },
             { "colour": "green" },
         ]);
+        assert_eq!(expected, data);
+    }
+
+    #[test]
+    fn set_string_api() {
+        let _lock = lock_test();
+        let _t = new_glean(None, true);
+
+        type SimpleArray = Vec<i64>;
+
+        let metric: ObjectMetric<SimpleArray> = ObjectMetric::new(CommonMetricData {
+            name: "object".into(),
+            category: "test".into(),
+            send_in_pings: vec!["test1".into()],
+            ..Default::default()
+        });
+
+        let arr_str = String::from("[1, 2, 3]");
+        metric.set_string(arr_str);
+
+        let data = metric.test_get_value(None).expect("no object recorded");
+        let expected = json!([1, 2, 3]);
         assert_eq!(expected, data);
     }
 }

--- a/glean-core/src/metrics/object.rs
+++ b/glean-core/src/metrics/object.rs
@@ -78,27 +78,6 @@ impl ObjectMetric {
         });
     }
 
-    /// Sets to the specified structure from a string in JSON encoding
-    ///
-    /// # Arguments
-    ///
-    /// * `glean` - the Glean instance this metric belongs to.
-    /// * `value` - the value to set.
-    pub fn set_str(&self, value: String) {
-        let metric = self.clone();
-        crate::launch_with_glean(move |glean| {
-            let value = match serde_json::from_str(&value) {
-                Ok(s) => s,
-                Err(_) => {
-                    let msg = "Cannot set invalid json";
-                    record_error(glean, &metric.meta, ErrorType::InvalidValue, msg, None);
-                    return;
-                }
-            };
-            metric.set_sync(glean, value)
-        })
-    }
-
     /// Get current value
     #[doc(hidden)]
     pub fn get_value<'a, S: Into<Option<&'a str>>>(


### PR DESCRIPTION
…ence

This also removes the API from glean-core because it's not needed there.