### PR TITLE
Remove debug printing in some tests

### DIFF
--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -208,19 +208,12 @@ impl DatetimeMetric {
                 time.second(),
                 time.nanosecond(),
             ),
-            TimeUnit::Microsecond => {
-                eprintln!(
-                    "microseconds. nanoseconds={}, nanoseconds/1000={}",
-                    time.nanosecond(),
-                    time.nanosecond() / 1000
-                );
-                d.date().and_hms_nano_opt(
-                    time.hour(),
-                    time.minute(),
-                    time.second(),
-                    time.nanosecond() / 1000,
-                )
-            }
+            TimeUnit::Microsecond => d.date().and_hms_nano_opt(
+                time.hour(),
+                time.minute(),
+                time.second(),
+                time.nanosecond() / 1000,
+            ),
             TimeUnit::Millisecond => d.date().and_hms_nano_opt(
                 time.hour(),
                 time.minute(),

--- a/glean-core/tests/collection_enabled.rs
+++ b/glean-core/tests/collection_enabled.rs
@@ -124,7 +124,7 @@ fn nofollows_ping_can_ride_along() {
             .unwrap();
 
         if obj["ping_name"].as_str().unwrap() == "nofollows" {
-            assert_eq!(2, counter_val, "{:?}", json);
+            assert_eq!(2, counter_val, "{json:?}");
         } else {
             let seq = json["ping_info"]["seq"].as_i64().unwrap();
 
@@ -132,7 +132,7 @@ fn nofollows_ping_can_ride_along() {
                 0 => assert_eq!(1, counter_val),
                 1 => assert_eq!(3, counter_val),
                 2 => assert_eq!(8, counter_val),
-                _ => panic!("unexpected sequence number: {}", seq),
+                _ => panic!("unexpected sequence number: {seq}"),
             }
         }
     }
@@ -162,7 +162,7 @@ fn nofollows_ping_can_ride_along() {
             0 => assert_eq!(1, counter_val),
             1 => assert_eq!(3, counter_val),
             2 => assert_eq!(8, counter_val),
-            _ => panic!("unexpected sequence number: {}", seq),
+            _ => panic!("unexpected sequence number: {seq}"),
         }
     }
 }

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -144,7 +144,6 @@ fn snapshot_correctly_clears_the_stores() {
         assert_eq!(1, s.as_array().unwrap().len());
         assert_eq!("telemetry", s[0]["category"]);
         assert_eq!("test_event_clear", s[0]["name"]);
-        println!("{:?}", s[0].get("extra"));
         assert!(s[0].get("extra").is_none());
     }
 }

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -117,7 +117,6 @@ fn test_metrics_must_report_experimentation_id() {
         .collect(&glean, &ping_type, None, "", "")
         .unwrap();
     let metrics = ping.content["metrics"].as_object().unwrap();
-    println!("TLDEBUG Metrics:\n{:?}", metrics);
 
     let strings = metrics["string"].as_object().unwrap();
     assert_eq!(


### PR DESCRIPTION
The `datetime.rs` was an unconditional error print, no one noticed for 4 years!
The second one is just in a test, swallowed by the test system all the time.
The third one now makes the beta clippy test fail. It's also in a test so no one would see it anyway.