### PR TITLE
Bug 1894635 - Python: Use importlib.metadata instead of deprecated pkg_resources

### DIFF
--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -7,7 +7,7 @@
 import warnings
 
 
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 from semver import VersionInfo  # type: ignore
 
 
@@ -21,8 +21,8 @@ from ._loader import load_metrics, load_pings
 
 __version__: str = "unknown"
 try:
-    __version__ = str(get_distribution("glean-sdk").version)
-except DistributionNotFound:  # pragma: no cover
+    __version__ = importlib.metadata.version("glean-sdk")
+except importlib.metadata.PackageNotFoundError:  # pragma: no cover
     pass
 
 

--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,2 +1,1 @@
-setuptools
 ../..


### PR DESCRIPTION
importlib.metadata is available since Python 3.8, the minimum Python we support.