### PR TITLE
Bug 1857411 - point to new links

### DIFF
--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -505,4 +505,4 @@ describe("myTestSuite", () => {
 - [Swift API docs](../../../swift/Classes/Glean.html#/s:5GleanAAC10initialize13uploadEnabled13configuration9buildInfoySb_AA13ConfigurationVAA05BuildG0VtF)
 - [Python API docs](../../../python/glean/index.html#glean.Glean.initialize)
 - [Rust API docs](../../../docs/glean/fn.initialize.html)
-- [JavaScript API docs](https://mozilla.github.io/glean.js/functions/core_glean.default.initialize.html)
+- [JavaScript API docs](https://mozilla.github.io/glean.js/getting_started/setup/#initializing-gleanjs)

--- a/docs/user/reference/general/shutdown.md
+++ b/docs/user/reference/general/shutdown.md
@@ -74,4 +74,3 @@ is explicitly using the `webext` target.
 ## Reference
 
 * [Rust API docs](../../../docs/glean/fn.shutdown.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_glean.default.html#shutdown)

--- a/docs/user/reference/general/toggling-upload-status.md
+++ b/docs/user/reference/general/toggling-upload-status.md
@@ -131,4 +131,4 @@ uploadSwitch.addEventListener("change", event => {
 * [Swift API docs](../../../swift/Classes/Glean.html#/s:5GleanAAC16setUploadEnabledyySbF)
 * [Python API docs](../../../python/glean/index.html#glean.Glean.set_upload_enabled)
 * [Rust API docs](../../../docs/glean/fn.set_upload_enabled.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_glean.default.html#setUploadEnabled)
+* [JavaScript API docs](https://mozilla.github.io/glean.js/reference/uploaders/#uploadenabled)

--- a/docs/user/reference/metrics/boolean.md
+++ b/docs/user/reference/metrics/boolean.md
@@ -289,4 +289,3 @@ N/A
 * [Swift API docs](../../../swift/Classes/BooleanMetricType.html)
 * [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.BooleanMetric)
 * [Rust API docs](../../../docs/glean/private/boolean/struct.BooleanMetric.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_boolean.default.html)

--- a/docs/user/reference/metrics/counter.md
+++ b/docs/user/reference/metrics/counter.md
@@ -336,4 +336,3 @@ N/A
 * [Swift API docs](../../../swift/Classes/CounterMetricType.html)
 * [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.CounterMetric)
 * [Rust API docs](../../../docs/glean/private/counter/struct.CounterMetric.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_counter.default.html)

--- a/docs/user/reference/metrics/datetime.md
+++ b/docs/user/reference/metrics/datetime.md
@@ -417,4 +417,3 @@ Carefully consider the required resolution for recording your metric, and choose
 * [Swift API docs](../../../swift/Classes/DatetimeMetricType.html)
 * [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.DatetimeMetricType)
 * [Rust API docs](../../../docs/glean/private/struct.DatetimeMetric.html)
-* [Datetime API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_datetime.default.html)

--- a/docs/user/reference/metrics/event.md
+++ b/docs/user/reference/metrics/event.md
@@ -403,4 +403,3 @@ Each extra key contains additional metadata:
 * [Swift API docs](../../../swift/Classes/EventMetricType.html)
 * [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.EventMetricType)
 * [Rust API docs](../../../docs/glean/private/event/struct.EventMetric.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_event.default.html)

--- a/docs/user/reference/metrics/labeled_booleans.md
+++ b/docs/user/reference/metrics/labeled_booleans.md
@@ -318,4 +318,3 @@ accessibility:
 * Swift API docs: [`LabeledMetricType`](../../../swift/Classes/LabeledMetricType.html), [`BooleanMetricType`](../../../swift/Classes/BooleanMetricType.html)
 * Python API docs: [`LabeledBooleanMetricType`](../../../python/glean/metrics/labeled.html#glean.metrics.labeled.LabeledBooleanMetricType), [`BooleanMetricType`](../../../python/glean/metrics/index.html#glean.metrics.BooleanMetric)
 * Rust API docs: [`LabeledMetric`](../../../docs/glean/private/struct.LabeledMetric.html), [`BooleanMetricType`](../../../docs/glean/private/struct.BooleanMetric.html)
-* JavaScript API docs: [`LabeledMetricType`](https://mozilla.github.io/glean.js/classes/core_metrics_types_labeled.default.html), [`BooleanMetricType`](https://mozilla.github.io/glean.js/classes/core_metrics_types_boolean.default.html)

--- a/docs/user/reference/metrics/labeled_counters.md
+++ b/docs/user/reference/metrics/labeled_counters.md
@@ -334,4 +334,3 @@ accessibility:
 * Swift API docs: [`LabeledMetricType`](../../../swift/Classes/LabeledMetricType.html), [`CounterMetricType`](../../../swift/Classes/CounterMetricType.html)
 * Python API docs: [`LabeledCounterMetricType`](../../../python/glean/metrics/labeled.html#glean.metrics.labeled.LabeledCounterMetricType), [`CounterMetricType`](../../../python/glean/metrics/index.html#glean.metrics.CounterMetric)
 * Rust API docs: [`LabeledMetric`](../../../docs/glean/private/struct.LabeledMetric.html), [`CounterMetricType`](../../../docs/glean/private/struct.CounterMetric.html)
-* JavaScript API docs: [`LabeledMetricType`](https://mozilla.github.io/glean.js/classes/core_metrics_types_labeled.default.html), [`CounterMetricType`](https://mozilla.github.io/glean.js/classes/core_metrics_types_counter.default.html)

--- a/docs/user/reference/metrics/labeled_strings.md
+++ b/docs/user/reference/metrics/labeled_strings.md
@@ -307,4 +307,3 @@ login:
 * Swift API docs: [`LabeledMetricType`](../../../swift/Classes/LabeledMetricType.html), [`StringMetricType`](../../../swift/Classes/StringMetricType.html)
 * Python API docs: [`LabeledStringMetricType`](../../../python/glean/metrics/labeled.html#glean.metrics.labeled.LabeledStringMetricType), [`StringMetricType`](../../../python/glean/metrics/index.html#glean.metrics.StringMetricType)
 * Rust API docs: [`LabeledMetric`](../../../docs/glean/private/struct.LabeledMetric.html), [`StringMetricType`](../../../docs/glean/private/struct.StringMetric.html)
-* JavaScript API docs: [`LabeledMetricType`](https://mozilla.github.io/glean.js/classes/core_metrics_types_labeled.default.html), [`StringMetricType`](https://mozilla.github.io/glean.js/classes/core_metrics_types_string.default.html)

--- a/docs/user/reference/metrics/quantity.md
+++ b/docs/user/reference/metrics/quantity.md
@@ -316,4 +316,3 @@ Quantities have the required `unit` parameter, which is a free-form string for d
 * [Swift API docs](../../../swift/Classes/QuantityMetricType.html)
 * [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.QuantityMetric)
 * [Rust API docs](../../../docs/glean/private/quantity/struct.QuantityMetric.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_quantity.default.html#set)

--- a/docs/user/reference/metrics/string.md
+++ b/docs/user/reference/metrics/string.md
@@ -357,4 +357,3 @@ N/A
 * [Swift API docs](../../../swift/Classes/StringMetricType.html)
 * [Python API docs](../../../python/glean/metrics/string.html)
 * [Rust API docs](../../../docs/glean/private/struct.StringMetric.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_string.default.html#set)

--- a/docs/user/reference/metrics/timespan.md
+++ b/docs/user/reference/metrics/timespan.md
@@ -685,4 +685,3 @@ and use the largest possible value that will provide useful information so as to
 * [Swift API docs](../../../swift/Classes/TimespanMetricType.html)
 * [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.TimespanMetricType)
 * [Rust API docs](../../../docs/glean/private/struct.TimespanMetric.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_timespan.default.html)

--- a/docs/user/reference/metrics/url.md
+++ b/docs/user/reference/metrics/url.md
@@ -355,7 +355,3 @@ N/A
 ## Data questions
 
 * What is the base URL used to build the search query for the search engine?
-
-## Reference
-
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_url.default.html)

--- a/docs/user/reference/metrics/uuid.md
+++ b/docs/user/reference/metrics/uuid.md
@@ -422,4 +422,3 @@ N/A
 * [Swift API docs](../../../swift/Classes/UuidMetricType.html)
 * [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.UuidMetricType)
 * [Rust API docs](../../../docs/glean/private/uuid/struct.UuidMetric.html)
-* [JavaScript API docs](https://mozilla.github.io/glean.js/classes/core_metrics_types_uuid.default.html#set)


### PR DESCRIPTION
This PR
- Updates existing links to point to new gleanjs doc links that still exist
- Removes links to Javascript API docs that no longer exist.

In the future if we determine we need the JSDoc/API docs again we can find a new way to deploy them on a sub-route of the new docs