### PR TITLE
docs(metrics): remove wrong copy paste doc comment

### DIFF
--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -13,8 +13,6 @@ use crate::CommonMetricData;
 use crate::Glean;
 
 /// A custom distribution metric.
-///
-/// Memory distributions are used to accumulate and store memory sizes.
 #[derive(Clone, Debug)]
 pub struct CustomDistributionMetric {
     meta: Arc<CommonMetricDataInternal>,


### PR DESCRIPTION
Presumably copy pasted from:

https://github.com/mozilla/glean/blob/c7118eea672938e215ebe38801d275047014f0fc/glean-core/src/metrics/memory_distribution.rs#L26-L28