### PR TITLE
Bug 1894595 - Python: Depend on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ maintainers = [
 dependencies = [
   "semver>=2.13.0",
   "glean_parser~=14.0",
+  "setuptools>=68.0.0",
 ]
 
 [project.urls]

--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,2 +1,1 @@
-setuptools
 ../..


### PR DESCRIPTION
This fixes the issue of missing `pkg_resources` on Python 3.12