### PR TITLE
Bug 1897219 - Add a global map of ping->[ride-along-pings] so we can correctly call it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v60.1.0...main)
 
+* Rust
+  * Accept a ping schedule map on initialize ([#2839](https://github.com/mozilla/glean/pull/2839))
+
 # v60.1.0 (2024-05-06)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v60.0.0...v60.1.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -261,6 +261,7 @@ open class GleanInternalAPI internal constructor() {
                 enableEventTimestamps = configuration.enableEventTimestamps,
                 experimentationId = configuration.experimentationId,
                 enableInternalPings = configuration.enableInternalPings,
+                pingSchedule = emptyMap(),
             )
             val clientInfo = getClientInfo(configuration, buildInfo)
             val callbacks = OnGleanEventsImpl(this@GleanInternalAPI)

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -195,7 +195,8 @@ public class Glean {
             rateLimit: nil,
             enableEventTimestamps: configuration.enableEventTimestamps,
             experimentationId: configuration.experimentationId,
-            enableInternalPings: configuration.enableInternalPings
+            enableInternalPings: configuration.enableInternalPings,
+            pingSchedule: [:]
         )
         let clientInfo = getClientInfo(configuration, buildInfo: buildInfo)
         let callbacks = OnGleanEventsImpl(glean: self)

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -234,6 +234,7 @@ class Glean:
             enable_event_timestamps=configuration.enable_event_timestamps,
             experimentation_id=configuration.experimentation_id,
             enable_internal_pings=configuration.enable_internal_pings,
+            ping_schedule={},
         )
 
         _uniffi.glean_initialize(cfg, client_info, callbacks)

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -119,6 +119,7 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
             enable_event_timestamps=False,
             experimentation_id=None,
             enable_internal_pings=False,
+            ping_schedule={},
         )
         if not glean_initialize_for_subprocess(cfg):
             log.error("Couldn't initialize Glean in subprocess")

--- a/glean-core/rlb/src/configuration.rs
+++ b/glean-core/rlb/src/configuration.rs
@@ -6,6 +6,7 @@ use log::LevelFilter;
 
 use crate::net::PingUploader;
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// The default server pings are sent to.
@@ -48,6 +49,10 @@ pub struct Configuration {
     pub experimentation_id: Option<String>,
     /// Whether to enable internal pings. Default: true
     pub enable_internal_pings: bool,
+    /// A ping schedule map.
+    /// Maps a ping name to a list of pings to schedule along with it.
+    /// Only used if the ping's own ping schedule list is empty.
+    pub ping_schedule: HashMap<String, Vec<String>>,
 }
 
 /// Configuration builder.
@@ -96,6 +101,10 @@ pub struct Builder {
     pub experimentation_id: Option<String>,
     /// Whether to enable internal pings. Default: true
     pub enable_internal_pings: bool,
+    /// A ping schedule map.
+    /// Maps a ping name to a list of pings to schedule along with it.
+    /// Only used if the ping's own ping schedule list is empty.
+    pub ping_schedule: HashMap<String, Vec<String>>,
 }
 
 impl Builder {
@@ -120,6 +129,7 @@ impl Builder {
             enable_event_timestamps: true,
             experimentation_id: None,
             enable_internal_pings: true,
+            ping_schedule: HashMap::new(),
         }
     }
 
@@ -140,6 +150,7 @@ impl Builder {
             enable_event_timestamps: self.enable_event_timestamps,
             experimentation_id: self.experimentation_id,
             enable_internal_pings: self.enable_internal_pings,
+            ping_schedule: self.ping_schedule,
         }
     }
 
