### PR TITLE
Bug 1929905 - docs: Use theme's variables to define tab colors

### DIFF
--- a/docs/shared/glean.css
+++ b/docs/shared/glean.css
@@ -15,6 +15,25 @@ a.header code:hover {
     background-color: rgba(230, 230, 230, 1);
 }
 
+:root {
+    --tab-bg: #f1f1f1;
+    --tab-fg: #000;
+    --tab-bg-disabled: var(--tab-bg);
+    --tab-fg-disabled: #ccc;
+    --tab-border: #ccc;
+    --tab-bg-active: #ccc;
+    --tab-fg-active: #000;
+}
+
+.coal, .navy, .ayu {
+    --tab-bg: var(--bg);
+    --tab-fg: var(--fg);
+    --tab-bg-disabled: var(--tab-bg);
+    --tab-fg-disabled: #505254;
+    --tab-bg-active: #e6e6e6;
+    --tab-fg-active: #000;
+}
+
 /* Style the tab */
 .tabs {
     display: flex;
@@ -23,8 +42,9 @@ a.header code:hover {
 }
 
 .tabbar {
-    border: 1px solid #ccc;
-    background-color: #f1f1f1;
+    border: 1px solid var(--tab-border);
+    background-color: var(--tab-bg);
+    color: var(--tab-fg);
     width: 100%;
     box-sizing: border-box;
 }
@@ -32,6 +52,7 @@ a.header code:hover {
 /* Style the buttons that are used to open the tab content */
 .tabbar button {
     background-color: inherit;
+    color: var(--tab-fg);
     float: left;
     border: none;
     outline: none;
@@ -42,7 +63,8 @@ a.header code:hover {
 
 /* Change background color of buttons on hover */
 .tabbar button:hover {
-    background-color: #ddd;
+    background-color: var(--tab-bg-active);
+    color: var(--tab-fg-active);
 }
 
 .tabbar button.disabled:hover {
@@ -51,11 +73,13 @@ a.header code:hover {
 
 /* Create an active/current tablink class */
 .tabbar button.active {
-    background-color: #ccc;
+    background-color: var(--tab-bg-active);
+    color: var(--tab-fg-active);
 }
 
 .tabbar button.disabled {
-    color: #ccc;
+    background-color: var(--tab-bg-disabled);
+    color: var(--tab-fg-disabled);
     cursor: default;
 }
 
@@ -68,7 +92,7 @@ a.header code:hover {
 .tab {
     display: none;
     width: 100%;
-    border: 1px solid #ccc;
+    border: 1px solid var(--tab-border);
     border-top: none;
     padding: 6px 12px;
     box-sizing: border-box;


### PR DESCRIPTION
This makes it look nice for the dark themes too

[doc only]

---

Currently for the Ayu theme:

![image](https://github.com/user-attachments/assets/d78f1d72-ecaf-42d7-afe8-45fcd967a411)

New for the Ayu theme:

![image](https://github.com/user-attachments/assets/7936392c-5aa8-4a78-956f-45a310412cbb)

Navy:

![image](https://github.com/user-attachments/assets/79780f0b-110c-45a4-bad2-3075de1b6315)

And Coal:

![image](https://github.com/user-attachments/assets/6778701f-f176-49aa-aab8-a29364202547)
