### PR TITLE
Release v64.5.1

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 64.5.0
+libraryVersion: 64.5.1
 groupId: org.mozilla.telemetry
 projects:
   glean:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Unreleased changes
 
+[Full changelog](https://github.com/mozilla/glean/compare/v64.5.1...main)
+
+# v64.5.1 (2025-06-23)
+
 * Swift
   * No change dot-release to fix failed Swift package deploy to `mozilla/glean-swift`
 
-[Full changelog](https://github.com/mozilla/glean/compare/v64.5.0...main)
+[Full changelog](https://github.com/mozilla/glean/compare/v64.5.0...v64.5.1)
 
 # v64.5.0 (2025-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased changes
 
+* Swift
+  * No change dot-release to fix failed Swift package deploy to `mozilla/glean-swift`
+
 [Full changelog](https://github.com/mozilla/glean/compare/v64.5.0...main)
 
 # v64.5.0 (2025-06-18)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "glean"
-version = "64.5.0"
+version = "64.5.1"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "64.5.0"
+version = "64.5.1"
 dependencies = [
  "android_logger",
  "bincode",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4183,9 +4183,9 @@ SOFTWARE.
 
 The following text applies to code linked from these dependencies:
 
-* [glean-core 64.5.0]( https://github.com/mozilla/glean )
+* [glean-core 64.5.1]( https://github.com/mozilla/glean )
 * [glean-build 17.2.0]( https://github.com/mozilla/glean )
-* [glean 64.5.0]( https://github.com/mozilla/glean )
+* [glean 64.5.1]( https://github.com/mozilla/glean )
 * [zeitstempel 0.1.1]( https://github.com/badboy/zeitstempel )
 
 ```

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "64.5.0"
+version = "64.5.1"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean"
-version = "64.5.0"
+version = "64.5.1"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "Glean SDK Rust language bindings"
 repository = "https://github.com/mozilla/glean"
@@ -23,7 +23,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies.glean-core]
 path = ".."
-version = "64.5.0"
+version = "64.5.1"
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -548,7 +548,7 @@ except:
     void apply(Project project) {
         isOffline = project.gradle.startParameter.offline
 
-        project.ext.glean_version = "64.5.0"
+        project.ext.glean_version = "64.5.1"
         def parserVersion = gleanParserVersion(project)
 
         // Print the required glean_parser version to the console. This is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "glean-sdk"
-version = "64.5.0"
+version = "64.5.1"
 requires-python = ">=3.8"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
This is an "empty" dot-release in order to fix a failed deploy to `mozilla/glean-swift`