@@ -194,6 +205,12 @@ impl Builder {
     /// Set whether to enable internal pings.
     pub fn with_internal_pings(mut self, value: bool) -> Self {
         self.enable_internal_pings = value;
+        self
+    }
+
+    /// Set the ping schedule map.
+    pub fn with_ping_schedule(mut self, value: HashMap<String, Vec<String>>) -> Self {
+        self.ping_schedule = value;
         self
     }
 }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -123,6 +123,7 @@ fn initialize_internal(cfg: Configuration, client_info: ClientInfoMetrics) -> Op
         enable_event_timestamps: cfg.enable_event_timestamps,
         experimentation_id: cfg.experimentation_id,
         enable_internal_pings: cfg.enable_internal_pings,
+        ping_schedule: cfg.ping_schedule,
     };
 
     glean_core::glean_initialize(core_cfg, client_info.into(), callbacks);

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -1423,3 +1423,51 @@ fn configure_ping_throttling() {
     // `seconds_per_interval` before running the next test, since shutting down
     // will wait for the queue to clear.
 }
+
+#[test]
+fn pings_ride_along_builtin_pings() {
+    let _lock = lock_test();
+
+    // Define a fake uploader that reports back the submission headers
+    // using a crossbeam channel.
+    let (s, r) = crossbeam_channel::bounded::<String>(3);
+
+    #[derive(Debug)]
+    pub struct FakeUploader {
+        sender: crossbeam_channel::Sender<String>,
+    }
+    impl net::PingUploader for FakeUploader {
+        fn upload(&self, upload_request: net::PingUploadRequest) -> net::UploadResult {
+            self.sender.send(upload_request.url).unwrap();
+            net::UploadResult::http_status(200)
+        }
+    }
+
+    let _ride_along_ping =
+        private::PingType::new("ride-along", true, true, true, true, true, vec![], vec![]);
+
+    // Create a custom configuration to use a fake uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().to_path_buf();
+
+    let ping_schedule = HashMap::from([("baseline".to_string(), vec!["ride-along".to_string()])]);
+
+    let cfg = ConfigurationBuilder::new(true, tmpname, GLOBAL_APPLICATION_ID)
+        .with_server_endpoint("invalid-test-host")
+        .with_uploader(FakeUploader { sender: s })
+        .with_ping_schedule(ping_schedule)
+        .build();
+
+    let _t = new_glean(Some(cfg), true);
+
+    // Simulate becoming active.
+    handle_client_active();
+
+    // We expect a baseline ping to be generated here (reason: 'active').
+    let url = r.recv().unwrap();
+    assert!(url.contains("baseline"));
+
+    // We expect a ride-along ping to ride along.
+    let url = r.recv().unwrap();
+    assert!(url.contains("ride-along"));
+}

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -121,6 +121,7 @@ where
 ///     enable_event_timestamps: true,
 ///     experimentation_id: None,
 ///     enable_internal_pings: true,
+///     ping_schedule: Default::default(),
 /// };
 /// let mut glean = Glean::new(cfg).unwrap();
 /// let ping = PingType::new("sample", true, false, true, true, true, vec![], vec![]);
