### PR TITLE
Bug 1893207 - CI: Switch to M1 medium workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,14 +506,14 @@ jobs:
       - setup-rust-toolchain
       - restore_cache:
           name: Restore rubygems cache
-          key: swift-docs-gems-v19
+          key: swift-docs-gems-v20
       - run:
           name: Install jazzy
-          command: gem install jazzy
+          command: gem install --no-document jazzy
       - save_cache:
           name: Save rubygems cache
           # NEEDS TO CHANGE WHEN JAZZY OR RUBY IS UPDATED
-          key: swift-docs-gems-v19
+          key: swift-docs-gems-v20
           paths:
             - ~/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,8 +524,8 @@ jobs:
 
             # For some reason everything works fine if we use the host clang,
             # not the Xcode-bundled clang.
-            echo '[target.x86_64-apple-darwin]' >> ~/.cargo/config
-            echo 'linker = "/usr/bin/clang"' >> ~/.cargo/config
+            echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config
+            echo 'linker = "/usr/bin/cc"' >> ~/.cargo/config
 
             # List available devices -- allows us to see what's there
             DEVICES=$(xcrun xctrace list devices 2>&1)
@@ -608,8 +608,8 @@ jobs:
 
             # For some reason everything works fine if we use the host clang,
             # not the Xcode-bundled clang.
-            echo '[target.x86_64-apple-darwin]' >> ~/.cargo/config
-            echo 'linker = "/usr/bin/clang"' >> ~/.cargo/config
+            echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config
+            echo 'linker = "/usr/bin/cc"' >> ~/.cargo/config
 
             # List available devices -- allows us to see what's there
             DEVICES=$(xcrun xctrace list devices 2>&1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,8 +219,8 @@ commands:
           name: Get ghr release tool
           command: |
             GHR_VERSION=v0.16.2
-            GHR=ghr_${GHR_VERSION}_darwin_amd64
-            GHR_SHA256=da2e6592a50c725660684d5ff19cd3751a28cc3948dc69dab9ec98940b5e33ac
+            GHR=ghr_${GHR_VERSION}_darwin_arm64
+            GHR_SHA256=f762742b3a1a6a10c87ca1bfcc043e9e535ce4d1defa02e4e9d5a4875c1116ba
             curl -sfSL --retry 5 -O "https://github.com/tcnksm/ghr/releases/download/${GHR_VERSION}/${GHR}.zip"
             echo "${GHR_SHA256} *${GHR}.zip" | shasum -a 256 -c -
             unzip "${GHR}.zip"
@@ -873,7 +873,7 @@ jobs:
       - run:
           name: Install Python development tools for host
           command: |
-            rustup target add aarch64-apple-darwin
+            rustup target add x86_64-apple-darwin
             make setup-python
       - run:
           name: Build macOS x86_64 wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,7 +476,7 @@ jobs:
   Check Swift formatting:
     macos:
       xcode: "15.1"
-    resource_class: "macos.x86.medium.gen2"
+    resource_class: "macos.m1.medium.gen1"
     steps:
       - checkout
       - run:
@@ -484,11 +484,7 @@ jobs:
           command: |
             export HOMEBREW_NO_AUTO_UPDATE=1
             export HOMEBREW_NO_INSTALL_CLEANUP=1
-            # swiftlint 0.53.0
-            SWIFTLINT_SHA256="6e7ca377eb3bbfe43e09825f91ca238382e68d6d1c79f947b0b6eeed79c13650"
-            curl https://raw.githubusercontent.com/Homebrew/homebrew-core/0e4a16c4875adafd3ef2cb39c587d0cbb19c618c/Formula/s/swiftlint.rb > swiftlint.rb
-            echo "${SWIFTLINT_SHA256} *swiftlint.rb" | shasum -a 256 -c -
-            brew install ./swiftlint.rb
+            brew install swiftlint
       - run:
           name: Run swiftlint
           command: |
@@ -498,7 +494,7 @@ jobs:
   iOS build and test:
     macos:
       xcode: "15.1"
-    resource_class: "macos.x86.medium.gen2"
+    resource_class: "macos.m1.medium.gen1"
     steps:
       - checkout
       - run:
@@ -598,7 +594,7 @@ jobs:
   iOS integration test:
     macos:
       xcode: "15.1"
-    resource_class: "macos.x86.medium.gen2"
+    resource_class: "macos.m1.medium.gen1"
     steps:
       - checkout
       - skip-if-doc-only
@@ -643,7 +639,7 @@ jobs:
   iOS Framework release:
     macos:
       xcode: "15.1"
-    resource_class: "macos.x86.medium.gen2"
+    resource_class: "macos.m1.medium.gen1"
     steps:
       - checkout
       - attach_workspace:
@@ -869,7 +865,7 @@ jobs:
   pypi-macos-release:
     macos:
       xcode: "15.1"
-    resource_class: "macos.x86.medium.gen2"
+    resource_class: "macos.m1.medium.gen1"
     steps:
       - install-rustup
       - setup-rust-toolchain


### PR DESCRIPTION
These are twice as costly per usage minute.
macos.x86.medium.gen2 will be gone in June 2024.
Maybe the raw performance makes up for the increase in costs.