### PR TITLE
Various Gradle dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    * Updated to Android NDK 28 and SDK 35 ([#3074](https://github.com/mozilla/glean/pull/3080))
    * Updated Kotlin to version 2.1.10 ([#3074](https://github.com/mozilla/glean/pull/3080))
    * Updated Android Gradle Plugin to 8.8.2 ([#3074](https://github.com/mozilla/glean/pull/3080))
+   * Updated JNA to version 5.17.0 ([#3081](https://github.com/mozilla/glean/pull/3081))
 * Rust
   * Report more desktop architectures in `client_info.architecture` ([bug 1944694](https://bugzilla.mozilla.org/show_bug.cgi?id=1944694))
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ androidx-annotation = "1.9.1"
 androidx-appcompat = "1.7.0"
 androidx-browser = "1.8.0"
 androidx-lifecycle = "2.8.7"
-androidx-work = "2.9.1"
+androidx-work = "2.10.0"
 
 # JNA
 jna = "5.17.0"
@@ -38,7 +38,7 @@ androidx-test-uiautomator = "2.3.0"
 
 # Third Party Testing
 junit = "4.13.2"
-mockito = "5.15.2"
+mockito = "5.16.1"
 mockwebserver = "4.12.0"
 robolectric = "4.14.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ androidx-lifecycle = "2.8.7"
 androidx-work = "2.9.1"
 
 # JNA
-jna = "5.14.0"
+jna = "5.17.0"
 
 # Linting and Static Analysis
 detekt = "1.23.8"


### PR DESCRIPTION
Most importantly, this bumps JNA to version 5.17.0 which includes Android 16KB page size support. Note that AppServices will require the same JNA bump when Glean is next updated there.