### PR TITLE
Use the same test ping names consistently throughout all tests

### DIFF
--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -535,7 +535,7 @@ class GleanTest {
                 category = "telemetry",
                 lifetime = Lifetime.PING,
                 name = "string_metric",
-                sendInPings = listOf("default"),
+                sendInPings = listOf("store1"),
             ),
         )
 

--- a/glean-core/python/tests/data/core.yaml
+++ b/glean-core/python/tests/data/core.yaml
@@ -20,7 +20,7 @@ telemetry:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
 core_ping:
@@ -37,7 +37,7 @@ core_ping:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   created:
@@ -52,7 +52,7 @@ core_ping:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   sessions:
@@ -66,7 +66,7 @@ core_ping:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   durations:
@@ -82,7 +82,7 @@ core_ping:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   searches:
@@ -105,7 +105,7 @@ core_ping:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   flash_usage:
@@ -120,7 +120,7 @@ core_ping:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   default_browser:
@@ -134,7 +134,7 @@ core_ping:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
 environment:
@@ -149,7 +149,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   os:
@@ -163,7 +163,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   os_version:
@@ -177,7 +177,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   device:
@@ -194,7 +194,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   arch:
@@ -221,7 +221,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   default_search:
@@ -236,7 +236,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   display_version:
@@ -251,7 +251,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   distribution_id:
@@ -266,7 +266,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   campaign_id:
@@ -281,7 +281,7 @@ environment:
     notification_emails:
       - CHANGE-ME@example.com
     send_in_pings:
-      - core
+      - store1
     expires: 2100-01-01
 
   event_example:

