### PR TITLE
Bug 1892234 - Kotlin: Dispatch several more metric type recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * Updated Android SDK target to version 36 ([#3180](https://github.com/mozilla/glean/pull/3180))
   * Updated Gradle to 8.14.3 ([#3180](https://github.com/mozilla/glean/pull/3180))
   * Updated Kotlin to 2.2.0 ([#3182](https://github.com/mozilla/glean/pull/3182))
+  * BREAKING CHANGE: Dispatch most metric recordings on a Kotlin dispatcher to avoid calling into glean-core early.
+    This does not change any behavior: The dispatch queue is worked on right after initialization ([#3183](https://github.com/mozilla/glean/pull/3183))
 * Python
   * Bump minimum required Python version to 3.9 ([#3164](https://github.com/mozilla/glean/issues/3164))
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -46,7 +46,7 @@ class BooleanMetricType {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored boolean value
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.BooleanMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording boolean metrics.
  *
@@ -12,4 +17,48 @@ package mozilla.telemetry.glean.private
  *
  * The boolean API only exposes the [set] method.
  */
-typealias BooleanMetricType = mozilla.telemetry.glean.internal.BooleanMetric
+class BooleanMetricType {
+    lateinit var inner: BooleanMetric
+
+    constructor(meta: CommonMetricData) {
+        Dispatchers.Delayed.launch {
+            inner = BooleanMetric(meta)
+        }
+    }
+
+    constructor(metric: BooleanMetric) {
+        inner = metric
+    }
+
+    /**
+     * Sets to the specified boolean value.
+     *
+     * @param value The value to set.
+     */
+    fun set(value: Boolean) {
+        Dispatchers.Delayed.launch {
+            inner.set(value)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored boolean value
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.CounterMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording counter metrics.
  *
@@ -13,4 +18,48 @@ package mozilla.telemetry.glean.private
  * The counter API only exposes the [add] method, which takes care of validating the input
  * data and making sure that limits are enforced.
  */
-typealias CounterMetricType = mozilla.telemetry.glean.internal.CounterMetric
+class CounterMetricType {
+    lateinit var inner: CounterMetric
+
+    constructor(meta: CommonMetricData) {
+        Dispatchers.Delayed.launch {
+            inner = CounterMetric(meta)
+        }
+    }
+
+    constructor(metric: CounterMetric) {
+        inner = metric
+    }
+
+    /**
+     * Increases the counter by `amount`.
+     *
+     * @param amount The amount to increase by. Should be positive.
+     */
+    fun add(amount: Int = 1) {
+        Dispatchers.Delayed.launch {
+            inner.add(amount)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored value
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -47,8 +47,8 @@ class CounterMetricType {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
-     * @return value of the stored value
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
+     * @return the stored value for the counter
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
@@ -57,7 +57,7 @@ class CounterMetricType {
     /**
      * Returns the number of errors recorded for the given metric.
      *
-     * @param errorType The type of the error recorded.
+     * @param errorType The type of error to get the error count of
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -5,6 +5,7 @@
 package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.internal.CustomDistributionMetric
 import mozilla.telemetry.glean.testing.ErrorType
 
@@ -32,22 +33,50 @@ class CustomDistributionMetricType(
     bucketCount: Long,
     histogramType: HistogramType,
 ) : HistogramBase {
-    val inner = CustomDistributionMetric(meta, rangeMin, rangeMax, bucketCount, histogramType)
+    val inner: CustomDistributionMetric by lazy {
+        CustomDistributionMetric(meta, rangeMin, rangeMax, bucketCount, histogramType)
+    }
 
     /**
-     * Delegate common methods to the underlying type directly.
+     * Accumulates precisely one signed sample and appends it to the metric.
+     *
+     * @param sample The singular sample to be recorded by the metric.
      */
-    fun accumulateSingleSample(sample: Long) = inner.accumulateSingleSample(sample)
-    override fun accumulateSamples(samples: List<Long>) = inner.accumulateSamples(samples)
+    fun accumulateSingleSample(sample: Long) {
+        Dispatchers.Delayed.launch {
+            inner.accumulateSingleSample(sample)
+        }
+    }
 
     /**
-     * Testing-only methods get an annotation
+     * Accumulates the provided signed samples in the metric.
+     *
+     * @param samples The list holding the samples to be recorded by the metric.
      */
+    override fun accumulateSamples(samples: List<Long>) {
+        Dispatchers.Delayed.launch {
+            inner.accumulateSamples(samples)
+        }
+    }
 
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored distribution data
+     */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
     fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
 
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -64,7 +64,7 @@ class CustomDistributionMetricType(
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored distribution data
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DenominatorMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DenominatorMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.DenominatorMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording a denominator of a rate metric,
  * where the denominator is external.
@@ -15,4 +20,38 @@ package mozilla.telemetry.glean.private
  * The denominator API exposes the [add] method,
  * which takes care of validating the input data and making sure that limits are enforced.
  */
-typealias DenominatorMetricType = mozilla.telemetry.glean.internal.DenominatorMetric
+class DenominatorMetricType(private var meta: CommonMetricData, var numerators: List<CommonMetricData>) {
+    val inner: DenominatorMetric by lazy { DenominatorMetric(meta, numerators) }
+
+    /**
+     * Increases the denominator by `amount`.
+     *
+     * @param amount The amount to increase by. Should be non-negative.
+     */
+    fun add(amount: Int) {
+        Dispatchers.Delayed.launch {
+            inner.add(amount)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored rate
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DenominatorMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DenominatorMetricType.kt
@@ -26,7 +26,7 @@ class DenominatorMetricType(private var meta: CommonMetricData, var numerators: 
     /**
      * Increases the denominator by `amount`.
      *
-     * @param amount The amount to increase by. Should be non-negative.
+     * @param amount The amount to increase by. Should be positive.
      */
     fun add(amount: Int) {
         Dispatchers.Delayed.launch {
@@ -39,7 +39,7 @@ class DenominatorMetricType(private var meta: CommonMetricData, var numerators: 
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored rate
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
@@ -71,7 +71,7 @@ class EventMetricType<ExtraObject> constructor(
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored events
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -5,11 +5,40 @@
 package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
-import mozilla.telemetry.glean.internal.LabeledBoolean
-import mozilla.telemetry.glean.internal.LabeledCounter
-import mozilla.telemetry.glean.internal.LabeledQuantity
-import mozilla.telemetry.glean.internal.LabeledString
 import mozilla.telemetry.glean.testing.ErrorType
+import mozilla.telemetry.glean.internal.LabeledBoolean as InternalLabeledBoolean
+import mozilla.telemetry.glean.internal.LabeledCounter as InternalLabeledCounter
+import mozilla.telemetry.glean.internal.LabeledQuantity as InternalLabeledQuantity
+import mozilla.telemetry.glean.internal.LabeledString as InternalLabeledString
+
+class LabeledBoolean constructor(meta: CommonLabeledMetricData, labels: List<String>?) {
+    val metric = InternalLabeledBoolean(meta, labels)
+
+    fun get(label: String): BooleanMetricType {
+        return BooleanMetricType(metric.get(label))
+    }
+}
+class LabeledCounter constructor(meta: CommonLabeledMetricData, labels: List<String>?) {
+    val metric = InternalLabeledCounter(meta, labels)
+
+    fun get(label: String): CounterMetricType {
+        return CounterMetricType(metric.get(label))
+    }
+}
+class LabeledQuantity constructor(meta: CommonLabeledMetricData, labels: List<String>?) {
+    val metric = InternalLabeledQuantity(meta, labels)
+
+    fun get(label: String): QuantityMetricType {
+        return QuantityMetricType(metric.get(label))
+    }
+}
+class LabeledString constructor(meta: CommonLabeledMetricData, labels: List<String>?) {
+    val metric = InternalLabeledString(meta, labels)
+
+    fun get(label: String): StringMetricType {
+        return StringMetricType(metric.get(label))
+    }
+}
 
 /**
  * This implements the developer facing API for labeled metrics.
@@ -114,10 +143,10 @@ class LabeledMetricType<T>(
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetNumRecordedErrors(errorType: ErrorType): Int {
         return when (this.inner) {
-            is LabeledCounter -> this.inner.testGetNumRecordedErrors(errorType)
-            is LabeledBoolean -> this.inner.testGetNumRecordedErrors(errorType)
-            is LabeledString -> this.inner.testGetNumRecordedErrors(errorType)
-            is LabeledQuantity -> this.inner.testGetNumRecordedErrors(errorType)
+            is LabeledCounter -> this.inner.metric.testGetNumRecordedErrors(errorType)
+            is LabeledBoolean -> this.inner.metric.testGetNumRecordedErrors(errorType)
+            is LabeledString -> this.inner.metric.testGetNumRecordedErrors(errorType)
+            is LabeledQuantity -> this.inner.metric.testGetNumRecordedErrors(errorType)
             else -> error("Can not create a labeled version of this metric type")
         }
     }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -5,6 +5,7 @@
 package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.internal.MemoryDistributionMetric
 import mozilla.telemetry.glean.testing.ErrorType
 
@@ -15,24 +16,49 @@ import mozilla.telemetry.glean.testing.ErrorType
  * allowing developers to record values that were previously registered in the metrics.yaml file.
  */
 class MemoryDistributionMetricType(meta: CommonMetricData, memoryUnit: MemoryUnit) : HistogramBase {
-    val inner = MemoryDistributionMetric(meta, memoryUnit)
+    val inner: MemoryDistributionMetric by lazy { MemoryDistributionMetric(meta, memoryUnit) }
 
     /**
-     * Delegate common methods to the underlying type directly.
+     * Accumulates the provided sample in the metric.
+     *
+     * @param sample The sample to be recorded by the metric.
+     *               The sample is assumed to be in the configured memory unit of the metric.
      */
-
-    fun accumulate(sample: Long) = inner.accumulate(sample)
-
-    override fun accumulateSamples(samples: List<Long>) = inner.accumulateSamples(samples)
+    fun accumulate(sample: Long) {
+        Dispatchers.Delayed.launch {
+            inner.accumulate(sample)
+        }
+    }
 
     /**
-     * Testing-only methods get an annotation
+     * Accumulates the provided signed samples in the metric.
+     *
+     * @param samples The list holding the samples to be recorded by the metric.
      */
+    override fun accumulateSamples(samples: List<Long>) {
+        Dispatchers.Delayed.launch {
+            inner.accumulateSamples(samples)
+        }
+    }
 
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored distribution data
+     */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
     fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
 
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -33,7 +33,7 @@ class MemoryDistributionMetricType(meta: CommonMetricData, memoryUnit: MemoryUni
     /**
      * Accumulates the provided signed samples in the metric.
      *
-     * @param samples The list holding the samples to be recorded by the metric.
+     * @param samples A list of the samples to be recorded to the metric.
      */
     override fun accumulateSamples(samples: List<Long>) {
         Dispatchers.Delayed.launch {
@@ -46,7 +46,7 @@ class MemoryDistributionMetricType(meta: CommonMetricData, memoryUnit: MemoryUni
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored distribution data
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/NumeratorMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/NumeratorMetricType.kt
@@ -38,7 +38,7 @@ class NumeratorMetricType(private var meta: CommonMetricData) {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored rate
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/ObjectMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/ObjectMetricType.kt
@@ -50,7 +50,7 @@ class ObjectMetricType<K> constructor(
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored object as a JSON value
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.QuantityMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording quantity metrics.
  *
@@ -12,4 +17,48 @@ package mozilla.telemetry.glean.private
  *
  * The quantity API only exposes the [set] method.
  */
-typealias QuantityMetricType = mozilla.telemetry.glean.internal.QuantityMetric
+class QuantityMetricType {
+    lateinit var inner: QuantityMetric
+
+    constructor(meta: CommonMetricData) {
+        Dispatchers.Delayed.launch {
+            inner = QuantityMetric(meta)
+        }
+    }
+
+    constructor(metric: QuantityMetric) {
+        inner = metric
+    }
+
+    /**
+     * Sets the value. Must be non-negative.
+     *
+     * @param value The value to set. Must be non-negative.
+     */
+    fun set(value: Long) {
+        Dispatchers.Delayed.launch {
+            inner.set(value)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored quantity value
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -46,8 +46,8 @@ class QuantityMetricType {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
-     * @return value of the stored quantity value
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
+     * @return value of the stored quantity metric
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/RateMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/RateMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.RateMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording rate metrics.
  *
@@ -13,4 +18,49 @@ package mozilla.telemetry.glean.private
  * The rate API exposes the [addToNumerator] and [addToDenominator] method, which takes care of validating the input
  * data and making sure that limits are enforced.
  */
-typealias RateMetricType = mozilla.telemetry.glean.internal.RateMetric
+class RateMetricType(private var meta: CommonMetricData) {
+    val inner: RateMetric by lazy { RateMetric(meta) }
+
+    /**
+     * Increases the numerator by `amount`.
+     *
+     * @param amount The amount to increase by. Should be non-negative.
+     */
+    fun addToNumerator(amount: Int) {
+        Dispatchers.Delayed.launch {
+            inner.addToNumerator(amount)
+        }
+    }
+
+    /**
+     * Increases the denominator by `amount`.
+     *
+     * @param amount The amount to increase by. Should be non-negative.
+     */
+    fun addToDenominator(amount: Int) {
+        Dispatchers.Delayed.launch {
+            inner.addToDenominator(amount)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored rate
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/RateMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/RateMetricType.kt
@@ -48,7 +48,7 @@ class RateMetricType(private var meta: CommonMetricData) {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored rate
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -48,7 +48,7 @@ class StringListMetricType constructor(private var meta: CommonMetricData) {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored string list
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.StringMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording string metrics.
  *
@@ -13,4 +18,48 @@ package mozilla.telemetry.glean.private
  * The string API only exposes the [set] method, which takes care of validating the input
  * data and making sure that limits are enforced.
  */
-typealias StringMetricType = mozilla.telemetry.glean.internal.StringMetric
+class StringMetricType {
+    lateinit var inner: StringMetric
+
+    constructor(meta: CommonMetricData) {
+        Dispatchers.Delayed.launch {
+            inner = StringMetric(meta)
+        }
+    }
+
+    constructor(metric: StringMetric) {
+        inner = metric
+    }
+
+    /**
+     * Sets to the specified value.
+     *
+     * @param value The value to set the metric to.
+     */
+    fun set(value: String) {
+        Dispatchers.Delayed.launch {
+            inner.set(value)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored string
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -47,7 +47,7 @@ class StringMetricType {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored string
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TextMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TextMetricType.kt
@@ -37,7 +37,7 @@ class TextMetricType constructor(private var meta: CommonMetricData) {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored text as a string
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TextMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TextMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.TextMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording text metrics.
  *
@@ -13,4 +18,38 @@ package mozilla.telemetry.glean.private
  * The text API only exposes the [set] method, which takes care of validating the input
  * data and making sure that limits are enforced.
  */
-typealias TextMetricType = mozilla.telemetry.glean.internal.TextMetric
+class TextMetricType constructor(private var meta: CommonMetricData) {
+    val inner: TextMetric by lazy { TextMetric(meta) }
+
+    /**
+     * Sets to the specified value.
+     *
+     * @param value The text to set the metric to.
+     */
+    fun set(value: String) {
+        Dispatchers.Delayed.launch {
+            inner.set(value)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored text as a string
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -30,16 +30,16 @@ class TimespanMetricType constructor(private var meta: CommonMetricData, var tim
     fun start() = inner.start()
 
     /**
-     * Stops tracking time for the provided metric. Sets the metric to the elapsed time.
+     * Stops tracking time for the provided metric and records the elapsed time.
      *
-     * This will record an error if no `set_start` was called.
+     * This will record an error if no `start` was called, or if 'stop' has already been called.
      */
     fun stop() = inner.stop()
 
     /**
-     * Aborts a previous `set_start` call.
+     * Aborts a previous `start` call.
      *
-     * No error is recorded if no `set_start` was called.
+     * No error is recorded if `start` was not called.
      */
     fun cancel() = inner.cancel()
 
@@ -66,7 +66,7 @@ class TimespanMetricType constructor(private var meta: CommonMetricData, var tim
     /**
      * Explicitly sets the timespan value.
      *
-     *  @param elapsed The elapsed time to record.
+     *  @param elapsed The elapsed time to record in nanoseconds
      */
     fun setRawNanos(elapsed: Long) {
         Dispatchers.Delayed.launch {
@@ -79,7 +79,7 @@ class TimespanMetricType constructor(private var meta: CommonMetricData, var tim
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored timespan as an integer
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.TimespanMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording timespans.
  *
@@ -12,24 +17,81 @@ package mozilla.telemetry.glean.private
  *
  * The timespans API exposes the [start], [stop] and [cancel] methods.
  */
-typealias TimespanMetricType = mozilla.telemetry.glean.internal.TimespanMetric
+class TimespanMetricType constructor(private var meta: CommonMetricData, var timeUnit: TimeUnit) {
+    val inner: TimespanMetric by lazy { TimespanMetric(meta, timeUnit) }
 
-/**
- * Convenience method to simplify measuring a function or block of code
- *
- * If the measured function throws, the measurement is canceled and the exception rethrown.
- */
-@Suppress("TooGenericExceptionCaught")
-fun <U> TimespanMetricType.measure(funcToMeasure: () -> U): U {
-    this.start()
+    /**
+     * Starts tracking time for the provided metric.
+     *
+     * This records an error if it's already tracking time (i.e. start was
+     * already called with no corresponding `set_stop`).
+     * In that case the original start time will be preserved.
+     */
+    fun start() = inner.start()
 
-    val returnValue = try {
-        funcToMeasure()
-    } catch (e: Exception) {
-        this.cancel()
-        throw e
+    /**
+     * Stops tracking time for the provided metric. Sets the metric to the elapsed time.
+     *
+     * This will record an error if no `set_start` was called.
+     */
+    fun stop() = inner.stop()
+
+    /**
+     * Aborts a previous `set_start` call.
+     *
+     * No error is recorded if no `set_start` was called.
+     */
+    fun cancel() = inner.cancel()
+
+    /**
+     * Convenience method to simplify measuring a function or block of code
+     *
+     * If the measured function throws, the measurement is canceled and the exception rethrown.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun <U> measure(funcToMeasure: () -> U): U {
+        this.start()
+
+        val returnValue = try {
+            funcToMeasure()
+        } catch (e: Exception) {
+            this.cancel()
+            throw e
+        }
+
+        this.stop()
+        return returnValue
     }
 
-    this.stop()
-    return returnValue
+    /**
+     * Explicitly sets the timespan value.
+     *
+     *  @param elapsed The elapsed time to record.
+     */
+    fun setRawNanos(elapsed: Long) {
+        Dispatchers.Delayed.launch {
+            inner.setRawNanos(elapsed)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored timespan as an integer
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -27,7 +27,7 @@ class TimingDistributionMetricType(meta: CommonMetricData, timeUnit: TimeUnit) :
     fun start() = inner.start()
 
     /**
-     * Stops tracking time for the provided metric and associated timer id.
+     * Stops tracking time for the provided metric and associated timer id and accumulates the sample to the metric.
      *
      * @param timerId A timer ID from a previous `start()` call
      */
@@ -41,9 +41,9 @@ class TimingDistributionMetricType(meta: CommonMetricData, timeUnit: TimeUnit) :
     fun cancel(timerId: GleanTimerId) = inner.cancel(timerId)
 
     /**
-     * Accumulates precisely one signed sample and appends it to the metric.
+     * Accumulates precisely one signed sample to the metric.
      *
-     * @param sample The singular sample to be recorded by the metric.
+     * @param sample A single sample to be recorded by the metric.
      */
     fun accumulateSingleSample(sample: Long) {
         Dispatchers.Delayed.launch {
@@ -87,7 +87,7 @@ class TimingDistributionMetricType(meta: CommonMetricData, timeUnit: TimeUnit) :
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored distribution data
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -20,23 +20,42 @@ class TimingDistributionMetricType(meta: CommonMetricData, timeUnit: TimeUnit) :
     val inner: TimingDistributionMetric by lazy { TimingDistributionMetric(meta, timeUnit) }
 
     /**
-     * Delegate common methods to the underlying type directly.
+     * Starts tracking time for the provided metric.
+     *
+     * @return a timer ID to use with `stopAndAccumulate` or `cancel`
      */
-
     fun start() = inner.start()
+
+    /**
+     * Stops tracking time for the provided metric and associated timer id.
+     *
+     * @param timerId A timer ID from a previous `start()` call
+     */
     fun stopAndAccumulate(timerId: GleanTimerId) = inner.stopAndAccumulate(timerId)
+
+    /**
+     * Aborts a previous `start()` call.
+     *
+     * @param timerId A timer ID from a previous `start()` call
+     */
     fun cancel(timerId: GleanTimerId) = inner.cancel(timerId)
 
     /**
-     * Additional functionality
+     * Accumulates precisely one signed sample and appends it to the metric.
+     *
+     * @param sample The singular sample to be recorded by the metric.
      */
-
     fun accumulateSingleSample(sample: Long) {
         Dispatchers.Delayed.launch {
             inner.accumulateSingleSample(sample)
         }
     }
 
+    /**
+     * Accumulates the provided signed samples in the metric.
+     *
+     * @param samples The list holding the samples to be recorded by the metric.
+     */
     override fun accumulateSamples(samples: List<Long>) {
         Dispatchers.Delayed.launch {
             inner.accumulateSamples(samples)
@@ -64,13 +83,23 @@ class TimingDistributionMetricType(meta: CommonMetricData, timeUnit: TimeUnit) :
     }
 
     /**
-     * Testing-only methods get an annotation
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored distribution data
      */
-
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
     fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
 
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UrlMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UrlMetricType.kt
@@ -22,9 +22,9 @@ class UrlMetricType constructor(private var meta: CommonMetricData) {
     val inner: UrlMetric by lazy { UrlMetric(meta) }
 
     /**
-     *  Sets to the specified URL.
+     *  Records the specified URL to the metric
      *
-     * @param url The URL to set the metric to.
+     * @param url The String representation of the URL to set the metric to.
      */
     fun set(url: String) {
         Dispatchers.Delayed.launch {
@@ -37,7 +37,7 @@ class UrlMetricType constructor(private var meta: CommonMetricData) {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored URL as a string
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UrlMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UrlMetricType.kt
@@ -4,6 +4,11 @@
 
 package mozilla.telemetry.glean.private
 
+import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
+import mozilla.telemetry.glean.internal.UrlMetric
+import mozilla.telemetry.glean.testing.ErrorType
+
 /**
  * This implements the developer facing API for recording URL metrics.
  *
@@ -13,4 +18,38 @@ package mozilla.telemetry.glean.private
  * The URL API only exposes the [set] method, which takes care of validating the input
  * data and making sure that limits are enforced.
  */
-typealias UrlMetricType = mozilla.telemetry.glean.internal.UrlMetric
+class UrlMetricType constructor(private var meta: CommonMetricData) {
+    val inner: UrlMetric by lazy { UrlMetric(meta) }
+
+    /**
+     *  Sets to the specified URL.
+     *
+     * @param url The URL to set the metric to.
+     */
+    fun set(url: String) {
+        Dispatchers.Delayed.launch {
+            inner.set(url)
+        }
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored URL as a string
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
+    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+
+    /**
+     * Returns the number of errors recorded for the given metric.
+     *
+     * @param errorType The type of the error recorded.
+     * @return the number of errors recorded for the metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+}

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
@@ -5,6 +5,7 @@
 package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
+import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.internal.UuidMetric
 import java.util.UUID
 
@@ -18,19 +19,39 @@ import java.util.UUID
  *
  * The internal constructor is only used by [LabeledMetricType] directly.
  */
-class UuidMetricType(meta: CommonMetricData) {
-    val inner = UuidMetric(meta)
+class UuidMetricType(private var meta: CommonMetricData) {
+    val inner: UuidMetric by lazy { UuidMetric(meta) }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    @JvmOverloads
-    fun testGetValue(pingName: String? = null): UUID? {
-        return inner.testGetValue(pingName)?.let { UUID.fromString(it) }
+    /**
+     * Sets to the specified value.
+     *
+     * @param value The uuid to set the metric to.
+     */
+    fun set(value: UUID) {
+        Dispatchers.Delayed.launch {
+            inner.set(value.toString())
+        }
     }
 
-    fun set(value: UUID) = inner.set(value.toString())
-
+    /**
+     * Generates a new random uuid and sets the metric to it.
+     */
     fun generateAndSet(): UUID {
-        val uuid = inner.generateAndSet()
-        return UUID.fromString(uuid)
+        val uuid = UUID.randomUUID()
+        this.set(uuid)
+        return uuid
+    }
+
+    /**
+     * Returns the stored value for testing purposes only. This function will attempt to await the
+     * last task (if any) writing to the the metric's storage engine before returning a value.
+     *
+     * @param pingName represents the name of the ping to retrieve the metric for.
+     *                 Defaults to the first value in `sendInPings`.
+     * @return value of the stored UUID
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetValue(pingName: String? = null): UUID? {
+        return inner.testGetValue(pingName)?.let { UUID.fromString(it) }
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
@@ -25,7 +25,7 @@ class UuidMetricType(private var meta: CommonMetricData) {
     /**
      * Sets to the specified value.
      *
-     * @param value The uuid to set the metric to.
+     * @param value A UUID type with the value to record
      */
     fun set(value: UUID) {
         Dispatchers.Delayed.launch {
@@ -35,6 +35,8 @@ class UuidMetricType(private var meta: CommonMetricData) {
 
     /**
      * Generates a new random uuid and sets the metric to it.
+     *
+     * @return the generated UUID
      */
     fun generateAndSet(): UUID {
         val uuid = UUID.randomUUID()
@@ -47,7 +49,7 @@ class UuidMetricType(private var meta: CommonMetricData) {
      * last task (if any) writing to the the metric's storage engine before returning a value.
      *
      * @param pingName represents the name of the ping to retrieve the metric for.
-     *                 Defaults to the first value in `sendInPings`.
+     *                 Defaults to the first ping listed in `send_in_pings` in the metric definition.
      * @return value of the stored UUID
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -82,7 +82,7 @@ impl UuidMetric {
         self.set_sync(glean, value.to_string())
     }
 
-    /// Generates a new random [`Uuid`'] and sets the metric to it.
+    /// Generates a new random [`Uuid`] and sets the metric to it.
     pub fn generate_and_set(&self) -> String {
         let uuid = Uuid::new_v4();
 

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -83,6 +83,8 @@ impl UuidMetric {
     }
 
     /// Generates a new random [`Uuid`] and sets the metric to it.
+    ///
+    /// Returns the generated UUID formatted as a hex string.
     pub fn generate_and_set(&self) -> String {
         let uuid = Uuid::new_v4();
 


### PR DESCRIPTION
This should mitigate yet another early libxul loading in Fenix.

---

This implements the list put together in https://docs.google.com/document/d/1vFgZp9K7pSc7kC_uB1T6JRCFRatr-6t4FcwFJL-ka7k/edit?tab=t.0#heading=h.a22b38t3zasz