### PR TITLE
Bug 1909246 - Set the default pre-init task queue size to 1 million tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Make auto-flush behavior configurable and time-based ([#2871](https://github.com/mozilla/glean/pull/2871))
 * Android
   * Update to Gradle v8.9 ([#2909](https://github.com/mozilla/glean/pull/2909))
+* Rust
+  * Remove cargo feature `preinit_million_queue` and set the default pre-init queue size to 10^6 for all consumers([Bug 1909246](https://bugzilla.mozilla.org/show_bug.cgi?id=1909246))
 
 # v60.4.0 (2024-07-23)
 

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -16,7 +16,7 @@ application start using Glean.
 ## Behavior when uninitialized
 
 Any API called before Glean is initialized is queued and applied at initialization.
-To avoid unbounded memory growth the queue is bounded (currently to a maximum of 100 tasks),
+To avoid unbounded memory growth the queue is bounded (currently to a maximum of 1 million tasks),
 and further calls are dropped.
 
 The number of calls dropped, if any,

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -60,7 +60,5 @@ ctor = "0.2.2"
 uniffi = { version = "0.27.0", default-features = false, features = ["build"] }
 
 [features]
-# Increases the preinit queue limit to 10^6
-preinit_million_queue = []
 # Enable `env_logger`. Only works on non-Android non-iOS targets.
 enable_env_logger = ["env_logger"]

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -633,6 +633,7 @@ class GleanTest {
     }
 
     @Test
+    @Ignore("oops, long running test see Bug 1911350 for more info")
     fun `overflowing the task queue records telemetry`() {
         delayMetricsPing(context)
         val server = getMockWebServer()
@@ -651,7 +652,7 @@ class GleanTest {
             ),
         )
 
-        repeat(1010) {
+        repeat(1000010) {
             counterMetric.add()
         }
 
@@ -684,7 +685,7 @@ class GleanTest {
         )
         assertEquals(
             "Ping payload: $jsonContent",
-            1000,
+            1000000,
             counters.getInt("telemetry.repeatedly"),
         )
     }

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -40,8 +40,5 @@ libc = "0.2"
 serde_json = "1.0.44"
 tempfile = "3.1.0"
 
-[features]
-preinit_million_queue = ["glean-core/preinit_million_queue"]
-
 [[example]]
 name = "ping-lifetime-flush"

--- a/glean-core/rlb/tests/overflowing_preinit.rs
+++ b/glean-core/rlb/tests/overflowing_preinit.rs
@@ -54,6 +54,7 @@ mod metrics {
 /// The pre-init dispatcher queue records how many recordings over the limit it saw.
 ///
 /// This is an integration test to avoid dealing with resetting the dispatcher.
+#[ignore] // oops, long running test see Bug 1911350 for more info
 #[test]
 fn overflowing_the_task_queue_records_telemetry() {
     common::enable_test_logging();
@@ -67,14 +68,14 @@ fn overflowing_the_task_queue_records_telemetry() {
         .build();
 
     // Insert a bunch of tasks to overflow the queue.
-    for _ in 0..1010 {
+    for _ in 0..1000010 {
         metrics::rapid_counting.add(1);
     }
 
     // Now initialize Glean
     common::initialize(cfg);
 
-    assert_eq!(Some(1000), metrics::rapid_counting.test_get_value(None));
+    assert_eq!(Some(1000000), metrics::rapid_counting.test_get_value(None));
 
     // The metrics counts the total number of overflowing tasks,
     // (and the count of tasks in the queue when we overflowed: bug 1764573)

--- a/glean-core/src/dispatcher/global.rs
+++ b/glean-core/src/dispatcher/global.rs
@@ -11,10 +11,7 @@ use std::time::Duration;
 use super::{DispatchError, DispatchGuard, Dispatcher};
 use crossbeam_channel::RecvTimeoutError;
 
-#[cfg(feature = "preinit_million_queue")]
 pub const GLOBAL_DISPATCHER_LIMIT: usize = 1000000;
-#[cfg(not(feature = "preinit_million_queue"))]
-pub const GLOBAL_DISPATCHER_LIMIT: usize = 1000;
 
 static GLOBAL_DISPATCHER: Lazy<RwLock<Option<Dispatcher>>> =
     Lazy::new(|| RwLock::new(Some(Dispatcher::new(GLOBAL_DISPATCHER_LIMIT))));


### PR DESCRIPTION
This also removes the associated Rust feature: `preinit_million_queue`. This feature was previously used to conditionally compile with the 1 million task queue size only when building for gecko.