### PR TITLE
Always set android.ndkVersion values

### DIFF
--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -36,8 +36,10 @@ kotlin {
 }
 
 android {
-    compileSdkVersion rootProject.ext.build.compileSdkVersion
     namespace = "mozilla.telemetry.glean"
+
+    ndkVersion rootProject.ext.build.ndkVersion
+    compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.build['minSdkVersion']

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -16,6 +16,8 @@ kotlin {
 
 android {
     namespace = "org.mozilla.samples.gleancore"
+
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {


### PR DESCRIPTION
When I follow the build docs and set `ndk.dir` to point to the r28b NDK, I get warnings (non-fatal errors?) when the glean samples build.

```
> Task :glean-sample-app:stripDebugDebugSymbols
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
[CXX1104] NDK from ndk.dir at /home/tcampbell/.mozbuild/android-ndk-r28b had version [28.1.13356709] which disagrees with android.ndkVersion [27.0.12077973]
Unable to strip the following libraries, packaging them as they are: libjnidispatch.so, libxul.so.
```

This is comes from android gradle stuff: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/cxx/configure/NdkLocator.kt;l=132-141;drc=26709c6175be5fd0ad355c3e5b750b56023ea08f

The simplest hygiene fix is to just declare the ndkVersion in these cases to match the project one.