### PR TITLE
Allow client_info section to be reduced

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -54,6 +54,7 @@ class PingType<ReasonCodesEnum> (
     enabled: Boolean,
     val schedulesPings: List<String>,
     val reasonCodes: List<String>,
+    includedInfoSections: List<String> = emptyList(),
 ) where ReasonCodesEnum : Enum<ReasonCodesEnum>, ReasonCodesEnum : ReasonCode {
     private var testCallback: ((ReasonCodesEnum?) -> Unit)? = null
     private val innerPing: GleanPingType
@@ -65,9 +66,10 @@ class PingType<ReasonCodesEnum> (
             sendIfEmpty = sendIfEmpty,
             preciseTimestamps = preciseTimestamps,
             includeInfoSections = includeInfoSections,
+            enabled = enabled,
             schedulesPings = schedulesPings,
             reasonCodes = reasonCodes,
-            enabled = enabled,
+            includedInfoSections = includedInfoSections,
         )
     }
 

--- a/glean-core/rlb/examples/crashing-threads.rs
+++ b/glean-core/rlb/examples/crashing-threads.rs
@@ -87,8 +87,19 @@ pub mod glean_metrics {
 }
 
 #[allow(non_upper_case_globals)]
-pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, true, true, vec![], vec![]));
+pub static PrototypePing: Lazy<PingType> = Lazy::new(|| {
+    PingType::new(
+        "prototype",
+        true,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    )
+});
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/examples/delayed-ping-data.rs
+++ b/glean-core/rlb/examples/delayed-ping-data.rs
@@ -74,8 +74,19 @@ impl net::PingUploader for MovingUploader {
 }
 
 #[allow(non_upper_case_globals)]
-pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, false, true, true, vec![], vec![]));
+pub static PrototypePing: Lazy<PingType> = Lazy::new(|| {
+    PingType::new(
+        "prototype",
+        true,
+        true,
+        false,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    )
+});
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/examples/long-running.rs
+++ b/glean-core/rlb/examples/long-running.rs
@@ -40,8 +40,19 @@ impl net::PingUploader for FakeUploader {
 }
 
 #[allow(non_upper_case_globals)]
-pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, true, true, true, vec![], vec![]));
+pub static PrototypePing: Lazy<PingType> = Lazy::new(|| {
+    PingType::new(
+        "prototype",
+        true,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    )
+});
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/examples/ping-lifetime-flush.rs
+++ b/glean-core/rlb/examples/ping-lifetime-flush.rs
@@ -75,8 +75,19 @@ impl net::PingUploader for MovingUploader {
 }
 
 #[allow(non_upper_case_globals)]
