### PR TITLE
feature request: local metric handle synced on `Drop`

### DIFF
--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -269,4 +269,29 @@ impl CustomDistributionMetric {
             test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
     }
+
+    /// Returns a thread-local handle to this [`CustomDistribution`]. See
+    /// [`LocalCustomDistribution`] docs.
+    pub fn local(&self) -> LocalCustomDistribution {
+        todo!()
+    }
+}
+
+/// A thread-local handle to a [`CustomDistribution`] syncing all accumulated
+/// samples to its global [`CustomDistribution`] on [`Drop::drop`].
+pub struct LocalCustomDistribution {}
+
+impl LocalCustomDistribution {
+    /// Accumulate a single sample to this [`LocalCustomDistribution`]. Note
+    /// that the value is only synced to the global instance on [`Drop::drop`]
+    /// of [`LocalCustomDistribution`].
+    pub fn accumulate_single_sample(&mut self, value: i64) {
+        todo!();
+    }
+}
+
+impl Drop for LocalCustomDistribution {
+    fn drop(&mut self) {
+        todo!("sync accumulated samples to global instance.")
+    }
 }


### PR DESCRIPTION
As part of the larger [Fast UDP IO for Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1901292) project, I would like to record the size of each UDP datagram send and received. See [Bugzilla 1906853](https://bugzilla.mozilla.org/show_bug.cgi?id=1906853) for details.

My first (naive) approach was to use two `MemoryDistribution` metrics. Note for the sake of genericity, I will proceed with the more generic `CustomDistribution` below.

Increasing a Glean metric in Firefox's HTTP/3 QUIC IO hot path decreases performance significantly. See local testing described in [this comment](https://phabricator.services.mozilla.com/D216034#7453056), where instrumentation alone takes ~2.7% of the CPU time.

To build an intuition: say that we have a 100 Mbit/s transfer, the metric would be increased 8738 times per second.

This has also been discussed in the Glean matrix room:

https://matrix.to/#/!SCdsJdSTaQHjzEVrAE:mozilla.org/$5Oc8Tj8fiuYuNNE37NL3ZfSiNqVfTiRSi6V4OGiC6dI?via=mozilla.org&via=matrix.org&via=abolivier.bzh

A solution that I can think of is a thread-local handle to a Glean metric, that is only synchronized with its global parent on `Drop`, e.g. in my case, on closing of the HTTP/3 QUIC connection.

I sketched this idea in this commit. Before I continue down this road, I would like to hear from you as Glean experts. Is this a good approach? Can you think of a better one?