### PR TITLE
Bug 1787234 - Fix `GleanTestLocalServer` test rule leaking between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Make auto-flush behavior configurable and time-based ([#2871](https://github.com/mozilla/glean/pull/2871))
 * Android
   * Update to Gradle v8.9 ([#2909](https://github.com/mozilla/glean/pull/2909))
+  * Fixed `GleanTestLocalServer` test rule to prevent leaking between tests([Bug 1787234](https://bugzilla.mozilla.org/show_bug.cgi?id=1787234))
 * Rust
   * Remove cargo feature `preinit_million_queue` and set the default pre-init queue size to 10^6 for all consumers([Bug 1909246](https://bugzilla.mozilla.org/show_bug.cgi?id=1909246))
 


### PR DESCRIPTION
This adds an override for the `TestWatcher` `finished` method that ensures that the underlying `WorkManager` executor is properly terminated, and then closes the `WorkManager` database.