### PR TITLE
Bug 1900308 - Android: Delay log init until Glean is getting initialized

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 282 utf-8
+personal_ws-1.1 en 283 utf-8
 AAR
 AARs
 ABI
@@ -175,6 +175,7 @@ html
 iMacs
 illumos
 init
+initializer
 inlined
 instrumentations
 integrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean/compare/v60.3.0...main)
 
 * Android
+  * Delay log init until Glean is getting initialized ([#2858](https://github.com/mozilla/glean/pull/2858))
   * Update to Gradle v8.8 ([#2860](https://github.com/mozilla/glean/pull/2860))
   * Updated Kotlin to version 1.9.24 ([#2861](https://github.com/mozilla/glean/pull/2861))
 

--- a/docs/dev/SUMMARY.md
+++ b/docs/dev/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Android bindings](android/index.md)
     - [Setup Build Environment](android/setup-android-build-environment.md)
     - [Android SDK/NDK versions](android/sdk-ndk-versions.md)
+    - [Logging](android/logging.md)
     - [Development with android-components](android/development-with-android-components.md)
     - [Locally-published components in Fenix](android/locally-published-components-in-fenix.md)
     - [Substituting glean_parser](android/glean-parser-substitution.md)

--- a/docs/dev/android/logging.md
+++ b/docs/dev/android/logging.md
@@ -1,0 +1,12 @@
+# Logging
+
+Logs from `glean-core` are only passed through to the Android logging framework when `Glean.initialize` is called for the first time.
+This means any logging that might happen before that, e.g. from early metric collection will not be collected.
+
+If these logs are needed for debugging add the following initializer to `Glean.kt`:
+
+```kotlin
+init {
+    gleanEnableLogging()
+}
+```

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -149,10 +149,6 @@ open class GleanInternalAPI internal constructor() {
 
     internal var isCustomDataPath: Boolean = false
 
-    init {
-        gleanEnableLogging()
-    }
-
     /**
      * Initialize the Glean SDK.
      *
@@ -185,6 +181,8 @@ open class GleanInternalAPI internal constructor() {
         configuration: Configuration = Configuration(),
         buildInfo: BuildInfo,
     ) {
+        gleanEnableLogging()
+
         configuration.dataPath?.let { safeDataPath ->
             // When the `dataPath` is provided, we need to make sure:
             //   1. The database path provided is not `glean_data`.


### PR DESCRIPTION
This should avoid loading the native library early