### PR TITLE
Docs: Give correct number of allowed static lables

### DIFF
--- a/docs/user/_includes/labels-parameter.md
+++ b/docs/user/_includes/labels-parameter.md
@@ -6,7 +6,7 @@ The labels in this list must match the following requirements:
 * Conform to the [label format](index.md#label-format).
 * Each label must have a maximum of 71 characters.
 * Each label must only contain printable ASCII characters.
-* This list itself is limited to 100 labels.
+* This list itself is limited to 4096 labels.
 
 {{#include ../../shared/blockquote-warning.html}}
 


### PR DESCRIPTION
This limit was raised to 4096 back in 2022 already (bug 1772163)

[doc only]