### PR TITLE
[TESTING] Usage metrics logging

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -147,6 +147,10 @@ open class GleanInternalAPI internal constructor() {
 
     internal var isCustomDataPath: Boolean = false
 
+    init {
+        gleanEnableLogging()
+    }
+
     /**
      * Initialize the Glean SDK.
      *
@@ -179,8 +183,6 @@ open class GleanInternalAPI internal constructor() {
         configuration: Configuration = Configuration(),
         buildInfo: BuildInfo,
     ) {
-        gleanEnableLogging()
-
         configuration.dataPath?.let { safeDataPath ->
             // When the `dataPath` is provided, we need to make sure:
             //   1. The database path provided is not `glean_data`.

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -450,7 +450,11 @@ impl Database {
     pub fn record(&self, glean: &Glean, data: &CommonMetricDataInternal, value: &Metric) {
         let name = data.identifier(glean);
         for ping_name in data.storage_names() {
-            if glean.is_ping_enabled(ping_name) {
+            let enabled = glean.is_ping_enabled(ping_name);
+            if name.starts_with("usage") {
+                log::error!("record. Storing metric {name:?}, lifetime: {:?}, ping: {ping_name:?}, enabled: {enabled:?}", data.inner.lifetime);
+            }
+            if enabled {
                 if let Err(e) =
                     self.record_per_lifetime(data.inner.lifetime, ping_name, &name, value)
                 {
@@ -484,6 +488,9 @@ impl Database {
         metric: &Metric,
     ) -> Result<()> {
         let final_key = Self::get_storage_key(storage_name, Some(key));
+        if final_key.starts_with("usage") {
+            log::error!("record_per_lifetime. Storing metric '{final_key:?}, lifetime: {lifetime:?}");
+        }
 
         // Lifetime::Ping data is not immediately persisted to disk if
         // Glean has `delay_ping_lifetime_io` set to true
@@ -518,7 +525,11 @@ impl Database {
     {
         let name = data.identifier(glean);
         for ping_name in data.storage_names() {
-            if glean.is_ping_enabled(ping_name) {
+            let enabled = glean.is_ping_enabled(ping_name);
+            if name.starts_with("usage") {
+                log::error!("record_with. Storing metric {name:?}, lifetime: {:?}, ping: {ping_name:?}, enabled: {enabled:?}", data.inner.lifetime);
+            }
+            if enabled {
                 if let Err(e) = self.record_per_lifetime_with(
                     data.inner.lifetime,
                     ping_name,
@@ -559,6 +570,9 @@ impl Database {
         F: FnMut(Option<Metric>) -> Metric,
     {
         let final_key = Self::get_storage_key(storage_name, Some(key));
+        if final_key.starts_with("usage") {
+            log::error!("record_per_lifetime_with. Storing metric '{final_key:?}, lifetime: {lifetime:?}");
+        }
 
         // Lifetime::Ping data is not persisted to disk if
         // Glean has `delay_ping_lifetime_io` set to true

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -75,7 +75,13 @@ impl StringMetric {
     /// Sets to the specified value synchronously.
     #[doc(hidden)]
     pub fn set_sync<S: Into<String>>(&self, glean: &Glean, value: S) {
-        if !self.should_record(glean) {
+        let value = value.into();
+        let should_record = self.should_record(glean);
+        let ident = self.meta.base_identifier();
+        if ident.starts_with("usage") {
+            log::error!("string.set_sync. name={ident:?}, value: {:?}, should_record: {:?}", value, should_record);
+        }
+        if !should_record {
             return;
         }
 


### PR DESCRIPTION
This enables Glean logging as soon as the object is instantiated,
instead of only when it's intialized.
This causes a load of the underlying library, which is why we avoid that
in release.