### PR TITLE
Swift: Use String(decoding:as:) to directly decode the UTF8 bytes

### DIFF
--- a/glean-core/ios/Glean/Metrics/ObjectMetric.swift
+++ b/glean-core/ios/Glean/Metrics/ObjectMetric.swift
@@ -13,7 +13,7 @@ extension Array: ObjectSerialize where Element: Codable {
     public func intoSerializedObject() -> String {
         let jsonEncoder = JSONEncoder()
         let jsonData = try! jsonEncoder.encode(self)
-        let json = String(data: jsonData, encoding: String.Encoding.utf8)!
+        let json = String(decoding: jsonData, as: UTF8.self)
         return json
     }
 }

--- a/glean-core/ios/GleanTests/TestUtils.swift
+++ b/glean-core/ios/GleanTests/TestUtils.swift
@@ -104,9 +104,7 @@ func tearDownStubs() {
 func JSONStringify(_ json: Any) -> String {
     do {
         let data = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-        if let string = String(data: data, encoding: String.Encoding.utf8) {
-            return string
-        }
+        return String(decoding: data, as: UTF8.self)
     } catch {
         print(error)
     }


### PR DESCRIPTION
This is otherwise a `non_optional_string_data_conversion` swiftlint warning (in swiftlint 0.55.1 at least, we might be using a different swiftlint in CI right now).
