### PR TITLE
Bug 1804711 - Add schedules_pings property to pings so that pings can be scheduled to be sent alongside other pings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v59.0.0...main)
 
+* Added support for `ping_schedule` metadata property so that pings can be scheduled to be sent when other pings are sent. (([#2791]https://github.com/mozilla/glean/pull/2791))
+
 # v59.0.0 (2024-03-28)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v58.1.0...v59.0.0)

--- a/docs/user/reference/yaml/pings.md
+++ b/docs/user/reference/yaml/pings.md
@@ -80,7 +80,6 @@ It may contain [markdown syntax](https://www.markdownguide.org/basic-syntax/).
 _default: `{}`_
 
 A dictionary of extra metadata associated with this ping.
-Currently the only allowed key is `tags` (see below).
 
 ##### `tags`
 
@@ -89,6 +88,20 @@ _default: `[]`_
 A list of tag names associated with this ping.
 Must correspond to an entry specified in a [tags file](./tags.md).
 
+##### `ping_schedule`
+
+_default: `[]`_
+
+A list of ping names. When one of *those* pings is sent, then *this* ping is
+also sent, with the same `reason`. This is useful if you want a ping to
+be scheduled and sent at the same frequency as another ping, like `baseline`.
+
+> Pings cannot list themselves under `ping_schedule`, however it is possible to
+> accidentally create cycles of pings where Ping A schedules Ping B, which
+> schedules Ping C, which in turn schedules Ping A. This can result in a
+> constant stream of pings being sent. Please use caution with `ping_schedule`,
+> and ensure that you have not accidentally created any cycles with the
+> ping references.
 
 #### `include_client_id`
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -50,6 +50,7 @@ class PingType<ReasonCodesEnum> (
     sendIfEmpty: Boolean,
     preciseTimestamps: Boolean,
     includeInfoSections: Boolean,
+    val schedulesPings: List<String>,
     val reasonCodes: List<String>,
 ) where ReasonCodesEnum : Enum<ReasonCodesEnum>, ReasonCodesEnum : ReasonCode {
     private var testCallback: ((ReasonCodesEnum?) -> Unit)? = null
@@ -62,6 +63,7 @@ class PingType<ReasonCodesEnum> (
             sendIfEmpty = sendIfEmpty,
             preciseTimestamps = preciseTimestamps,
             includeInfoSections = includeInfoSections,
+            schedulesPings = schedulesPings,
             reasonCodes = reasonCodes,
         )
     }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -480,6 +480,7 @@ class GleanTest {
             sendIfEmpty = false,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
         val stringMetric = StringMetricType(
@@ -847,6 +848,7 @@ class GleanTest {
             sendIfEmpty = false,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
         val stringMetric = StringMetricType(

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/debug/GleanDebugActivityTest.kt
@@ -250,6 +250,7 @@ class GleanDebugActivityTest {
             sendIfEmpty = true,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/pings/CustomPingTest.kt
@@ -78,6 +78,7 @@ class CustomPingTest {
             sendIfEmpty = true,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = emptyList(),
         )
 
@@ -108,6 +109,7 @@ class CustomPingTest {
             sendIfEmpty = true,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = emptyList(),
         )
 
@@ -182,6 +184,7 @@ class CustomPingTest {
             sendIfEmpty = true,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = emptyList(),
         )
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/EventMetricTypeTest.kt
@@ -508,6 +508,7 @@ class EventMetricTypeTest {
             sendIfEmpty = false,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -55,6 +55,7 @@ class PingTypeTest {
             sendIfEmpty = false,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
 
@@ -122,6 +123,7 @@ class PingTypeTest {
             sendIfEmpty = false,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
 
@@ -170,6 +172,7 @@ class PingTypeTest {
             sendIfEmpty = false,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
 
@@ -218,6 +221,7 @@ class PingTypeTest {
             sendIfEmpty = false,
             preciseTimestamps = true,
             includeInfoSections = true,
+            schedulesPings = emptyList(),
             reasonCodes = listOf(),
         )
 
@@ -267,6 +271,7 @@ class PingTypeTest {
             sendIfEmpty = false,
             reasonCodes = listOf(),
             preciseTimestamps = true,
+            schedulesPings = emptyList(),
             includeInfoSections = true,
         )
 

--- a/glean-core/ios/Glean/Metrics/Ping.swift
+++ b/glean-core/ios/Glean/Metrics/Ping.swift
@@ -41,6 +41,7 @@ public class Ping<ReasonCodesEnum: ReasonCodes> {
         sendIfEmpty: Bool,
         preciseTimestamps: Bool,
         includeInfoSections: Bool,
+        schedulesPings: [String],
         reasonCodes: [String]
     ) {
         self.name = name
@@ -51,6 +52,7 @@ public class Ping<ReasonCodesEnum: ReasonCodes> {
             sendIfEmpty,
             preciseTimestamps,
             includeInfoSections,
+            schedulesPings,
             reasonCodes
         )
     }

--- a/glean-core/ios/GleanTests/GleanTests.swift
+++ b/glean-core/ios/GleanTests/GleanTests.swift
@@ -259,6 +259,7 @@ class GleanTests: XCTestCase {
             sendIfEmpty: false,
             preciseTimestamps: true,
             includeInfoSections: true,
+            schedulesPings: [],
             reasonCodes: []
         )
 
@@ -417,6 +418,7 @@ class GleanTests: XCTestCase {
             sendIfEmpty: false,
             preciseTimestamps: true,
             includeInfoSections: true,
+            schedulesPings: [],
             reasonCodes: []
         )
 

--- a/glean-core/ios/GleanTests/Metrics/PingTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/PingTests.swift
@@ -41,6 +41,7 @@ class PingTests: XCTestCase {
             sendIfEmpty: false,
             preciseTimestamps: true,
             includeInfoSections: true,
+            schedulesPings: [],
             reasonCodes: []
         )
 
@@ -88,6 +89,7 @@ class PingTests: XCTestCase {
             sendIfEmpty: false,
             preciseTimestamps: true,
             includeInfoSections: true,
+            schedulesPings: [],
             reasonCodes: []
         )
 
@@ -125,6 +127,7 @@ class PingTests: XCTestCase {
             sendIfEmpty: true,
             preciseTimestamps: true,
             includeInfoSections: true,
+            schedulesPings: [],
             reasonCodes: []
         )
 
@@ -217,6 +220,7 @@ class PingTests: XCTestCase {
             sendIfEmpty: true,
             preciseTimestamps: true,
             includeInfoSections: true,
+            schedulesPings: [],
             reasonCodes: ["was_tested"]
         )
 

--- a/glean-core/python/glean/_loader.py
+++ b/glean-core/python/glean/_loader.py
@@ -61,6 +61,7 @@ _ARGS = [
     "send_in_pings",
     "precise_timestamps",
     "include_info_sections",
+    "schedules_pings",
     "time_unit",
 ]
 

--- a/glean-core/python/glean/metrics/ping.py
+++ b/glean-core/python/glean/metrics/ping.py
@@ -17,6 +17,7 @@ class PingType:
         send_if_empty: bool,
         precise_timestamps: bool,
         include_info_sections: bool,
+        schedules_pings: List[str],
         reason_codes: List[str],
     ):
         """
@@ -32,6 +33,7 @@ class PingType:
             send_if_empty,
             precise_timestamps,
             include_info_sections,
+            schedules_pings,
             reason_codes,
         )
         self._test_callback = None  # type: Optional[Callable[[Optional[str]], None]]

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -280,6 +280,7 @@ def test_dont_schedule_pings_if_metrics_disabled(safe_httpserver):
         send_if_empty=False,
         precise_timestamps=True,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
 
@@ -301,6 +302,7 @@ def test_dont_schedule_pings_if_there_is_no_ping_content(safe_httpserver):
         send_if_empty=False,
         precise_timestamps=True,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
 
@@ -365,6 +367,7 @@ def test_ping_collection_must_happen_after_currently_scheduled_metrics_recording
         send_if_empty=False,
         precise_timestamps=True,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
     string_metric = StringMetricType(
@@ -693,6 +696,7 @@ def test_dont_allow_multiprocessing(monkeypatch, safe_httpserver):
         send_if_empty=True,
         precise_timestamps=True,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
 
@@ -766,6 +770,7 @@ def test_presubmit_makes_a_valid_ping(tmpdir, ping_schema_url, monkeypatch):
         send_if_empty=True,
         precise_timestamps=True,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
 
@@ -826,6 +831,7 @@ def test_flipping_upload_enabled_respects_order_of_events(tmpdir, monkeypatch):
         send_if_empty=True,
         precise_timestamps=True,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
 
@@ -935,6 +941,7 @@ def test_sending_of_custom_pings(safe_httpserver):
         send_if_empty=False,
         precise_timestamps=True,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
 
@@ -1017,6 +1024,7 @@ def test_glean_shutdown(safe_httpserver):
         send_if_empty=False,
         precise_timestamps=False,
         include_info_sections=True,
+        schedules_pings=[],
         reason_codes=[],
     )
 

--- a/glean-core/rlb/examples/crashing-threads.rs
+++ b/glean-core/rlb/examples/crashing-threads.rs
@@ -88,7 +88,7 @@ pub mod glean_metrics {
 
 #[allow(non_upper_case_globals)]
 pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![]));
+    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![], vec![]));
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/examples/long-running.rs
+++ b/glean-core/rlb/examples/long-running.rs
@@ -41,7 +41,7 @@ impl net::PingUploader for FakeUploader {
 
 #[allow(non_upper_case_globals)]
 pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![]));
+    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![], vec![]));
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/examples/prototype.rs
+++ b/glean-core/rlb/examples/prototype.rs
@@ -29,7 +29,7 @@ pub mod glean_metrics {
 
 #[allow(non_upper_case_globals)]
 pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![]));
+    Lazy::new(|| PingType::new("prototype", true, true, true, true, vec![], vec![]));
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -23,7 +23,7 @@
 //! let cfg = ConfigurationBuilder::new(true, "/tmp/data", "org.mozilla.glean_core.example").build();
 //! glean::initialize(cfg, ClientInfoMetrics::unknown());
 //!
-//! let prototype_ping = PingType::new("prototype", true, true, true, true, vec!());
+//! let prototype_ping = PingType::new("prototype", true, true, true, true, vec!(), vec!());
 //!
 //! prototype_ping.submit(None);
 //! ```

--- a/glean-core/rlb/src/private/ping.rs
+++ b/glean-core/rlb/src/private/ping.rs
@@ -34,6 +34,7 @@ impl PingType {
         send_if_empty: bool,
         precise_timestamps: bool,
         include_info_sections: bool,
+        schedules_pings: Vec<String>,
         reason_codes: Vec<String>,
     ) -> Self {
         let inner = glean_core::metrics::PingType::new(
@@ -42,6 +43,7 @@ impl PingType {
             send_if_empty,
             precise_timestamps,
             include_info_sections,
+            schedules_pings,
             reason_codes,
         );
 

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -49,7 +49,7 @@ fn send_a_ping() {
 
     // Define a new ping and submit it.
     const PING_NAME: &str = "test-ping";
-    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![]);
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![], vec![]);
     custom_ping.submit(None);
 
     // Wait for the ping to arrive.
@@ -90,7 +90,7 @@ fn send_a_ping_without_info_sections() {
 
     // Define a new ping and submit it.
     const PING_NAME: &str = "noinfo-ping";
-    let custom_ping = private::PingType::new(PING_NAME, true, true, true, false, vec![]);
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, false, vec![], vec![]);
     custom_ping.submit(None);
 
     // Wait for the ping to arrive.
@@ -594,7 +594,7 @@ fn ping_collection_must_happen_after_concurrently_scheduled_metrics_recordings()
     );
 
     let ping_name = "custom_ping_1";
-    let ping = private::PingType::new(ping_name, true, false, true, true, vec![]);
+    let ping = private::PingType::new(ping_name, true, false, true, true, vec![], vec![]);
     let metric = private::StringMetric::new(CommonMetricData {
         name: "string_metric".into(),
         category: "telemetry".into(),
@@ -1097,7 +1097,7 @@ fn flipping_upload_enabled_respects_order_of_events() {
         .build();
 
     // We create a ping and a metric before we initialize Glean
-    let sample_ping = PingType::new("sample-ping-1", true, false, true, true, vec![]);
+    let sample_ping = PingType::new("sample-ping-1", true, false, true, true, vec![], vec![]);
     let metric = private::StringMetric::new(CommonMetricData {
         name: "string_metric".into(),
         category: "telemetry".into(),
@@ -1141,7 +1141,7 @@ fn registering_pings_before_init_must_work() {
     }
 
     // Create a custom ping and attempt its registration.
-    let sample_ping = PingType::new("pre-register", true, true, true, true, vec![]);
+    let sample_ping = PingType::new("pre-register", true, true, true, true, vec![], vec![]);
 
     // Create a custom configuration to use a fake uploader.
     let dir = tempfile::tempdir().unwrap();
@@ -1193,7 +1193,7 @@ fn test_a_ping_before_submission() {
     let _t = new_glean(Some(cfg), true);
 
     // Create a custom ping and register it.
-    let sample_ping = PingType::new("custom1", true, true, true, true, vec![]);
+    let sample_ping = PingType::new("custom1", true, true, true, true, vec![], vec![]);
 
     let metric = CounterMetric::new(CommonMetricData {
         name: "counter_metric".into(),
@@ -1310,7 +1310,7 @@ fn signaling_done() {
 
     // Define a new ping and submit it.
     const PING_NAME: &str = "test-ping";
-    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![]);
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![], vec![]);
     custom_ping.submit(None);
     custom_ping.submit(None);
 
@@ -1381,7 +1381,7 @@ fn configure_ping_throttling() {
 
     // Define a new ping.
     const PING_NAME: &str = "test-ping";
-    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![]);
+    let custom_ping = private::PingType::new(PING_NAME, true, true, true, true, vec![], vec![]);
 
     // Submit and receive it `pings_per_interval` times.
     for _ in 0..pings_per_interval {

--- a/glean-core/rlb/tests/init_fails.rs
+++ b/glean-core/rlb/tests/init_fails.rs
@@ -42,8 +42,9 @@ mod pings {
     use once_cell::sync::Lazy;
 
     #[allow(non_upper_case_globals)]
-    pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
+    pub static validation: Lazy<PingType> = Lazy::new(|| {
+        glean::private::PingType::new("validation", true, true, true, true, vec![], vec![])
+    });
 }
 
 /// Test scenario: Glean initialization fails.

--- a/glean-core/rlb/tests/never_init.rs
+++ b/glean-core/rlb/tests/never_init.rs
@@ -38,8 +38,9 @@ mod pings {
     use once_cell::sync::Lazy;
 
     #[allow(non_upper_case_globals)]
-    pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
+    pub static validation: Lazy<PingType> = Lazy::new(|| {
+        glean::private::PingType::new("validation", true, true, true, true, vec![], vec![])
+    });
 }
 
 /// Test scenario: Glean is never initialized.

--- a/glean-core/rlb/tests/no_time_to_init.rs
+++ b/glean-core/rlb/tests/no_time_to_init.rs
@@ -40,8 +40,9 @@ mod pings {
     use once_cell::sync::Lazy;
 
     #[allow(non_upper_case_globals)]
-    pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
+    pub static validation: Lazy<PingType> = Lazy::new(|| {
+        glean::private::PingType::new("validation", true, true, true, true, vec![], vec![])
+    });
 }
 
 /// Test scenario: Glean initialization fails.

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -170,7 +170,8 @@ fn validate_against_schema() {
     text_metric.set("loooooong text".repeat(100));
 
     // Define a new ping and submit it.
-    let custom_ping = glean::private::PingType::new(PING_NAME, true, true, true, true, vec![]);
+    let custom_ping =
+        glean::private::PingType::new(PING_NAME, true, true, true, true, vec![], vec![]);
     custom_ping.submit(None);
 
     // Wait for the ping to arrive.

--- a/glean-core/rlb/tests/simple.rs
+++ b/glean-core/rlb/tests/simple.rs
@@ -40,8 +40,9 @@ mod pings {
     use once_cell::sync::Lazy;
 
     #[allow(non_upper_case_globals)]
-    pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
+    pub static validation: Lazy<PingType> = Lazy::new(|| {
+        glean::private::PingType::new("validation", true, true, true, true, vec![], vec![])
+    });
 }
 
 /// Test scenario: A clean run

--- a/glean-core/rlb/tests/upload_timing.rs
+++ b/glean-core/rlb/tests/upload_timing.rs
@@ -96,8 +96,9 @@ mod pings {
     use once_cell::sync::Lazy;
 
     #[allow(non_upper_case_globals)]
-    pub static validation: Lazy<PingType> =
-        Lazy::new(|| glean::private::PingType::new("validation", true, true, true, true, vec![]));
+    pub static validation: Lazy<PingType> = Lazy::new(|| {
+        glean::private::PingType::new("validation", true, true, true, true, vec![], vec![])
+    });
 }
 
 // Define a fake uploader that sleeps.

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -123,7 +123,7 @@ where
 ///     enable_internal_pings: true,
 /// };
 /// let mut glean = Glean::new(cfg).unwrap();
-/// let ping = PingType::new("sample", true, false, true, true, vec![]);
+/// let ping = PingType::new("sample", true, false, true, true, vec![], vec![]);
 /// glean.register_ping_type(&ping);
 ///
 /// let call_counter: CounterMetric = CounterMetric::new(CommonMetricData {

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -292,7 +292,7 @@ enum ErrorType {
 };
 
 interface PingType {
-    constructor(string name, boolean include_client_id, boolean send_if_empty, boolean precise_timestamps, boolean include_info_sections, sequence<string> reason_codes);
+    constructor(string name, boolean include_client_id, boolean send_if_empty, boolean precise_timestamps, boolean include_info_sections, sequence<string> schedules_pings, sequence<string> reason_codes);
     void submit(optional string? reason = null);
 };
 

--- a/glean-core/src/internal_pings.rs
+++ b/glean-core/src/internal_pings.rs
@@ -27,6 +27,7 @@ impl InternalPings {
                 true,
                 true,
                 true,
+                vec![],
                 vec![
                     "active".to_string(),
                     "dirty_startup".to_string(),
@@ -40,6 +41,7 @@ impl InternalPings {
                 false,
                 true,
                 true,
+                vec![],
                 vec![
                     "overdue".to_string(),
                     "reschedule".to_string(),
@@ -55,6 +57,7 @@ impl InternalPings {
                 false,
                 true,
                 true,
+                vec![],
                 vec![
                     "startup".to_string(),
                     "inactive".to_string(),
@@ -68,6 +71,7 @@ impl InternalPings {
                 true,
                 true,
                 true,
+                vec![],
                 vec!["at_init".to_string(), "set_upload_enabled".to_string()],
             ),
         }

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -1168,7 +1168,16 @@ fn disabled_pings_are_not_submitted() {
     let dir = tempfile::tempdir().unwrap();
     let (mut glean, _t) = new_glean(Some(dir));
 
-    let ping = PingType::new_internal("custom-disabled", true, false, true, true, vec![], false);
+    let ping = PingType::new_internal(
+        "custom-disabled",
+        true,
+        false,
+        true,
+        true,
+        vec![],
+        vec![],
+        false,
+    );
     glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -138,7 +138,7 @@ impl PingType {
         self.0.include_info_sections
     }
 
-    pub(crate) fn schedules_pings(&self) -> &Vec<String> {
+    pub(crate) fn schedules_pings(&self) -> &[String] {
         &self.0.schedules_pings
     }
 
@@ -259,6 +259,17 @@ impl PingType {
                     "The ping '{}' was submitted and will be sent as soon as possible",
                     ping.name
                 );
+
+                if !ping.schedules_pings.is_empty() {
+                    log::info!(
+                        "The ping '{}' is being used to schedule other pings: {:?}",
+                        ping.name,
+                        ping.schedules_pings
+                    );
+                    for scheduled_ping_name in &ping.schedules_pings {
+                        glean.submit_ping_by_name(scheduled_ping_name, reason);
+                    }
+                }
 
                 true
             }

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -29,6 +29,8 @@ struct InnerPing {
     pub precise_timestamps: bool,
     /// Whether to include the {client|ping}_info sections on assembly.
     pub include_info_sections: bool,
+    /// Other pings that should be scheduled when this ping is sent.
+    pub schedules_pings: Vec<String>,
     /// The "reason" codes that this ping can send
     pub reason_codes: Vec<String>,
 
@@ -46,6 +48,7 @@ impl fmt::Debug for PingType {
             .field("send_if_empty", &self.0.send_if_empty)
             .field("precise_timestamps", &self.0.precise_timestamps)
             .field("include_info_sections", &self.0.include_info_sections)
+            .field("schedules_pings", &self.0.schedules_pings)
             .field("reason_codes", &self.0.reason_codes)
             .finish()
     }
@@ -71,6 +74,7 @@ impl PingType {
         send_if_empty: bool,
         precise_timestamps: bool,
         include_info_sections: bool,
+        schedules_pings: Vec<String>,
         reason_codes: Vec<String>,
     ) -> Self {
         Self::new_internal(
@@ -79,17 +83,20 @@ impl PingType {
             send_if_empty,
             precise_timestamps,
             include_info_sections,
+            schedules_pings,
             reason_codes,
             true,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_internal<A: Into<String>>(
         name: A,
         include_client_id: bool,
         send_if_empty: bool,
         precise_timestamps: bool,
         include_info_sections: bool,
+        schedules_pings: Vec<String>,
         reason_codes: Vec<String>,
         enabled: bool,
     ) -> Self {
@@ -99,6 +106,7 @@ impl PingType {
             send_if_empty,
             precise_timestamps,
             include_info_sections,
+            schedules_pings,
             reason_codes,
             enabled,
         }));
@@ -128,6 +136,10 @@ impl PingType {
 
     pub(crate) fn include_info_sections(&self) -> bool {
         self.0.include_info_sections
+    }
+
+    pub(crate) fn schedules_pings(&self) -> &Vec<String> {
+        &self.0.schedules_pings
     }
 
     /// Submits the ping for eventual uploading.

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -32,6 +32,8 @@ pub struct Ping<'a> {
     pub headers: HeaderMap,
     /// Whether the content contains {client|ping}_info sections.
     pub includes_info_sections: bool,
+    /// Other pings that should be scheduled when this ping is sent.
+    pub schedules_pings: Vec<String>,
 }
 
 /// Collect a ping's data, assemble it into its full payload and store it on disk.
@@ -314,6 +316,7 @@ impl PingMaker {
             url_path,
             headers: self.get_headers(glean),
             includes_info_sections: ping.include_info_sections(),
+            schedules_pings: ping.schedules_pings().to_vec(),
         })
     }
 

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -337,7 +337,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, true, vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, vec![], vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory
@@ -364,7 +364,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, true, vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, vec![], vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory
@@ -400,7 +400,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, true, vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, vec![], vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -1032,6 +1032,7 @@ mod test {
             true,
             true,
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1071,6 +1072,7 @@ mod test {
             true,
             true,
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1107,6 +1109,7 @@ mod test {
             /* send_if_empty */ true,
             true,
             true,
+            vec![],
             vec![],
         );
         glean.register_ping_type(&ping_type);
@@ -1145,6 +1148,7 @@ mod test {
             true,
             true,
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1181,6 +1185,7 @@ mod test {
             /* send_if_empty */ true,
             true,
             true,
+            vec![],
             vec![],
         );
         glean.register_ping_type(&ping_type);
@@ -1220,6 +1225,7 @@ mod test {
             /* send_if_empty */ true,
             true,
             true,
+            vec![],
             vec![],
         );
         glean.register_ping_type(&ping_type);
@@ -1336,6 +1342,7 @@ mod test {
             true,
             true,
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1409,6 +1416,7 @@ mod test {
             true,
             true,
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1465,6 +1473,7 @@ mod test {
             /* send_if_empty */ true,
             true,
             true,
+            vec![],
             vec![],
         );
         glean.register_ping_type(&ping_type);
@@ -1544,6 +1553,7 @@ mod test {
             true,
             true,
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1622,6 +1632,7 @@ mod test {
             /* send_if_empty */ true,
             true,
             true,
+            vec![],
             vec![],
         );
         glean.register_ping_type(&ping_type);
@@ -1703,6 +1714,7 @@ mod test {
             /* send_if_empty */ true,
             true,
             true,
+            vec![],
             vec![],
         );
         glean.register_ping_type(&ping_type);

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -167,6 +167,7 @@ fn test_sending_of_event_ping_when_it_fills_up() {
             false,
             true,
             true,
+            vec![],
             vec!["max_capacity".to_string()],
         ));
     }
@@ -452,6 +453,7 @@ fn event_storage_trimming() {
             false,
             true,
             true,
+            vec![],
             vec![],
         ));
 

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -247,3 +247,25 @@ fn events_ping_with_metric_but_no_events_is_not_sent() {
     assert!(events_ping.submit_sync(&glean, None));
     assert_eq!(1, get_queued_pings(glean.get_data_path()).unwrap().len());
 }
+
+#[test]
+fn test_scheduled_pings_are_sent() {
+    let (mut glean, _t) = new_glean(None);
+
+    let piggyback_ping = PingType::new("piggyback", true, true, true, true, vec![], vec![]);
+    glean.register_ping_type(&piggyback_ping);
+
+    let trigger_ping = PingType::new(
+        "trigger",
+        true,
+        true,
+        true,
+        true,
+        vec!["piggyback".into()],
+        vec![],
+    );
+    glean.register_ping_type(&trigger_ping);
+
+    assert!(trigger_ping.submit_sync(&glean, None));
+    assert_eq!(2, get_queued_pings(glean.get_data_path()).unwrap().len());
+}

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -15,7 +15,7 @@ use glean_core::Lifetime;
 fn write_ping_to_disk() {
     let (mut glean, _temp) = new_glean(None);
 
-    let ping = PingType::new("metrics", true, false, true, true, vec![]);
+    let ping = PingType::new("metrics", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -36,7 +36,7 @@ fn write_ping_to_disk() {
 fn disabling_upload_clears_pending_pings() {
     let (mut glean, _t) = new_glean(None);
 
-    let ping = PingType::new("metrics", true, false, true, true, vec![]);
+    let ping = PingType::new("metrics", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -105,9 +105,9 @@ fn deletion_request_only_when_toggled_from_on_to_off() {
 fn empty_pings_with_flag_are_sent() {
     let (mut glean, _t) = new_glean(None);
 
-    let ping1 = PingType::new("custom-ping1", true, true, true, true, vec![]);
+    let ping1 = PingType::new("custom-ping1", true, true, true, true, vec![], vec![]);
     glean.register_ping_type(&ping1);
-    let ping2 = PingType::new("custom-ping2", true, false, true, true, vec![]);
+    let ping2 = PingType::new("custom-ping2", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&ping2);
 
     // No data is stored in either of the custom pings
@@ -139,10 +139,10 @@ fn test_pings_submitted_metric() {
         None,
     );
 
-    let metrics_ping = PingType::new("metrics", true, false, true, true, vec![]);
+    let metrics_ping = PingType::new("metrics", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&metrics_ping);
 
-    let baseline_ping = PingType::new("baseline", true, false, true, true, vec![]);
+    let baseline_ping = PingType::new("baseline", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&baseline_ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -218,7 +218,7 @@ fn test_pings_submitted_metric() {
 fn events_ping_with_metric_but_no_events_is_not_sent() {
     let (mut glean, _t) = new_glean(None);
 
-    let events_ping = PingType::new("events", true, true, true, true, vec![]);
+    let events_ping = PingType::new("events", true, true, true, true, vec![], vec![]);
     glean.register_ping_type(&events_ping);
     let counter = CounterMetric::new(CommonMetricData {
         name: "counter".into(),

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -13,7 +13,7 @@ fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
     let (tempdir, _) = tempdir();
     let (mut glean, t) = new_glean(Some(tempdir));
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, true, vec![]);
+    let ping_type = PingType::new("store1", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -95,7 +95,7 @@ fn test_metrics_must_report_experimentation_id() {
     })
     .unwrap();
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, true, vec![]);
+    let ping_type = PingType::new("store1", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -149,7 +149,7 @@ fn experimentation_id_is_removed_if_send_if_empty_is_false() {
     .unwrap();
     let ping_maker = PingMaker::new();
 
-    let unknown_ping_type = PingType::new("unknown", true, false, true, true, vec![]);
+    let unknown_ping_type = PingType::new("unknown", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&unknown_ping_type);
 
     assert!(ping_maker
@@ -165,7 +165,7 @@ fn collect_must_report_none_when_no_data_is_stored() {
 
     let (mut glean, ping_maker, ping_type, _t) = set_up_basic_ping();
 
-    let unknown_ping_type = PingType::new("unknown", true, false, true, true, vec![]);
+    let unknown_ping_type = PingType::new("unknown", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&ping_type);
 
     assert!(ping_maker
@@ -189,7 +189,7 @@ fn seq_number_must_be_sequential() {
 
     for i in 0..=1 {
         for ping_name in ["store1", "store2"].iter() {
-            let ping_type = PingType::new(*ping_name, true, false, true, true, vec![]);
+            let ping_type = PingType::new(*ping_name, true, false, true, true, vec![], vec![]);
             let ping = ping_maker
                 .collect(&glean, &ping_type, None, "", "")
                 .unwrap();
@@ -202,7 +202,7 @@ fn seq_number_must_be_sequential() {
 
     // Test that ping sequence numbers increase independently.
     {
-        let ping_type = PingType::new("store1", true, false, true, true, vec![]);
+        let ping_type = PingType::new("store1", true, false, true, true, vec![], vec![]);
 
         // 3rd ping of store1
         let ping = ping_maker
@@ -220,7 +220,7 @@ fn seq_number_must_be_sequential() {
     }
 
     {
-        let ping_type = PingType::new("store2", true, false, true, true, vec![]);
+        let ping_type = PingType::new("store2", true, false, true, true, vec![], vec![]);
 
         // 3rd ping of store2
         let ping = ping_maker
@@ -231,7 +231,7 @@ fn seq_number_must_be_sequential() {
     }
 
     {
-        let ping_type = PingType::new("store1", true, false, true, true, vec![]);
+        let ping_type = PingType::new("store1", true, false, true, true, vec![], vec![]);
 
         // 5th ping of store1
         let ping = ping_maker
@@ -246,7 +246,7 @@ fn seq_number_must_be_sequential() {
 fn clear_pending_pings() {
     let (mut glean, _t) = new_glean(None);
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, true, vec![]);
+    let ping_type = PingType::new("store1", true, false, true, true, vec![], vec![]);
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -274,7 +274,7 @@ fn no_pings_submitted_if_upload_disabled() {
     // Regression test, bug 1603571
 
     let (mut glean, _t) = new_glean(None);
-    let ping_type = PingType::new("store1", true, true, true, true, vec![]);
+    let ping_type = PingType::new("store1", true, true, true, true, vec![], vec![]);
     glean.register_ping_type(&ping_type);
 
     assert!(ping_type.submit_sync(&glean, None));
@@ -292,7 +292,7 @@ fn no_pings_submitted_if_upload_disabled() {
 fn metadata_is_correctly_added_when_necessary() {
     let (mut glean, _t) = new_glean(None);
     glean.set_debug_view_tag("valid-tag");
-    let ping_type = PingType::new("store1", true, true, true, true, vec![]);
+    let ping_type = PingType::new("store1", true, true, true, true, vec![], vec![]);
     glean.register_ping_type(&ping_type);
 
     assert!(ping_type.submit_sync(&glean, None));


### PR DESCRIPTION
This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1804711.

This relies on https://github.com/mozilla/glean_parser/pull/682.

What this does it make it possible for a Glean ping to declare that it wants to be sent when another ping is sent. Supposing some product wanted to sent a ping as frequently as the baseline ping, then that ping could use the `ping_schedule` metadata property and list `baseline`.

This pull request is the part that takes the reverse-mapping that glean_parser creates, and actually does the lookup for other scheduled pings when a ping is sent.

I note this in one of the commit messages, but I think it's worth calling out here too:

While glean_parser will try to prevent the base-case of pings trying to schedule _themselves_ when being sent, nothing in this stack takes care of the problem of recursive cycles of pings.

So if we have PingA scheduled to be sent when PingB is sent, and PingB is scheduled to be sent when PingC is sent, and PingC is scheduled to be sent when PingA is sent... things get messy indeed, and I think we might get stuck in a ping-sending loop.