### PR TITLE
CI: Test Windows builds on Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,9 +219,9 @@ commands:
           name: Set up dependencies for Python for Windows
           command: |
             echo "export WINEDEBUG=-all" >> $BASH_ENV
-            wget https://bootstrap.pypa.io/pip/3.8/get-pip.py
+            wget https://bootstrap.pypa.io/get-pip.py
             $WINPYTHON get-pip.py
-            echo "import site" >> winpython/python38._pth
+            echo "import site" >> winpython/python39._pth
             echo "import sys; sys.path.insert(0, '')" >> winpython/sitecustomize.py
             # The Windows-Python-installed-inside-Wine thing can't actually build wheels,
             # so just install all of the wheels that were created as part of creating the
@@ -770,7 +770,7 @@ jobs:
 
   Python Windows x86_64 tests:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
     steps:
       - checkout
       - skip-if-doc-only
@@ -782,9 +782,10 @@ jobs:
       - run:
           name: Install Python for Windows
           command: |
-            wget https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-amd64.zip
+            wget https://www.python.org/ftp/python/3.9.13/python-3.9.13-embed-amd64.zip
             mkdir winpython
-            unzip python-3.8.2-embed-amd64.zip -d winpython
+            unzip python-3.9.13-embed-amd64.zip -d winpython
+            rm python-3.9.13-embed-amd64.zip
             echo "export WINPYTHON=\"wine64-stable winpython/python.exe\"" >> $BASH_ENV
       - install-python-windows-deps
       - run:
@@ -792,7 +793,7 @@ jobs:
           command: |
             rustc tools/patches/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir wine_shims --target x86_64-pc-windows-gnu
             # This preloads our bcryptprimitives shim.
-            shimpath='Z:\\\\home\\\\circleci\\\\project\\\\wine_shims\\\\bcryptprimitives.dll'
+            shimpath='Z:/home/circleci/project/wine_shims/bcryptprimitives.dll'
             echo "import ctypes; ctypes.cdll.LoadLibrary('$shimpath')" >> winpython/sitecustomize.py
       - run:
           name: Run tests
@@ -801,7 +802,7 @@ jobs:
 
   Python Windows i686 tests:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
     steps:
       - checkout
       - skip-if-doc-only
@@ -815,9 +816,10 @@ jobs:
       - run:
           name: Install Python for Windows
           command: |
-            wget https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-win32.zip
+            wget https://www.python.org/ftp/python/3.9.13/python-3.9.13-embed-win32.zip
             mkdir winpython
-            unzip python-3.8.2-embed-win32.zip -d winpython
+            unzip python-3.9.13-embed-win32.zip -d winpython
+            rm python-3.9.13-embed-win32.zip
             echo "export WINPYTHON=\"wine winpython/python.exe\"" >> $BASH_ENV
       - install-python-windows-deps
       - run:
@@ -825,7 +827,7 @@ jobs:
           command: |
             rustc tools/patches/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir wine_shims --target i686-pc-windows-gnu
             # This preloads our bcryptprimitives shim.
-            shimpath='Z:\\\\home\\\\circleci\\\\project\\\\wine_shims\\\\bcryptprimitives.dll'
+            shimpath='Z:/home/circleci/project/wine_shims/bcryptprimitives.dll'
             echo "import ctypes; ctypes.cdll.LoadLibrary('$shimpath')" >> winpython/sitecustomize.py
       - run:
           name: Run tests

--- a/bin/build-win.sh
+++ b/bin/build-win.sh
@@ -6,8 +6,8 @@ if ! command -v wine64 >/dev/null; then
   exit 1
 fi
 
-if ! python3 --version | grep -q 3.8; then
-  echo "Python 3.8 required."
+if ! python3 --version | grep -q 3.9; then
+  echo "Python 3.9 required."
   echo "Use pyenv or your package manager to install it."
   exit 1
 fi
@@ -35,14 +35,14 @@ export WINEDEBUG=-all
 if [ ! -d "winpython" ]; then
   mkdir winpython
 
-  wget https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-amd64.zip -O winpython/python-3.8.2-embed-amd64.zip
-  unzip winpython/python-3.8.2-embed-amd64.zip -d winpython
+  wget https://www.python.org/ftp/python/3.9.13/python-3.9.13-embed-amd64.zip -O winpython/python-3.9.13-embed-amd64.zip
+  unzip winpython/python-3.9.13-embed-amd64.zip -d winpython
 fi
 
 if [ ! -f "winpython/Scripts/pip.exe" ]; then
   wget https://bootstrap.pypa.io/get-pip.py -O winpython/get-pip.py
   $WINPYTHON winpython/get-pip.py
-  echo "import site" >> winpython/python38._pth
+  echo "import site" >> winpython/python39._pth
   echo "import sys; sys.path.insert(0, '')" >> winpython/sitecustomize.py
 fi
 

