### PR TITLE
Update some CI tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,9 +218,9 @@ commands:
       - run:
           name: Get ghr release tool
           command: |
-            GHR_VERSION=v0.16.0
+            GHR_VERSION=v0.16.2
             GHR=ghr_${GHR_VERSION}_darwin_amd64
-            GHR_SHA256=67f61cbb8ad201e28829b558d5349e1cabf667acba33db0f9ac7e05a14ed98bc
+            GHR_SHA256=da2e6592a50c725660684d5ff19cd3751a28cc3948dc69dab9ec98940b5e33ac
             curl -sfSL --retry 5 -O "https://github.com/tcnksm/ghr/releases/download/${GHR_VERSION}/${GHR}.zip"
             echo "${GHR_SHA256} *${GHR}.zip" | shasum -a 256 -c -
             unzip "${GHR}.zip"
@@ -231,9 +231,9 @@ commands:
       - run:
           name: Get ghr release tool
           command: |
-            GHR_VERSION=v0.16.0
+            GHR_VERSION=v0.16.2
             GHR=ghr_${GHR_VERSION}_linux_amd64
-            GHR_SHA256=02b69903e6b61272706db44ba184bb9ba5d1c806cb65edd1fcb1e561e443ce83
+            GHR_SHA256=084ed9819dff71ea77f77a3071a643b6d1cbe5d2ab57bb5f56bb23de17189cd0
             curl -sfSL --retry 5 -O "https://github.com/tcnksm/ghr/releases/download/${GHR_VERSION}/${GHR}.tar.gz"
             echo "${GHR_SHA256} *${GHR}.tar.gz" | sha256sum -c -
             tar -xf "${GHR}.tar.gz"
@@ -251,9 +251,9 @@ jobs:
       - run:
           name: Install cargo-deny
           command: |
-            DENY_VERSION=0.13.7
+            DENY_VERSION=0.14.20
             DENY="cargo-deny-${DENY_VERSION}-x86_64-unknown-linux-musl"
-            DENY_SHA256=0e20f4302c1054a3f1a8e0e22eb15cfa3173c0e2dcbb62cfe7d6fe40dc27abd9
+            DENY_SHA256=1c9f8cfc23647346f1aa7ba0ed3167191f3198aba3dc5a957fda6f85a82fc424
             curl -sfSL --retry 5 -O "https://github.com/EmbarkStudios/cargo-deny/releases/download/${DENY_VERSION}/${DENY}.tar.gz"
             echo "${DENY_SHA256} *${DENY}.tar.gz" | shasum -a 256 -c -
             tar -xvf "${DENY}.tar.gz"
@@ -365,9 +365,9 @@ jobs:
       - run:
           name: Install mdbook-dtmo
           command: |
-              MDBOOK_VERSION=0.13.1
-              MDBOOK="mdbook-dtmo-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-              MDBOOK_SHA256=b27992bec9b336375c5662853da492b96cb6a472c0d5538e40e034fdeba40478
+              MDBOOK_VERSION=0.15.2
+              MDBOOK="mdbook-dtmo-${MDBOOK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+              MDBOOK_SHA256=87f5cb874faadc745f033b646d358669b172edf19d2ca0a4e291a9c627e52e13
               curl -sfSL --retry 5 -O "https://github.com/badboy/mdbook-dtmo/releases/download/${MDBOOK_VERSION}/${MDBOOK}"
               echo "${MDBOOK_SHA256} *${MDBOOK}" | shasum -a 256 -c -
               tar -xvf "${MDBOOK}"

--- a/deny.toml
+++ b/deny.toml
@@ -1,12 +1,9 @@
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
 allow = [
     "MPL-2.0",
     "Apache-2.0",
     "MIT",
     "BSD-2-Clause",
-    "BSD-3-Clause",
     "Zlib",
     "Unicode-DFS-2016",
 ]
@@ -28,16 +25,5 @@ skip = [
 
 # Avoid certain crates
 deny = [
-  # We can allow the windows-sys and windows_$arch crates,
-  # now that m-c allows them (and potentially overrides some uses)
-
-  # We do not want to pull in the `windows` crate.
-  # We _only_ allow it as a dependency in the chain from `uniffi_core`;
-  # this will be overriden in m-c.
-  # See https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-wrappers-field-optional for the wrapper configuration
-  # We allow the chain from uniffi_core to windows here.
-  { name = "oneshot", version = "*", wrappers = ["uniffi_core"] },
-  { name = "loom", version = "*", wrappers = ["oneshot"] },
-  { name = "generator", version = "*", wrappers = ["loom"] },
-  { name = "windows", version = "0.48.0", wrappers = ["generator"] },
+  { name = "windows", version = "0.48.0" },
 ]


### PR DESCRIPTION
Updates for:

* ghr
* cargo-deny
* mdbook-dtmo

---

Just noticed some warnings/failures after installing `cargo-deny` locally