--- a/glean-core/rlb/src/private/event.rs
+++ b/glean-core/rlb/src/private/event.rs
@@ -96,7 +96,7 @@ mod test {
         let metric: EventMetric<traits::NoExtraKeys> = EventMetric::new(CommonMetricData {
             name: "event".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         });
 
@@ -133,7 +133,7 @@ mod test {
         let metric: EventMetric<SomeExtra> = EventMetric::new(CommonMetricData {
             name: "event".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         });
 
@@ -188,7 +188,7 @@ mod test {
             CommonMetricData {
                 name: "event".into(),
                 category: "test".into(),
-                send_in_pings: vec!["test1".into()],
+                send_in_pings: vec!["store1".into()],
                 ..Default::default()
             },
             vec!["key1".into(), "key2".into()],

--- a/glean-core/rlb/src/private/object.rs
+++ b/glean-core/rlb/src/private/object.rs
@@ -110,7 +110,7 @@ mod test {
         let metric: ObjectMetric<SimpleArray> = ObjectMetric::new(CommonMetricData {
             name: "object".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         });
 
@@ -144,7 +144,7 @@ mod test {
         let metric: ObjectMetric<BalloonsObject> = ObjectMetric::new(CommonMetricData {
             name: "object".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         });
 
@@ -178,7 +178,7 @@ mod test {
         let metric: ObjectMetric<SimpleArray> = ObjectMetric::new(CommonMetricData {
             name: "object".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         });
 
@@ -225,7 +225,7 @@ mod test {
         let metric: ObjectMetric<StackTrace> = ObjectMetric::new(CommonMetricData {
             name: "object".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         });
 

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -629,7 +629,7 @@ fn basic_metrics_should_be_cleared_when_disabling_uploading() {
     let metric = private::StringMetric::new(CommonMetricData {
         name: "string_metric".into(),
         category: "telemetry".into(),
-        send_in_pings: vec!["default".into()],
+        send_in_pings: vec!["store1".into()],
         lifetime: Lifetime::Ping,
         disabled: false,
         ..Default::default()

--- a/glean-core/rlb/tests/custom_distribution_buffered.rs
+++ b/glean-core/rlb/tests/custom_distribution_buffered.rs
@@ -24,7 +24,7 @@ mod metrics {
             CommonMetricData {
                 name: "measure".into(),
                 category: "sample".into(),
-                send_in_pings: vec!["validation".into()],
+                send_in_pings: vec!["store1".into()],
                 lifetime: Lifetime::Ping,
                 disabled: false,
                 ..Default::default()

--- a/glean-core/rlb/tests/memory_distribution_buffered.rs
+++ b/glean-core/rlb/tests/memory_distribution_buffered.rs
@@ -24,7 +24,7 @@ mod metrics {
             CommonMetricData {
                 name: "measure".into(),
                 category: "sample".into(),
-                send_in_pings: vec!["validation".into()],
+                send_in_pings: vec!["store1".into()],
                 lifetime: Lifetime::Ping,
                 disabled: false,
                 ..Default::default()

--- a/glean-core/rlb/tests/timing_distribution_buffered.rs
+++ b/glean-core/rlb/tests/timing_distribution_buffered.rs
@@ -25,7 +25,7 @@ mod metrics {
             CommonMetricData {
                 name: "boo".into(),
                 category: "sample".into(),
-                send_in_pings: vec!["validation".into()],
+                send_in_pings: vec!["store1".into()],
                 lifetime: Lifetime::Ping,
                 disabled: false,
                 ..Default::default()

--- a/glean-core/rlb/tests/timing_distribution_single_sample.rs
+++ b/glean-core/rlb/tests/timing_distribution_single_sample.rs
@@ -26,7 +26,7 @@ mod metrics {
             CommonMetricData {
                 name: "boo".into(),
                 category: "sample".into(),
-                send_in_pings: vec!["validation".into()],
+                send_in_pings: vec!["store1".into()],
                 lifetime: Lifetime::Ping,
                 disabled: false,
                 ..Default::default()

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -758,7 +758,7 @@ mod test {
         let (mut glean, dir) = new_glean(None);
         let db = EventDatabase::new(dir.path()).unwrap();
 
-        let test_storage = "test-storage";
+        let test_storage = "store1";
         let test_category = "category";
         let test_name = "name";
         let test_timestamp = 2;

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -426,15 +426,15 @@ mod test {
         let (mut glean, _t) = new_glean(None);
         let ping_maker = PingMaker::new();
 
-        assert_eq!(0, ping_maker.get_ping_seq(&glean, "custom"));
-        assert_eq!(1, ping_maker.get_ping_seq(&glean, "custom"));
+        assert_eq!(0, ping_maker.get_ping_seq(&glean, "store1"));
+        assert_eq!(1, ping_maker.get_ping_seq(&glean, "store1"));
 
         glean.set_upload_enabled(false);
-        assert_eq!(0, ping_maker.get_ping_seq(&glean, "custom"));
-        assert_eq!(0, ping_maker.get_ping_seq(&glean, "custom"));
+        assert_eq!(0, ping_maker.get_ping_seq(&glean, "store1"));
+        assert_eq!(0, ping_maker.get_ping_seq(&glean, "store1"));
 
         glean.set_upload_enabled(true);
-        assert_eq!(0, ping_maker.get_ping_seq(&glean, "custom"));
-        assert_eq!(1, ping_maker.get_ping_seq(&glean, "custom"));
+        assert_eq!(0, ping_maker.get_ping_seq(&glean, "store1"));
+        assert_eq!(1, ping_maker.get_ping_seq(&glean, "store1"));
     }
 }

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -396,7 +396,7 @@ fn snapshot_sorts_the_timestamps() {
 fn ensure_custom_ping_events_dont_overflow() {
     let (glean, _dir) = new_glean(None);
 
-    let store_name = "store-name";
+    let store_name = "store1";
     let event_meta = CommonMetricData {
         name: "name".into(),
         category: "category".into(),
@@ -441,7 +441,7 @@ fn ensure_custom_ping_events_dont_overflow() {
 fn ensure_custom_ping_events_from_multiple_runs_work() {
     let (mut tempdir, _) = tempdir();
 
-    let store_name = "store-name";
+    let store_name = "store1";
     let event = EventMetric::new(
         CommonMetricData {
             name: "name".into(),
@@ -570,7 +570,7 @@ fn with_event_timestamps() {
     };
     let glean = Glean::new(cfg).unwrap();
 
-    let store_name = "store-name";
+    let store_name = "store1";
     let event = EventMetric::new(
         CommonMetricData {
             name: "name".into(),

--- a/glean-core/tests/rate.rs
+++ b/glean-core/tests/rate.rs
@@ -16,7 +16,7 @@ fn rate_smoke() {
     let metric: RateMetric = RateMetric::new(CommonMetricData {
         name: "rate".into(),
         category: "test".into(),
-        send_in_pings: vec!["test1".into()],
+        send_in_pings: vec!["store1".into()],
         ..Default::default()
     });
 
@@ -52,7 +52,7 @@ fn numerator_smoke() {
     let metric: NumeratorMetric = NumeratorMetric::new(CommonMetricData {
         name: "rate".into(),
         category: "test".into(),
-        send_in_pings: vec!["test1".into()],
+        send_in_pings: vec!["store1".into()],
         ..Default::default()
     });
 
@@ -89,14 +89,14 @@ fn denominator_smoke() {
     let meta1 = CommonMetricData {
         name: "rate1".into(),
         category: "test".into(),
-        send_in_pings: vec!["test1".into()],
+        send_in_pings: vec!["store1".into()],
         ..Default::default()
     };
 
     let meta2 = CommonMetricData {
         name: "rate2".into(),
         category: "test".into(),
-        send_in_pings: vec!["test1".into()],
+        send_in_pings: vec!["store1".into()],
         ..Default::default()
     };
 
@@ -105,7 +105,7 @@ fn denominator_smoke() {
         CommonMetricData {
             name: "counter".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         },
         vec![meta1.clone(), meta2.clone()],

--- a/glean-core/tests/storage.rs
+++ b/glean-core/tests/storage.rs
@@ -26,14 +26,14 @@ fn can_snapshot() {
     let local_metric = StringMetric::new(CommonMetricData {
         name: "can_snapshot_local_metric".into(),
         category: "local".into(),
-        send_in_pings: vec!["store".into()],
+        send_in_pings: vec!["store1".into()],
         ..Default::default()
     });
 
     local_metric.set_sync(&glean, "snapshot 42");
 
     assert!(StorageManager
-        .snapshot(glean.storage(), "store", true)
+        .snapshot(glean.storage(), "store1", true)
         .is_some())
 }
 
@@ -77,7 +77,7 @@ fn storage_is_thread_safe() {
     let threadsafe_metric = CounterMetric::new(CommonMetricData {
         name: "threadsafe".into(),
         category: "global".into(),
-        send_in_pings: vec!["core".into(), "metrics".into()],
+        send_in_pings: vec!["store1".into(), "metrics".into()],
         ..Default::default()
     });
     let threadsafe_metric = Arc::new(threadsafe_metric);
@@ -99,7 +99,7 @@ fn storage_is_thread_safe() {
     child.join().unwrap();
 
     let snapshot = StorageManager
-        .snapshot_as_json(glean.lock().unwrap().storage(), "core", true)
+        .snapshot_as_json(glean.lock().unwrap().storage(), "store1", true)
         .unwrap();
     assert_eq!(json!({"counter": { "global.threadsafe": 4 }}), snapshot);
 }

--- a/glean-core/tests/string_list.rs
+++ b/glean-core/tests/string_list.rs
@@ -18,25 +18,25 @@ fn list_can_store_multiple_items() {
     let list: StringListMetric = StringListMetric::new(CommonMetricData {
         name: "list".into(),
         category: "local".into(),
-        send_in_pings: vec!["core".into()],
+        send_in_pings: vec!["store1".into()],
         ..Default::default()
     });
 
     list.add_sync(&glean, "first");
-    assert_eq!(list.get_value(&glean, "core").unwrap(), vec!["first"]);
+    assert_eq!(list.get_value(&glean, "store1").unwrap(), vec!["first"]);
 
     list.add_sync(&glean, "second");
     assert_eq!(
-        list.get_value(&glean, "core").unwrap(),
+        list.get_value(&glean, "store1").unwrap(),
         vec!["first", "second"]
     );
 
     list.set_sync(&glean, vec!["third".into()]);
-    assert_eq!(list.get_value(&glean, "core").unwrap(), vec!["third"]);
+    assert_eq!(list.get_value(&glean, "store1").unwrap(), vec!["third"]);
 
     list.add_sync(&glean, "fourth");
     assert_eq!(
-        list.get_value(&glean, "core").unwrap(),
+        list.get_value(&glean, "store1").unwrap(),
         vec!["third", "fourth"]
     );
 }

--- a/glean-core/tests/timespan.rs
+++ b/glean-core/tests/timespan.rs
@@ -331,7 +331,7 @@ fn time_cannot_go_backwards() {
         CommonMetricData {
             name: "raw_timespan".into(),
             category: "test".into(),
-            send_in_pings: vec!["test1".into()],
+            send_in_pings: vec!["store1".into()],
             ..Default::default()
         },
         TimeUnit::Millisecond,
@@ -340,7 +340,7 @@ fn time_cannot_go_backwards() {
     // Time cannot go backwards.
     metric.set_start(&glean, 10);
     metric.set_stop(&glean, 0);
-    assert!(metric.get_value(&glean, "test1").is_none());
+    assert!(metric.get_value(&glean, "store1").is_none());
     assert_eq!(
         Ok(1),
         test_get_num_recorded_errors(&glean, metric.meta(), ErrorType::InvalidValue),

--- a/glean-core/tests/uuid.rs
+++ b/glean-core/tests/uuid.rs
@@ -18,19 +18,19 @@ fn uuid_is_generated_and_stored() {
     let uuid: UuidMetric = UuidMetric::new(CommonMetricData {
         name: "uuid".into(),
         category: "local".into(),
-        send_in_pings: vec!["core".into()],
+        send_in_pings: vec!["store1".into()],
         ..Default::default()
     });
 
     uuid.generate_and_set_sync(&glean);
-    let snapshot = glean.snapshot("core", false);
+    let snapshot = glean.snapshot("store1", false);
     assert!(
         snapshot.contains(r#""local.uuid": ""#),
         "Snapshot 1: {snapshot}"
     );
 
     uuid.generate_and_set_sync(&glean);
-    let snapshot = glean.snapshot("core", false);
+    let snapshot = glean.snapshot("store1", false);
     assert!(
         snapshot.contains(r#""local.uuid": ""#),
         "Snapshot 2: {snapshot}"


### PR DESCRIPTION
This is in preparation of the further changes coming to how we handle pings.