### PR TITLE
Bug 1915744 - Rust sample: Add an event metric without extra keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "glean-build"
-version = "15.0.0"
+version = "15.0.1"
 dependencies = [
  "tempfile",
  "xshell-venv",

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 rust-version = "1.76"
 
 [package.metadata.glean]
-glean-parser = "15.0.0"
+glean-parser = "15.0.1"
 
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "main" }

--- a/glean-core/build/Cargo.toml
+++ b/glean-core/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-build"
-version = "15.0.0"
+version = "15.0.1"
 edition = "2021"
 description = "Glean SDK Rust build helper"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/build/src/lib.rs
+++ b/glean-core/build/src/lib.rs
@@ -39,7 +39,7 @@ use std::env;
 
 use xshell_venv::{Result, Shell, VirtualEnv};
 
-const GLEAN_PARSER_VERSION: &str = "15.0.0";
+const GLEAN_PARSER_VERSION: &str = "15.0.1";
 
 /// A Glean Rust bindings generator.
 pub struct Builder {

--- a/glean-core/python/glean/__init__.py
+++ b/glean-core/python/glean/__init__.py
@@ -30,7 +30,7 @@ __author__ = "The Glean Team"
 __email__ = "glean-team@mozilla.com"
 
 
-GLEAN_PARSER_VERSION = "15.0.0"
+GLEAN_PARSER_VERSION = "15.0.1"
 parser_version = VersionInfo.parse(GLEAN_PARSER_VERSION)
 parser_version_next_major = parser_version.bump_major()
 

--- a/samples/rust/metrics.yaml
+++ b/samples/rust/metrics.yaml
@@ -68,6 +68,10 @@ test.metrics:
       - aLabel
       - 2label
 
+  sample_event_no_keys:
+    <<: *defaults
+    type: event
+
   sample_event:
     <<: *defaults
     type: event


### PR DESCRIPTION
glean_parser generated the wrong code for this, so this acts as a regression test.

requires https://github.com/mozilla/glean_parser/pull/750