### PR TITLE
Bug 1891744 - Python: make installing from sdist possible

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-uniffi-bindgen = ["run", "--package", "embedded-uniffi-bindgen", "--"]
+uniffi-bindgen = ["run", "--package", "uniffi-bindgen", "--"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,7 +890,7 @@ jobs:
       - run:
           name: Build macOS universal2 wheel
           command: |
-            make build-python-wheel MATURIN_FLAG="--target universal2-apple-darwin"
+            make build-python-wheel GLEAN_BUILD_TARGET="universal2-apple-darwin"
       - run:
           name: Upload wheels to PyPI
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ commands:
       - run:
           name: Build Windows wheel
           command: |
-            make build-python-wheel CARGO_BUILD_TARGET=x86_64-pc-windows-gnu
+            make build-python-wheel GLEAN_BUILD_TARGET=x86_64-pc-windows-gnu
 
   build-windows-i686-wheel:
     steps:
@@ -174,7 +174,7 @@ commands:
       - run:
           name: Build Windows wheel
           command: |
-            make build-python-wheel CARGO_BUILD_TARGET=i686-pc-windows-gnu
+            make build-python-wheel GLEAN_BUILD_TARGET=i686-pc-windows-gnu
 
   install-python-windows-deps:
     steps:
@@ -882,11 +882,11 @@ jobs:
       - run:
           name: Build macOS x86_64 wheel
           command: |
-            make build-python-wheel CARGO_BUILD_TARGET=x86_64-apple-darwin
+            make build-python-wheel GLEAN_BUILD_TARGET=x86_64-apple-darwin
       - run:
           name: Build macOS aarch64 wheel
           command: |
-            make build-python-wheel CARGO_BUILD_TARGET=aarch64-apple-darwin
+            make build-python-wheel GLEAN_BUILD_TARGET=aarch64-apple-darwin
       - run:
           name: Build macOS universal2 wheel
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,16 +233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "embedded-uniffi-bindgen"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi",
- "uniffi_bindgen",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +999,16 @@ dependencies = [
  "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi-bindgen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi",
+ "uniffi_bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ name = "glean-bundle"
 version = "1.0.0"
 dependencies = [
  "glean-core",
+ "uniffi-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ members = [
 
 default-members = [
   "glean-core",
-  "glean-core/rlb",
   "tools/embedded-uniffi-bindgen",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build-python: setup-python ## Build the Python bindings
 
 build-python-wheel: setup-python  ## Build a Python wheel
 	VIRTUAL_ENV=$(GLEAN_PYENV) \
-		$(GLEAN_PYENV)/bin/maturin build --release $(MATURIN_FLAG)
+		$(GLEAN_PYENV)/bin/maturin build --release $(MATURIN_FLAG) $(addprefix --target ,$(GLEAN_BUILD_TARGET))
 
 build-python-sdist: setup-python ## Build a Python source distribution
 	VIRTUAL_ENV=$(GLEAN_PYENV) \

--- a/Makefile
+++ b/Makefile
@@ -43,17 +43,14 @@ build-apk: build-kotlin ## Build an apk of the Glean sample app
 	./gradlew glean-sample-app:build glean-sample-app:assembleAndroidTest
 
 build-python: setup-python ## Build the Python bindings
-	PATH=$(PWD)/bin:$(PATH) \
 	VIRTUAL_ENV=$(GLEAN_PYENV) \
 		$(GLEAN_PYENV)/bin/maturin develop
 
 build-python-wheel: setup-python  ## Build a Python wheel
-	PATH=$(PWD)/bin:$(PATH) \
 	VIRTUAL_ENV=$(GLEAN_PYENV) \
 		$(GLEAN_PYENV)/bin/maturin build --release $(MATURIN_FLAG)
 
 build-python-sdist: setup-python ## Build a Python source distribution
-	PATH=$(PWD)/bin:$(PATH) \
 	VIRTUAL_ENV=$(GLEAN_PYENV) \
 		$(GLEAN_PYENV)/bin/maturin build --release --sdist $(MATURIN_FLAG)
 

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ build-python: setup-python ## Build the Python bindings
 
 build-python-wheel: setup-python  ## Build a Python wheel
 	VIRTUAL_ENV=$(GLEAN_PYENV) \
-		$(GLEAN_PYENV)/bin/maturin build --release $(MATURIN_FLAG) $(addprefix --target ,$(GLEAN_BUILD_TARGET))
+		$(GLEAN_PYENV)/bin/maturin build --release $(addprefix --target ,$(GLEAN_BUILD_TARGET))
 
 build-python-sdist: setup-python ## Build a Python source distribution
 	VIRTUAL_ENV=$(GLEAN_PYENV) \
-		$(GLEAN_PYENV)/bin/maturin build --release --sdist $(MATURIN_FLAG)
+		$(GLEAN_PYENV)/bin/maturin build --release --sdist
 
 build-xcframework:
 	./bin/build-xcframework.sh

--- a/bin/uniffi-bindgen
+++ b/bin/uniffi-bindgen
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# This is a host tool. Do not listen to the build target.
-unset CARGO_BUILD_TARGET
-
-exec cargo run --package uniffi-bindgen -- $*

--- a/bin/uniffi-bindgen
+++ b/bin/uniffi-bindgen
@@ -3,4 +3,4 @@
 # This is a host tool. Do not listen to the build target.
 unset CARGO_BUILD_TARGET
 
-exec cargo run --package embedded-uniffi-bindgen -- $*
+exec cargo run --package uniffi-bindgen -- $*

--- a/glean-core/bundle/Cargo.toml
+++ b/glean-core/bundle/Cargo.toml
@@ -20,3 +20,7 @@ crate-type = ["staticlib", "cdylib"]
 [dependencies.glean-core]
 # No version specified, we build against what's available here.
 path = ".."
+
+# Needed in order for maturin to find it during builds from `sdist`
+[dev-dependencies.uniffi-bindgen]
+path = "../../tools/embedded-uniffi-bindgen"

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -577,7 +577,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$ACTION\" = \"indexbuild\" ]; then\n  echo \"Skipping code generation in 'indexbuild' build. See https://bugzilla.mozilla.org/show_bug.cgi?id=1744504 for more info.\"\n  exit 0\nfi\nbash $PWD/../../build-scripts/xc-cargo.sh cargo run --package embedded-uniffi-bindgen -- generate $INPUT_FILE_PATH --language swift --out-dir $SRCROOT/Glean/Generated/uniffi --no-format $SCRIPT_INPUT_FILE_0\n";
+			shellScript = "if [ \"$ACTION\" = \"indexbuild\" ]; then\n  echo \"Skipping code generation in 'indexbuild' build. See https://bugzilla.mozilla.org/show_bug.cgi?id=1744504 for more info.\"\n  exit 0\nfi\nbash $PWD/../../build-scripts/xc-cargo.sh cargo run --package uniffi-bindgen -- generate $INPUT_FILE_PATH --language swift --out-dir $SRCROOT/Glean/Generated/uniffi --no-format $SCRIPT_INPUT_FILE_0\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/glean-core/rlb/tests/test-shutdown-blocking.sh
+++ b/glean-core/rlb/tests/test-shutdown-blocking.sh
@@ -17,7 +17,7 @@ trap cleanup INT ABRT TERM EXIT
 tmp="${TMPDIR:-/tmp}"
 datapath=$(mktemp -d "${tmp}/glean_long_running.XXXX")
 
-cargo run --example long-running -- "$datapath"
+cargo run -p glean --example long-running -- "$datapath"
 count=$(ls -1q "$datapath/pending_pings" | wc -l)
 
 if [[ "$count" -eq 0 ]]; then

--- a/glean-core/rlb/tests/test-thread-crashing.sh
+++ b/glean-core/rlb/tests/test-thread-crashing.sh
@@ -19,7 +19,7 @@ datapath=$(mktemp -d "${tmp}/glean_long_running.XXXX")
 
 RUSTFLAGS="-C panic=abort" \
 RUST_LOG=debug \
-cargo run --example crashing-threads -- "$datapath"
+cargo run -p glean --example crashing-threads -- "$datapath"
 ret=$?
 count=$(ls -1q "$datapath/pending_pings" | wc -l)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ python-source = "glean-core/python"
 module-name = "glean._uniffi"
 bindings = "uniffi"
 manifest-path = "glean-core/bundle/Cargo.toml"
+include = [{ path = "tools/embedded-uniffi-bindgen/**/*", format = "sdist" }]
 
 [tool.coverage.run]
 source = ["glean"]

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-name = "embedded-uniffi-bindgen"
+name = "uniffi-bindgen"
 version = "0.1.0"
-authors = ["The Firefox Sync Developers <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/tools/embedded-uniffi-bindgen/src/lib.rs
+++ b/tools/embedded-uniffi-bindgen/src/lib.rs
@@ -1,0 +1,1 @@
+// intentionally left empty. only exists to make a warning go away


### PR DESCRIPTION
Turns out we currently cannot actualy install glean-sdk from just the source distribution (sdist).

This PR should tackle that.
The following now works:

```
$ make build-python-sdist
$ cd samples/python
$ python3 -m venv venv
$ venv/bin/python3 -m pip install setuptools  # only needed for Python 3.12 I guess -- we should fix that
$ venv/bin/python3 -m pip install ../../target/wheels/glean_sdk-*.tar.gz
```

I plan on filing a bug with `maturin` so they can fix up (or remove) `default-members` when they rewrite the `Cargo.toml`.

I think it should be fine for us for now to not have it be a `default-member`: `make build-rust` invokes `cargo build --all` anyway