--- a/docs/dev/python/setting-up-python-build-environment.md
+++ b/docs/dev/python/setting-up-python-build-environment.md
@@ -10,6 +10,12 @@ Glean requires Python 3.8 or later.
 
 Make sure it is installed on your system and accessible on the `PATH` as `python3`.
 
+{{#include ../../shared/blockquote-info.html}}
+
+## Development on Windows
+
+> Due to limitations of CI, we only test Windows on Python 3.9 or later.
+
 ### Setting up Rust
 
 If you've already set up Rust for building Glean for Android or iOS, you already have everything you need and can skip this section.

--- a/tools/docker-winbuild/Dockerfile
+++ b/tools/docker-winbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/python:3.8
+FROM cimg/python:3.9
 
 RUN sudo apt-get update -qq \
   && sudo apt-get install -qy --no-install-recommends \
@@ -10,20 +10,23 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
 
 RUN export PATH=$HOME/.cargo/bin:$PATH \
   && rustup target add x86_64-pc-windows-gnu \
-  && echo '[target.x86_64-pc-windows-gnu]' >> ~/.cargo/config \
-  && echo 'linker = "/usr/bin/x86_64-w64-mingw32-gcc"' >> ~/.cargo/config
+  && echo '[target.x86_64-pc-windows-gnu]' >> ~/.cargo/config.toml \
+  && echo 'linker = "/usr/bin/x86_64-w64-mingw32-gcc"' >> ~/.cargo/config.toml
 
 RUN wine64-stable wineboot \
   && mkdir ~/winpython \
   && cd ~/winpython \
-  && wget https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-amd64.zip \
-  && unzip python-3.8.2-embed-amd64.zip -d ~/winpython \
+  && wget https://www.python.org/ftp/python/3.9.13/python-3.9.13-embed-amd64.zip \
+  && unzip python-3.9.13-embed-amd64.zip -d ~/winpython \
+  && rm python-3.9.13-embed-amd64.zip \
   && echo "export WINPYTHON=\"wine64-stable $HOME/winpython/python.exe\"" >> ~/.profile \
+  && echo "export PYTHONHASHSEED=4" >> ~/.profile \
+  && echo "export WINEDEBUG=-all" >> ~/.profile \
   && wget https://bootstrap.pypa.io/get-pip.py \
   && wine64-stable ~/winpython/python.exe get-pip.py \
-  && echo "import site" >> ~/winpython/python38._pth \
+  && echo "import site" >> ~/winpython/python39._pth \
   && echo "import sys; sys.path.insert(0, '')" >> ~/winpython/sitecustomize.py \
-  && echo "import ctypes; ctypes.cdll.LoadLibrary('Z:\\\\home\\\\circleci\\\\project\\\\wine_shims\\\\bcryptprimitives.dll')" >> ~/winpython/sitecustomize.py
+  && echo "import ctypes; ctypes.cdll.LoadLibrary('Z:/home/circleci/project/wine_shims/bcryptprimitives.dll')" >> ~/winpython/sitecustomize.py
 
 ADD init.sh /home/circleci/init.sh
 ADD build.sh /home/circleci/build.sh

--- a/tools/docker-winbuild/build.sh
+++ b/tools/docker-winbuild/build.sh
@@ -7,14 +7,14 @@ make build-python-wheel GLEAN_BUILD_TARGET=x86_64-pc-windows-gnu
 
 # Bit of a cleanup to reduce install time
 sed \
-  -e 'g/^mypy/d' \
-  -e 'g/^ruff/d' \
-  -e 'g/^twine/d' \
-  -e 'g/^coverage/d' \
-  -e 'g/^jsonschema/d' \
+  -e '/^mypy/d' \
+  -e '/^ruff/d' \
+  -e '/^twine/d' \
+  -e '/^coverage/d' \
+  -e '/^jsonschema/d' \
   -i \
   glean-core/python/requirements_dev.txt
- 
+
 find ~/.cache/pip -name "*.whl" -exec $WINPYTHON -m pip install {} \;
 $WINPYTHON -m pip install -r glean-core/python/requirements_dev.txt --no-warn-script-location
 $WINPYTHON -m pip install --force-reinstall target/wheels/*.whl --no-warn-script-location

--- a/tools/docker-winbuild/init.sh
+++ b/tools/docker-winbuild/init.sh
@@ -3,6 +3,6 @@
 git clone --depth=1 https://github.com/mozilla/glean ~/project
 
 PATH=$HOME/.cargo/bin:$PATH \
-  rustc tools/patches/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir project/wine_shims --target x86_64-pc-windows-gnu
+  rustc tools/patches/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir ~/project/wine_shims --target x86_64-pc-windows-gnu
 
 exec bash -l


### PR DESCRIPTION
Python 3.8 is technically EoL.
However we continue to support Python 3.8.
But we don't test on that minimal version anymore on Windows.

---

We might decide to do this for the next release. For now #3115 fixes CI.