### PR TITLE
Bug 1855257 - Add a configuration option to disable internal pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Hide `glean_timestamp` from event extras in tests ([#2776](https://github.com/mozilla/glean/pull/2776))
+  * Add a configuration option to disable internal pings ([#2786](https://github.com/mozilla/glean/pull/2786/))
 
 # v58.1.0 (2024-03-12)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -261,6 +261,7 @@ open class GleanInternalAPI internal constructor() {
                 rateLimit = null,
                 enableEventTimestamps = configuration.enableEventTimestamps,
                 experimentationId = configuration.experimentationId,
+                enableInternalPings = configuration.enableInternalPings,
             )
             val clientInfo = getClientInfo(configuration, buildInfo)
             val callbacks = OnGleanEventsImpl(this@GleanInternalAPI)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -21,6 +21,9 @@ import mozilla.telemetry.glean.net.PingUploader
  *           This should ONLY be used when setting up Glean on a non-main process.
  * @property logLevel An optional [LevelFilter] that controls how verbose the internal logging is.
  * @property enableEventTimestamps (Experimental) Whether to add a wallclock timestamp to all events.
+ * @property experimentationId An experimentation identifier derived by the application
+ *           to be sent with all pings.
+ * @property enableInternalPings Whether to enable internal pings.
  */
 data class Configuration @JvmOverloads constructor(
     val serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
@@ -34,6 +37,7 @@ data class Configuration @JvmOverloads constructor(
     val logLevel: LevelFilter? = null,
     val enableEventTimestamps: Boolean = true,
     val experimentationId: String? = null,
+    val enableInternalPings: Boolean = true,
 ) {
     companion object {
         /**

--- a/glean-core/ios/Glean/Config/Configuration.swift
+++ b/glean-core/ios/Glean/Config/Configuration.swift
@@ -12,6 +12,7 @@ public struct Configuration {
     let logLevel: LevelFilter?
     let enableEventTimestamps: Bool
     let experimentationId: String?
+    let enableInternalPings: Bool
 
     struct Constants {
         static let defaultTelemetryEndpoint = "https://incoming.telemetry.mozilla.org"
@@ -27,7 +28,10 @@ public struct Configuration {
     ///   * dataPath an optional String that specifies where to store data locally on the device.
     ///   This should ONLY be used when setting up Glean on a non-main process.
     ///   * logLevel an optional log level that controls how verbose the internal logging is.
-    ///   * enableEventTimestamps (Experimental) whether to add a wallclock timestamp to all events.
+    ///   * enableEventTimestamps (Experimental) whether to add a wallclock timestamp to all events
+    ///   * experimentationId An experimentation identifier derived by the application
+    ///   to be sent with all pings.
+    ///   * enableInternalPings Whether to enable internal pings.
     public init(
         maxEvents: Int32? = nil,
         channel: String? = nil,
@@ -35,7 +39,8 @@ public struct Configuration {
         dataPath: String? = nil,
         logLevel: LevelFilter? = nil,
         enableEventTimestamps: Bool = true,
-        experimentationId: String? = nil
+        experimentationId: String? = nil,
+        enableInternalPings: Bool = true
     ) {
         self.serverEndpoint = serverEndpoint ?? Constants.defaultTelemetryEndpoint
         self.maxEvents = maxEvents
@@ -44,5 +49,6 @@ public struct Configuration {
         self.logLevel = logLevel
         self.enableEventTimestamps = enableEventTimestamps
         self.experimentationId = experimentationId
+        self.enableInternalPings = enableInternalPings
     }
 }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -194,7 +194,8 @@ public class Glean {
             logLevel: configuration.logLevel,
             rateLimit: nil,
             enableEventTimestamps: configuration.enableEventTimestamps,
-            experimentationId: configuration.experimentationId
+            experimentationId: configuration.experimentationId,
+            enableInternalPings: configuration.enableInternalPings
         )
         let clientInfo = getClientInfo(configuration, buildInfo: buildInfo)
         let callbacks = OnGleanEventsImpl(glean: self)

--- a/glean-core/python/glean/config.py
+++ b/glean-core/python/glean/config.py
@@ -34,6 +34,7 @@ class Configuration:
         allow_multiprocessing: bool = True,
         enable_event_timestamps: bool = True,
         experimentation_id: Optional[str] = None,
+        enable_internal_pings: bool = True,
     ):
         """
         Args:
@@ -49,6 +50,9 @@ class Configuration:
                 to offload some work (such as ping uploading).
             enable_event_timestamps (bool): (Experimental) Whether to add a
                 wallclock timestamp to all events. Default: `True`.
+            experimentation_id (string): An experimentation identifier derived
+                by the application to be sent with all pings. Default: None.
+            enable_internal_pings (bool): Whether to enable internal pings. Default: `True`.
         """
         if server_endpoint is None:
             server_endpoint = DEFAULT_TELEMETRY_ENDPOINT
@@ -61,6 +65,7 @@ class Configuration:
         self._allow_multiprocessing = allow_multiprocessing
         self._enable_event_timestamps = enable_event_timestamps
         self._experimentation_id = experimentation_id
+        self._enable_internal_pings = enable_internal_pings
 
     @property
     def server_endpoint(self) -> str:
@@ -100,6 +105,11 @@ class Configuration:
     def experimentation_id(self) -> Optional[str]:
         """An experimentation id that will be sent in all pings"""
         return self._experimentation_id
+
+    @property
+    def enable_internal_pings(self) -> bool:
+        """Whether to enable internal pings."""
+        return self._enable_internal_pings
 
     @property
     def ping_uploader(self) -> net.BaseUploader:

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -233,6 +233,7 @@ class Glean:
             rate_limit=None,
             enable_event_timestamps=configuration.enable_event_timestamps,
             experimentation_id=configuration.experimentation_id,
+            enable_internal_pings=configuration.enable_internal_pings,
         )
 
         _uniffi.glean_initialize(cfg, client_info, callbacks)

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -118,6 +118,7 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
             rate_limit=None,
             enable_event_timestamps=False,
             experimentation_id=None,
+            enable_internal_pings=False,
         )
         if not glean_initialize_for_subprocess(cfg):
             log.error("Couldn't initialize Glean in subprocess")

--- a/glean-core/rlb/src/configuration.rs
+++ b/glean-core/rlb/src/configuration.rs
@@ -46,6 +46,8 @@ pub struct Configuration {
     /// be noted that this has an underlying StringMetric and so should conform to the limitations that
     /// StringMetric places on length, etc.
     pub experimentation_id: Option<String>,
+    /// Whether to enable internal pings. Default: true
+    pub enable_internal_pings: bool,
 }
 
 /// Configuration builder.
@@ -92,6 +94,8 @@ pub struct Builder {
     /// be noted that this has an underlying StringMetric and so should conform to the limitations that
     /// StringMetric places on length, etc.
     pub experimentation_id: Option<String>,
+    /// Whether to enable internal pings. Default: true
+    pub enable_internal_pings: bool,
 }
 
 impl Builder {
@@ -115,6 +119,7 @@ impl Builder {
             rate_limit: None,
             enable_event_timestamps: true,
             experimentation_id: None,
+            enable_internal_pings: true,
         }
     }
 
@@ -134,6 +139,7 @@ impl Builder {
             rate_limit: self.rate_limit,
             enable_event_timestamps: self.enable_event_timestamps,
             experimentation_id: self.experimentation_id,
+            enable_internal_pings: self.enable_internal_pings,
         }
     }
 
@@ -182,6 +188,12 @@ impl Builder {
     /// Set whether to add a wallclock timestamp to all events (experimental).
     pub fn with_experimentation_id(mut self, value: String) -> Self {
         self.experimentation_id = Some(value);
+        self
+    }
+
+    /// Set whether to enable internal pings.
+    pub fn with_internal_pings(mut self, value: bool) -> Self {
+        self.enable_internal_pings = value;
         self
     }
 }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -122,6 +122,7 @@ fn initialize_internal(cfg: Configuration, client_info: ClientInfoMetrics) -> Op
         rate_limit: cfg.rate_limit,
         enable_event_timestamps: cfg.enable_event_timestamps,
         experimentation_id: cfg.experimentation_id,
+        enable_internal_pings: cfg.enable_internal_pings,
     };
 
     glean_core::glean_initialize(core_cfg, client_info.into(), callbacks);

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -120,6 +120,7 @@ where
 ///     rate_limit: None,
 ///     enable_event_timestamps: true,
 ///     experimentation_id: None,
+///     enable_internal_pings: true,
 /// };
 /// let mut glean = Glean::new(cfg).unwrap();
 /// let ping = PingType::new("sample", true, false, true, true, vec![]);
@@ -208,7 +209,7 @@ impl Glean {
             core_metrics: CoreMetrics::new(),
             additional_metrics: AdditionalMetrics::new(),
             database_metrics: DatabaseMetrics::new(),
-            internal_pings: InternalPings::new(),
+            internal_pings: InternalPings::new(cfg.enable_internal_pings),
             upload_manager,
             data_path: PathBuf::from(&cfg.data_path),
             application_id,
@@ -288,7 +289,9 @@ impl Glean {
         }
 
         // We set this only for non-subprocess situations.
-        glean.schedule_metrics_pings = cfg.use_core_mps;
+        // If internal pings are disabled, we don't set up the MPS either,
+        // it wouldn't send any data anyway.
+        glean.schedule_metrics_pings = cfg.enable_internal_pings && cfg.use_core_mps;
 
         // We only scan the pendings pings directories **after** dealing with the upload state.
         // If upload is disabled, we delete all pending pings files
@@ -305,6 +308,7 @@ impl Glean {
         data_path: &str,
         application_id: &str,
         upload_enabled: bool,
+        enable_internal_pings: bool,
     ) -> Self {
         let cfg = InternalConfiguration {
             data_path: data_path.into(),
@@ -320,6 +324,7 @@ impl Glean {
             rate_limit: None,
             enable_event_timestamps: true,
             experimentation_id: None,
+            enable_internal_pings,
         };
 
         let mut glean = Self::new(cfg).unwrap();

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -90,6 +90,7 @@ dictionary InternalConfiguration {
     PingRateLimit? rate_limit;
     boolean enable_event_timestamps;
     string? experimentation_id;
+    boolean enable_internal_pings;
 };
 
 // How to specify the rate pings may be uploaded before they are throttled.

--- a/glean-core/src/internal_pings.rs
+++ b/glean-core/src/internal_pings.rs
@@ -19,9 +19,9 @@ pub struct InternalPings {
 }
 
 impl InternalPings {
-    pub fn new() -> InternalPings {
+    pub fn new(enabled: bool) -> InternalPings {
         InternalPings {
-            baseline: PingType::new(
+            baseline: PingType::new_internal(
                 "baseline",
                 true,
                 true,
@@ -32,8 +32,9 @@ impl InternalPings {
                     "dirty_startup".to_string(),
                     "inactive".to_string(),
                 ],
+                enabled,
             ),
-            metrics: PingType::new(
+            metrics: PingType::new_internal(
                 "metrics",
                 true,
                 false,
@@ -46,8 +47,9 @@ impl InternalPings {
                     "tomorrow".to_string(),
                     "upgrade".to_string(),
                 ],
+                enabled,
             ),
-            events: PingType::new(
+            events: PingType::new_internal(
                 "events",
                 true,
                 false,
@@ -58,6 +60,7 @@ impl InternalPings {
                     "inactive".to_string(),
                     "max_capacity".to_string(),
                 ],
+                enabled,
             ),
             deletion_request: PingType::new(
                 "deletion-request",

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -135,6 +135,8 @@ pub struct InternalConfiguration {
     /// be noted that this has an underlying StringMetric and so should conform to the limitations that
     /// StringMetric places on length, etc.
     pub experimentation_id: Option<String>,
+    /// Whether to enable internal pings. Default: true
+    pub enable_internal_pings: bool,
 }
 
 /// How to specify the rate at which pings may be uploaded before they are throttled.

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -19,7 +19,7 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
         None => tempfile::tempdir().unwrap(),
     };
     let tmpname = dir.path().display().to_string();
-    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
     (glean, dir)
 }
 
@@ -39,7 +39,7 @@ fn path_is_constructed_from_data() {
 fn experiment_id_and_branch_get_truncated_if_too_long() {
     let t = tempfile::tempdir().unwrap();
     let name = t.path().display().to_string();
-    let glean = Glean::with_options(&name, "org.mozilla.glean.tests", true);
+    let glean = Glean::with_options(&name, "org.mozilla.glean.tests", true, true);
 
     // Generate long strings for the used ids.
     let very_long_id = "test-experiment-id".repeat(10);
@@ -80,7 +80,7 @@ fn experiment_id_and_branch_get_truncated_if_too_long() {
 fn limits_on_experiments_extras_are_applied_correctly() {
     let t = tempfile::tempdir().unwrap();
     let name = t.path().display().to_string();
-    let glean = Glean::with_options(&name, "org.mozilla.glean.tests", true);
+    let glean = Glean::with_options(&name, "org.mozilla.glean.tests", true, true);
 
     let experiment_id = "test-experiment_id".to_string();
     let branch_id = "test-branch-id".to_string();
@@ -136,7 +136,7 @@ fn limits_on_experiments_extras_are_applied_correctly() {
 fn experiments_status_is_correctly_toggled() {
     let t = tempfile::tempdir().unwrap();
     let name = t.path().display().to_string();
-    let glean = Glean::with_options(&name, "org.mozilla.glean.tests", true);
+    let glean = Glean::with_options(&name, "org.mozilla.glean.tests", true, true);
 
     // Define the experiment's data.
     let experiment_id: String = "test-toggle-experiment".into();
@@ -197,6 +197,7 @@ fn experimentation_id_is_set_correctly() {
         rate_limit: None,
         enable_event_timestamps: true,
         experimentation_id: Some(experimentation_id.to_string()),
+        enable_internal_pings: true,
     })
     .unwrap();
 
@@ -217,7 +218,7 @@ fn client_id_and_first_run_date_must_be_regenerated() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
     {
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
 
         glean.data_store.as_ref().unwrap().clear_all();
 
@@ -234,7 +235,7 @@ fn client_id_and_first_run_date_must_be_regenerated() {
     }
 
     {
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
         assert!(glean
             .core_metrics
             .client_id
@@ -337,7 +338,7 @@ fn client_id_is_managed_correctly_when_toggling_uploading() {
 fn client_id_is_set_to_known_value_when_uploading_disabled_at_start() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
-    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, false);
+    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, false, true);
 
     assert_eq!(
         *KNOWN_CLIENT_ID,
@@ -353,7 +354,7 @@ fn client_id_is_set_to_known_value_when_uploading_disabled_at_start() {
 fn client_id_is_set_to_random_value_when_uploading_enabled_at_start() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
-    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
 
     let current_client_id = glean
         .core_metrics
@@ -367,7 +368,7 @@ fn client_id_is_set_to_random_value_when_uploading_enabled_at_start() {
 fn enabling_when_already_enabled_is_a_noop() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
-    let mut glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+    let mut glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
 
     assert!(!glean.set_upload_enabled(true));
 }
@@ -376,7 +377,7 @@ fn enabling_when_already_enabled_is_a_noop() {
 fn disabling_when_already_disabled_is_a_noop() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
-    let mut glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, false);
+    let mut glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, false, true);
 
     assert!(!glean.set_upload_enabled(false));
 }
@@ -599,14 +600,14 @@ fn test_first_run() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
     {
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
         // Check that this is indeed the first run.
         assert!(glean.is_first_run());
     }
 
     {
         // Other runs must be not marked as "first run".
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
         assert!(!glean.is_first_run());
     }
 }
@@ -616,7 +617,7 @@ fn test_dirty_bit() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
     {
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
         // The dirty flag must not be set the first time Glean runs.
         assert!(!glean.is_dirty_flag_set());
 
@@ -628,7 +629,7 @@ fn test_dirty_bit() {
     {
         // Check that next time Glean runs, it correctly picks up the "dirty flag".
         // It is expected to be 'true'.
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
         assert!(glean.is_dirty_flag_set());
 
         // Set the dirty flag to false.
@@ -639,7 +640,7 @@ fn test_dirty_bit() {
     {
         // Check that next time Glean runs, it correctly picks up the "dirty flag".
         // It is expected to be 'false'.
-        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+        let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
         assert!(!glean.is_dirty_flag_set());
     }
 }
@@ -1063,7 +1064,7 @@ fn test_empty_application_id() {
     let dir = tempfile::tempdir().unwrap();
     let tmpname = dir.path().display().to_string();
 
-    let glean = Glean::with_options(&tmpname, "", true);
+    let glean = Glean::with_options(&tmpname, "", true, true);
     // Check that this is indeed the first run.
     assert!(glean.is_first_run());
 }
@@ -1078,7 +1079,7 @@ fn records_database_file_size() {
     let tmpname = dir.path().display().to_string();
 
     // Initialize Glean once to ensure we create the database and did not error.
-    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
     let database_size = &glean.database_metrics.size;
     let data = database_size.get_value(&glean, "metrics");
 
@@ -1087,7 +1088,7 @@ fn records_database_file_size() {
     drop(glean);
 
     // Initialize Glean again to record file size.
-    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true);
+    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, true);
 
     let database_size = &glean.database_metrics.size;
     let data = database_size.get_value(&glean, "metrics");
@@ -1158,4 +1159,47 @@ fn test_activity_api() {
 
     // Check that we set everything we needed for the 'inactive' status.
     assert!(!glean.is_dirty_flag_set());
+}
+
+#[test]
+fn disabled_pings_are_not_submitted() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dir = tempfile::tempdir().unwrap();
+    let (mut glean, _t) = new_glean(Some(dir));
+
+    let ping = PingType::new_internal("custom-disabled", true, false, true, true, vec![], false);
+    glean.register_ping_type(&ping);
+
+    // We need to store a metric as an empty ping is not stored.
+    let counter = CounterMetric::new(CommonMetricData {
+        name: "counter".into(),
+        category: "local".into(),
+        send_in_pings: vec!["custom-disabled".into()],
+        ..Default::default()
+    });
+    counter.add_sync(&glean, 1);
+
+    assert!(!ping.submit_sync(&glean, None));
+}
+
+#[test]
+fn internal_pings_can_be_disabled() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().display().to_string();
+    let glean = Glean::with_options(&tmpname, GLOBAL_APPLICATION_ID, true, false);
+
+    // We need to store a metric as an empty ping is not stored.
+    let counter = CounterMetric::new(CommonMetricData {
+        name: "counter".into(),
+        category: "local".into(),
+        send_in_pings: vec!["baseline".into()],
+        ..Default::default()
+    });
+    counter.add_sync(&glean, 1);
+
+    let submitted = glean.internal_pings.baseline.submit_sync(&glean, None);
+    assert!(!submitted);
 }

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -235,7 +235,7 @@ mod test {
     fn test_experiments_json_serialization() {
         let t = tempfile::tempdir().unwrap();
         let name = t.path().display().to_string();
-        let glean = Glean::with_options(&name, "org.mozilla.glean", true);
+        let glean = Glean::with_options(&name, "org.mozilla.glean", true, true);
 
         let extra: HashMap<String, String> = [("test-key".into(), "test-value".into())]
             .iter()
@@ -264,7 +264,7 @@ mod test {
     fn test_experiments_json_serialization_empty() {
         let t = tempfile::tempdir().unwrap();
         let name = t.path().display().to_string();
-        let glean = Glean::with_options(&name, "org.mozilla.glean", true);
+        let glean = Glean::with_options(&name, "org.mozilla.glean", true, true);
 
         let metric = ExperimentMetric::new(&glean, "some-experiment".to_string());
 

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -63,6 +63,7 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
         rate_limit: None,
         enable_event_timestamps: false,
         experimentation_id: None,
+        enable_internal_pings: true,
     };
     let glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -481,6 +481,7 @@ fn with_event_timestamps() {
         rate_limit: None,
         enable_event_timestamps: true,
         experimentation_id: None, // Enabling event timestamps
+        enable_internal_pings: true,
     };
     let glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -91,6 +91,7 @@ fn test_metrics_must_report_experimentation_id() {
         rate_limit: None,
         enable_event_timestamps: true,
         experimentation_id: Some("test-experimentation-id".to_string()),
+        enable_internal_pings: true,
     })
     .unwrap();
     let ping_maker = PingMaker::new();
@@ -143,6 +144,7 @@ fn experimentation_id_is_removed_if_send_if_empty_is_false() {
         rate_limit: None,
         enable_event_timestamps: true,
         experimentation_id: Some("test-experimentation-id".to_string()),
+        enable_internal_pings: true,
     })
     .unwrap();
     let ping_maker = PingMaker::new();


### PR DESCRIPTION
This will mark the internal pings metrics, baseline and events as
disabled and will not send them.
Data recorded for these pings is still recorded, but never cleared out.

This setting should only be used for apps that definitely do not want
any of these pings and do not record any metrics of their own into those
pings.

---

Ok, I came up with another idea how to implement this: we finally introduce the `enabled` flag on pings (but only internally!).
We then set it to `false` when asked to do and check it along with the normal flow.
This PR is not ready for review yet (code duplication, no testing, etc), but putting it up to see if that's the direction we want it to. 
I also will take this and try it on m-c for the linked bug. 