### PR TITLE
Bug 1976479 - Report a glean.ping.uploader_capabilities list in pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * General
   * Performance improvement: Reduce file system operations when recording events ([#3179](https://github.com/mozilla/glean/pull/3179))
   * `LabeledMetric` improvement: Added `testGetValue` as a test method on all labeled metric types ([#3190](https://github.com/mozilla/glean/pull/3190))
+  * New metric: `glean.ping.uploader_capabilities` reporting the requested uploader capabilities for a ping ([#3188](https://github.com/mozilla/glean/pull/3188))
 * Android
   * Updated Android Gradle Plugin to 8.11.0 ([#3180](https://github.com/mozilla/glean/pull/3180))
   * Updated Android SDK target to version 36 ([#3180](https://github.com/mozilla/glean/pull/3180))

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -950,3 +950,23 @@ glean:
       - chutten@mozilla.com
       - glean-team@mozilla.com
     expires: never
+
+glean.ping:
+  uploader_capabilities:
+    type: string_list
+    description: |
+      The list of requested uploader capabilities for the ping this is sent in.
+      Should be the same as the ones defined for that particular ping.
+
+      This metric is only attached to a ping if it already contains other data.
+    send_in_pings:
+      - all-pings
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1976479
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1976479#c2
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never

--- a/glean-core/python/glean/testing/__init__.py
+++ b/glean-core/python/glean/testing/__init__.py
@@ -73,8 +73,9 @@ class _RecordingUploader(base_uploader.BaseUploader):
     package since it runs in the ping upload worker subprocess.
     """
 
-    def __init__(self, file_path):
+    def __init__(self, file_path, capabilities=None):
         self.file_path = file_path
+        self.capabilities = set(capabilities or {})
 
     def do_upload(
         self, capable_request: "CapablePingUploadRequest"
@@ -85,7 +86,9 @@ class _RecordingUploader(base_uploader.BaseUploader):
         UploadResult.HTTP_STATUS,
         UploadResult.INCAPABLE,
     ]:
-        request = capable_request.capable(lambda _capabilities: True)
+        request = capable_request.capable(
+            lambda capabilities: set(capabilities).issubset(self.capabilities)
+        )
         assert request is not None
         data = request.body
         headers = request.headers


### PR DESCRIPTION
Because I already prototyped that here's it as a PR.
Would benefit from more extensive tests.
And also checking that my logic is right to attach it only when there's already other data. 
And making sure it doesn't overwrite existing `string_list` metrics.
And also it hard-codes the `"string_list"` string in the code, which I don't like.

All in all I'd appreciate if someone takes this over and finishes it.