### PR TITLE
Python: Remove already-skipped tests

### DIFF
--- a/glean-core/python/tests/metrics/test_timing_distribution.py
+++ b/glean-core/python/tests/metrics/test_timing_distribution.py
@@ -109,39 +109,6 @@ def test_stopping_a_non_existent_timer_records_an_error():
     assert 1 == metric.test_get_num_recorded_errors(testing.ErrorType.INVALID_STATE)
 
 
-# Doesn't really test anything anymore
-@pytest.mark.skip
-def test_time_unit_controls_truncation():
-    max_sample_time = 1000 * 1000 * 1000 * 60 * 10
-
-    for unit in [TimeUnit.NANOSECOND, TimeUnit.MICROSECOND, TimeUnit.MILLISECOND]:
-        metric = metrics.TimingDistributionMetricType(
-            CommonMetricData(
-                disabled=False,
-                category="telemetry",
-                lifetime=Lifetime.APPLICATION,
-                name=f"timing_distribution_{unit.name}",
-                send_in_pings=["baseline"],
-                dynamic_label=None,
-            ),
-            time_unit=unit,
-        )
-
-        for _value in [
-            1,
-            100,
-            100000,
-            max_sample_time,
-            max_sample_time * 1000,
-            max_sample_time * 1000000,
-        ]:
-            timer_id = metric.start()
-            metric.stop_and_accumulate(timer_id)
-
-        snapshot = metric.test_get_value()
-        assert len(snapshot.values) < 318
-
-
 def test_measure():
     """
     Test the TimingDistributionMetricType.measure context manager.

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -163,11 +163,6 @@ def test_exeperimentation_id_recording():
     assert "alpha-beta-gamma-delta" == Glean.test_get_experimentation_id()
 
 
-@pytest.mark.skip
-def test_sending_of_background_pings():
-    pass
-
-
 def test_initialize_must_not_crash_if_data_dir_is_messed_up(tmpdir):
     filename = tmpdir / "dummy_file"
 
@@ -228,11 +223,6 @@ def test_initializing_twice_is_a_no_op():
     )
 
     assert before_config is Glean._configuration
-
-
-@pytest.mark.skip
-def test_dont_handle_events_when_uninitialized():
-    pass
 
 
 def test_dont_schedule_pings_if_metrics_disabled(safe_httpserver):
@@ -304,22 +294,6 @@ def test_the_app_channel_must_be_correctly_set():
 def test_get_language_tag_reports_the_tag_for_the_default_locale():
     tag = _util.get_locale_tag()
     assert re.match("(und)|([a-z][a-z]-[A-Z][A-Z])", tag)
-
-
-@pytest.mark.skip
-def test_get_language_tag_reports_the_correct_tag_for_a_non_default_language():
-    """
-    Not relevant for non-Java platforms.
-    """
-    pass
-
-
-@pytest.mark.skip
-def test_get_language_reports_the_modern_translation_for_some_languages():
-    """
-    Not relevant for non-Java platforms.
-    """
-    pass
 
 
 def test_ping_collection_must_happen_after_currently_scheduled_metrics_recordings(


### PR DESCRIPTION
These tests are either empty, not testing anything or broken. They haven't been touched in 2+ years. They won't be touched. Let's get rid of them.