### PR TITLE
Python: Report `client_info.architecture` again based on what Python tells us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Updated Kotlin to 2.2.0 ([#3182](https://github.com/mozilla/glean/pull/3182))
 * Python
   * Bump minimum required Python version to 3.9 ([#3164](https://github.com/mozilla/glean/issues/3164))
+  * Report `client_info.architecture` as reported from Python again ([#3185](https://github.com/mozilla/glean/issues/3185))
 
 # v64.5.2 (2025-07-01)
 

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 import shutil
 import tempfile
+import platform
 import threading
 from typing import Dict, Optional, Set, TYPE_CHECKING
 
@@ -210,7 +211,7 @@ class Glean:
             app_display_version=cls._application_version,
             app_build_date=dt,
             channel=configuration.channel,
-            architecture="Unknown",
+            architecture=platform.machine() or "Unknown",
             os_version="Unknown",
             locale=None,
             device_manufacturer=None,


### PR DESCRIPTION
We used to do that before until 23f778c1be.
platform.machine is documented here:
https://docs.python.org/3/library/platform.html#platform.machine

---

I don't know why I dropped it back then and never re-introduced it. But I also can't find a bug to re-implement it.
anyone knows?