### PR TITLE
Bug 1966698 - Kotlin: Dispatch setEnabled on thje Kotlin dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
    * Updated to Android NDK r28b ([#3118](https://github.com/mozilla/glean/pull/3118))
 * Kotlin
    * Added support for labeled quantity metric type ([#3121](https://github.com/mozilla/glean/pull/3121))
+   * BUGFIX: Ensure the inner ping object is initialized before accessing it ([#3132](https://github.com/mozilla/glean/pull/3132))
 * Swift
    * Added support for labeled quantity metric type ([#3121](https://github.com/mozilla/glean/pull/3121))
 * Python

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -125,6 +125,8 @@ class PingType<ReasonCodesEnum> (
      * and all pending pings of that type to be deleted.
      */
     fun setEnabled(enabled: Boolean) {
-        this.innerPing.setEnabled(enabled)
+        Dispatchers.Delayed.launch {
+            this.innerPing.setEnabled(enabled)
+        }
     }
 }


### PR DESCRIPTION
`this.innerPing` is lazy-initialized. It might not be set by the time `setEnabled` is called. By putting it on the dispatcher it is guaranteed to exist, because initialization is dispatched from `init` and that _always_ runs first.