### PR TITLE
event database: Use a Mutex instead of a RwLock

### DIFF
--- a/glean-core/src/histogram/exponential.rs
+++ b/glean-core/src/histogram/exponential.rs
@@ -195,12 +195,12 @@ mod test {
     fn accumulate_large_numbers() {
         let mut hist = Histogram::exponential(1, 500, 10);
 
-        hist.accumulate(u64::max_value());
-        hist.accumulate(u64::max_value());
+        hist.accumulate(u64::MAX);
+        hist.accumulate(u64::MAX);
 
         assert_eq!(2, hist.count());
         // Saturate before overflowing
-        assert_eq!(u64::max_value(), hist.sum());
+        assert_eq!(u64::MAX, hist.sum());
         assert_eq!(2, hist.values[&500]);
     }
 }

--- a/glean-core/src/histogram/linear.rs
+++ b/glean-core/src/histogram/linear.rs
@@ -167,12 +167,12 @@ mod test {
     fn accumulate_large_numbers() {
         let mut hist = Histogram::linear(1, 500, 10);
 
-        hist.accumulate(u64::max_value());
-        hist.accumulate(u64::max_value());
+        hist.accumulate(u64::MAX);
+        hist.accumulate(u64::MAX);
 
         assert_eq!(2, hist.count());
         // Saturate before overflowing
-        assert_eq!(u64::max_value(), hist.sum());
+        assert_eq!(u64::MAX, hist.sum());
         assert_eq!(2, hist.values[&500]);
     }
 }

--- a/glean-core/tests/counter.rs
+++ b/glean-core/tests/counter.rs
@@ -168,10 +168,7 @@ fn saturates_at_boundary() {
     });
 
     counter.add_sync(&glean, 2);
-    counter.add_sync(&glean, i32::max_value());
+    counter.add_sync(&glean, i32::MAX);
 
-    assert_eq!(
-        i32::max_value(),
-        counter.get_value(&glean, Some("store1")).unwrap()
-    );
+    assert_eq!(i32::MAX, counter.get_value(&glean, Some("store1")).unwrap());
 }

--- a/glean-core/tests/timing_distribution.rs
+++ b/glean-core/tests/timing_distribution.rs
@@ -296,7 +296,7 @@ fn large_nanoseconds_values() {
     );
 
     let time = Duration::from_secs(10).as_nanos() as u64;
-    assert!(time > u64::from(u32::max_value()));
+    assert!(time > u64::from(u32::MAX));
 
     let id = 4u64.into();
     metric.set_start(id, 0);


### PR DESCRIPTION
We use this lock to synchronize the file access outside of it.
Thus we always need an exclusive lock, which is why we always used a `write` lock.
But if that's all we need a `Mutex` is really just good enough.
And newer Clippy was complaining about that