### PR TITLE
bug 1959771 - Ensure there's a global Glean before using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * General
   * Increase the maximum label length to 111 ([#3108](https://github.com/mozilla/glean/pull/3108))
   * Allow `test_get_{attribution|distribution}` to wait on init if in progress ([bug 1959515](https://bugzilla.mozilla.org/show_bug.cgi?id=1959515))
+  * Fix race where setting ping enabled, ping registered, server knobs, debug tag, source tag, logging, ping submission, attribution, or distribution could crash if it comes in between init being called and the Global Glean being setup. ([bug 1959771](https://bugzilla.mozilla.org/show_bug.cgi?id=1959771))
 
 # v64.1.0 (2025-04-07)
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -887,7 +887,7 @@ pub fn glean_set_collection_enabled(enabled: bool) {
 /// and all pending pings of that type to be deleted.
 pub fn set_ping_enabled(ping: &PingType, enabled: bool) {
     let ping = ping.clone();
-    if was_initialize_called() {
+    if was_initialize_called() && core::global_glean().is_some() {
         crate::launch_with_glean_mut(move |glean| glean.set_ping_enabled(&ping, enabled));
     } else {
         let m = &PRE_INIT_PING_ENABLED;
@@ -902,7 +902,7 @@ pub(crate) fn register_ping_type(ping: &PingType) {
     // we dispatch ping registration on the thread pool.
     // Registering a ping should not block the application.
     // Submission itself is also dispatched, so it will always come after the registration.
-    if was_initialize_called() {
+    if was_initialize_called() && core::global_glean().is_some() {
         let ping = ping.clone();
         crate::launch_with_glean_mut(move |glean| {
             glean.register_ping_type(&ping);
@@ -1016,7 +1016,7 @@ pub fn glean_apply_server_knobs_config(json: String) {
 /// This will return `false` in case `tag` is not a valid tag and `true` otherwise.
 /// If called before Glean is initialized it will always return `true`.
 pub fn glean_set_debug_view_tag(tag: String) -> bool {
-    if was_initialize_called() {
+    if was_initialize_called() && core::global_glean().is_some() {
         crate::launch_with_glean_mut(move |glean| {
             glean.set_debug_view_tag(&tag);
         });
@@ -1054,7 +1054,7 @@ pub fn glean_get_debug_view_tag() -> Option<String> {
 /// * `tags` - A vector of at most 5 valid HTTP header values. Individual
 ///   tags must match the regex: "[a-zA-Z0-9-]{1,20}".
 pub fn glean_set_source_tags(tags: Vec<String>) -> bool {
-    if was_initialize_called() {
+    if was_initialize_called() && core::global_glean().is_some() {
         crate::launch_with_glean_mut(|glean| {
             glean.set_source_tags(tags);
         });
@@ -1079,7 +1079,7 @@ pub fn glean_set_source_tags(tags: Vec<String>) -> bool {
 ///
 /// * `value` - The value of the log pings option
 pub fn glean_set_log_pings(value: bool) {
-    if was_initialize_called() {
+    if was_initialize_called() && core::global_glean().is_some() {
         crate::launch_with_glean_mut(move |glean| {
             glean.set_log_pings(value);
         });
@@ -1176,7 +1176,8 @@ pub fn glean_submit_ping_by_name_sync(ping_name: String, reason: Option<String>)
         return false;
     }
 
-    core::with_glean(|glean| glean.submit_ping_by_name(&ping_name, reason.as_deref()))
+    core::with_opt_glean(|glean| glean.submit_ping_by_name(&ping_name, reason.as_deref()))
+        .unwrap_or(false)
 }
 
 /// EXPERIMENTAL: Register a listener object to recieve notifications of event recordings.
@@ -1271,7 +1272,7 @@ pub fn glean_set_dirty_flag(new_value: bool) {
 /// Updates attribution fields with new values.
 /// AttributionMetrics fields with `None` values will not overwrite older values.
 pub fn glean_update_attribution(attribution: AttributionMetrics) {
-    if was_initialize_called() {
+    if was_initialize_called() && core::global_glean().is_some() {
         core::with_glean(|glean| glean.update_attribution(attribution));
     } else {
         PRE_INIT_ATTRIBUTION
@@ -1294,7 +1295,7 @@ pub fn glean_test_get_attribution() -> AttributionMetrics {
 /// Updates distribution fields with new values.
 /// DistributionMetrics fields with `None` values will not overwrite older values.
 pub fn glean_update_distribution(distribution: DistributionMetrics) {
-    if was_initialize_called() {
+    if was_initialize_called() && core::global_glean().is_some() {
         core::with_glean(|glean| glean.update_distribution(distribution));
     } else {
         PRE_INIT_DISTRIBUTION


### PR DESCRIPTION
I _would_ prefer to merely check the global_glean, but in tests we reset INITIALIZE_CALLED but we don't reset core::GLEAN, so here we are.