### PR TITLE
Bug 1970856 - Count distinct labels before spilling into __other__ bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Python
   * Stop building wheels for Windows i686 ([#3144](https://github.com/mozilla/glean/pull/3144))
+* General
+  * BUGFIX: Count distinct labels, not total labels, before spilling into `__other__` bucket ([#3157](https://github.com/mozilla/glean/pull/3157))
 
 # v64.4.0 (2025-05-30)
 

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::collections::{hash_map::Entry, HashMap};
 use std::mem;
 use std::sync::{Arc, Mutex};
@@ -385,10 +386,10 @@ pub fn validate_dynamic_label(
         }
     }
 
-    let mut label_count = 0;
+    let mut labels = HashSet::new();
     let prefix = &key[..=base_identifier.len()];
-    let mut snapshotter = |_: &[u8], _: &Metric| {
-        label_count += 1;
+    let mut snapshotter = |metric_id: &[u8], _: &Metric| {
+        labels.insert(metric_id.to_vec());
     };
 
     let lifetime = meta.inner.lifetime;
@@ -398,6 +399,7 @@ pub fn validate_dynamic_label(
             .iter_store_from(lifetime, store, Some(prefix), &mut snapshotter);
     }
 
+    let label_count = labels.len();
     let error = if label_count >= MAX_LABELS {
         true
     } else if label.len() > MAX_LABEL_LENGTH {


### PR DESCRIPTION
If a labeled metrics records in MULTIPLE pings every ping counts as a use of a label.

That means a single labeled metric recorded into 16+ pings can only ever use a single label, before new labels being changed to `__other__`.

We don't have any metric that goes into 16 pings.
But we probably have some that go into 2 pings.
That means this metric can only use 8 labels maximum.

That's bad.