### PR TITLE
Small fixes to the iOS build

### DIFF
--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -21,7 +21,6 @@ if [[ -n "${DEVELOPER_SDK_DIR:-}" ]]; then
 #  # In this case, we need to add an extra library search path for build scripts and proc-macros,
 #  # which run on the host instead of the target.
 #  # (macOS Big Sur does not have linkable libraries in /usr/lib/.)
-  local libpath
   libpath="${DEVELOPER_SDK_DIR}/MacOSX.sdk/usr/lib"
   export LIBRARY_PATH="${libpath}:${LIBRARY_PATH:-}"
 fi

--- a/glean-core/ios/Glean/Metrics/ObjectMetric.swift
+++ b/glean-core/ios/Glean/Metrics/ObjectMetric.swift
@@ -13,7 +13,7 @@ extension Array: ObjectSerialize where Element: Codable {
     public func intoSerializedObject() -> String {
         let jsonEncoder = JSONEncoder()
         let jsonData = try! jsonEncoder.encode(self)
-        let json = String(decoding: jsonData, as: UTF8.self)
+        let json = String(data: jsonData, encoding: String.Encoding.utf8)!
         return json
     }
 }

--- a/glean-core/ios/GleanTests/TestUtils.swift
+++ b/glean-core/ios/GleanTests/TestUtils.swift
@@ -104,7 +104,9 @@ func tearDownStubs() {
 func JSONStringify(_ json: Any) -> String {
     do {
         let data = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-        return String(decoding: data, as: UTF8.self)
+        if let string = String(data: data, encoding: String.Encoding.utf8) {
+            return string
+        }
     } catch {
         print(error)
     }


### PR DESCRIPTION
This will actually likely currently fail on CI, because the `swiftlint` we use there is older?
I have swiftlint 0.57 locally.

We might wanna update that check to Xcode 16 soon.