### PR TITLE
Bug 1968902 - Android: Use Rust 1.86.0 for builds [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * General
   * Permit non-ASCII in dynamic labels ([bug 1968533](https://bugzilla.mozilla.org/show_bug.cgi?id=1968533))
+* Android
+  * Build release artifacts on Rust 1.86.0 to avoid broken files ([#3149](https://github.com/mozilla/glean/pull/3149))
 
 # v64.3.1 (2025-05-23)
 

--- a/taskcluster/scripts/rustup-setup.sh
+++ b/taskcluster/scripts/rustup-setup.sh
@@ -30,8 +30,8 @@ TOOLCHAIN="${1:-stable}"
 # No argument -> default stable install
 if [ "${TOOLCHAIN}" = "stable" ]; then
     echo "Installing Rust stable & Android targets"
-    rustup toolchain install stable --profile minimal
-    rustup default stable
+    rustup toolchain install 1.86.0 --profile minimal
+    rustup default 1.86.0
     rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android
 else
     echo "Installing Rust ${TOOLCHAIN}"


### PR DESCRIPTION
This reverts commit 8c594d6ad93850108e526b191dcb84648bcc012d.