### PR TITLE
Python: Replace deprecated pkg_resources usage with importlib_resources

### DIFF
--- a/glean-core/python/glean/_builtins.py
+++ b/glean-core/python/glean/_builtins.py
@@ -7,16 +7,26 @@
 This module loads the built-in metrics and pings.
 """
 
-from pkg_resources import resource_filename
+import sys
 
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 from ._loader import load_metrics, load_pings
 
+# Python <3.12 makes this something like `glean._builtin`,
+# above that it's just `glean`.
+pkg_name = __name__.split(".")[0]
 
-metrics = load_metrics(resource_filename(__name__, "metrics.yaml"), config={"allow_reserved": True})
+ref = importlib_resources.files(pkg_name) / "metrics.yaml"
+with importlib_resources.as_file(ref) as path:
+    metrics = load_metrics(path, config={"allow_reserved": True})
 
-
-pings = load_pings(resource_filename(__name__, "pings.yaml"), config={"allow_reserved": True})
+ref = importlib_resources.files(pkg_name) / "pings.yaml"
+with importlib_resources.as_file(ref) as path:
+    pings = load_pings(path, config={"allow_reserved": True})
 
 
 __all__ = ["metrics", "pings"]

--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -12,7 +12,6 @@ ruff==0.7.2
 semver==2.13.0
 setuptools-git==1.2
 twine==5.0.0
-types-pkg_resources==0.1.3
 wheel==0.45.0
 maturin==1.7.4
 patchelf>=0.17; sys_platform == "linux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ maintainers = [
 dependencies = [
   "semver>=2.13.0",
   "glean_parser~=15.2",
+  "importlib_resources>=1.3; python_version=='3.8'"
 ]
 
 [project.urls]


### PR DESCRIPTION
as per the migration guide in https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename