### PR TITLE
Bug 1906365 - Gradle plugin: support using an external venv.

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 283 utf-8
+personal_ws-1.1 en 284 utf-8
 AAR
 AARs
 ABI
@@ -271,6 +271,7 @@ urlbar
 validator
 vendored
 vendoring
+virtualenv
 walkthrough
 walkthroughs
 webextension

--- a/docs/user/language-bindings/android/android-build-configuration-options.md
+++ b/docs/user/language-bindings/android/android-build-configuration-options.md
@@ -80,3 +80,13 @@ ext.gleanExpireByVersion = 25
 Different products have different ways to compute the product version at build-time.
 For this reason the Glean Gradle plugin cannot provide an automated way to detect the product major version at build time.
 When using the expiration by version feature in Android, products must provide the major version by themselves.
+
+## `gleanPythonEnvDir`
+
+By default, the Glean Gradle plugin will manage its own Python virtualenv in `$gradleUserHomeDir/glean` to install `glean_parser`. By specifying a path in `ext.gleanPythonEnvDir` you can reuse an existing Python virtualenv.
+
+```groovy
+ext.gleanExpireByVersion = "$buildDir/externallyManagedVenv"
+```
+
+`glean_parser` must be available in that virtualenv, the Gradle plugin will make no attempt at installing it.

--- a/docs/user/language-bindings/android/android-offline-builds.md
+++ b/docs/user/language-bindings/android/android-offline-builds.md
@@ -10,7 +10,7 @@ To build a Glean-using application in offline mode, you can either:
 
 ### Provide an externally-managed virtualenv
 
-Set `ext.gleanPythonEnvDir` to your existing virtualenv before applying the plugin, see [`gleanPythonEnvDir`](./android-build-configuration-options.md#gleanPythonEnvDir).
+Set `ext.gleanPythonEnvDir` to your existing virtualenv before applying the plugin, see [`gleanPythonEnvDir`](./android-build-configuration-options.md#gleanpythonenvdir).
 
 ### Provide a Python interpreter and the required wheels
 

--- a/docs/user/language-bindings/android/android-offline-builds.md
+++ b/docs/user/language-bindings/android/android-offline-builds.md
@@ -6,7 +6,15 @@ The Glean Kotlin SDK uses a Python script, [`glean_parser`](https://github.com/m
 
 For offline builds, the Python environment, and packages of `glean_parser` and its dependencies must be provided prior to building the Glean-using application.
 
-To build a Glean-using application in offline mode, do the following:
+To build a Glean-using application in offline mode, you can either:
+
+### Provide an externally-managed virtualenv
+
+Set `ext.gleanPythonEnvDir` to your existing virtualenv before applying the plugin, see [`gleanPythonEnvDir`](./android-build-configuration-options.md#gleanPythonEnvDir).
+
+### Provide a Python interpreter and the required wheels
+
+In this mode Glean will setup its own virtualenv in `$gradleUserHomeDir/glean`, controlled by the `GLEAN_PYTHON` and `GLEAN_PYTHON_WHEELS_DIR` environment variables.
 
 - Install Python 3.8 or later and ensure it's on the `PATH`.
 

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -1,5 +1,5 @@
 This directory contains a Gradle plugin for build-time functionality,
 such as generating specific metrics and documentation.
 
-See `docs/user/adding-glean-to-your-project/index.md` for information about using this
+See `docs/user/user/adding-glean-to-your-project/index.md` for information about using this
 plugin.

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -560,11 +560,12 @@ except:
         // builds.
         println("Requires glean_parser ${parserVersion}")
 
-        File envDir = setupPythonEnvironmentTasks(project, parserVersion)
-        // Store in both gleanCondaDir (for backward compatibility reasons) and
-        // the more accurate gleanPythonEnvDir variables.
-        project.ext.set("gleanCondaDir", envDir)
-        project.ext.set("gleanPythonEnvDir", envDir)
+        if (!project.ext.has("gleanPythonEnvDir")) {
+            File envDir = setupPythonEnvironmentTasks(project, parserVersion)
+            project.ext.set("gleanPythonEnvDir", envDir)
+        }
+        // Also store in gleanCondaDir for backward compatibility reasons
+        project.ext.set("gleanCondaDir", project.ext.gleanPythonEnvDir)
 
         setupExtractMetricsFromAARTasks(project)
 
@@ -579,9 +580,9 @@ except:
         }
 
         if (project.android.hasProperty('applicationVariants')) {
-            project.android.applicationVariants.all(setupTasks(project, envDir, true, parserVersion))
+            project.android.applicationVariants.all(setupTasks(project, project.ext.gleanPythonEnvDir, true, parserVersion))
         } else {
-            project.android.libraryVariants.all(setupTasks(project, envDir, false, parserVersion))
+            project.android.libraryVariants.all(setupTasks(project, project.ext.gleanPythonEnvDir, false, parserVersion))
         }
     }
 }


### PR DESCRIPTION
mozilla-central uses a vendored copy of glean_parser except for the Android parts which currently download their own copy at build time through the Gradle plugin.

This provides a way to re-use an existing Python virtualenv, in the case of mozilla-central managed by mach, instead of setting up a bespoke one.

This has been tested locally and in [this Try run](https://treeherder.mozilla.org/jobs?repo=try&revision=fd0a81c9c14b1d9bad8e3656a4f564c3fcecdb08) where we can see that [the gradle-dependencies task](https://firefox-ci-tc.services.mozilla.com/tasks/cNe0bMCLSDi_bYCr3FNw7g) (using `gradle --online`) doesn't use Miniconda anymore and [the Android Searchfox task](https://firefox-ci-tc.services.mozilla.com/tasks/R6Rn09OBQ9-sqUblJdu_yA) (using `gradle --offline`) succeeds without supplying the glean_parser wheels.