### PR TITLE
Bump `rust-android-gradle` to 0.9.4.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kotlinx-coroutines = "1.8.0"
 kotlinx-serialization = "1.6.3"
 
 # Mozilla
-rust-android-gradle = "0.9.3"
+rust-android-gradle = "0.9.4"
 
 # AndroidX
 androidx-annotation = "1.7.1"


### PR DESCRIPTION
Version 0.9.4 has the fix for mozilla/rust-android-gradle#145. My NDK lives in a "non-standard" location (I'm using the one that `./mach bootstrap` installs), and 0.9.3 doesn't extract the version from it correctly.

We bumped App Services to 0.9.4 in mozilla/application-services#6210; I bumped Glean locally while working on https://phabricator.services.mozilla.com/D206066, and thought I'd send y'all the patch 😊 Thanks!