### PR TITLE
UniFFI: Pass library path when generating foreign-language bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
+ "glob",
  "uniffi",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ build-xcframework:
 bindgen-python: glean-core/python/glean/_uniffi/glean.py glean-core/python/glean/_uniffi/__init__.py # Generate the uniffi wrapper code manually
 
 glean-core/python/glean/_uniffi/glean.py: glean-core/src/glean.udl
+	cargo build -p glean-bundle
 	cargo uniffi-bindgen generate $< --language python --out-dir $(@D)
 
 glean-core/python/glean/_uniffi/__init__.py:

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 anyhow = "1"
 camino = "1.1.1"
 uniffi = { version = "0.29.0", default-features = false, features = ["bindgen"] }
+glob = "0.3.2"
 
 [lib]
 test = false


### PR DESCRIPTION
We will be using macros soon, and that's when we need the library file to parse out additional types.

Unfortunately currently maturin in particular determines library mode based on whether there's _any_ UDL file in tree, which no way to overwrite this (https://github.com/PyO3/maturin/issues/2617). So we simply go look for the library and always pass it along. We do that for every one of our targets, then we won't even need to pass a new flag to uniffi-bindgen in the calling scripts.

---

This should fix the compile issues of #3135 