-pub static PrototypePing: Lazy<PingType> =
-    Lazy::new(|| PingType::new("prototype", true, true, false, true, true, vec![], vec![]));
+pub static PrototypePing: Lazy<PingType> = Lazy::new(|| {
+    PingType::new(
+        "prototype",
+        true,
+        true,
+        false,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    )
+});
 
 fn main() {
     env_logger::init();

--- a/glean-core/rlb/src/private/ping.rs
+++ b/glean-core/rlb/src/private/ping.rs
@@ -44,6 +44,7 @@ impl PingType {
         enabled: bool,
         schedules_pings: Vec<String>,
         reason_codes: Vec<String>,
+        included_info_sections: Vec<String>,
     ) -> Self {
         let inner = glean_core::metrics::PingType::new(
             name.into(),
@@ -54,6 +55,7 @@ impl PingType {
             enabled,
             schedules_pings,
             reason_codes,
+            included_info_sections,
         );
 
         Self {

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -297,7 +297,7 @@ enum ErrorType {
 };
 
 interface PingType {
-    constructor(string name, boolean include_client_id, boolean send_if_empty, boolean precise_timestamps, boolean include_info_sections, boolean enabled, sequence<string> schedules_pings, sequence<string> reason_codes);
+    constructor(string name, boolean include_client_id, boolean send_if_empty, boolean precise_timestamps, boolean include_info_sections, boolean enabled, sequence<string> schedules_pings, sequence<string> reason_codes, sequence<string> included_info_sections);
     void submit(optional string? reason = null);
 };
 

--- a/glean-core/src/internal_pings.rs
+++ b/glean-core/src/internal_pings.rs
@@ -34,6 +34,7 @@ impl InternalPings {
                     "dirty_startup".to_string(),
                     "inactive".to_string(),
                 ],
+                vec![],
             ),
             metrics: PingType::new(
                 "metrics",
@@ -50,6 +51,7 @@ impl InternalPings {
                     "tomorrow".to_string(),
                     "upgrade".to_string(),
                 ],
+                vec![],
             ),
             events: PingType::new(
                 "events",
@@ -64,6 +66,7 @@ impl InternalPings {
                     "inactive".to_string(),
                     "max_capacity".to_string(),
                 ],
+                vec![],
             ),
             deletion_request: PingType::new(
                 "deletion-request",
@@ -74,6 +77,7 @@ impl InternalPings {
                 true, // The deletion-request should not be disabled
                 vec![],
                 vec!["at_init".to_string(), "set_upload_enabled".to_string()],
+                vec![],
             ),
         }
     }

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -1187,6 +1187,7 @@ fn disabled_pings_are_not_submitted() {
         false,
         vec![],
         vec![],
+        vec![],
     );
     glean.register_ping_type(&ping);
 
@@ -1239,6 +1240,7 @@ fn pings_are_controllable_from_remote_settings_config() {
         false,
         vec![],
         vec![],
+        vec![],
     );
     glean.register_ping_type(&disabled_ping);
     let enabled_ping = PingType::new(
@@ -1248,6 +1250,7 @@ fn pings_are_controllable_from_remote_settings_config() {
         true,
         true,
         true,
+        vec![],
         vec![],
         vec![],
     );

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -35,6 +35,9 @@ struct InnerPing {
     pub schedules_pings: Vec<String>,
     /// The "reason" codes that this ping can send
     pub reason_codes: Vec<String>,
+    /// The list of client info fields that will be included.
+    /// When empty all fields are included.
+    pub included_info_sections: Vec<String>,
 }
 
 impl fmt::Debug for PingType {
@@ -48,6 +51,7 @@ impl fmt::Debug for PingType {
             .field("enabled", &self.0.enabled)
             .field("schedules_pings", &self.0.schedules_pings)
             .field("reason_codes", &self.0.reason_codes)
+            .field("included_info_sections", &self.0.included_info_sections)
             .finish()
     }
 }
@@ -80,6 +84,7 @@ impl PingType {
         enabled: bool,
         schedules_pings: Vec<String>,
         reason_codes: Vec<String>,
+        included_info_sections: Vec<String>,
     ) -> Self {
         Self::new_internal(
             name,
@@ -90,6 +95,7 @@ impl PingType {
             enabled,
             schedules_pings,
             reason_codes,
+            included_info_sections,
         )
     }
 
@@ -103,6 +109,7 @@ impl PingType {
         enabled: bool,
         schedules_pings: Vec<String>,
         reason_codes: Vec<String>,
+        included_info_sections: Vec<String>,
     ) -> Self {
         let this = Self(Arc::new(InnerPing {
             name: name.into(),
@@ -113,6 +120,7 @@ impl PingType {
             enabled,
             schedules_pings,
             reason_codes,
+            included_info_sections,
         }));
 
         // Register this ping.
@@ -128,6 +136,10 @@ impl PingType {
 
     pub(crate) fn include_client_id(&self) -> bool {
         self.0.include_client_id
+    }
+
+    pub(crate) fn included_info_sections(&self) -> &[String] {
+        &self.0.included_info_sections
     }
 
     pub(crate) fn send_if_empty(&self) -> bool {

--- a/glean-core/src/upload/directory.rs
+++ b/glean-core/src/upload/directory.rs
@@ -337,7 +337,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, true, true, vec![], vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, true, vec![], vec![], vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory
@@ -364,7 +364,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, true, true, vec![], vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, true, vec![], vec![], vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory
@@ -400,7 +400,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
 
         // Register a ping for testing
-        let ping_type = PingType::new("test", true, true, true, true, true, vec![], vec![]);
+        let ping_type = PingType::new("test", true, true, true, true, true, vec![], vec![], vec![]);
         glean.register_ping_type(&ping_type);
 
         // Submit the ping to populate the pending_pings directory

--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -1034,6 +1034,7 @@ mod test {
             true,
             vec![],
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1075,6 +1076,7 @@ mod test {
             true,
             vec![],
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1112,6 +1114,7 @@ mod test {
             true,
             true,
             true,
+            vec![],
             vec![],
             vec![],
         );
@@ -1153,6 +1156,7 @@ mod test {
             true,
             vec![],
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1190,6 +1194,7 @@ mod test {
             true,
             true,
             true,
+            vec![],
             vec![],
             vec![],
         );
@@ -1231,6 +1236,7 @@ mod test {
             true,
             true,
             true,
+            vec![],
             vec![],
             vec![],
         );
@@ -1350,6 +1356,7 @@ mod test {
             true,
             vec![],
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1425,6 +1432,7 @@ mod test {
             true,
             vec![],
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1482,6 +1490,7 @@ mod test {
             true,
             true,
             true,
+            vec![],
             vec![],
             vec![],
         );
@@ -1562,6 +1571,7 @@ mod test {
             true,
             true,
             true,
+            vec![],
             vec![],
             vec![],
         );
@@ -1645,6 +1655,7 @@ mod test {
             true,
             vec![],
             vec![],
+            vec![],
         );
         glean.register_ping_type(&ping_type);
 
@@ -1726,6 +1737,7 @@ mod test {
             true,
             true,
             true,
+            vec![],
             vec![],
             vec![],
         );

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -172,6 +172,7 @@ fn test_sending_of_event_ping_when_it_fills_up() {
             true,
             vec![],
             vec!["max_capacity".to_string()],
+            vec![],
         ));
     }
 
@@ -239,6 +240,7 @@ fn test_server_knobs_config_changing_max_events() {
             true,
             vec![],
             vec!["max_capacity".to_string()],
+            vec![],
         ));
     }
 
@@ -533,6 +535,7 @@ fn event_storage_trimming() {
             true,
             true,
             true,
+            vec![],
             vec![],
             vec![],
         ));

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -16,7 +16,17 @@ use glean_core::Lifetime;
 fn write_ping_to_disk() {
     let (mut glean, _temp) = new_glean(None);
 
-    let ping = PingType::new("metrics", true, false, true, true, true, vec![], vec![]);
+    let ping = PingType::new(
+        "metrics",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -37,7 +47,17 @@ fn write_ping_to_disk() {
 fn disabling_upload_clears_pending_pings() {
     let (mut glean, _t) = new_glean(None);
 
-    let ping = PingType::new("metrics", true, false, true, true, true, vec![], vec![]);
+    let ping = PingType::new(
+        "metrics",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -106,7 +126,17 @@ fn deletion_request_only_when_toggled_from_on_to_off() {
 fn empty_pings_with_flag_are_sent() {
     let (mut glean, _t) = new_glean(None);
 
-    let ping1 = PingType::new("custom-ping1", true, true, true, true, true, vec![], vec![]);
+    let ping1 = PingType::new(
+        "custom-ping1",
+        true,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping1);
     let ping2 = PingType::new(
         "custom-ping2",
@@ -115,6 +145,7 @@ fn empty_pings_with_flag_are_sent() {
         true,
         true,
         true,
+        vec![],
         vec![],
         vec![],
     );
@@ -151,10 +182,30 @@ fn test_pings_submitted_metric() {
         None,
     );
 
-    let metrics_ping = PingType::new("metrics", true, false, true, true, true, vec![], vec![]);
+    let metrics_ping = PingType::new(
+        "metrics",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&metrics_ping);
 
-    let baseline_ping = PingType::new("baseline", true, false, true, true, true, vec![], vec![]);
+    let baseline_ping = PingType::new(
+        "baseline",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&baseline_ping);
 
     // We need to store a metric as an empty ping is not stored.
@@ -230,7 +281,17 @@ fn test_pings_submitted_metric() {
 fn events_ping_with_metric_but_no_events_is_not_sent() {
     let (mut glean, _t) = new_glean(None);
 
-    let events_ping = PingType::new("events", true, true, true, true, true, vec![], vec![]);
+    let events_ping = PingType::new(
+        "events",
+        true,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&events_ping);
     let counter = CounterMetric::new(CommonMetricData {
         name: "counter".into(),
@@ -264,7 +325,17 @@ fn events_ping_with_metric_but_no_events_is_not_sent() {
 fn test_scheduled_pings_are_sent() {
     let (mut glean, _t) = new_glean(None);
 
-    let piggyback_ping = PingType::new("piggyback", true, true, true, true, true, vec![], vec![]);
+    let piggyback_ping = PingType::new(
+        "piggyback",
+        true,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&piggyback_ping);
 
     let trigger_ping = PingType::new(
@@ -275,6 +346,7 @@ fn test_scheduled_pings_are_sent() {
         true,
         true,
         vec!["piggyback".into()],
+        vec![],
         vec![],
     );
     glean.register_ping_type(&trigger_ping);
@@ -287,7 +359,17 @@ fn test_scheduled_pings_are_sent() {
 fn database_write_timings_get_recorded() {
     let (mut glean, _t) = new_glean(None);
 
-    let metrics_ping = PingType::new("metrics", true, false, true, true, true, vec![], vec![]);
+    let metrics_ping = PingType::new(
+        "metrics",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&metrics_ping);
 
     // We need to store a metric to record something.

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -13,7 +13,17 @@ fn set_up_basic_ping() -> (Glean, PingMaker, PingType, tempfile::TempDir) {
     let (tempdir, _) = tempdir();
     let (mut glean, t) = new_glean(Some(tempdir));
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, true, true, vec![], vec![]);
+    let ping_type = PingType::new(
+        "store1",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -98,7 +108,17 @@ fn test_metrics_must_report_experimentation_id() {
     })
     .unwrap();
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, true, true, vec![], vec![]);
+    let ping_type = PingType::new(
+        "store1",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -155,7 +175,17 @@ fn experimentation_id_is_removed_if_send_if_empty_is_false() {
     .unwrap();
     let ping_maker = PingMaker::new();
 
-    let unknown_ping_type = PingType::new("unknown", true, false, true, true, true, vec![], vec![]);
+    let unknown_ping_type = PingType::new(
+        "unknown",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&unknown_ping_type);
 
     assert!(ping_maker
@@ -171,7 +201,17 @@ fn collect_must_report_none_when_no_data_is_stored() {
 
     let (mut glean, ping_maker, ping_type, _t) = set_up_basic_ping();
 
-    let unknown_ping_type = PingType::new("unknown", true, false, true, true, true, vec![], vec![]);
+    let unknown_ping_type = PingType::new(
+        "unknown",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping_type);
 
     assert!(ping_maker
@@ -195,8 +235,17 @@ fn seq_number_must_be_sequential() {
 
     for i in 0..=1 {
         for ping_name in ["store1", "store2"].iter() {
-            let ping_type =
-                PingType::new(*ping_name, true, false, true, true, true, vec![], vec![]);
+            let ping_type = PingType::new(
+                *ping_name,
+                true,
+                false,
+                true,
+                true,
+                true,
+                vec![],
+                vec![],
+                vec![],
+            );
             let ping = ping_maker
                 .collect(&glean, &ping_type, None, "", "")
                 .unwrap();
@@ -209,7 +258,17 @@ fn seq_number_must_be_sequential() {
 
     // Test that ping sequence numbers increase independently.
     {
-        let ping_type = PingType::new("store1", true, false, true, true, true, vec![], vec![]);
+        let ping_type = PingType::new(
+            "store1",
+            true,
+            false,
+            true,
+            true,
+            true,
+            vec![],
+            vec![],
+            vec![],
+        );
 
         // 3rd ping of store1
         let ping = ping_maker
@@ -227,7 +286,17 @@ fn seq_number_must_be_sequential() {
     }
 
     {
-        let ping_type = PingType::new("store2", true, false, true, true, true, vec![], vec![]);
+        let ping_type = PingType::new(
+            "store2",
+            true,
+            false,
+            true,
+            true,
+            true,
+            vec![],
+            vec![],
+            vec![],
+        );
 
         // 3rd ping of store2
         let ping = ping_maker
@@ -238,7 +307,17 @@ fn seq_number_must_be_sequential() {
     }
 
     {
-        let ping_type = PingType::new("store1", true, false, true, true, true, vec![], vec![]);
+        let ping_type = PingType::new(
+            "store1",
+            true,
+            false,
+            true,
+            true,
+            true,
+            vec![],
+            vec![],
+            vec![],
+        );
 
         // 5th ping of store1
         let ping = ping_maker
@@ -253,7 +332,17 @@ fn seq_number_must_be_sequential() {
 fn clear_pending_pings() {
     let (mut glean, _t) = new_glean(None);
     let ping_maker = PingMaker::new();
-    let ping_type = PingType::new("store1", true, false, true, true, true, vec![], vec![]);
+    let ping_type = PingType::new(
+        "store1",
+        true,
+        false,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping_type);
 
     // Record something, so the ping will have data
@@ -281,7 +370,17 @@ fn no_pings_submitted_if_upload_disabled() {
     // Regression test, bug 1603571
 
     let (mut glean, _t) = new_glean(None);
-    let ping_type = PingType::new("store1", true, true, true, true, true, vec![], vec![]);
+    let ping_type = PingType::new(
+        "store1",
+        true,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping_type);
 
     assert!(ping_type.submit_sync(&glean, None));
@@ -299,7 +398,17 @@ fn no_pings_submitted_if_upload_disabled() {
 fn metadata_is_correctly_added_when_necessary() {
     let (mut glean, _t) = new_glean(None);
     glean.set_debug_view_tag("valid-tag");
-    let ping_type = PingType::new("store1", true, true, true, true, true, vec![], vec![]);
+    let ping_type = PingType::new(
+        "store1",
+        true,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+        vec![],
+    );
     glean.register_ping_type(&ping_type);
 
     assert!(ping_type.submit_sync(&glean, None));


### PR DESCRIPTION
First draft of how to reduce the client info fields.
Requires https://github.com/mozilla/glean_parser/pull/766