### PR TITLE
bug 1959515 - Let test_get_{attribution|distribution} wait on init if in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Increase the maximum label length to 111 ([#3108](https://github.com/mozilla/glean/pull/3108))
+  * Allow `test_get_{attribution|distribution}` to wait on init if in progress ([bug 1959515](https://bugzilla.mozilla.org/show_bug.cgi?id=1959515))
 
 # v64.1.0 (2025-04-07)
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -1287,6 +1287,7 @@ pub fn glean_update_attribution(attribution: AttributionMetrics) {
 /// Returns the current attribution metrics.
 /// Panics if called before init.
 pub fn glean_test_get_attribution() -> AttributionMetrics {
+    join_init();
     core::with_glean(|glean| glean.test_get_attribution())
 }
 
@@ -1309,6 +1310,7 @@ pub fn glean_update_distribution(distribution: DistributionMetrics) {
 /// Returns the current distribution metrics.
 /// Panics if called before init.
 pub fn glean_test_get_distribution() -> DistributionMetrics {
+    join_init();
     core::with_glean(|glean| glean.test_get_distribution())
 }
 


### PR DESCRIPTION
They'll still crash before init, as advertised.