### PR TITLE
FXIOS-12331 Add support for Xcode input file lists (.xcfilelist) to the iOS sdk_generator.sh script

### DIFF
--- a/glean-core/ios/sdk_generator.sh
+++ b/glean-core/ios/sdk_generator.sh
@@ -152,13 +152,13 @@ else
             infilevar="SCRIPT_INPUT_FILE_LIST_${i}"
             infile="${!infilevar}"
 
-            while read line; do
+            while read -r line; do
                 YAML_FILES+=("${line}")
-            done <<<"$(cat $infile)"
+            done <"$infile"
         done
     fi
 
-    echo "Discovered YAML input files: ${YAML_FILES[@]}"
+    echo "Discovered YAML input files: ${YAML_FILES[*]}"
 fi
 
 if [ -z "$SOURCE_ROOT" ]; then


### PR DESCRIPTION
[FXIOS-12331 Jira Ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12331)

## Context
This PR adds support for Xcode input file lists (.xcfilelist) to the iOS sdk_generator.sh script.

These changes are also to be mirrored in the Firefox for iOS codebase in this PR: https://github.com/mozilla-mobile/firefox-ios/pull/26910

## Background
I am suggesting these changes so the iOS team can automate adding new input files to the Xcode "Glean SDK Generator Script" build phase. An input file list allows us to use a separate script to add new metric YAML input files for the generator script. Without a file list, an iOS dev would have to manually add new input file paths each time to this Xcode build phase step, which would be tedious and a step that's easy to forget.

Please refer to the [FXIOS Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12331) and its comments for additional context.

---

I'm a newbie shell script writer, so I'm more than welcome to suggestions on how to implement these changes better! Thanks! 🙏 


cc @badboy 