### PR TITLE
Python: Properly export rate/text metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Python
    * Added support for labeled quantity metric type ([#3121](https://github.com/mozilla/glean/pull/3121))
    * Make rate metric actually usable ([#3131](https://github.com/mozilla/glean/pull/3131))
+   * Make text metric actually usable ([#3131](https://github.com/mozilla/glean/pull/3131))
 
 [Full changelog](https://github.com/mozilla/glean/compare/v64.2.0...main)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * Added support for labeled quantity metric type ([#3121](https://github.com/mozilla/glean/pull/3121))
 * Python
    * Added support for labeled quantity metric type ([#3121](https://github.com/mozilla/glean/pull/3121))
+   * Make rate metric actually usable ([#3131](https://github.com/mozilla/glean/pull/3131))
 
 [Full changelog](https://github.com/mozilla/glean/compare/v64.2.0...main)
 

--- a/docs/user/reference/metrics/rate.md
+++ b/docs/user/reference/metrics/rate.md
@@ -460,5 +460,6 @@ network:
 
 ## Reference
 
+* [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.RateMetric)
 * [Rust API docs](../../../docs/glean/private/struct.RateMetric.html)
 * [Swift API docs](../../../swift/Classes/RateMetric.html)

--- a/docs/user/reference/metrics/text.md
+++ b/docs/user/reference/metrics/text.md
@@ -294,5 +294,6 @@ refer to the [metrics YAML registry format](../yaml/metrics.md) reference page.
 
 ## Reference
 
+* [Python API docs](../../../python/glean/metrics/index.html#glean.metrics.TextMetric)
 * [Rust API docs](../../../docs/glean/private/struct.TextMetric.html)
 * [Swift API docs](../../../swift/Classes/TextMetric.html)

--- a/glean-core/python/glean/metrics/__init__.py
+++ b/glean-core/python/glean/metrics/__init__.py
@@ -27,6 +27,7 @@ from .._uniffi import NumeratorMetric as NumeratorMetricType
 from .._uniffi import QuantityMetric as QuantityMetricType
 from .._uniffi import RateMetric as RateMetricType
 from .._uniffi import StringListMetric as StringListMetricType
+from .._uniffi import TextMetric as TextMetricType
 
 # Export wrapper implementations for metric types
 from .datetime import DatetimeMetricType
@@ -74,6 +75,7 @@ __all__ = [
     "RecordedExperiment",
     "StringListMetricType",
     "StringMetricType",
+    "TextMetricType",
     "TimerId",
     "TimespanMetricType",
     "TimeUnit",

--- a/glean-core/python/glean/metrics/__init__.py
+++ b/glean-core/python/glean/metrics/__init__.py
@@ -21,8 +21,11 @@ from .._uniffi import RecordedExperiment
 # Re-export some metrics directly
 from .._uniffi import BooleanMetric as BooleanMetricType
 from .._uniffi import CounterMetric as CounterMetricType
+from .._uniffi import DenominatorMetric as DenominatorMetricType
 from .._uniffi import MemoryDistributionMetric as MemoryDistributionMetricType
+from .._uniffi import NumeratorMetric as NumeratorMetricType
 from .._uniffi import QuantityMetric as QuantityMetricType
+from .._uniffi import RateMetric as RateMetricType
 from .._uniffi import StringListMetric as StringListMetricType
 
 # Export wrapper implementations for metric types
@@ -49,6 +52,7 @@ __all__ = [
     "CommonMetricData",
     "CounterMetricType",
     "DatetimeMetricType",
+    "DenominatorMetricType",
     "DistributionMetrics",
     "EventExtras",
     "EventMetricType",
@@ -60,17 +64,19 @@ __all__ = [
     "Lifetime",
     "MemoryDistributionMetricType",
     "MemoryUnit",
+    "NumeratorMetricType",
     "ObjectMetricType",
     "ObjectSerialize",
     "PingType",
     "QuantityMetricType",
+    "RateMetricType",
     "RecordedEvent",
     "RecordedExperiment",
     "StringListMetricType",
     "StringMetricType",
-    "TimeUnit",
     "TimerId",
     "TimespanMetricType",
+    "TimeUnit",
     "TimingDistributionMetricType",
     "UrlMetricType",
     "UuidMetricType",

--- a/glean-core/python/tests/metrics/test_rate.py
+++ b/glean-core/python/tests/metrics/test_rate.py
@@ -1,0 +1,135 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pathlib import Path
+
+from glean import metrics
+from glean.metrics import Lifetime, CommonMetricData
+from glean.testing import ErrorType
+
+
+ROOT = Path(__file__).parent
+
+
+def test_rate_smoke():
+    metric = metrics.RateMetricType(
+        CommonMetricData(
+            category="test",
+            name="rate",
+            lifetime=Lifetime.PING,
+            send_in_pings=["store1"],
+            dynamic_label=None,
+            disabled=False,
+        ),
+    )
+
+    # Adding 0 doesn't error.
+    metric.add_to_numerator(0)
+    metric.add_to_denominator(0)
+    assert 0 == metric.test_get_num_recorded_errors(ErrorType.INVALID_VALUE)
+
+    # Adding a negative value errors.
+    metric.add_to_numerator(-1)
+    metric.add_to_denominator(-1)
+    assert 2 == metric.test_get_num_recorded_errors(ErrorType.INVALID_VALUE)
+
+    # Getting the value returns 0s if that's all we have.
+    value = metric.test_get_value()
+    assert 0 == value.numerator
+    assert 0 == value.denominator
+
+    # And normal values of course work.
+    metric.add_to_numerator(22)
+    metric.add_to_denominator(7)
+
+    value = metric.test_get_value()
+    assert 22 == value.numerator
+    assert 7 == value.denominator
+
+
+def test_numerator_smoke():
+    metric = metrics.NumeratorMetricType(
+        CommonMetricData(
+            category="test",
+            name="numerator",
+            lifetime=Lifetime.PING,
+            send_in_pings=["store1"],
+            dynamic_label=None,
+            disabled=False,
+        ),
+    )
+
+    # Adding 0 doesn't error.
+    metric.add_to_numerator(0)
+    assert 0 == metric.test_get_num_recorded_errors(ErrorType.INVALID_VALUE)
+
+    # Adding a negative value errors.
+    metric.add_to_numerator(-1)
+    assert 1 == metric.test_get_num_recorded_errors(ErrorType.INVALID_VALUE)
+
+    # Getting the value returns 0s if that's all we have.
+    value = metric.test_get_value()
+    assert 0 == value.numerator
+    assert 0 == value.denominator
+
+    # And normal values of course work.
+    metric.add_to_numerator(22)
+
+    value = metric.test_get_value()
+    assert 22 == value.numerator
+    assert 0 == value.denominator
+
+
+def test_denominator_smoke():
+    meta1 = CommonMetricData(
+        category="test",
+        name="rate1",
+        lifetime=Lifetime.PING,
+        send_in_pings=["store1"],
+        dynamic_label=None,
+        disabled=False,
+    )
+
+    meta2 = CommonMetricData(
+        category="test",
+        name="rate2",
+        lifetime=Lifetime.PING,
+        send_in_pings=["store1"],
+        dynamic_label=None,
+        disabled=False,
+    )
+
+    # This acts like a normal counter.
+    denom = metrics.DenominatorMetricType(
+        CommonMetricData(
+            category="test",
+            name="counter",
+            lifetime=Lifetime.PING,
+            send_in_pings=["store1"],
+            dynamic_label=None,
+            disabled=False,
+        ),
+        [meta1, meta2],
+    )
+
+    num1 = metrics.NumeratorMetricType(meta1)
+    num2 = metrics.NumeratorMetricType(meta2)
+
+    num1.add_to_numerator(3)
+    num2.add_to_numerator(5)
+
+    denom.add(7)
+
+    # no errors
+    assert 0 == num1.test_get_num_recorded_errors(ErrorType.INVALID_VALUE)
+    assert 0 == num2.test_get_num_recorded_errors(ErrorType.INVALID_VALUE)
+
+    # Getting the value returns what is stored
+    value = num1.test_get_value()
+    assert 3 == value.numerator
+    assert 7 == value.denominator
+
+    value = num2.test_get_value()
+    assert 5 == value.numerator
+    assert 7 == value.denominator

--- a/glean-core/python/tests/metrics/test_text.py
+++ b/glean-core/python/tests/metrics/test_text.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pathlib import Path
+
+from glean import metrics
+from glean.metrics import Lifetime, CommonMetricData
+from glean.testing import ErrorType
+
+
+ROOT = Path(__file__).parent
+
+
+def test_text_smoke():
+    metric = metrics.TextMetricType(
+        CommonMetricData(
+            category="test",
+            name="text",
+            lifetime=Lifetime.PING,
+            send_in_pings=["store1"],
+            dynamic_label=None,
+            disabled=False,
+        ),
+    )
+
+    metric.set("hello world")
+    assert 0 == metric.test_get_num_recorded_errors(ErrorType.INVALID_OVERFLOW)
+
+    assert "hello world" == metric.test_get_value()
+
+
+def test_text_truncation():
+    metric = metrics.TextMetricType(
+        CommonMetricData(
+            category="test",
+            name="text",
+            lifetime=Lifetime.PING,
+            send_in_pings=["store1"],
+            dynamic_label=None,
+            disabled=False,
+        ),
+    )
+
+    test_string = "01234567890" * (200 * 1024)
+    metric.set(test_string)
+
+    assert test_string[: (200 * 1024)] == metric.test_get_value()
+    assert 1 == metric.test_get_num_recorded_errors(ErrorType.INVALID_OVERFLOW)

--- a/glean-core/tests/rate.rs
+++ b/glean-core/tests/rate.rs
@@ -123,7 +123,7 @@ fn denominator_smoke() {
     assert!(test_get_num_recorded_errors(&glean, num1.meta(), ErrorType::InvalidValue).is_err());
     assert!(test_get_num_recorded_errors(&glean, num2.meta(), ErrorType::InvalidValue).is_err());
 
-    // Getting the value returns 0s if that's all we have.
+    // Getting the value returns what is stored
     let data = num1.get_value(&glean, None).unwrap();
     assert_eq!(3, data.numerator);
     assert_eq!(7, data.denominator);

--- a/glean-core/tests/text.rs
+++ b/glean-core/tests/text.rs
@@ -98,12 +98,12 @@ fn long_text_values_are_truncated() {
         ..Default::default()
     });
 
-    let test_sting = "01234567890".repeat(200 * 1024);
-    metric.set_sync(&glean, test_sting.clone());
+    let test_string = "01234567890".repeat(200 * 1024);
+    metric.set_sync(&glean, test_string.clone());
 
     // Check that data was truncated
     assert_eq!(
-        test_sting[..(200 * 1024)],
+        test_string[..(200 * 1024)],
         metric.get_value(&glean, "store1").unwrap()
     );
 


### PR DESCRIPTION
Trying this again.

Turns out we never actually exposed them and thus they were unusable, even though we claimed it exists!

(currently based against https://github.com/mozilla/glean/pull/3129, will merge cleanly into main after it)