### PR TITLE
Bug 1719905 - Fixes leaked sqlite database in Android GleanTestRule

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestRule.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/testing/GleanTestRule.kt
@@ -74,4 +74,12 @@ class GleanTestRule(
             clearStores = true,
         )
     }
+
+    override fun finished(description: Description?) {
+        // This closes the database to help prevent leaking it during tests.
+        // See Bug1719905 for more info.
+        WorkManagerTestInitHelper.closeWorkDatabase()
+
+        super.finished(description)
+    }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java
@@ -8,6 +8,7 @@ import android.content.Context;
 
 import androidx.work.testing.WorkManagerTestInitHelper;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +37,11 @@ public class GleanFromJavaTest {
     @Before
     public void setup() {
         WorkManagerTestInitHelper.initializeTestWorkManager(appContext);
+    }
+
+    @After
+    public void cleanup() {
+        WorkManagerTestInitHelper.closeWorkDatabase();
     }
 
     @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/TestUtil.kt
@@ -127,9 +127,6 @@ internal fun resetGlean(
         ShadowLog.stream = System.out
     }
 
-    // We're using the WorkManager in a bunch of places, and Glean will crash
-    // in tests without this line. Let's simply put it here.
-    WorkManagerTestInitHelper.initializeTestWorkManager(context)
     Glean.resetGlean(context, config, clearStores, uploadEnabled = uploadEnabled)
 }
 

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/AccumulationsBeforeGleanInitTest.kt
@@ -28,11 +28,19 @@ class AccumulationsBeforeGleanInitTest {
     val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
-    @After
     @Before
-    fun cleanup() {
+    fun setup() {
         Glean.testDestroyGleanHandle()
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
+    }
+
+    @After
+    fun cleanup() {
+        Glean.testDestroyGleanHandle()
+
+        // This closes the database to help prevent leaking it during tests.
+        // See Bug1719905 for more info.
+        WorkManagerTestInitHelper.closeWorkDatabase()
     }
 
     private fun forceInitGlean() {

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -71,6 +71,10 @@ class MetricsPingSchedulerTest {
         // Once all data is cleared, destroy the handle.
         // Individual tests will start Glean if necessary.
         Glean.testDestroyGleanHandle()
+
+        // This closes the database to help prevent leaking it during tests.
+        // See Bug1719905 for more info.
+        WorkManagerTestInitHelper.closeWorkDatabase()
     }
 
     @Test

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/PingUploadWorkerTest.kt
@@ -6,9 +6,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.BackoffPolicy
 import androidx.work.NetworkType
 import androidx.work.WorkerParameters
+import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.telemetry.glean.config.Configuration
 import mozilla.telemetry.glean.getWorkerStatus
 import mozilla.telemetry.glean.resetGlean
+import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -30,9 +32,18 @@ class PingUploadWorkerTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+
         MockitoAnnotations.openMocks(this)
         resetGlean(context, config = Configuration())
         pingUploadWorker = PingUploadWorker(context, workerParams!!)
+    }
+
+    @After
+    fun cleanup() {
+        // This closes the database to help prevent leaking it during tests.
+        // See Bug1719905 for more info.
+        WorkManagerTestInitHelper.closeWorkDatabase()
     }
 
     @Test


### PR DESCRIPTION
This fixes the leaked sqlite database errors found when using the GleanTestRule and also when running Glean android tests. Thanks to :jonalmeida for pointing us to the fix.