### PR TITLE
Bug 1913578 - CI: Update node in use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -989,7 +989,7 @@ jobs:
       - checkout
       - run:
           name: Install linkchecker
-          command: npm install -g link-checker
+          command: npm install link-checker
       - attach_workspace:
           at: build/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1038,8 +1038,8 @@ jobs:
           command: |
             git config user.email "jrediger@mozilla.com"
             git config user.name "CircleCI docs-deploy job"
-            npm install -g --silent gh-pages@2.0.1
-            gh-pages --dotfiles --message "[skip ci] Updates" --dist build/docs
+            npm install gh-pages@6.1.1
+            npx gh-pages --dotfiles --message "[skip ci] Updates" --dist build/docs
 
 ###########################################################################
 # Workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,7 +984,7 @@ jobs:
 
   docs-linkcheck:
     docker:
-      - image: cimg/node:17.9
+      - image: cimg/node:22.6
     steps:
       - checkout
       - run:
@@ -1015,7 +1015,7 @@ jobs:
   # via https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
   docs-deploy:
     docker:
-      - image: node:8.10.0
+      - image: cimg/node:22.6
     steps:
       - checkout
       - attach_workspace:

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ linkcheck: docs linkcheck-raw  ## Run link-checker on the generated docs
 
 linkcheck-raw:
 	# Requires https://www.npmjs.com/package/link-checker
-	link-checker \
+	npx link-checker \
 		build/docs \
     --disable-external true \
     --allow-hash-href true \


### PR DESCRIPTION
Hopefully this fixes an issue with a transitive dependency of link-checker when run on Node 17 While at it we also  drop an ancient version of Node used for docs deploy.