### PR TITLE
Bug 1866559 - Support "no-info"-configured pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v57.0.0...main)
 
 * General
-  * Update `glean_parser` to v12.0.1 ([release notes](https://github.com/mozilla/glean_parser/releases/tag/v12.0.0))
+  * Update `glean_parser` to v13.0.0 ([release notes](https://github.com/mozilla/glean_parser/releases/tag/v13.0.0))
 * Rust
   * New metric type: Object ([#2489](https://github.com/mozilla/glean/pull/2489))
 * Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Update `glean_parser` to v13.0.0 ([release notes](https://github.com/mozilla/glean_parser/releases/tag/v13.0.0))
 * Rust
   * New metric type: Object ([#2489](https://github.com/mozilla/glean/pull/2489))
+  * BREAKING CHANGE: Support pings without `{client|ping}_info` sections ([#2756](https://github.com/mozilla/glean/pull/2756))
 * Android
   * Upgrade Android NDK to r26c ([#2745](https://github.com/mozilla/glean/pull/2745))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "glean-build"
-version = "12.0.1"
+version = "13.0.0"
 dependencies = [
  "tempfile",
  "xshell-venv",

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ docs-python: build-python ## Build the Python documentation
 .PHONY: docs rust-docs swift-docs
 
 docs-metrics: setup-python ## Build the internal metrics documentation
-	$(GLEAN_PYENV)/bin/pip install glean_parser~=12.0
+	$(GLEAN_PYENV)/bin/pip install glean_parser~=13.0
 	$(GLEAN_PYENV)/bin/glean_parser translate --allow-reserved \
 		 -f markdown \
 		 -o ./docs/user/user/collected-metrics \

--- a/docs/user/user/pings/index.md
+++ b/docs/user/user/pings/index.md
@@ -16,11 +16,14 @@ that are assembled out of the box without any developer intervention.
 Every ping payload has the following keys at the top-level:
 
 - The [`ping_info` section](#the-ping_info-section) contains core metadata
-  that is included in **every** ping.
+  that is included in every ping that doesn't set the
+  `metadata.include_info_sections` property to `false`.
 
 - The [`client_info` section](#the-client_info-section) contains information that identifies the client.
-  It is included in most pings (including all built-in pings), but may be excluded from pings
-  where we don't want to connect client information with the other metrics in the ping.
+  It is included in every ping that doesn't set the
+  `metadata.include_info_sections` property to `false`.
+  When included, it contains a persistent client identifier `client_id`,
+  except when the `include_client_id` property is set to `false`.
 
 The following keys are only present if any metrics or events were recorded for the given ping:
 
@@ -36,7 +39,8 @@ for more details for each metric type in the `metrics` and `events` section.
 ### The `ping_info` section
 
 Metadata about the ping itself.
-This section is included in **every** ping.
+This section is included in every ping that doesn't set the
+`metadata.include_info_sections` property to `false`.
 
 The following fields are included in the `ping_info` section.
 Optional fields are marked accordingly.
@@ -102,6 +106,9 @@ A limited amount of metrics that are generally useful across products.
 The data is provided by the embedding application or automatically fetched by the Glean SDK.
 It is collected at initialization time and sent in every ping afterwards.
 For historical reasons it contains metrics that are only useful on a certain platform.
+
+This section is included in every ping that doesn't set the
+`metadata.include_info_sections` property to `false`.
 
 {{#include ../../../shared/blockquote-info.html}}
 

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 rust-version = "1.66"
 
 [package.metadata.glean]
-glean-parser = "12.0.1"
+glean-parser = "13.0.0"
 
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "main" }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -49,6 +49,7 @@ class PingType<ReasonCodesEnum> (
     includeClientId: Boolean,
     sendIfEmpty: Boolean,
     preciseTimestamps: Boolean,
+    includeInfoSections: Boolean,
     val reasonCodes: List<String>,
 ) where ReasonCodesEnum : Enum<ReasonCodesEnum>, ReasonCodesEnum : ReasonCode {
     private var testCallback: ((ReasonCodesEnum?) -> Unit)? = null
@@ -60,6 +61,7 @@ class PingType<ReasonCodesEnum> (
             includeClientId = includeClientId,
             sendIfEmpty = sendIfEmpty,
             preciseTimestamps = preciseTimestamps,
+            includeInfoSections = includeInfoSections,
             reasonCodes = reasonCodes,
         )
     }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -479,6 +479,7 @@ class GleanTest {
             includeClientId = true,
             sendIfEmpty = false,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
         val stringMetric = StringMetricType(
@@ -845,6 +846,7 @@ class GleanTest {
             includeClientId = true,
             sendIfEmpty = false,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
         val stringMetric = StringMetricType(

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -249,6 +249,7 @@ class GleanDebugActivityTest {
             includeClientId = false,
             sendIfEmpty = true,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
@@ -77,6 +77,7 @@ class CustomPingTest {
             includeClientId = true,
             sendIfEmpty = true,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = emptyList(),
         )
 
@@ -106,6 +107,7 @@ class CustomPingTest {
             includeClientId = true,
             sendIfEmpty = true,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = emptyList(),
         )
 
@@ -179,6 +181,7 @@ class CustomPingTest {
             includeClientId = true,
             sendIfEmpty = true,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = emptyList(),
         )
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -507,6 +507,7 @@ class EventMetricTypeTest {
             includeClientId = true,
             sendIfEmpty = false,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -54,6 +54,7 @@ class PingTypeTest {
             includeClientId = true,
             sendIfEmpty = false,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
 
@@ -120,6 +121,7 @@ class PingTypeTest {
             includeClientId = true,
             sendIfEmpty = false,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
 
@@ -167,6 +169,7 @@ class PingTypeTest {
             includeClientId = true,
             sendIfEmpty = false,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
 
@@ -214,6 +217,7 @@ class PingTypeTest {
             includeClientId = false,
             sendIfEmpty = false,
             preciseTimestamps = true,
+            includeInfoSections = true,
             reasonCodes = listOf(),
         )
 
@@ -263,6 +267,7 @@ class PingTypeTest {
             sendIfEmpty = false,
             reasonCodes = listOf(),
             preciseTimestamps = true,
+            includeInfoSections = true,
         )
 
         val counter = CounterMetricType(

--- a/glean-core/build/Cargo.toml
+++ b/glean-core/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-build"
-version = "12.0.1"
+version = "13.0.0"
 edition = "2021"
 description = "Glean SDK Rust build helper"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/build/src/lib.rs
+++ b/glean-core/build/src/lib.rs
@@ -39,7 +39,7 @@ use std::env;
 
 use xshell_venv::{Result, Shell, VirtualEnv};
 
-const GLEAN_PARSER_VERSION: &str = "12.0.1";
+const GLEAN_PARSER_VERSION: &str = "13.0.0";
 
 /// A Glean Rust bindings generator.
 pub struct Builder {

--- a/glean-core/ios/Glean/Metrics/Ping.swift
+++ b/glean-core/ios/Glean/Metrics/Ping.swift
@@ -40,6 +40,7 @@ public class Ping<ReasonCodesEnum: ReasonCodes> {
         includeClientId: Bool,
         sendIfEmpty: Bool,
         preciseTimestamps: Bool,
+        includeInfoSections: Bool,
         reasonCodes: [String]
     ) {
         self.name = name
@@ -49,6 +50,7 @@ public class Ping<ReasonCodesEnum: ReasonCodes> {
             includeClientId,
             sendIfEmpty,
             preciseTimestamps,
+            includeInfoSections,
             reasonCodes
         )
     }

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -258,6 +258,7 @@ class GleanTests: XCTestCase {
             includeClientId: true,
             sendIfEmpty: false,
             preciseTimestamps: true,
+            includeInfoSections: true,
             reasonCodes: []
         )
 
@@ -415,6 +416,7 @@ class GleanTests: XCTestCase {
             includeClientId: true,
             sendIfEmpty: false,
             preciseTimestamps: true,
+            includeInfoSections: true,
             reasonCodes: []
         )
 

--- a/glean-core/ios/GleanTests/Metrics/PingTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/PingTests.swift
@@ -40,6 +40,7 @@ class PingTests: XCTestCase {
             includeClientId: true,
             sendIfEmpty: false,
             preciseTimestamps: true,
+            includeInfoSections: true,
             reasonCodes: []
         )
 
@@ -86,6 +87,7 @@ class PingTests: XCTestCase {
             includeClientId: false,
             sendIfEmpty: false,
             preciseTimestamps: true,
+            includeInfoSections: true,
             reasonCodes: []
         )
 
@@ -122,6 +124,7 @@ class PingTests: XCTestCase {
             includeClientId: false,
             sendIfEmpty: true,
             preciseTimestamps: true,
+            includeInfoSections: true,
             reasonCodes: []
         )
 
@@ -213,6 +216,7 @@ class PingTests: XCTestCase {
             includeClientId: true,
             sendIfEmpty: true,
             preciseTimestamps: true,
+            includeInfoSections: true,
             reasonCodes: ["was_tested"]
         )
 

--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=12.0
+GLEAN_PARSER_VERSION=13.0
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034

--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -31,7 +31,7 @@ __author__ = "The Glean Team"
 __email__ = "glean-team@mozilla.com"
 
 
-GLEAN_PARSER_VERSION = "12.0.1"
+GLEAN_PARSER_VERSION = "13.0.0"
 parser_version = VersionInfo.parse(GLEAN_PARSER_VERSION)
 parser_version_next_major = parser_version.bump_major()
 

--- a/glean-core/python/glean/_loader.py
+++ b/glean-core/python/glean/_loader.py
@@ -61,6 +61,7 @@ _ARGS = [
     "reason_codes",
     "send_in_pings",
     "precise_timestamps",
+    "include_info_sections",
     "time_unit",
 ]
 

--- a/glean-core/python/glean/metrics/ping.py
+++ b/glean-core/python/glean/metrics/ping.py
@@ -16,6 +16,7 @@ class PingType:
         include_client_id: bool,
         send_if_empty: bool,
         precise_timestamps: bool,
+        include_info_sections: bool,
         reason_codes: List[str],
     ):
         """
@@ -26,7 +27,12 @@ class PingType:
         """
         self._reason_codes = reason_codes
         self._inner = GleanPingType(
-            name, include_client_id, send_if_empty, precise_timestamps, reason_codes
+            name,
+            include_client_id,
+            send_if_empty,
+            precise_timestamps,
+            include_info_sections,
+            reason_codes,
         )
         self._test_callback = None  # type: Optional[Callable[[Optional[str]], None]]
 

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -279,6 +279,7 @@ def test_dont_schedule_pings_if_metrics_disabled(safe_httpserver):
         include_client_id=True,
         send_if_empty=False,
         precise_timestamps=True,
+        include_info_sections=True,
         reason_codes=[],
     )
 
@@ -299,6 +300,7 @@ def test_dont_schedule_pings_if_there_is_no_ping_content(safe_httpserver):
         include_client_id=True,
         send_if_empty=False,
         precise_timestamps=True,
+        include_info_sections=True,
         reason_codes=[],
     )
 
@@ -365,6 +367,7 @@ def test_ping_collection_must_happen_after_currently_scheduled_metrics_recording
         include_client_id=True,
         send_if_empty=False,
         precise_timestamps=True,
+        include_info_sections=True,
         reason_codes=[],
     )
     string_metric = StringMetricType(
@@ -694,6 +697,7 @@ def test_dont_allow_multiprocessing(monkeypatch, safe_httpserver):
         include_client_id=True,
         send_if_empty=True,
         precise_timestamps=True,
+        include_info_sections=True,
         reason_codes=[],
     )
 
@@ -766,6 +770,7 @@ def test_presubmit_makes_a_valid_ping(tmpdir, ping_schema_url, monkeypatch):
         include_client_id=True,
         send_if_empty=True,
         precise_timestamps=True,
+        include_info_sections=True,
         reason_codes=[],
     )
 
@@ -828,6 +833,7 @@ def test_flipping_upload_enabled_respects_order_of_events(tmpdir, monkeypatch):
         include_client_id=True,
         send_if_empty=True,
         precise_timestamps=True,
+        include_info_sections=True,
         reason_codes=[],
     )
 
@@ -936,6 +942,7 @@ def test_sending_of_custom_pings(safe_httpserver):
         include_client_id=True,
         send_if_empty=False,
         precise_timestamps=True,
+        include_info_sections=True,
         reason_codes=[],
     )
 
@@ -1019,6 +1026,7 @@ def test_glean_shutdown(safe_httpserver):
         include_client_id=True,
         send_if_empty=False,
         precise_timestamps=False,
+        include_info_sections=True,
         reason_codes=[],
     )
 

--- a/glean-core/rlb/examples/crashing-threads.rs
+++ b/glean-core/rlb/examples/crashing-threads.rs
@@ -88,7 +88,7 @@ pub mod glean_metrics {
 
 #[allow(non_upper_case_globals)]
 pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, vec![]));
+    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![]));
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/examples/long-running.rs
+++ b/glean-core/rlb/examples/long-running.rs
@@ -33,12 +33,7 @@ pub mod glean_metrics {
 struct FakeUploader;
 
 impl net::PingUploader for FakeUploader {
-    fn upload(
-        &self,
-        _url: String,
-        _body: Vec<u8>,
-        _headers: Vec<(String, String)>,
-    ) -> net::UploadResult {
+    fn upload(&self, _upload_request: net::PingUploadRequest) -> net::UploadResult {
         thread::sleep(time::Duration::from_millis(100));
         net::UploadResult::http_status(200)
     }

--- a/glean-core/rlb/examples/long-running.rs
+++ b/glean-core/rlb/examples/long-running.rs
@@ -46,7 +46,7 @@ impl net::PingUploader for FakeUploader {
 
 #[allow(non_upper_case_globals)]
 pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, vec![]));
+    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![]));
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/examples/prototype.rs
+++ b/glean-core/rlb/examples/prototype.rs
@@ -29,7 +29,7 @@ pub mod glean_metrics {
 
 #[allow(non_upper_case_globals)]
 pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, vec![]));
+    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![]));
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -23,7 +23,7 @@
 //! let cfg = ConfigurationBuilder::new(true, "/tmp/data", "org.mozilla.glean_core.example").build();
 //! glean::initialize(cfg, ClientInfoMetrics::unknown());
 //!
-//! let prototype_ping = PingType::new("prototype", true, true, true, vec!());
+//! let prototype_ping = PingType::new("prototype", true, true, true, true, vec!());
 //!
 //! prototype_ping.submit(None);
 //! ```

--- a/glean-core/rlb/src/net/http_uploader.rs
+++ b/glean-core/rlb/src/net/http_uploader.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::net::{PingUploader, UploadResult};
+use crate::net::{PingUploadRequest, PingUploader, UploadResult};
 
 /// A simple mechanism to upload pings over HTTPS.
 #[derive(Debug)]
@@ -13,12 +13,9 @@ impl PingUploader for HttpUploader {
     ///
     /// # Arguments
     ///
-    /// * `url` - the URL path to upload the data to.
-    /// * `body` - the serialized text data to send.
-    /// * `headers` - a vector of tuples containing the headers to send with
-    ///   the request, i.e. (Name, Value).
-    fn upload(&self, url: String, _body: Vec<u8>, _headers: Vec<(String, String)>) -> UploadResult {
-        log::debug!("TODO bug 1675468: submitting to {:?}", url);
+    /// * `upload_request` - the requested upload.
+    fn upload(&self, upload_request: PingUploadRequest) -> UploadResult {
+        log::debug!("TODO bug 1675468: submitting to {:?}", upload_request.url);
         UploadResult::http_status(200)
     }
 }

--- a/glean-core/rlb/src/private/ping.rs
+++ b/glean-core/rlb/src/private/ping.rs
@@ -33,6 +33,7 @@ impl PingType {
         include_client_id: bool,
         send_if_empty: bool,
         precise_timestamps: bool,
+        include_info_sections: bool,
         reason_codes: Vec<String>,
     ) -> Self {
         let inner = glean_core::metrics::PingType::new(
@@ -40,6 +41,7 @@ impl PingType {
             include_client_id,
             send_if_empty,
             precise_timestamps,
+            include_info_sections,
             reason_codes,
         );
 

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -22,22 +22,16 @@ use crate::common_test::{lock_test, new_glean, GLOBAL_APPLICATION_ID};
 fn send_a_ping() {
     let _lock = lock_test();
 
-    let (s, r) = crossbeam_channel::bounded::<String>(1);
+    let (s, r) = crossbeam_channel::bounded::<net::PingUploadRequest>(1);
 
-    // Define a fake uploader that reports back the submission URL
-    // using a crossbeam channel.
+    // Define a fake uploader that reports back the ping upload request.
     #[derive(Debug)]
     pub struct FakeUploader {
-        sender: crossbeam_channel::Sender<String>,
+        sender: crossbeam_channel::Sender<net::PingUploadRequest>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -59,8 +53,50 @@ fn send_a_ping() {
     custom_ping.submit(None);
 
     // Wait for the ping to arrive.
-    let url = r.recv().unwrap();
-    assert!(url.contains(PING_NAME));
+    let upload_request = r.recv().unwrap();
+    assert!(upload_request.body_has_info_sections);
+    assert_eq!(upload_request.ping_name, PING_NAME);
+    assert!(upload_request.url.contains(PING_NAME));
+}
+
+#[test]
+fn send_a_ping_without_info_sections() {
+    let _lock = lock_test();
+
+    let (s, r) = crossbeam_channel::bounded::<net::PingUploadRequest>(1);
+
+    // Define a fake uploader that reports back the ping upload request.
+    #[derive(Debug)]
+    pub struct FakeUploader {
+        sender: crossbeam_channel::Sender<net::PingUploadRequest>,
+    }
+    impl net::PingUploader for FakeUploader {
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request).unwrap();
+            net::UploadResult::http_status(200)
+        }
+    }
+
+    // Create a custom configuration to use a fake uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().to_path_buf();
+
+    let cfg = ConfigurationBuilder::new(true, tmpname, GLOBAL_APPLICATION_ID)
+        .with_server_endpoint("invalid-test-host")
+        .with_uploader(FakeUploader { sender: s })
+        .build();
+
+    let _t = new_glean(Some(cfg), true);
+
+    // Define a new ping and submit it.
+    const PING_NAME: &str = "noinfo-ping";
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, false, vec![]);
+    custom_ping.submit(None);
+
+    // Wait for the ping to arrive.
+    let upload_request = r.recv().unwrap();
+    assert!(!upload_request.body_has_info_sections);
+    assert_eq!(upload_request.ping_name, PING_NAME);
 }
 
 #[test]
@@ -190,13 +226,8 @@ fn sending_of_foreground_background_pings() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -263,13 +294,8 @@ fn sending_of_startup_baseline_ping() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -315,13 +341,8 @@ fn no_dirty_baseline_on_clean_shutdowns() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -543,12 +564,8 @@ fn ping_collection_must_happen_after_concurrently_scheduled_metrics_recordings()
         sender: crossbeam_channel::Sender<(String, JsonValue)>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            let net::PingUploadRequest { body, url, .. } = upload_request;
             // Decode the gzipped body.
             let mut gzip_decoder = GzDecoder::new(&body[..]);
             let mut s = String::with_capacity(body.len());
@@ -681,13 +698,8 @@ fn sending_deletion_ping_if_disabled_outside_of_run() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -731,13 +743,8 @@ fn no_sending_of_deletion_ping_if_unchanged_outside_of_run() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -779,12 +786,8 @@ fn deletion_request_ping_contains_experimentation_id() {
         sender: crossbeam_channel::Sender<JsonValue>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            _url: String,
-            body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            let body = upload_request.body;
             let mut gzip_decoder = GzDecoder::new(&body[..]);
             let mut body_str = String::with_capacity(body.len());
             let data: JsonValue = gzip_decoder
@@ -847,12 +850,8 @@ fn test_sending_of_startup_baseline_ping_with_application_lifetime_metric() {
         sender: crossbeam_channel::Sender<(String, JsonValue)>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            let net::PingUploadRequest { url, body, .. } = upload_request;
             // Decode the gzipped body.
             let mut gzip_decoder = GzDecoder::new(&body[..]);
             let mut s = String::with_capacity(body.len());
@@ -932,13 +931,8 @@ fn setting_debug_view_tag_before_initialization_should_not_crash() {
         sender: crossbeam_channel::Sender<Vec<(String, String)>>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            _url: String,
-            _body: Vec<u8>,
-            headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(headers).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.headers).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -983,13 +977,8 @@ fn setting_source_tags_before_initialization_should_not_crash() {
         sender: crossbeam_channel::Sender<Vec<(String, String)>>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            _url: String,
-            _body: Vec<u8>,
-            headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(headers).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.headers).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -1033,13 +1022,8 @@ fn setting_source_tags_after_initialization_should_not_crash() {
         sender: crossbeam_channel::Sender<Vec<(String, String)>>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            _url: String,
-            _body: Vec<u8>,
-            headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(headers).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.headers).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -1097,13 +1081,8 @@ fn flipping_upload_enabled_respects_order_of_events() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -1155,13 +1134,8 @@ fn registering_pings_before_init_must_work() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -1201,13 +1175,8 @@ fn test_a_ping_before_submission() {
         sender: crossbeam_channel::Sender<String>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
-            self.sender.send(url).unwrap();
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }
@@ -1308,12 +1277,7 @@ fn signaling_done() {
         counter: Arc<Mutex<HashMap<ThreadId, u32>>>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            _url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
+        fn upload(&self, _upload_request: net::PingUploadRequest) -> net::UploadResult {
             let mut map = self.counter.lock().unwrap();
             *map.entry(thread::current().id()).or_insert(0) += 1;
 
@@ -1385,17 +1349,12 @@ fn configure_ping_throttling() {
         done: Arc<std::sync::atomic::AtomicBool>,
     }
     impl net::PingUploader for FakeUploader {
-        fn upload(
-            &self,
-            url: String,
-            _body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> net::UploadResult {
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
             if self.done.load(std::sync::atomic::Ordering::SeqCst) {
                 // If we've outlived the test, just lie.
                 return net::UploadResult::http_status(200);
             }
-            self.sender.send(url).unwrap();
+            self.sender.send(upload_request.url).unwrap();
             net::UploadResult::http_status(200)
         }
     }

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -55,7 +55,7 @@ fn send_a_ping() {
 
     // Define a new ping and submit it.
     const PING_NAME: &str = "test-ping";
-    let custom_ping = private::PingType::new(PING_NAME, true, true, true, vec![]);
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![]);
     custom_ping.submit(None);
 
     // Wait for the ping to arrive.
@@ -577,7 +577,7 @@ fn ping_collection_must_happen_after_concurrently_scheduled_metrics_recordings()
     );
 
     let ping_name = "custom_ping_1";
-    let ping = private::PingType::new(ping_name, true, false, true, vec![]);
+    let ping = private::PingType::new(ping_name, true, false, true, true, vec![]);
     let metric = private::StringMetric::new(CommonMetricData {
         name: "string_metric".into(),
         category: "telemetry".into(),
@@ -1118,7 +1118,7 @@ fn flipping_upload_enabled_respects_order_of_events() {
         .build();
 
     // We create a ping and a metric before we initialize Glean
-    let sample_ping = PingType::new("sample-ping-1", true, false, true, vec![]);
+    let sample_ping = PingType::new("sample-ping-1", true, false, true, true, vec![]);
     let metric = private::StringMetric::new(CommonMetricData {
         name: "string_metric".into(),
         category: "telemetry".into(),
@@ -1167,7 +1167,7 @@ fn registering_pings_before_init_must_work() {
     }
 
     // Create a custom ping and attempt its registration.
-    let sample_ping = PingType::new("pre-register", true, true, true, vec![]);
+    let sample_ping = PingType::new("pre-register", true, true, true, true, vec![]);
 
     // Create a custom configuration to use a fake uploader.
     let dir = tempfile::tempdir().unwrap();
@@ -1224,7 +1224,7 @@ fn test_a_ping_before_submission() {
     let _t = new_glean(Some(cfg), true);
 
     // Create a custom ping and register it.
-    let sample_ping = PingType::new("custom1", true, true, true, vec![]);
+    let sample_ping = PingType::new("custom1", true, true, true, true, vec![]);
 
     let metric = CounterMetric::new(CommonMetricData {
         name: "counter_metric".into(),
@@ -1346,7 +1346,7 @@ fn signaling_done() {
 
     // Define a new ping and submit it.
     const PING_NAME: &str = "test-ping";
-    let custom_ping = private::PingType::new(PING_NAME, true, true, true, vec![]);
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![]);
     custom_ping.submit(None);
     custom_ping.submit(None);
 
@@ -1422,7 +1422,7 @@ fn configure_ping_throttling() {
 
     // Define a new ping.
     const PING_NAME: &str = "test-ping";
-    let custom_ping = private::PingType::new(PING_NAME, true, true, true, vec![]);
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![]);
 
     // Submit and receive it `pings_per_interval` times.
     for _ in 0..pings_per_interval {

--- a/glean-core/rlb/tests/init_fails.rs
+++ b/glean-core/rlb/tests/init_fails.rs
@@ -43,7 +43,7 @@ mod pings {
 
     #[allow(non_upper_case_globals)]
     pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, vec![]));
+        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
 }
 
 /// Test scenario: Glean initialization fails.

--- a/glean-core/rlb/tests/never_init.rs
+++ b/glean-core/rlb/tests/never_init.rs
@@ -39,7 +39,7 @@ mod pings {
 
     #[allow(non_upper_case_globals)]
     pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, vec![]));
+        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
 }
 
 /// Test scenario: Glean is never initialized.

--- a/glean-core/rlb/tests/no_time_to_init.rs
+++ b/glean-core/rlb/tests/no_time_to_init.rs
@@ -41,7 +41,7 @@ mod pings {
 
     #[allow(non_upper_case_globals)]
     pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, vec![]));
+        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
 }
 
 /// Test scenario: Glean initialization fails.

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -10,7 +10,7 @@ use glean_core::TextMetric;
 use jsonschema_valid::{self, schemas::Draft};
 use serde_json::Value;
 
-use glean::net::UploadResult;
+use glean::net::{PingUploadRequest, UploadResult};
 use glean::private::*;
 use glean::{
     traits, ClientInfoMetrics, CommonMetricData, ConfigurationBuilder, HistogramType, MemoryUnit,
@@ -60,13 +60,8 @@ fn validate_against_schema() {
         sender: crossbeam_channel::Sender<Vec<u8>>,
     }
     impl glean::net::PingUploader for ValidatingUploader {
-        fn upload(
-            &self,
-            _url: String,
-            body: Vec<u8>,
-            _headers: Vec<(String, String)>,
-        ) -> UploadResult {
-            self.sender.send(body).unwrap();
+        fn upload(&self, ping_request: PingUploadRequest) -> UploadResult {
+            self.sender.send(ping_request.body).unwrap();
             UploadResult::http_status(200)
         }
     }

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -176,7 +176,7 @@ fn validate_against_schema() {
     text_metric.set("loooooong text".repeat(100));
 
     // Define a new ping and submit it.
-    let custom_ping = glean::private::PingType::new(PING_NAME, true, true, true, vec![]);
+    let custom_ping = glean::private::PingType::new(PING_NAME, true, true, true, true, vec![]);
     custom_ping.submit(None);
 
     // Wait for the ping to arrive.

--- a/glean-core/rlb/tests/simple.rs
+++ b/glean-core/rlb/tests/simple.rs
@@ -41,7 +41,7 @@ mod pings {
 
     #[allow(non_upper_case_globals)]
     pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, vec![]));
+        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
 }
 
 /// Test scenario: A clean run

--- a/glean-core/rlb/tests/upload_timing.rs
+++ b/glean-core/rlb/tests/upload_timing.rs
@@ -97,7 +97,7 @@ mod pings {
 
     #[allow(non_upper_case_globals)]
     pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, vec![]));
+        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
 }
 
 // Define a fake uploader that sleeps.

--- a/glean-core/rlb/tests/upload_timing.rs
+++ b/glean-core/rlb/tests/upload_timing.rs
@@ -108,13 +108,9 @@ struct FakeUploader {
 }
 
 impl net::PingUploader for FakeUploader {
-    fn upload(
-        &self,
-        _url: String,
-        body: Vec<u8>,
-        _headers: Vec<(String, String)>,
-    ) -> net::UploadResult {
+    fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
         let calls = self.calls.fetch_add(1, Ordering::SeqCst);
+        let body = upload_request.body;
         let decode = |body: Vec<u8>| {
             let mut gzip_decoder = GzDecoder::new(&body[..]);
             let mut s = String::with_capacity(body.len());

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -122,7 +122,7 @@ where
 ///     experimentation_id: None,
 /// };
 /// let mut glean = Glean::new(cfg).unwrap();
-/// let ping = PingType::new("sample", true, false, true, vec![]);
+/// let ping = PingType::new("sample", true, false, true, true, vec![]);
 /// glean.register_ping_type(&ping);
 ///
 /// let call_counter: CounterMetric = CounterMetric::new(CommonMetricData {

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -201,6 +201,10 @@ dictionary PingRequest {
     sequence<u8> body;
     // A map with all the headers to be sent with the request.
     record<DOMString, string> headers;
+    // Whether the body has {client|ping}_info sections.
+    boolean body_has_info_sections;
+    // The ping's name. Likely also somewhere in `path`.
+    string ping_name;
 };
 
 // An enum representing the possible upload tasks to be performed by an uploader.

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -287,7 +287,7 @@ enum ErrorType {
 };
 
 interface PingType {
-    constructor(string name, boolean include_client_id, boolean send_if_empty, boolean precise_timestamps, sequence<string> reason_codes);
+    constructor(string name, boolean include_client_id, boolean send_if_empty, boolean precise_timestamps, boolean include_info_sections, sequence<string> reason_codes);
     void submit(optional string? reason = null);
 };
 

--- a/glean-core/src/internal_pings.rs
+++ b/glean-core/src/internal_pings.rs
@@ -26,6 +26,7 @@ impl InternalPings {
                 true,
                 true,
                 true,
+                true,
                 vec![
                     "active".to_string(),
                     "dirty_startup".to_string(),
@@ -36,6 +37,7 @@ impl InternalPings {
                 "metrics",
                 true,
                 false,
+                true,
                 true,
                 vec![
                     "overdue".to_string(),
@@ -50,6 +52,7 @@ impl InternalPings {
                 true,
                 false,
                 true,
+                true,
                 vec![
                     "startup".to_string(),
                     "inactive".to_string(),
@@ -58,6 +61,7 @@ impl InternalPings {
             ),
             deletion_request: PingType::new(
                 "deletion-request",
+                true,
                 true,
                 true,
                 true,

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -26,6 +26,8 @@ struct InnerPing {
     pub send_if_empty: bool,
     /// Whether to use millisecond-precise start/end times.
     pub precise_timestamps: bool,
+    /// Whether to include the {client|ping}_info sections on assembly.
+    pub include_info_sections: bool,
     /// The "reason" codes that this ping can send
     pub reason_codes: Vec<String>,
 }
@@ -37,6 +39,7 @@ impl fmt::Debug for PingType {
             .field("include_client_id", &self.0.include_client_id)
             .field("send_if_empty", &self.0.send_if_empty)
             .field("precise_timestamps", &self.0.precise_timestamps)
+            .field("include_info_sections", &self.0.include_info_sections)
             .field("reason_codes", &self.0.reason_codes)
             .finish()
     }
@@ -61,6 +64,7 @@ impl PingType {
         include_client_id: bool,
         send_if_empty: bool,
         precise_timestamps: bool,
+        include_info_sections: bool,
         reason_codes: Vec<String>,
     ) -> Self {
         let this = Self(Arc::new(InnerPing {
@@ -68,6 +72,7 @@ impl PingType {
             include_client_id,
             send_if_empty,
             precise_timestamps,
+            include_info_sections,
             reason_codes,
         }));
 
@@ -92,6 +97,10 @@ impl PingType {
 
     pub(crate) fn precise_timestamps(&self) -> bool {
         self.0.precise_timestamps
+    }
+
+    pub(crate) fn include_info_sections(&self) -> bool {
+        self.0.include_info_sections
     }
 
     /// Submits the ping for eventual uploading.

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -18,11 +18,17 @@ use crate::{DELETION_REQUEST_PINGS_DIRECTORY, PENDING_PINGS_DIRECTORY};
 /// A representation of the data extracted from a ping file,
 #[derive(Clone, Debug, Default)]
 pub struct PingPayload {
+    /// The ping's doc_id.
     pub document_id: String,
+    /// The path to upload the ping to.
     pub upload_path: String,
+    /// The ping body as JSON-encoded string.
     pub json_body: String,
+    /// HTTP headers to include in the upload request.
     pub headers: Option<HeaderMap>,
+    /// Whether the ping body contains {client|ping}_info
     pub body_has_info_sections: bool,
+    /// The ping's name. (Also likely in the upload_path.)
     pub ping_name: String,
 }
 

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -303,7 +303,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory
@@ -329,7 +329,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory
@@ -364,7 +364,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -979,7 +979,14 @@ mod test {
         let (mut glean, _t) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit the ping multiple times
@@ -1011,7 +1018,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit the ping multiple times
@@ -1041,7 +1055,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit a ping
@@ -1071,7 +1092,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit a ping
@@ -1101,7 +1129,14 @@ mod test {
         let (mut glean, _t) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit a ping
@@ -1133,7 +1168,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit a ping
@@ -1221,7 +1263,14 @@ mod test {
         glean.set_debug_view_tag("valid-tag");
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit a ping
@@ -1267,7 +1316,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit the ping multiple times
@@ -1317,7 +1373,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // Submit the ping multiple times
@@ -1385,7 +1448,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         // How many pings we allow at maximum
@@ -1457,7 +1527,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         let expected_number_of_pings = 3;
@@ -1531,7 +1608,14 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, /* send_if_empty */ true, true, vec![]);
+        let ping_type = PingType::new(
+            "test",
+            true,
+            /* send_if_empty */ true,
+            true,
+            true,
+            vec![],
+        );
         glean.register_ping_type(&ping_type);
 
         let expected_number_of_pings = 2;

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -329,7 +329,8 @@ impl PingUploadManager {
             upload_path: path,
             json_body: body,
             headers,
-            ..
+            body_has_info_sections,
+            ping_name,
         } = ping;
         let mut request = PingRequest::builder(
             &self.language_binding_name,
@@ -337,7 +338,9 @@ impl PingUploadManager {
         )
         .document_id(&document_id)
         .path(path)
-        .body(body);
+        .body(body)
+        .body_has_info_sections(body_has_info_sections)
+        .ping_name(ping_name);
 
         if let Some(headers) = headers {
             request = request.headers(headers);

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -166,6 +166,7 @@ fn test_sending_of_event_ping_when_it_fills_up() {
             true,
             false,
             true,
+            true,
             vec!["max_capacity".to_string()],
         ));
     }
@@ -449,6 +450,7 @@ fn event_storage_trimming() {
             store_name.to_string(),
             true,
             false,
+            true,
             true,
             vec![],
         ));

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -15,7 +15,7 @@ use glean_core::Lifetime;
 fn write_ping_to_disk() {
     let (mut glean, _temp) = new_glean(None);
 
-    let ping = PingType::new("metrics", true, false, true, vec![]);
+    let ping = PingType::new("metrics", true, false, true, true, vec![]);
     glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -36,7 +36,7 @@ fn write_ping_to_disk() {
 fn disabling_upload_clears_pending_pings() {
     let (mut glean, _t) = new_glean(None);
 
-    let ping = PingType::new("metrics", true, false, true, vec![]);
+    let ping = PingType::new("metrics", true, false, true, true, vec![]);
     glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -105,9 +105,9 @@ fn deletion_request_only_when_toggled_from_on_to_off() {
 fn empty_pings_with_flag_are_sent() {
     let (mut glean, _t) = new_glean(None);
 
-    let ping1 = PingType::new("custom-ping1", true, true, true, vec![]);
+    let ping1 = PingType::new("custom-ping1", true, true, true, true, vec![]);
     glean.register_ping_type(&ping1);
-    let ping2 = PingType::new("custom-ping2", true, false, true, vec![]);
+    let ping2 = PingType::new("custom-ping2", true, false, true, true, vec![]);
     glean.register_ping_type(&ping2);
 
     // No data is stored in either of the custom pings
@@ -139,10 +139,10 @@ fn test_pings_submitted_metric() {
         None,
     );
 
-    let metrics_ping = PingType::new("metrics", true, false, true, vec![]);
+    let metrics_ping = PingType::new("metrics", true, false, true, true, vec![]);
     glean.register_ping_type(&metrics_ping);
 
-    let baseline_ping = PingType::new("baseline", true, false, true, vec![]);
+    let baseline_ping = PingType::new("baseline", true, false, true, true, vec![]);
     glean.register_ping_type(&baseline_ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -218,7 +218,7 @@ fn test_pings_submitted_metric() {
 fn events_ping_with_metric_but_no_events_is_not_sent() {
     let (mut glean, _t) = new_glean(None);
 
-    let events_ping = PingType::new("events", true, true, true, vec![]);
+    let events_ping = PingType::new("events", true, true, true, true, vec![]);
     glean.register_ping_type(&events_ping);
     let counter = CounterMetric::new(CommonMetricData {
         name: "counter".into(),

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -13,7 +13,7 @@ fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
     let (tempdir, _) = tempdir();
     let (mut glean, t) = new_glean(Some(tempdir));
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, vec![]);
+    let ping_type = PingType::new("store1", true, false, true, true, vec![]);
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -94,7 +94,7 @@ fn test_metrics_must_report_experimentation_id() {
     })
     .unwrap();
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, vec![]);
+    let ping_type = PingType::new("store1", true, false, true, true, vec![]);
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -147,7 +147,7 @@ fn experimentation_id_is_removed_if_send_if_empty_is_false() {
     .unwrap();
     let ping_maker = PingMaker::new();
 
-    let unknown_ping_type = PingType::new("unknown", true, false, true, vec![]);
+    let unknown_ping_type = PingType::new("unknown", true, false, true, true, vec![]);
     glean.register_ping_type(&unknown_ping_type);
 
     assert!(ping_maker
@@ -163,7 +163,7 @@ fn collect_must_report_none_when_no_data_is_stored() {
 
     let (mut glean, ping_maker, ping_type, _t) = set_up_basic_ping();
 
-    let unknown_ping_type = PingType::new("unknown", true, false, true, vec![]);
+    let unknown_ping_type = PingType::new("unknown", true, false, true, true, vec![]);
     glean.register_ping_type(&ping_type);
 
     assert!(ping_maker
@@ -187,7 +187,7 @@ fn seq_number_must_be_sequential() {
 
     for i in 0..=1 {
         for ping_name in ["store1", "store2"].iter() {
-            let ping_type = PingType::new(*ping_name, true, false, true, vec![]);
+            let ping_type = PingType::new(*ping_name, true, false, true, true, vec![]);
             let ping = ping_maker
                 .collect(&glean, &ping_type, None, "", "")
                 .unwrap();
@@ -200,7 +200,7 @@ fn seq_number_must_be_sequential() {
 
     // Test that ping sequence numbers increase independently.
     {
-        let ping_type = PingType::new("store1", true, false, true, vec![]);
+        let ping_type = PingType::new("store1", true, false, true, true, vec![]);
 
         // 3rd ping of store1
         let ping = ping_maker
@@ -218,7 +218,7 @@ fn seq_number_must_be_sequential() {
     }
 
     {
-        let ping_type = PingType::new("store2", true, false, true, vec![]);
+        let ping_type = PingType::new("store2", true, false, true, true, vec![]);
 
         // 3rd ping of store2
         let ping = ping_maker
@@ -229,7 +229,7 @@ fn seq_number_must_be_sequential() {
     }
 
     {
-        let ping_type = PingType::new("store1", true, false, true, vec![]);
+        let ping_type = PingType::new("store1", true, false, true, true, vec![]);
 
         // 5th ping of store1
         let ping = ping_maker
@@ -244,7 +244,7 @@ fn seq_number_must_be_sequential() {
 fn clear_pending_pings() {
     let (mut glean, _t) = new_glean(None);
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, vec![]);
+    let ping_type = PingType::new("store1", true, false, true, true, vec![]);
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -272,7 +272,7 @@ fn no_pings_submitted_if_upload_disabled() {
     // Regression test, bug 1603571
 
     let (mut glean, _t) = new_glean(None);
-    let ping_type = PingType::new("store1", true, true, true, vec![]);
+    let ping_type = PingType::new("store1", true, true, true, true, vec![]);
     glean.register_ping_type(&ping_type);
 
     assert!(ping_type.submit_sync(&glean, None));
@@ -290,7 +290,7 @@ fn no_pings_submitted_if_upload_disabled() {
 fn metadata_is_correctly_added_when_necessary() {
     let (mut glean, _t) = new_glean(None);
     glean.set_debug_view_tag("valid-tag");
-    let ping_type = PingType::new("store1", true, true, true, vec![]);
+    let ping_type = PingType::new("store1", true, true, true, true, vec![]);
     glean.register_ping_type(&ping_type);
 
     assert!(ping_type.submit_sync(&glean, None));

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -50,7 +50,7 @@ abstract class GleanMetricsYamlTransform implements TransformAction<TransformPar
 @SuppressWarnings("GrPackage")
 class GleanPlugin implements Plugin<Project> {
     // The version of glean_parser to install from PyPI.
-    private String GLEAN_PARSER_VERSION = "12.0"
+    private String GLEAN_PARSER_VERSION = "13.0"
     // The version of Miniconda is explicitly specified.
     // Miniconda3-4.5.12 is known to not work on Windows.
     private String MINICONDA_VERSION = "4.5.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ maintainers = [
 
 dependencies = [
   "semver>=2.13.0",
-  "glean_parser~=12.0",
+  "glean_parser~=13.0",
 ]
 
 [project.urls]

--- a/samples/rust/src/main.rs
+++ b/samples/rust/src/main.rs
@@ -22,12 +22,10 @@ pub mod glean_metrics {
 struct MovingUploader(String);
 
 impl net::PingUploader for MovingUploader {
-    fn upload(
-        &self,
-        url: String,
-        body: Vec<u8>,
-        headers: Vec<(String, String)>,
-    ) -> net::UploadResult {
+    fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+        let net::PingUploadRequest {
+            body, url, headers, ..
+        } = upload_request;
         let mut gzip_decoder = GzDecoder::new(&body[..]);
         let mut s = String::with_capacity(body.len());
 


### PR DESCRIPTION
This is a prerequisite for OHTTP support. Brings in glean_parser v13 to support it.

Only Rust's uploader does anything with this information. I suppose we could log/throw/record data if a noinfo ping makes it into an unsupported LB's uploader, but I figured just sending it normally might be the more kind approach.

Lotta changed files in this one, I'm afraid. If you'd like to follow the code changes chronologically by how the data flows, the individual commits are arranged in that manner (though Github's review UI is shite at handling that, so my condolences).