### PR TITLE
Revert "Python: Use importlib.metadata instead of deprecated pkg_reso…

### DIFF
--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -7,7 +7,7 @@
 import warnings
 
 
-import importlib.metadata
+from pkg_resources import get_distribution, DistributionNotFound
 from semver import VersionInfo  # type: ignore
 
 
@@ -21,8 +21,8 @@ from ._loader import load_metrics, load_pings
 
 __version__: str = "unknown"
 try:
-    __version__ = importlib.metadata.version("glean-sdk")
-except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+    __version__ = str(get_distribution("glean-sdk").version)
+except DistributionNotFound:  # pragma: no cover
     pass
 
 

--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,1 +1,2 @@
+setuptools
 ../..


### PR DESCRIPTION
…urces"

This reverts commit b384d2cfdfa7117e4e5f923af1171c90e9d5b3d7.

--

let's see about those windows python failures in CI