### PR TITLE
Doc formatting: Address overly long paragraphs

### DIFF
--- a/glean-core/src/error_recording.rs
+++ b/glean-core/src/error_recording.rs
@@ -23,6 +23,7 @@ use crate::Glean;
 use crate::Lifetime;
 
 /// The possible error types for metric recording.
+///
 /// Note: the cases in this enum must be kept in sync with the ones
 /// in the platform-specific code (e.g. `ErrorType.kt`) and with the
 /// metrics in the registry files.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -700,7 +700,9 @@ pub fn shutdown() {
     });
 }
 
-/// Asks the database to persist ping-lifetime data to disk. Probably expensive to call.
+/// Asks the database to persist ping-lifetime data to disk.
+///
+/// Probably expensive to call.
 /// Only has effect when Glean is configured with `delay_ping_lifetime_io: true`.
 /// If Glean hasn't been initialized this will dispatch and return Ok(()),
 /// otherwise it will block until the persist is done and return its Result.

--- a/glean-core/src/metrics/remote_settings_config.rs
+++ b/glean-core/src/metrics/remote_settings_config.rs
@@ -7,9 +7,11 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 /// Represents a list of metrics and an associated boolean property
-/// indicating if the metric is enabledfrom the remote-settings
-/// configuration store. The expected format of this data is stringified JSON
-/// in the following format:
+/// indicating if the metric is enabled from the remote-settings
+/// configuration store.
+///
+/// The expected format of this data is stringified JSON in the following format:
+///
 /// ```json
 /// {
 ///     "category.metric_name": true


### PR DESCRIPTION
These now get caught in Rust beta.

[doc only]