### PR TITLE
Bug 1896193 - Collect samples of Rkv commit timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Bump the string length limit to 255 characters ([#2857](https://github.com/mozilla/glean/pull/2857))
+  * New metric `glean.database.write_time` to measure database writes ([#2845](https://github.com/mozilla/glean/pull/2845))
 * Android
   * Delay log init until Glean is getting initialized ([#2858](https://github.com/mozilla/glean/pull/2858))
   * Update to Gradle v8.8 ([#2860](https://github.com/mozilla/glean/pull/2860))

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -280,6 +280,19 @@ class MetricsPingSchedulerTest {
         // Setup a test server and make Glean point to it.
         val server = getMockWebServer()
 
+        // Trick Glean into not sending the overdue ping which will have `glean.databse` metrics.
+        val fakeNow = Calendar.getInstance()
+        fakeNow.clear()
+        @Suppress("MagicNumber") // it's a fixed date only used in tests.
+        fakeNow.set(2015, 6, 11, 2, 0, 0)
+        SystemClock.setCurrentTimeMillis(fakeNow.timeInMillis)
+
+        // Set the last sent date to yesterday.
+        val buildInfo = BuildInfo(versionCode = "0.0.1", versionName = "0.0.1", buildDate = Calendar.getInstance())
+        val mps = MetricsPingScheduler(context, buildInfo)
+
+        mps.updateSentDate(getISOTimeString(fakeNow, truncateTo = TimeUnit.DAY))
+
         resetGlean(
             context,
             Configuration(

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -720,6 +720,22 @@ glean.database:
       - glean-team@mozilla.com
     expires: never
 
+  write_time:
+    type: timing_distribution
+    time_unit: microsecond
+    description: |
+      The time it takes for a write-commit for the Glean database.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1896193
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1896193#c4
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+      - jrediger@mozilla.com
+    expires: never
+
 glean.validation:
   foreground_count:
     type: counter

--- a/glean-core/rlb/tests/test-thread-crashing.sh
+++ b/glean-core/rlb/tests/test-thread-crashing.sh
@@ -15,7 +15,7 @@ cleanup() {
 trap cleanup INT ABRT TERM EXIT
 
 tmp="${TMPDIR:-/tmp}"
-datapath=$(mktemp -d "${tmp}/glean_long_running.XXXX")
+datapath=$(mktemp -d "${tmp}/crashing_threads.XXXX")
 
 RUSTFLAGS="-C panic=abort" \
 RUST_LOG=debug \
@@ -23,10 +23,16 @@ cargo run -p glean --example crashing-threads -- "$datapath"
 ret=$?
 count=$(ls -1q "$datapath/pending_pings" | wc -l)
 
-if [[ $ret -eq 0 ]] && [[ "$count" -eq 1 ]]; then
+# We expect 2 pending pings:
+# - a metrics ping
+# - a prototype ping
+if [[ $ret -eq 0 ]] && [[ "$count" -eq 2 ]]; then
   echo "test result: ok."
   exit 0
 else
+  echo "Assertions:"
+  echo "  ret - expected: 0, was: $ret"
+  echo "  count - expected: 2, was: $count"
   echo "test result: FAILED."
   exit 101
 fi

--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -264,6 +264,9 @@ pub struct DatabaseMetrics {
 
     /// RKV's load result, indicating success or relaying the detected error.
     pub rkv_load_error: StringMetric,
+
+    /// The time it takes for a write-commit for the Glean database.
+    pub write_time: TimingDistributionMetric,
 }
 
 impl DatabaseMetrics {
@@ -289,6 +292,18 @@ impl DatabaseMetrics {
                 disabled: false,
                 dynamic_label: None,
             }),
+
+            write_time: TimingDistributionMetric::new(
+                CommonMetricData {
+                    name: "write_time".into(),
+                    category: "glean.database".into(),
+                    send_in_pings: vec!["metrics".into()],
+                    lifetime: Lifetime::Ping,
+                    disabled: false,
+                    dynamic_label: None,
+                },
+                TimeUnit::Microsecond,
+            ),
         }
     }
 }

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -234,8 +234,20 @@ impl PingMaker {
         url_path: &'a str,
     ) -> Option<Ping<'a>> {
         info!("Collecting {}", ping.name());
+        let database = glean.storage();
 
-        let mut metrics_data = StorageManager.snapshot_as_json(glean.storage(), ping.name(), true);
+        // HACK: Only for metrics pings we add the ping timings.
+        // But we want that to persist until the next metrics ping is actually sent.
+        let write_samples = database.write_timings.replace(Vec::with_capacity(64));
+        if !write_samples.is_empty() {
+            glean
+                .database_metrics
+                .write_time
+                .accumulate_samples_sync(glean, &write_samples);
+        }
+
+        let mut metrics_data = StorageManager.snapshot_as_json(database, ping.name(), true);
+
         let events_data = glean
             .event_storage()
             .snapshot_as_json(glean, ping.name(), true);

--- a/glean-core/src/scheduler.rs
+++ b/glean-core/src/scheduler.rs
@@ -202,7 +202,7 @@ fn start_scheduler(
             let mut now = now;
             loop {
                 let dur = when.until(now);
-                log::info!("Scheduling for {:?} after {}, reason {:?}", dur, now, when);
+                log::info!("Scheduling for {} after {:?}, reason {:?}", now, dur, when);
                 let mut timed_out = false;
                 {
                     match condvar.wait_timeout_while(cancelled_lock.lock().unwrap(), dur, |cancelled| !*cancelled) {

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -279,3 +279,32 @@ fn test_scheduled_pings_are_sent() {
     assert!(trigger_ping.submit_sync(&glean, None));
     assert_eq!(2, get_queued_pings(glean.get_data_path()).unwrap().len());
 }
+
+#[test]
+fn database_write_timings_get_recorded() {
+    let (mut glean, _t) = new_glean(None);
+
+    let metrics_ping = PingType::new("metrics", true, false, true, true, true, vec![], vec![]);
+    glean.register_ping_type(&metrics_ping);
+
+    // We need to store a metric to record something.
+    let counter = CounterMetric::new(CommonMetricData {
+        name: "counter".into(),
+        category: "local".into(),
+        send_in_pings: vec!["metrics".into()],
+        ..Default::default()
+    });
+    counter.add_sync(&glean, 1);
+
+    assert!(metrics_ping.submit_sync(&glean, None));
+
+    let mut queued_pings = get_queued_pings(glean.get_data_path()).unwrap();
+    assert_eq!(1, queued_pings.len(), "missing metrics ping");
+
+    let json = queued_pings.pop().unwrap().1;
+    let write_time = &json["metrics"]["timing_distribution"]["glean.database.write_time"];
+    assert!(
+        0 < write_time["sum"].as_i64().unwrap(),
+        "writing should take some time"
+    );
+}


### PR DESCRIPTION
Due to this being deep within the database we need to do things slightly differently.

We will measure the time ourselves and keep the samples. When we later assemble a ping we record those samples into the databse (incidentally triggering _another_ write for now). Then it just goes the usual way.

Maybe this should be optimized:

* Only collect the samples when actually assembling the `metrics` ping
* Don't put those values into the database, just add them to the generated data right away.