### PR TITLE
Python: Remove auditwheel

### DIFF
--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -1,4 +1,3 @@
-auditwheel==6.0.0
 coverage[toml]==7.2.2
 jsonschema==3.2.0
 mypy==1.4.1


### PR DESCRIPTION
Since switching to maturin in 959e3b44bcb3c41a4ac4f283fdf902bed4a80fdb the auditwheel package is not used anymore (maturin contains a reimplementation of its functionality that's enabled by default)