### PR TITLE
Log when metrics attempt to record against unknown pings

### DIFF
--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -542,6 +542,7 @@ impl Glean {
         }
 
         let Some(ping) = self.ping_registry.get(ping) else {
+            log::trace!("Unknown ping {ping}. Assuming disabled.");
             return false;
         };
 


### PR DESCRIPTION
This could've been helpful when debugging some test failures recently.