### PR TITLE
bug 1942364: switch to autograph gcp production for signing

### DIFF
--- a/taskcluster/glean_taskgraph/transforms/signing.py
+++ b/taskcluster/glean_taskgraph/transforms/signing.py
@@ -24,7 +24,7 @@ def build_upstream_artifacts(config, tasks):
             "taskId": {"task-reference": f"<{dep.kind}>"},
             "taskType": "build",
             "paths": publications_to_artifact_paths(name, version, module_info["publications"]),
-            "formats": ["autograph_gpg"],
+            "formats": ["gcp_prod_autograph_gpg"],
         }]}
 
         task.setdefault("worker", {})


### PR DESCRIPTION
This needs to wait for https://github.com/mozilla-releng/scriptworker-scripts/pull/1123 to be deployed before it can be merged.