### PR TITLE
Docs: Remove unneeded warning header

### DIFF
--- a/docs/user/reference/metrics/object.md
+++ b/docs/user/reference/metrics/object.md
@@ -2,8 +2,6 @@
 
 Record structured data.
 
-{{#include ../../../shared/blockquote-warning.html}}
-
 ## Recording API
 
 ### `set`


### PR DESCRIPTION
This breaks page layout a bit at the moment.

[doc only]