### PR TITLE
Bug 1973287 - Add `MetricType` implementation for `DualLabeledCounter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased changes
 
+* Rust
+  * Added `MetricType` implementation for `DualLabeledCounter` ([Bug 1973287](https://bugzilla.mozilla.org/show_bug.cgi?id=1973287))
+
 [Full changelog](https://github.com/mozilla/glean/compare/v64.5.1...main)
 
 # v64.5.1 (2025-06-23)

--- a/glean-core/src/metrics/dual_labeled_counter.rs
+++ b/glean-core/src/metrics/dual_labeled_counter.rs
@@ -63,6 +63,12 @@ impl ::malloc_size_of::MallocSizeOf for DualLabeledCounterMetric {
     }
 }
 
+impl MetricType for DualLabeledCounterMetric {
+    fn meta(&self) -> &CommonMetricDataInternal {
+        self.counter.meta()
+    }
+}
+
 impl DualLabeledCounterMetric {
     /// Creates a new dual labeled counter from the given metric instance and optional list of labels.
     pub fn new(


### PR DESCRIPTION
This adds the missing `MetricType` impl for `DualLabeledCounter` metrics