### PR TITLE
bug 1892097 - New TimingDistribution API for a single duration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v60.0.0...main)
 
+* Rust
+  * New `TimingDistribution` API for no-allocation single-duration accumulation. ([bug 1892097](https://bugzilla.mozilla.org/show_bug.cgi?id=1892097))
+
 # v60.0.0 (2024-04-22)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v59.0.0...v60.0.0)

--- a/glean-core/rlb/tests/timing_distribution_single_sample.rs
+++ b/glean-core/rlb/tests/timing_distribution_single_sample.rs
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This integration test should model how the RLB is used when embedded in another Rust application
+//! (e.g. FOG/Firefox Desktop).
+//!
+//! We write a single test scenario per file to avoid any state keeping across runs
+//! (different files run as different processes).
+
+mod common;
+
+use glean::{ConfigurationBuilder, ErrorType};
+use std::time::Duration;
+
+/// A timing_distribution
+mod metrics {
+    use glean::private::*;
+    use glean::{Lifetime, TimeUnit};
+    use glean_core::CommonMetricData;
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static boo: Lazy<TimingDistributionMetric> = Lazy::new(|| {
+        TimingDistributionMetric::new(
+            CommonMetricData {
+                name: "boo".into(),
+                category: "sample".into(),
+                send_in_pings: vec!["validation".into()],
+                lifetime: Lifetime::Ping,
+                disabled: false,
+                ..Default::default()
+            },
+            TimeUnit::Millisecond,
+        )
+    });
+}
+
+/// Test scenario: Ensure single-sample accumulation works.
+#[test]
+fn raw_duration_works() {
+    common::enable_test_logging();
+
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().to_path_buf();
+
+    let cfg = ConfigurationBuilder::new(true, tmpname, "firefox-desktop")
+        .with_server_endpoint("invalid-test-host")
+        .build();
+    common::initialize(cfg);
+
+    metrics::boo.accumulate_raw_duration(Duration::from_secs(1));
+
+    assert_eq!(
+        1,
+        metrics::boo.test_get_value(None).unwrap().count,
+        "Single sample: single count"
+    );
+
+    // Let's check overflow.
+    metrics::boo.accumulate_raw_duration(Duration::from_nanos(u64::MAX));
+
+    assert_eq!(2, metrics::boo.test_get_value(None).unwrap().count);
+    assert_eq!(
+        1,
+        metrics::boo.test_get_num_recorded_errors(ErrorType::InvalidOverflow)
+    );
+
+    glean::shutdown(); // Cleanly shut down at the end of the test.
+}

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::common_metric_data::CommonMetricDataInternal;
 use crate::error_recording::{record_error, test_get_num_recorded_errors, ErrorType};
@@ -409,6 +410,35 @@ impl TimingDistributionMetric {
         let metric = self.clone();
         crate::launch_with_glean(move |glean| {
             metric.accumulate_raw_samples_nanos_sync(glean, &samples)
+        })
+    }
+
+    /// Accumulates precisely one duration to the metric.
+    ///
+    /// Like `TimingDistribution::accumulate_single_sample`, but for use when the
+    /// duration is:
+    ///
+    ///  * measured externally, or
+    ///  * is in a unit different from the timing_distribution's internal TimeUnit.
+    ///
+    /// # Arguments
+    ///
+    /// * `duration` - The single duration to be recorded in the metric.
+    ///
+    /// ## Notes
+    ///
+    /// Reports an [`ErrorType::InvalidOverflow`] error if `duration` is longer than
+    /// `MAX_SAMPLE_TIME`.
+    ///
+    /// The API client is responsible for ensuring that `duration` is derived from a
+    /// monotonic clock source that behaves consistently over computer sleep across
+    /// the application's platforms. Otherwise the resulting data may not share the same
+    /// guarantees that other `timing_distribution` metrics' data do.
+    pub fn accumulate_raw_duration(&self, duration: Duration) {
+        let duration_ns = duration.as_nanos().try_into().unwrap_or(u64::MAX);
+        let metric = self.clone();
+        crate::launch_with_glean(move |glean| {
+            metric.accumulate_raw_samples_nanos_sync(glean, &[duration_ns])
         })
     }
 

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -6,6 +6,8 @@ use crate::metrics::DistributionData;
 use crate::metrics::TimerId;
 use crate::ErrorType;
 
+use std::time::Duration;
+
 /// A description for the [`TimingDistributionMetric`](crate::metrics::TimingDistributionMetric) type.
 ///
 /// When changing this trait, make sure all the operations are
@@ -102,6 +104,29 @@ pub trait TimingDistribution {
     /// Reports an [`ErrorType::InvalidOverflow`] error for samples that
     /// are longer than `MAX_SAMPLE_TIME`.
     fn accumulate_raw_samples_nanos(&self, samples: Vec<u64>);
+
+    /// Accumulates precisely one duration to the metric.
+    ///
+    /// Like `TimingDistribution::accumulate_single_sample`, but for use when the
+    /// duration is:
+    ///
+    ///  * measured externally, or
+    ///  * is in a unit different from the timing_distribution's internal TimeUnit.
+    ///
+    /// # Arguments
+    ///
+    /// * `duration` - The single duration to be recorded in the metric.
+    ///
+    /// ## Notes
+    ///
+    /// Reports an [`ErrorType::InvalidOverflow`] error if `duration` is longer than
+    /// `MAX_SAMPLE_TIME`.
+    ///
+    /// The API client is responsible for ensuring that `duration` is derived from a
+    /// monotonic clock source that behaves consistently over computer sleep across
+    /// the application's platforms. Otherwise the resulting data may not share the same
+    /// guarantees that other `timing_distribution` metrics' data do.
+    fn accumulate_raw_duration(&self, duration: Duration);
 
     /// **Exported for test purposes.**
     ///


### PR DESCRIPTION
Unfortunately I can't find timing_distribution tests that have a dispatcher, so I can't test this new API. Luckily, aside from a Duration -> u128 -> u64 conversion chain, all the logic is in accumulate_raw_samples_nanos_sync which is covered.