### PR TITLE
Bug 1892234 - Kotlin: Dispatch experiment API on the task queue

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -345,8 +345,10 @@ open class GleanInternalAPI internal constructor() {
         branch: String,
         extra: Map<String, String>? = null,
     ) {
-        var map = extra ?: mapOf()
-        gleanSetExperimentActive(experimentId, branch, map)
+        Dispatchers.Delayed.launch {
+            var map = extra ?: mapOf()
+            gleanSetExperimentActive(experimentId, branch, map)
+        }
     }
 
     /**
@@ -355,7 +357,9 @@ open class GleanInternalAPI internal constructor() {
      * @param experimentId The id of the experiment to deactivate.
      */
     fun setExperimentInactive(experimentId: String) {
-        gleanSetExperimentInactive(experimentId)
+        Dispatchers.Delayed.launch {
+            gleanSetExperimentInactive(experimentId)
+        }
     }
 
     /**


### PR DESCRIPTION
Extending 9d3a300c44 to also apply to the experiment API as that's (obviously) called by Nimbus early as well.

---

I should take this for a proper test drive again before releasing.