### PR TITLE
Bug 1910449 - Use daemon-threads with the MPS timer instead of the default user-threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v61.0.0...main)
 
+* Kotlin
+  * Change Metrics Ping Scheduler to use daemon threads ([#2930](https://github.com/mozilla/glean/pull/2930))
+
 # v61.0.0 (2024-08-21)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v60.5.0...v61.0.0)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Dispatchers.kt
@@ -6,7 +6,6 @@ package mozilla.telemetry.glean
 
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -83,8 +83,7 @@ internal class OnGleanEventsImpl(val glean: GleanInternalAPI) : OnGleanEvents {
     }
 
     override fun cancelUploads() {
-        // Cancel any pending workers here so that we don't accidentally upload or
-        // collect data after the upload has been disabled.
+        // Cancel any pending metrics ping scheduler tasks
         glean.metricsPingScheduler?.cancel()
         // Cancel any pending workers here so that we don't accidentally upload
         // data after the upload has been disabled.


### PR DESCRIPTION
Changing the MPS `java.util.Timer` to use daemon-threads instead of the default user-threads because user-threads can potentially prevent the application from terminating properly since the OS requires all user-threads to be joined before the app can terminate. Daemon-threads are terminated by the OS once all user-threads have completed and are not awaited before the application can terminate.