### PR TITLE
Bug 1887023 - Prepare to remove `service-glean`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Update to Gradle v8.8 ([#2860](https://github.com/mozilla/glean/pull/2860))
   * Updated Kotlin to version 1.9.24 ([#2861](https://github.com/mozilla/glean/pull/2861))
   * Default-enable `delayPingLifetimeIo` ([#2863](https://github.com/mozilla/glean/issues/2863))
+  * Preparing Glean to be able to remove `service-glean` from Android Components ([#2891](https://github.com/mozilla/glean/pull/2891))
 
 # v60.3.0 (2024-05-31)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -540,7 +540,7 @@ open class GleanInternalAPI internal constructor() {
      * API synchronously.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun enableTestingMode() {
+    fun enableTestingMode() {
         this.setTestingMode(true)
     }
 
@@ -549,7 +549,7 @@ open class GleanInternalAPI internal constructor() {
      * This can be called by tests to change test mode on-the-fly.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun setTestingMode(enabled: Boolean) {
+    fun setTestingMode(enabled: Boolean) {
         this.testingMode = enabled
         gleanSetTestMode(enabled)
         Dispatchers.API.setTestingMode(enabled)
@@ -570,7 +570,7 @@ open class GleanInternalAPI internal constructor() {
      * @param uploadEnabled whether upload is enabled
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun resetGlean(
+    fun resetGlean(
         context: Context,
         config: Configuration,
         clearStores: Boolean,
@@ -626,7 +626,7 @@ open class GleanInternalAPI internal constructor() {
      * @param port the local address to send pings to
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun testSetLocalEndpoint(port: Int) {
+    fun testSetLocalEndpoint(port: Int) {
         Glean.enableTestingMode()
 
         isSendingToTestEndpoint = true
@@ -644,7 +644,7 @@ open class GleanInternalAPI internal constructor() {
      * @param dataPath The path to the data folder. Must be set if `clearStores` is `true`.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun testDestroyGleanHandle(clearStores: Boolean = false, dataPath: String? = null) {
+    fun testDestroyGleanHandle(clearStores: Boolean = false, dataPath: String? = null) {
         // If it was initialized this also clears the directory
         gleanTestDestroyGlean(clearStores, dataPath)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/HistogramBase.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/HistogramBase.kt
@@ -22,3 +22,9 @@ interface HistogramBase {
      */
     fun accumulateSamples(samples: List<Long>)
 }
+
+// glean_parser template currently expects `HistogramMetricBase` as the name
+// and since this alias was defined in `service-glean` in android-components,
+// we need to keep the alias until the parser template is updated also.
+// See Bug 1906941 for more information.
+typealias HistogramMetricBase = mozilla.telemetry.glean.private.HistogramBase


### PR DESCRIPTION
In order to remove `service-glean` we need to first add an alias to accommodate glean_parser. We also need to make a few functions public so that they can be accessed by consumers.