### PR TITLE
Bug 1968018 - Revert JNA 5.17.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased changes
 
+* Android
+   * Reverted JNA to version 5.14.0 due crashes on Android 5 & 6 ([#3136](https://github.com/mozilla/glean/pull/3136))
+
 [Full changelog](https://github.com/mozilla/glean/compare/v64.3.0...main)
 
 # v64.3.0 (2025-05-21)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ androidx-lifecycle = "2.8.7"
 androidx-work = "2.10.0"
 
 # JNA
-jna = "5.17.0"
+jna = "5.14.0" # Don't update until Android 5/6 support is dropped
 
 # Linting and Static Analysis
 detekt = "1.23.8"


### PR DESCRIPTION
We're seeing new Android 5/6 startup crashes in Focus 139 now that early RC rollout has begun. @bendk found an [upstream bug report](https://github.com/java-native-access/jna/issues/1662) that suggests that our only real course of action is going to be reverting the update until we're able to drop support for Android <7 (currently in the decision brief stage).

For 139, I'm not sure if we're going to need to spin a 64.1.2 release specifically or if we can go all the way to 64.3.1. Thoughts on that, @travis79 and @badboy?