@@ -164,6 +165,7 @@ pub struct Glean {
     pub(crate) remote_settings_epoch: AtomicU8,
     pub(crate) remote_settings_config: Arc<Mutex<RemoteSettingsConfig>>,
     pub(crate) with_timestamps: bool,
+    pub(crate) ping_schedule: HashMap<String, Vec<String>>,
 }
 
 impl Glean {
@@ -224,6 +226,7 @@ impl Glean {
             remote_settings_epoch: AtomicU8::new(0),
             remote_settings_config: Arc::new(Mutex::new(RemoteSettingsConfig::new())),
             with_timestamps: cfg.enable_event_timestamps,
+            ping_schedule: cfg.ping_schedule.clone(),
         };
 
         // Ensuring these pings are registered.
@@ -325,6 +328,7 @@ impl Glean {
             enable_event_timestamps: true,
             experimentation_id: None,
             enable_internal_pings,
+            ping_schedule: Default::default(),
         };
 
         let mut glean = Self::new(cfg).unwrap();

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -91,6 +91,7 @@ dictionary InternalConfiguration {
     boolean enable_event_timestamps;
     string? experimentation_id;
     boolean enable_internal_pings;
+    record<string, sequence<string>> ping_schedule;
 };
 
 // How to specify the rate pings may be uploaded before they are throttled.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -137,6 +137,10 @@ pub struct InternalConfiguration {
     pub experimentation_id: Option<String>,
     /// Whether to enable internal pings. Default: true
     pub enable_internal_pings: bool,
+    /// A ping schedule map.
+    /// Maps a ping name to a list of pings to schedule along with it.
+    /// Only used if the ping's own ping schedule list is empty.
+    pub ping_schedule: HashMap<String, Vec<String>>,
 }
 
 /// How to specify the rate at which pings may be uploaded before they are throttled.

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -198,6 +198,7 @@ fn experimentation_id_is_set_correctly() {
         enable_event_timestamps: true,
         experimentation_id: Some(experimentation_id.to_string()),
         enable_internal_pings: true,
+        ping_schedule: Default::default(),
     })
     .unwrap();
 

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -283,7 +283,25 @@ impl PingType {
                     ping.name
                 );
 
-                if !ping.schedules_pings.is_empty() {
+                if ping.schedules_pings.is_empty() {
+                    let ping_schedule = glean
+                        .ping_schedule
+                        .get(ping.name)
+                        .map(|v| &v[..])
+                        .unwrap_or(&[]);
+
+                    if !ping_schedule.is_empty() {
+                        log::info!(
+                            "The ping '{}' is being used to schedule other pings: {:?}",
+                            ping.name,
+                            ping_schedule
+                        );
+
+                        for scheduled_ping_name in ping_schedule {
+                            glean.submit_ping_by_name(scheduled_ping_name, reason);
+                        }
+                    }
+                } else {
                     log::info!(
                         "The ping '{}' is being used to schedule other pings: {:?}",
                         ping.name,

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -64,6 +64,7 @@ pub fn new_glean(tempdir: Option<tempfile::TempDir>) -> (Glean, tempfile::TempDi
         enable_event_timestamps: false,
         experimentation_id: None,
         enable_internal_pings: true,
+        ping_schedule: Default::default(),
     };
     let glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -486,6 +486,7 @@ fn with_event_timestamps() {
         enable_event_timestamps: true,
         experimentation_id: None, // Enabling event timestamps
         enable_internal_pings: true,
+        ping_schedule: Default::default(),
     };
     let glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -92,6 +92,7 @@ fn test_metrics_must_report_experimentation_id() {
         enable_event_timestamps: true,
         experimentation_id: Some("test-experimentation-id".to_string()),
         enable_internal_pings: true,
+        ping_schedule: Default::default(),
     })
     .unwrap();
     let ping_maker = PingMaker::new();
@@ -145,6 +146,7 @@ fn experimentation_id_is_removed_if_send_if_empty_is_false() {
         enable_event_timestamps: true,
         experimentation_id: Some("test-experimentation-id".to_string()),
         enable_internal_pings: true,
+        ping_schedule: Default::default(),
     })
     .unwrap();
     let ping_maker = PingMaker::new();


### PR DESCRIPTION
This now adds a configuration option to pass a map along that would otherwise be set on the individual ping instances.
It thus works for the builtin pings.

The ping-specific list still works and is preferred, only if empty we go for the top-level map.

Aside:
Note that this is _technically_ a breaking change because the whole configuration is public and we cannot provide default values in Rust (we should really fix that as a breaking-change-thing).
If we go this route I'd still vote for handling this as a feature change only (and we'll mark the non-builder Rust API as "private", so changing it isn't a breaking change anymore). This saves us from the hefty coordination with a-s.
Consumers are fine either way, because we can handle the defaults in the bindings and for RLB we're the only ones using it and can deal with it.

I have the patch for m-c ready that would use this too.