### PR TITLE
Kotlin: Allow configuring delayPingLifetimeIo in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v60.2.0...main)
 
+* Android
+  * Allow configuring `delayPingLifetimeIo` in Kotlin and auto-flush this data after 1000 writes.
+    It is also auto-flushed on background. ([#2851](https://github.com/mozilla/glean/pull/2851))
+
 # v60.2.0 (2024-05-23)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v60.1.0...v60.2.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -252,7 +252,7 @@ open class GleanInternalAPI internal constructor() {
                 languageBindingName = LANGUAGE_BINDING_NAME,
                 uploadEnabled = uploadEnabled,
                 maxEvents = null,
-                delayPingLifetimeIo = false,
+                delayPingLifetimeIo = configuration.delayPingLifetimeIo,
                 appBuild = "none",
                 useCoreMps = false,
                 trimDataToRegisteredPings = false,
@@ -497,6 +497,16 @@ open class GleanInternalAPI internal constructor() {
      */
     fun setSourceTags(tags: Set<String>): Boolean {
         return gleanSetSourceTags(tags.toList())
+    }
+
+    /**
+     * Asks the database to persist ping-lifetime data to disk. Probably expensive to call.
+     * Only has effect when Glean is configured with `delay_ping_lifetime_io: true`.
+     * If Glean hasn't been initialized this will dispatch and return Ok(()),
+     * otherwise it will block until the persist is done and return its Result.
+     */
+    fun persistPingLifetimeData() {
+        return gleanPersistPingLifetimeData()
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -446,6 +446,9 @@ open class GleanInternalAPI internal constructor() {
      * Handle the background event and send the appropriate pings.
      */
     internal fun handleBackgroundEvent() {
+        // Persist data on backgrounding the app
+        persistPingLifetimeData()
+
         gleanHandleClientInactive()
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -24,6 +24,7 @@ import mozilla.telemetry.glean.net.PingUploader
  * @property experimentationId An experimentation identifier derived by the application
  *           to be sent with all pings.
  * @property enableInternalPings Whether to enable internal pings.
+ * @property delayPingLifetimeIo Whether Glean should delay persistence of data from metrics with ping lifetime.
  */
 data class Configuration @JvmOverloads constructor(
     val serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
@@ -38,6 +39,7 @@ data class Configuration @JvmOverloads constructor(
     val enableEventTimestamps: Boolean = true,
     val experimentationId: String? = null,
     val enableInternalPings: Boolean = true,
+    val delayPingLifetimeIo: Boolean = false,
 ) {
     companion object {
         /**

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -294,7 +294,7 @@ pub fn get_timestamp_ms() -> u64 {
 /// If Glean hasn't been initialized this will dispatch and return Ok(()),
 /// otherwise it will block until the persist is done and return its Result.
 pub fn persist_ping_lifetime_data() {
-    glean_core::persist_ping_lifetime_data();
+    glean_core::glean_persist_ping_lifetime_data();
 }
 
 #[cfg(test)]

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -53,6 +53,8 @@ namespace glean {
     boolean glean_set_source_tags(sequence<string> tags);
     void glean_set_log_pings(boolean value);
 
+    void glean_persist_ping_lifetime_data();
+
     void glean_handle_client_active();
     void glean_handle_client_inactive();
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -697,7 +697,7 @@ pub fn shutdown() {
 /// Only has effect when Glean is configured with `delay_ping_lifetime_io: true`.
 /// If Glean hasn't been initialized this will dispatch and return Ok(()),
 /// otherwise it will block until the persist is done and return its Result.
-pub fn persist_ping_lifetime_data() {
+pub fn glean_persist_ping_lifetime_data() {
     // This is async, we can't get the Error back to the caller.
     crate::launch_with_glean(|glean| {
         let _ = glean.persist_ping_lifetime_data();

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -1129,8 +1129,14 @@ pub fn glean_test_destroy_glean(clear_stores: bool, data_path: Option<String>) {
 
         // Only useful if Glean initialization finished successfully
         // and set up the storage.
-        let has_storage =
-            core::with_opt_glean(|glean| glean.storage_opt().is_some()).unwrap_or(false);
+        let has_storage = core::with_opt_glean(|glean| {
+            // We need to flush the ping lifetime data before a full shutdown.
+            glean
+                .storage_opt()
+                .map(|storage| storage.persist_ping_lifetime_data())
+                .is_some()
+        })
+        .unwrap_or(false);
         if has_storage {
             uploader_shutdown();
         }

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/GleanApplication.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/GleanApplication.kt
@@ -7,6 +7,7 @@ package org.mozilla.samples.gleancore
 import android.app.Application
 import android.util.Log
 import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.config.Configuration
 import org.mozilla.samples.gleancore.GleanMetrics.Basic
 import org.mozilla.samples.gleancore.GleanMetrics.Custom
 import org.mozilla.samples.gleancore.GleanMetrics.GleanBuildInfo
@@ -35,6 +36,7 @@ class GleanApplication : Application() {
             applicationContext = applicationContext,
             uploadEnabled = true,
             buildInfo = GleanBuildInfo.buildInfo,
+            configuration = Configuration(delayPingLifetimeIo = true),
         )
 
         Test.timespan.start()


### PR DESCRIPTION
For some documentation (also in the commit message):

 Persist ping-lifetime data after 1000 writes

We now automatically flush data to disk after 1000 writes into the
in-memory ping-lifetime map.

If `delay_ping_lifetime_io` is set to true, the data is now flushed to
disk in these cases:
* When `persist_ping_lifetime_data` is called by the application.
* At shutdown (that calls `persist_ping_lifetime_data`) automatically.
* Every 1000 writes
  * Calling `persist_ping_lifetime_data` resets the counter!

The downside with `delay_ping_lifetime_io` is the increased risk of
small windows of data loss:
Data is only persisted so often, so if the process crashes or is killed
in between the data is not persisted to disk and we will never know about.
We do our best to still persist frequently (after enough writes, on ping
submission, on background) and the application could decide to call
`persist_ping_lifetime_data` on their own as well, e.g. on idle.