### PR TITLE
New object metric in samples to ensure we generate valid code

### DIFF
--- a/samples/android/app/metrics.yaml
+++ b/samples/android/app/metrics.yaml
@@ -198,3 +198,20 @@ party:
             type: string
           diameter:
             type: number
+  animals:
+    type: object
+    description: >
+      Contains a list of party animals
+    notification_emails:
+      - CHANGE-ME@example.com
+    bugs:
+      - https://bugzilla.mozilla.org/TODO
+    data_reviews:
+      - http://example.com/reviews
+    data_sensitivity:
+      - technical
+    expires: never
+    structure:
+      type: array
+      items:
+        type: string

--- a/samples/android/app/src/main/java/org/mozilla/samples/gleancore/MainActivity.kt
+++ b/samples/android/app/src/main/java/org/mozilla/samples/gleancore/MainActivity.kt
@@ -52,6 +52,11 @@ open class MainActivity : AppCompatActivity() {
             balloons.add(Party.BalloonsObjectItem(colour = "green"))
             Party.balloons.set(balloons)
 
+            val animals = Party.AnimalsObject()
+            animals.add("Dog")
+            animals.add("Cat")
+            Party.animals.set(animals)
+
             // This is referencing the event ping named 'click' from the metrics.yaml file. In
             // order to illustrate adding extra information to the event, it is also adding to the
             // 'extras' field a dictionary of values.  Note that the dictionary keys must be

--- a/samples/ios/app/glean-sample-app/ViewController.swift
+++ b/samples/ios/app/glean-sample-app/ViewController.swift
@@ -63,6 +63,11 @@ class ViewController: UIViewController {
         balloons.append(Party.BalloonsObjectItem(colour: "green"))
         Party.balloons.set(balloons)
 
+        var animals: Party.AnimalsObject = []
+        animals.append("Dog")
+        animals.append("Cat")
+        Party.animals.set(animals)
+
         // This is referencing the event ping named 'click' from the metrics.yaml file. In
         // order to illustrate adding extra information to the event, it is also adding to the
         // 'extras' field a dictionary of values.  Note that the dictionary keys must be

--- a/samples/ios/app/metrics.yaml
+++ b/samples/ios/app/metrics.yaml
@@ -187,3 +187,21 @@ party:
             type: string
           diameter:
             type: number
+
+  animals:
+    type: object
+    description: >
+      Contains a list of party animals
+    notification_emails:
+      - CHANGE-ME@example.com
+    bugs:
+      - https://bugzilla.mozilla.org/TODO
+    data_reviews:
+      - http://example.com/reviews
+    data_sensitivity:
+      - technical
+    expires: never
+    structure:
+      type: array
+      items:
+        type: string


### PR DESCRIPTION
This was broken in an older glean_parser.

---

~~glean_parser changes pending before this can land.~~