### PR TITLE
CI: Build a bcryptprimitives shim for loading it in Python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,8 +749,15 @@ jobs:
             wget https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-amd64.zip
             mkdir winpython
             unzip python-3.8.2-embed-amd64.zip -d winpython
-            echo "export WINPYTHON=\"wine64 winpython/python.exe\"" >> $BASH_ENV
+            echo "export WINPYTHON=\"wine64-stable winpython/python.exe\"" >> $BASH_ENV
       - install-python-windows-deps
+      - run:
+          name: Build bcryptprimitives.dll shim
+          command: |
+            rustc tools/patches/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir wine_shims --target x86_64-pc-windows-gnu
+            # This preloads our bcryptprimitives shim.
+            shimpath='Z:\\\\home\\\\circleci\\\\project\\\\wine_shims\\\\bcryptprimitives.dll'
+            echo "import ctypes; ctypes.cdll.LoadLibrary('$shimpath')" >> winpython/sitecustomize.py
       - run:
           name: Run tests
           command: |
@@ -777,6 +784,13 @@ jobs:
             unzip python-3.8.2-embed-win32.zip -d winpython
             echo "export WINPYTHON=\"wine winpython/python.exe\"" >> $BASH_ENV
       - install-python-windows-deps
+      - run:
+          name: Build bcryptprimitives.dll shim
+          command: |
+            rustc tools/patches/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir wine_shims --target i686-pc-windows-gnu
+            # This preloads our bcryptprimitives shim.
+            shimpath='Z:\\\\home\\\\circleci\\\\project\\\\wine_shims\\\\bcryptprimitives.dll'
+            echo "import ctypes; ctypes.cdll.LoadLibrary('$shimpath')" >> winpython/sitecustomize.py
       - run:
           name: Run tests
           command: |

--- a/tools/docker-winbuild/Dockerfile
+++ b/tools/docker-winbuild/Dockerfile
@@ -1,0 +1,33 @@
+FROM cimg/python:3.8
+
+RUN sudo apt-get update -qq \
+  && sudo apt-get install -qy --no-install-recommends \
+    wine64 \
+    gcc-mingw-w64
+    
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
+  && echo 'export PATH=$HOME/.cargo/bin:$PATH' >> ~/.profile
+
+RUN export PATH=$HOME/.cargo/bin:$PATH \
+  && rustup target add x86_64-pc-windows-gnu \
+  && echo '[target.x86_64-pc-windows-gnu]' >> ~/.cargo/config \
+  && echo 'linker = "/usr/bin/x86_64-w64-mingw32-gcc"' >> ~/.cargo/config
+
+RUN wine64-stable wineboot \
+  && mkdir ~/winpython \
+  && cd ~/winpython \
+  && wget https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-amd64.zip \
+  && unzip python-3.8.2-embed-amd64.zip -d ~/winpython \
+  && echo "export WINPYTHON=\"wine64-stable $HOME/winpython/python.exe\"" >> ~/.profile \
+  && wget https://bootstrap.pypa.io/get-pip.py \
+  && wine64-stable ~/winpython/python.exe get-pip.py \
+  && echo "import site" >> ~/winpython/python38._pth \
+  && echo "import sys; sys.path.insert(0, '')" >> ~/winpython/sitecustomize.py \
+  && echo "import ctypes; ctypes.cdll.LoadLibrary('Z:\\\\home\\\\circleci\\\\project\\\\wine_shims\\\\bcryptprimitives.dll')" >> ~/winpython/sitecustomize.py
+
+ADD init.sh /home/circleci/init.sh
+ADD build.sh /home/circleci/build.sh
+
+RUN sudo chown circleci:circleci ~/*.sh 
+
+ENTRYPOINT ~/init.sh

--- a/tools/docker-winbuild/README.md
+++ b/tools/docker-winbuild/README.md
@@ -1,0 +1,29 @@
+# Run glean-py Windows tests in Docker
+
+This should be equivalent to what is running on CI.
+
+## Build the image
+
+```
+docker build -t gleanwin .
+```
+
+## Run a build & test
+
+```
+docker run -t -i --rm gleanwin
+```
+
+Inside the container:
+
+```
+~/build.sh
+```
+
+This builds the target, installs it for use in the wine environment and runs the Python tests.
+
+To rerun the tests:
+
+```
+$WINPYTHON -m pytest -s glean-core/python/tests
+```

--- a/tools/docker-winbuild/build.sh
+++ b/tools/docker-winbuild/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd ~/project
+
+make setup-python
+make build-python-wheel GLEAN_BUILD_TARGET=x86_64-pc-windows-gnu
+
+# Bit of a cleanup to reduce install time
+sed \
+  -e 'g/^mypy/d' \
+  -e 'g/^ruff/d' \
+  -e 'g/^twine/d' \
+  -e 'g/^coverage/d' \
+  -e 'g/^jsonschema/d' \
+  -i \
+  glean-core/python/requirements_dev.txt
+ 
+find ~/.cache/pip -name "*.whl" -exec $WINPYTHON -m pip install {} \;
+$WINPYTHON -m pip install -r glean-core/python/requirements_dev.txt --no-warn-script-location
+$WINPYTHON -m pip install --force-reinstall target/wheels/*.whl --no-warn-script-location
+
+$WINPYTHON -m pytest -s glean-core/python/tests

--- a/tools/docker-winbuild/init.sh
+++ b/tools/docker-winbuild/init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+git clone --depth=1 https://github.com/mozilla/glean ~/project
+
+PATH=$HOME/.cargo/bin:$PATH \
+  rustc tools/patches/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir project/wine_shims --target x86_64-pc-windows-gnu
+
+exec bash -l

--- a/tools/patches/bcryptprimitives.rs
+++ b/tools/patches/bcryptprimitives.rs
@@ -1,0 +1,23 @@
+// via https://github.com/rust-lang/rust/commit/07633821ed63360d4d7464998c29f4f588930a03
+// Shim for bcryptprimitives.dll. The Wine version shipped with Ubuntu 22.04
+// doesn't support it yet. Authored by @ChrisDenton
+
+#![crate_type = "cdylib"]
+#![allow(nonstandard_style)]
+
+#[no_mangle]
+pub unsafe extern "system" fn ProcessPrng(mut pbData: *mut u8, mut cbData: usize) -> i32 {
+    while cbData > 0 {
+        let size = core::cmp::min(cbData, u32::MAX as usize);
+        RtlGenRandom(pbData, size as u32);
+        cbData -= size;
+        pbData = pbData.add(size);
+    }
+    1
+}
+
+#[link(name = "advapi32")]
+extern "system" {
+    #[link_name = "SystemFunction036"]
+    pub fn RtlGenRandom(RandomBuffer: *mut u8, RandomBufferLength: u32) -> u8;
+}


### PR DESCRIPTION
This brings along a minimal shim for bcryptprimitives.dll. It's really minimal and _only_ necessary for the Wine build.
How I got there? Well, I found https://github.com/rust-lang/rust/commit/07633821ed63360d4d7464998c29f4f588930a03
I'm not even sure if we need the `ProcessPrng` implementation, but I'm not here to find out.

What didn't work? Setting `WINEPATH` to the directory. It still won't find the library. Preloading it once though fixes it all.

It now seems to work in CI again.
And it does work in a Docker container as well.
The reason it worked on my machine: On Fedora wine brings along the bcryptprimitives.dll