### PR TITLE
Avoid double-allocation (and free!) of all those strings

### DIFF
--- a/glean-core/src/common_metric_data.rs
+++ b/glean-core/src/common_metric_data.rs
@@ -90,9 +90,10 @@ impl Clone for CommonMetricDataInternal {
 
 impl From<CommonMetricData> for CommonMetricDataInternal {
     fn from(input_data: CommonMetricData) -> Self {
+        let disabled = input_data.disabled;
         Self {
-            inner: input_data.clone(),
-            disabled: AtomicU8::new(u8::from(input_data.disabled)),
+            inner: input_data,
+            disabled: AtomicU8::new(u8::from(disabled)),
         }
     }
 }


### PR DESCRIPTION
`CommonMetricData` already contains owned data (strings and a vec!). By calling `clone` we allocate new memory for those, copy data over, then put that into `CommonMetricDataInternal` ... and  then just drop the old values.
We can avoid the allocations by just picking out the one value we need first, then use the rest as is.