### PR TITLE
Remove package-dry run task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,21 +423,6 @@ jobs:
             - docs/shared
             - docs/index.html
 
-  Package Rust crates dry-run:
-    docker:
-      # Should always be the same version as the publish step below
-      - image: cimg/rust:1.82
-    steps:
-      - checkout
-      - run:
-          name: Package Cargo Package
-          command: |
-            pushd glean-core
-            cargo package --verbose
-
-            pushd rlb
-            cargo package --verbose
-
   Publish Rust crates:
     docker:
       - image: cimg/rust:1.82
@@ -1120,10 +1105,6 @@ workflows:
           filters: *ci-filters
       # iOS jobs run only on main by default, see below for manual-approved jobs
       - iOS build and test:
-          filters:
-            branches:
-              only: main
-      - Package Rust crates dry-run:
           filters:
             branches:
               only: main


### PR DESCRIPTION
It was sort of a good idea, but it will fail on breaking changes, e.g. `glean-core` adding a new function that's called from the RLB, as `cargo package` builds the package against `crates.io` versions, and that updated `glean-core` won't be available

[doc only]