### PR TITLE
CI: Fix Python 3.8 builds on Windows (Wine)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ commands:
           name: Set up dependencies for Python for Windows
           command: |
             echo "export WINEDEBUG=-all" >> $BASH_ENV
-            wget https://bootstrap.pypa.io/get-pip.py
+            wget https://bootstrap.pypa.io/pip/3.8/get-pip.py
             $WINPYTHON get-pip.py
             echo "import site" >> winpython/python38._pth
             echo "import sys; sys.path.insert(0, '')" >> winpython/sitecustomize.py


### PR DESCRIPTION
The old get-pip URL is now Python 3.9+ only.
For the time being however we keep working on Python 3.8