### PR TITLE
CI: Use nextest to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,38 @@ commands:
             sudo apt install --yes --no-install-recommends \
               python3-pip \
               python3.10-venv
+
+      - run:
+          name: Install nextest
+          command: |
+            NEXTEST_SHA256=bde8d231e435099b068e654c591224defe686c784b4920682ee12784b6bfcf9e
+            NEXTEST=cargo-nextest
+            curl -sfSL --retry 5 -o "${NEXTEST}.tar.gz" "https://get.nexte.st/0.9.87/linux"
+            echo "${NEXTEST_SHA256} *${NEXTEST}.tar.gz" | shasum -a 256 -c -
+            tar -xf "${NEXTEST}.tar.gz"
+            cp ./${NEXTEST} ~/.cargo/bin/
+      - run:
+          name: Install circleci-junit-fix
+          command: |
+            JUNIT_FIX_SHA256=e8dd9012c841d9c03037783db676aa43a2ac1900346ccf4a61bf9956acfc6032
+            JUNIT_FIX=circleci-junit-fix
+            JUNIT_FIX_VERSION=v0.2.0
+            curl -sfSL --retry 5 -o "${JUNIT_FIX}.tar.gz" "https://github.com/conradludgate/circleci-junit-fix/releases/download/${JUNIT_FIX_VERSION}/${JUNIT_FIX}-${JUNIT_FIX_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+            echo "${JUNIT_FIX_SHA256} *${JUNIT_FIX}.tar.gz" | shasum -a 256 -c -
+            tar -xf "${JUNIT_FIX}.tar.gz"
+            cp ./${JUNIT_FIX} ~/.cargo/bin/
       - run:
           name: Test
           command: |
-            cargo test --workspace --verbose --jobs 6 -- --nocapture
+            cargo nextest run --profile ci
+      - run:
+          name: Fix junit output
+          command: |
+            mkdir -p ~/test-results/
+            cat target/nextest/ci/junit.xml | circleci-junit-fix > ~/test-results/junit.xml
+          when: always
+      - store_test_results:
+          path: ~/test-results
       - run:
           name: Run Rust sample
           command: |

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"


### PR DESCRIPTION
nextest is a [next-generation test runner for Rust projects.](https://nexte.st/).

This isn't to say we _should_ do it.
But it was worth a look.

It's marginally faster (though our rust tests run in ~6s once built).
nextest does have junit output, which CircleCI has integration for, see the Tests tab on https://app.circleci.com/pipelines/github/mozilla/glean/12980/workflows/14ac220e-7661-411e-a7bc-76f44421ffa7/jobs/251666/tests
When all passes it's not interesting. But when a test fails you get it separated out nicely.
And because every test runs in a separate process these additional tests failing because the global lock is poisoned might go away too.

The change here _does_ rely on two external binaries (nextest and the circleci-junit-fix), so that's a bit of a risk (as always) (but I do the usual: checksum validation against locally verified archives)

I figured I put this up as a PR at least, then we can decide what we do.