### PR TITLE
Use semicolon as a PYTHONPATH separator on Windows

### DIFF
--- a/glean-core/python/glean/_process_dispatcher.py
+++ b/glean-core/python/glean/_process_dispatcher.py
@@ -123,7 +123,7 @@ class ProcessDispatcher:
             # Explicitly pass the contents of `sys.path` as `PYTHONPATH` to the
             # subprocess so that there aren't any module search path
             # differences.
-            python_path = ":".join(sys.path)
+            python_path = (";" if os.name == "nt" else ":").join(sys.path)
 
             # We re-use the existing environment and overwrite only the `PYTHONPATH`
             env = os.environ.copy()


### PR DESCRIPTION
This should fix path resolution issues in `_process_dispatcher_helper.py` on Windows.

I encountered the following issue while using `./mach raptor -t browsertime --browsertime-arg test_script=pageload --browsertime-arg browsertime.url=https://www.ebay.com --browsertime-arg iterations=1` from `mozilla-unified`. At the end of the test, the console shows:

```
Traceback (most recent call last):
  File "c:\users\yjugl\.mozbuild\srcdirs\mozilla-unified-f689344771d4\_virtualenvs\mach\lib\site-packages\glean\_subprocess\_process_dispatcher_helper.py", line 35, in <module>
    simple_log_level, func, args = pickle.loads(base64.b64decode(sys.argv[1]))
ModuleNotFoundError: No module named 'glean'
```

Before patch, on my machine:

- `simple_log_level, func, args = pickle.loads(base64.b64decode(sys.argv[1]))` fails with `ModuleNotFoundError`;
- printing `sys.path` from `_process_dispatcher_helper.py` yields an array where one of the entries agglomerates multiple paths together separated by a `:`, e.g. `'C:\\mozilla-source\\mozilla-unified\\testing\\mozharness:C:\\mozilla-source:C:\\mozilla-source\\mozilla-unified\\testing\\raptor:...'`.

After patch, on my machine:

- `simple_log_level, func, args = pickle.loads(base64.b64decode(sys.argv[1]))` succeeds;
- printing `sys.path` from `_process_dispatcher_helper.py` yields an array where every entry is a single path.