### PR TITLE
Bug 1892234 - Kotlin: Dispatch ping instantiation and submit on the task queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v64.0.1...main)
 
-* Android
+* Kotlin
    * Updated Android Gradle Plugin to 8.9.1 ([#3098](https://github.com/mozilla/glean/pull/3098))
    * Updated Kotlin to version 2.1.20 ([#3098](https://github.com/mozilla/glean/pull/3098))
+   * Dispatch ping API on the task queue ([#3101](https://github.com/mozilla/glean/pull/3101))
 
 # v64.0.1 (2025-04-01)
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -240,6 +240,10 @@ open class GleanInternalAPI internal constructor() {
         this.configuration = configuration
         this.httpClient = BaseUploader(configuration.httpClient)
 
+        // First flush the Kotlin-side queue.
+        // This will put things on the Rust-side queue, and thus keep them in the right order.
+        Dispatchers.Delayed.flushQueuedInitialTasks()
+
         // Execute startup off the main thread.
         Dispatchers.API.executeTask {
             val cfg = InternalConfiguration(
@@ -265,8 +269,6 @@ open class GleanInternalAPI internal constructor() {
             val callbacks = OnGleanEventsImpl(this@GleanInternalAPI)
             gleanInitialize(cfg, clientInfo, callbacks)
         }
-
-        Dispatchers.Delayed.flushQueuedInitialTasks()
     }
 
     /**

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -5,6 +5,7 @@
 package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.internal.PingType as GleanPingType
 
 /**
@@ -58,21 +59,23 @@ class PingType<ReasonCodesEnum> (
     val uploaderCapabilities: List<String>,
 ) where ReasonCodesEnum : Enum<ReasonCodesEnum>, ReasonCodesEnum : ReasonCode {
     private var testCallback: ((ReasonCodesEnum?) -> Unit)? = null
-    private val innerPing: GleanPingType
+    private lateinit var innerPing: GleanPingType
 
     init {
-        this.innerPing = GleanPingType(
-            name = name,
-            includeClientId = includeClientId,
-            sendIfEmpty = sendIfEmpty,
-            preciseTimestamps = preciseTimestamps,
-            includeInfoSections = includeInfoSections,
-            schedulesPings = schedulesPings,
-            reasonCodes = reasonCodes,
-            enabled = enabled,
-            followsCollectionEnabled = followsCollectionEnabled,
-            uploaderCapabilities = uploaderCapabilities,
-        )
+        Dispatchers.Delayed.launch {
+            this.innerPing = GleanPingType(
+                name = name,
+                includeClientId = includeClientId,
+                sendIfEmpty = sendIfEmpty,
+                preciseTimestamps = preciseTimestamps,
+                includeInfoSections = includeInfoSections,
+                schedulesPings = schedulesPings,
+                reasonCodes = reasonCodes,
+                enabled = enabled,
+                followsCollectionEnabled = followsCollectionEnabled,
+                uploaderCapabilities = uploaderCapabilities,
+            )
+        }
     }
 
     /**
@@ -109,8 +112,10 @@ class PingType<ReasonCodesEnum> (
         }
         this.testCallback = null
 
-        val reasonString = reason?.let { this.reasonCodes[it.code()] }
-        this.innerPing.submit(reasonString)
+        Dispatchers.Delayed.launch {
+            val reasonString = reason?.let { this.reasonCodes[it.code()] }
+            this.innerPing.submit(reasonString)
+        }
     }
 
     /**


### PR DESCRIPTION
This also ensures we run through the Kotlin task queue _before_ intializing Glean to keep the order correct.

This should mitigate yet another early libxul loading in Fenix due to Nimbus sending an early ping.

---

I tested this locally in a Fenix build, profiling startup using [simpleperf and samply](https://firefox-source-docs.mozilla.org/performance/profiling_with_simpleperf.html).
The profile doesn't show any `com.sun.jna.Native.load` or glean-core call on the `NimbusDbScope-t` stack.