### PR TITLE
Bug 1932320 - Don't record `pings_submitted` for custom pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v62.0.0...main)
 
+* General
+  * The `glean.validation.pings_submitted` metric will now only record counts for built-in pings ([#3010](https://github.com/mozilla/glean/pull/3010))
+
 # v62.0.0 (2024-11-05)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v61.2.0...v62.0.0)

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -756,7 +756,7 @@ glean.validation:
   pings_submitted:
     type: labeled_counter
     description: |
-      A count of the pings submitted, by ping type.
+      A count of the built-in pings submitted, by ping type.
 
       This metric appears in both the metrics and baseline pings.
 
@@ -764,6 +764,9 @@ glean.validation:
         the last metrics ping (including the last metrics ping)
       - On the baseline ping, the counts include the number of pings send since
         the last baseline ping (including the last baseline ping)
+
+      Note: Previously this also recorded the number of submitted custom pings.
+      Now it only records counts for the Glean built-in pings.
     send_in_pings:
       - metrics
       - baseline

--- a/glean-core/src/metrics/ping.rs
+++ b/glean-core/src/metrics/ping.rs
@@ -240,15 +240,20 @@ impl PingType {
                     return false;
                 }
 
+                const BUILTIN_PINGS: [&str; 4] =
+                    ["baseline", "metrics", "events", "deletion-request"];
+
                 // This metric is recorded *after* the ping is collected (since
                 // that is the only way to know *if* it will be submitted). The
                 // implication of this is that the count for a metrics ping will
                 // be included in the *next* metrics ping.
-                glean
-                    .additional_metrics
-                    .pings_submitted
-                    .get(ping.name)
-                    .add_sync(glean, 1);
+                if BUILTIN_PINGS.contains(&ping.name) {
+                    glean
+                        .additional_metrics
+                        .pings_submitted
+                        .get(ping.name)
+                        .add_sync(glean, 1);
+                }
 
                 if let Err(e) = ping_maker.store_ping(glean.get_data_path(), &ping) {
                     log::warn!(

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -157,6 +157,9 @@ fn test_pings_submitted_metric() {
     let baseline_ping = PingType::new("baseline", true, false, true, true, true, vec![], vec![]);
     glean.register_ping_type(&baseline_ping);
 
+    let custom_ping = PingType::new("custom", true, true, true, true, true, vec![], vec![]);
+    glean.register_ping_type(&custom_ping);
+
     // We need to store a metric as an empty ping is not stored.
     let counter = CounterMetric::new(CommonMetricData {
         name: "counter".into(),
@@ -167,6 +170,8 @@ fn test_pings_submitted_metric() {
     counter.add_sync(&glean, 1);
 
     assert!(metrics_ping.submit_sync(&glean, None));
+    // A custom ping is just never recorded.
+    assert!(custom_ping.submit_sync(&glean, None));
 
     // Check recording in the metrics ping
     assert_eq!(
@@ -176,6 +181,10 @@ fn test_pings_submitted_metric() {
     assert_eq!(
         None,
         pings_submitted.get("baseline").get_value(&glean, "metrics")
+    );
+    assert_eq!(
+        None,
+        pings_submitted.get("custom").get_value(&glean, "metrics")
     );
 
     // Check recording in the baseline ping
@@ -189,6 +198,10 @@ fn test_pings_submitted_metric() {
             .get("baseline")
             .get_value(&glean, "baseline")
     );
+    assert_eq!(
+        None,
+        pings_submitted.get("custom").get_value(&glean, "baseline")
+    );
 
     // Trigger 2 baseline pings.
     // This should record a count of 2 baseline pings in the metrics ping, but
@@ -196,6 +209,8 @@ fn test_pings_submitted_metric() {
     // baseline ping recorded in the baseline ping itsef.
     assert!(baseline_ping.submit_sync(&glean, None));
     assert!(baseline_ping.submit_sync(&glean, None));
+    // A custom ping is just never recorded.
+    assert!(custom_ping.submit_sync(&glean, None));
 
     // Check recording in the metrics ping
     assert_eq!(
@@ -210,6 +225,12 @@ fn test_pings_submitted_metric() {
             .get("baseline")
             .get_value(&glean, Some("metrics"))
     );
+    assert_eq!(
+        None,
+        pings_submitted
+            .get("custom")
+            .get_value(&glean, Some("metrics"))
+    );
 
     // Check recording in the baseline ping
     assert_eq!(
@@ -222,6 +243,12 @@ fn test_pings_submitted_metric() {
         Some(1),
         pings_submitted
             .get("baseline")
+            .get_value(&glean, Some("baseline"))
+    );
+    assert_eq!(
+        None,
+        pings_submitted
+            .get("custom")
             .get_value(&glean, Some("baseline"))
     );
 }


### PR DESCRIPTION
This implements solution (2) from https://bugzilla.mozilla.org/show_bug.cgi?id=1932320#c1, as that is easy to implement