### PR TITLE
Bug 1930572: add testGetValue for LabeledMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Performance improvement: Reduce file system operations when recording events ([#3179](https://github.com/mozilla/glean/pull/3179))
+  * `LabeledMetric` improvement: Added `testGetValue` as a test method on all labeled metric types ([#3190](https://github.com/mozilla/glean/pull/3190))
 * Android
   * Updated Android Gradle Plugin to 8.11.0 ([#3180](https://github.com/mozilla/glean/pull/3180))
   * Updated Android SDK target to version 36 ([#3180](https://github.com/mozilla/glean/pull/3180))

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ test-python: build-python ## Run all Python tests
 
 # Linting
 
+lint: lint-rust lint-kotlin lint-swift lint-yaml lint-python
+
 lint-rust: ## Run cargo-clippy to lint Rust code
 	cargo clippy --all --all-targets --all-features -- -D warnings -A unknown-lints
 

--- a/docs/user/reference/metrics/labeled_booleans.md
+++ b/docs/user/reference/metrics/labeled_booleans.md
@@ -118,8 +118,8 @@ import org.mozilla.yourApplication.GleanMetrics.Accessibility
 
 val values = Accessibility.features.testGetValue()
 // Do the booleans have the expected values?
-assertEquals(True, values["category.accessibility/screen_reader"])
-assertEquals(False, values["category.accessibility/high_contrast"])
+assertEquals(True, values["screen_reader"])
+assertEquals(False, values["high_contrast"])
 ```
 </div>
 
@@ -130,8 +130,8 @@ import org.mozilla.yourApplication.GleanMetrics.Accessibility;
 
 Map<String, ?> values = Accessibility.INSTANCE.features().testGetValue();
 // Do the booleans have the expected values?
-assertEquals(True, values["category.accessibility/screen_reader"]);
-assertEquals(False, values["category.accessibility/high_contrast"]);
+assertEquals(True, values["screen_reader"]);
+assertEquals(False, values["high_contrast"]);
 ```
 </div>
 
@@ -140,8 +140,8 @@ assertEquals(False, values["category.accessibility/high_contrast"]);
 ```Swift
 let values = Accessibility.features.testGetValue()
 // Do the booleans have the expected values?
-XCTAssertEqual(true, values["category.accessibility/screen_reader"])
-XCTAssertEqual(false, values["category.accessibility/high_contrast"])
+XCTAssertEqual(true, values["screen_reader"])
+XCTAssertEqual(false, values["high_contrast"])
 ```
 </div>
 
@@ -153,8 +153,8 @@ metrics = load_metrics("metrics.yaml")
 
 values = metrics.accessibility.features.testGetValue()
 # Do the booleans have the expected values?
-assert values["category.accessibility/screen_reader"]
-assert not values["category.accessibility/high_contrast"]
+assert values["screen_reader"]
+assert not values["high_contrast"]
 ```
 </div>
 
@@ -165,8 +165,8 @@ use glean_metrics::accessibility;
 
 let values = accessibility::features.test_get_value(None).unwrap();
 // Do the booleans have the expected values?
-assert!(values["category.accessibility/screen_reader"]);
-assert!(!values["category.accessibility/high_contrast"]);
+assert!(values["screen_reader"]);
+assert!(!values["high_contrast"]);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_booleans.md
+++ b/docs/user/reference/metrics/labeled_booleans.md
@@ -102,8 +102,10 @@ Glean.accessibility.features["high_contrast"].set(false);
 ### `testGetValue`
 
 Gets the recorded value for a given label in a labeled boolean metric.  
-Returns the count if data is stored.  
-Returns a language-specific empty/null value if no data is stored.
+Returns the boolean value if data is stored. The Glean SDK will return a map of each label with a
+stored value to its value.  
+Returns a language-specific empty/null value if no data is stored. The Glean SDK will always 
+return a map, but it will be empty if no data is stored.
 Has an optional argument to specify the name of the ping you wish to retrieve data from, except
 in Rust where it's required. `None` or no argument will default to the first value found for `send_in_pings`.
 
@@ -114,9 +116,10 @@ in Rust where it's required. `None` or no argument will default to the first val
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Accessibility
 
+val values = Accessibility.features.testGetValue()
 // Do the booleans have the expected values?
-assertEquals(True, Accessibility.features["screen_reader"].testGetValue())
-assertEquals(False, Accessibility.features["high_contrast"].testGetValue())
+assertEquals(True, values["category.accessibility/screen_reader"])
+assertEquals(False, values["category.accessibility/high_contrast"])
 ```
 </div>
 
@@ -125,18 +128,20 @@ assertEquals(False, Accessibility.features["high_contrast"].testGetValue())
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.Accessibility;
 
+Map<String, ?> values = Accessibility.INSTANCE.features().testGetValue();
 // Do the booleans have the expected values?
-assertEquals(True, Acessibility.INSTANCE.features()["screen_reader"].testGetValue());
-assertEquals(False, Acessibility.INSTANCE.features()["high_contrast"].testGetValue());
+assertEquals(True, values["category.accessibility/screen_reader"]);
+assertEquals(False, values["category.accessibility/high_contrast"]);
 ```
 </div>
 
 <div data-lang="Swift" class="tab">
 
 ```Swift
+let values = Accessibility.features.testGetValue()
 // Do the booleans have the expected values?
-XCTAssertEqual(true, Accessibility.features["screen_reader"].testGetValue())
-XCTAssertEqual(false, Accessibility.features["high_contrast"].testGetValue())
+XCTAssertEqual(true, values["category.accessibility/screen_reader"])
+XCTAssertEqual(false, values["category.accessibility/high_contrast"])
 ```
 </div>
 
@@ -146,9 +151,10 @@ XCTAssertEqual(false, Accessibility.features["high_contrast"].testGetValue())
 from glean import load_metrics
 metrics = load_metrics("metrics.yaml")
 
+values = metrics.accessibility.features.testGetValue()
 # Do the booleans have the expected values?
-assert metrics.accessibility.features["screen_reader"].test_get_value()
-assert not metrics.accessibility.features["high_contrast"].test_get_value()
+assert values["category.accessibility/screen_reader"]
+assert not values["category.accessibility/high_contrast"]
 ```
 </div>
 
@@ -157,9 +163,10 @@ assert not metrics.accessibility.features["high_contrast"].test_get_value()
 ```Rust
 use glean_metrics::accessibility;
 
+let values = accessibility::features.test_get_value(None).unwrap();
 // Do the booleans have the expected values?
-assert!(accessibility::features.get("screen_reader").test_get_value(None).unwrap());
-assert!(!accessibility::features.get("high_contrast").test_get_value(None).unwrap());
+assert!(values["category.accessibility/screen_reader"]);
+assert!(!values["category.accessibility/high_contrast"]);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_counters.md
+++ b/docs/user/reference/metrics/labeled_counters.md
@@ -115,8 +115,10 @@ Glean.stability.crashCount["native_code_crash"].add(3);
 ### `testGetValue`
 
 Gets the recorded value for a given label in a labeled counter metric.  
-Returns the count if data is stored.  
-Returns a language-specific empty/null value if no data is stored.
+Returns the count if data is stored. The Glean SDK will return a map of each label with a
+stored value to its value.  
+Returns a language-specific empty/null value if no data is stored. The Glean SDK will always
+return a map, but it will be empty if no data is stored.
 Has an optional argument to specify the name of the ping you wish to retrieve data from, except
 in Rust where it's required. `None` or no argument will default to the first value found for `send_in_pings`.
 
@@ -127,9 +129,10 @@ in Rust where it's required. `None` or no argument will default to the first val
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Stability
 
+val values = Stability.crashCount.testGetValue()
 // Do the counters have the expected values?
-assertEquals(1, Stability.crashCount["uncaught_exception"].testGetValue())
-assertEquals(3, Stability.crashCount["native_code_crash"].testGetValue())
+assertEquals(1, values["category.stability/uncaught_exception"])
+assertEquals(3, values["category.stability/native_code_crash"])
 ```
 </div>
 
@@ -138,18 +141,20 @@ assertEquals(3, Stability.crashCount["native_code_crash"].testGetValue())
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.Stability;
 
+Map<String, ?> values = Stability.INSTANCE.crashCount().testGetValue();
 // Do the counters have the expected values?
-assertEquals(1, Stability.INSTANCE.crashCount()["uncaught_exception"].testGetValue());
-assertEquals(3, Stability.INSTANCE.crashCount()["native_code_crash"].testGetValue());
+assertEquals(1, values["category.stability/uncaught_exception"]);
+assertEquals(3, values["category.stability/native_code_crash"]);
 ```
 </div>
 
 <div data-lang="Swift" class="tab">
 
 ```Swift
+let values = Stability.crashCount.testGetValue()
 // Do the counters have the expected values?
-XCTAssertEqual(1, Stability.crashCount["uncaught_exception"].testGetValue())
-XCTAssertEqual(3, Stability.crashCount["native_code_crash"].testGetValue())
+XCTAssertEqual(1, values["category.stability/uncaught_exception"])
+XCTAssertEqual(3, values["category.stability/native_code_crash"])
 ```
 </div>
 
@@ -159,9 +164,10 @@ XCTAssertEqual(3, Stability.crashCount["native_code_crash"].testGetValue())
 from glean import load_metrics
 metrics = load_metrics("metrics.yaml")
 
+values = metrics.stability.crash_count.test_get_value()
 # Do the counters have the expected values?
-assert 1 == metrics.stability.crash_count["uncaught_exception"].test_get_value()
-assert 3 == metrics.stability.crash_count["native_code_crash"].test_get_value()
+assert 1 == values["category.stability/uncaught_exception"]
+assert 3 == values["category.stability/native_code_crash"]
 ```
 </div>
 
@@ -170,9 +176,10 @@ assert 3 == metrics.stability.crash_count["native_code_crash"].test_get_value()
 ```Rust
 use glean_metrics::stability;
 
+let values = stability::crash_count.test_get_value(None).unwrap();
 // Do the counters have the expected values?
-assert_eq!(1, stability::crash_count.get("uncaught_exception").test_get_value().unwrap());
-assert_eq!(3, stability::crash_count.get("native_code_crash").test_get_value().unwrap());
+assert_eq!(1, values["uncaught_exception"]);
+assert_eq!(3, values["native_code_crash"]);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_counters.md
+++ b/docs/user/reference/metrics/labeled_counters.md
@@ -131,8 +131,8 @@ import org.mozilla.yourApplication.GleanMetrics.Stability
 
 val values = Stability.crashCount.testGetValue()
 // Do the counters have the expected values?
-assertEquals(1, values["category.stability/uncaught_exception"])
-assertEquals(3, values["category.stability/native_code_crash"])
+assertEquals(1, values["uncaught_exception"])
+assertEquals(3, values["native_code_crash"])
 ```
 </div>
 
@@ -143,8 +143,8 @@ import org.mozilla.yourApplication.GleanMetrics.Stability;
 
 Map<String, ?> values = Stability.INSTANCE.crashCount().testGetValue();
 // Do the counters have the expected values?
-assertEquals(1, values["category.stability/uncaught_exception"]);
-assertEquals(3, values["category.stability/native_code_crash"]);
+assertEquals(1, values["uncaught_exception"]);
+assertEquals(3, values["native_code_crash"]);
 ```
 </div>
 
@@ -153,8 +153,8 @@ assertEquals(3, values["category.stability/native_code_crash"]);
 ```Swift
 let values = Stability.crashCount.testGetValue()
 // Do the counters have the expected values?
-XCTAssertEqual(1, values["category.stability/uncaught_exception"])
-XCTAssertEqual(3, values["category.stability/native_code_crash"])
+XCTAssertEqual(1, values["uncaught_exception"])
+XCTAssertEqual(3, values["native_code_crash"])
 ```
 </div>
 
@@ -166,8 +166,8 @@ metrics = load_metrics("metrics.yaml")
 
 values = metrics.stability.crash_count.test_get_value()
 # Do the counters have the expected values?
-assert 1 == values["category.stability/uncaught_exception"]
-assert 3 == values["category.stability/native_code_crash"]
+assert 1 == values["uncaught_exception"]
+assert 3 == values["native_code_crash"]
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_quantity.md
+++ b/docs/user/reference/metrics/labeled_quantity.md
@@ -102,8 +102,10 @@ Glean.gfx.display["height"].set(aHeight);
 ### `testGetValue`
 
 Gets the recorded value for a given label in a labeled quantity metric.  
-Returns the quantity value if data is stored.  
-Returns a language-specific empty/null value if no data is stored.  
+Returns the quantity value if data is stored. The Glean SDK will return a map of each label with a
+stored value to its value.   
+Returns a language-specific empty/null value if no data is stored. The Glean SDK will always
+return a map, but it will be empty if no data is stored. 
 Has an optional argument to specify the name of the ping you wish to retrieve data from, except  
 in Rust where it's required. `None` or no argument will default to the first value found for `send_in_pings`.
 
@@ -114,8 +116,9 @@ in Rust where it's required. `None` or no argument will default to the first val
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Gfx
 
-assertEquals(433, Gfx.display["width"].testGetValue())
-assertEquals(42, Gfx.display["height"].testGetValue())
+val values = Gfx.display.testGetValue()
+assertEquals(433, values["category.gfx/width"])
+assertEquals(42, values["category.gfx/height"])
 ```
 
 </div>
@@ -124,15 +127,17 @@ assertEquals(42, Gfx.display["height"].testGetValue())
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.Gfx;
 
-assertEquals(433, Gfx.INSTANCE.display()["width"].testGetValue());
-assertEquals(42, Gfx.INSTANCE.display()["height"].testGetValue());
+Map<String, ?> values = 
+assertEquals(433, values["category.gfx/width"]);
+assertEquals(42, values["category.gfx/height"]);
 ```
 </div>
 <div data-lang="Swift" class="tab">
 
 ```Swift
-XCTAssertEqual(433, Gfx.display["width"].testGetValue())
-XCTAssertEqual(42, Gfx.display["heigth"].testGetValue())
+let values = Gfx.display.testGetValue()
+XCTAssertEqual(433, values["category.gfx/width"])
+XCTAssertEqual(42, values["category.gfx/heigth"])
 ```
 
 </div>
@@ -142,8 +147,9 @@ XCTAssertEqual(42, Gfx.display["heigth"].testGetValue())
 from glean import load_metrics
 metrics = load_metrics("metrics.yaml")
 
-assert 433 == metrics.gfx.display["width"].test_get_value()
-assert 42 == metrics.gfx.display["height"].test_get_value()
+values = metrics.gfx.display.test_get_value()
+assert 433 == values["category.gfx/width"]
+assert 42 == values["category.gfx/height"]
 ```
 
 </div>
@@ -152,9 +158,10 @@ assert 42 == metrics.gfx.display["height"].test_get_value()
 ```Rust
 use glean_metrics::gfx;
 
+let values = gfx::display.test_get_value(None).unwrap();
 // Was anything recorded?
-assert_eq!(433, gfx::display.get("width").test_get_value(None).unwrap());
-assert_eq!(42, gfx::display.get("height").test_get_value(None).unwrap());
+assert_eq!(433, values["category.gfx/width"]);
+assert_eq!(42, values["category.gfx/height"]);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_quantity.md
+++ b/docs/user/reference/metrics/labeled_quantity.md
@@ -117,8 +117,8 @@ in Rust where it's required. `None` or no argument will default to the first val
 import org.mozilla.yourApplication.GleanMetrics.Gfx
 
 val values = Gfx.display.testGetValue()
-assertEquals(433, values["category.gfx/width"])
-assertEquals(42, values["category.gfx/height"])
+assertEquals(433, values["width"])
+assertEquals(42, values["height"])
 ```
 
 </div>
@@ -128,16 +128,16 @@ assertEquals(42, values["category.gfx/height"])
 import org.mozilla.yourApplication.GleanMetrics.Gfx;
 
 Map<String, ?> values = 
-assertEquals(433, values["category.gfx/width"]);
-assertEquals(42, values["category.gfx/height"]);
+assertEquals(433, values["width"]);
+assertEquals(42, values["height"]);
 ```
 </div>
 <div data-lang="Swift" class="tab">
 
 ```Swift
 let values = Gfx.display.testGetValue()
-XCTAssertEqual(433, values["category.gfx/width"])
-XCTAssertEqual(42, values["category.gfx/heigth"])
+XCTAssertEqual(433, values["width"])
+XCTAssertEqual(42, values["heigth"])
 ```
 
 </div>
@@ -148,8 +148,8 @@ from glean import load_metrics
 metrics = load_metrics("metrics.yaml")
 
 values = metrics.gfx.display.test_get_value()
-assert 433 == values["category.gfx/width"]
-assert 42 == values["category.gfx/height"]
+assert 433 == values["width"]
+assert 42 == values["height"]
 ```
 
 </div>
@@ -160,8 +160,8 @@ use glean_metrics::gfx;
 
 let values = gfx::display.test_get_value(None).unwrap();
 // Was anything recorded?
-assert_eq!(433, values["category.gfx/width"]);
-assert_eq!(42, values["category.gfx/height"]);
+assert_eq!(433, values["width"]);
+assert_eq!(42, values["height"]);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_strings.md
+++ b/docs/user/reference/metrics/labeled_strings.md
@@ -111,7 +111,7 @@ import org.mozilla.yourApplication.GleanMetrics.Login
 
 val values = Login.errorsByStage.testGetValue()
 // Does the metric have the expected value?
-assertTrue(values["category.errorsByStage/server_auth"])
+assertTrue(values["server_auth"])
 ```
 </div>
 
@@ -122,7 +122,7 @@ import org.mozilla.yourApplication.GleanMetrics.Login;
 
 Map<String, ?> values = Login.INSTANCE.errorsByStage().testGetValue();
 // Does the metric have the expected value?
-assertTrue(values["category.errorsByStage/server_auth"]);
+assertTrue(values["server_auth"]);
 ```
 </div>
 
@@ -131,7 +131,7 @@ assertTrue(values["category.errorsByStage/server_auth"]);
 ```Swift
 let values = Login.errorsByStage.testGetValue()
 // Does the metric have the expected value?
-XCTAssert(values["category.errorsByStage/server_auth"])
+XCTAssert(values["server_auth"])
 ```
 
 </div>
@@ -144,7 +144,7 @@ metrics = load_metrics("metrics.yaml")
 
 values = metrics.login.errors_by_stage.testGetValue()
 # Does the metric have the expected value?
-assert "Invalid password" == values["category.errorsByStage/server_auth"])
+assert "Invalid password" == values["server_auth"])
 ```
 </div>
 
@@ -155,7 +155,7 @@ use glean_metrics::login;
 
 let values = login::errors_by_stage.test_get_value(None).unwrap();
 // Does the metric have the expected value?
-assert!(values["category.errorsByStage/server_auth"]);
+assert!(values["server_auth"]);
 ```
 </div>
 

--- a/docs/user/reference/metrics/labeled_strings.md
+++ b/docs/user/reference/metrics/labeled_strings.md
@@ -95,8 +95,10 @@ Glean.login.errorsByStage["server_auth"].set("Invalid password");
 ### `testGetValue`
 
 Gets the recorded value for a given label in a labeled string metric.  
-Returns the string if data is stored.  
-Returns a language-specific empty/null value if no data is stored.
+Returns the string if data is stored. The Glean SDK will return a map of each label with a
+stored value to its value.   
+Returns a language-specific empty/null value if no data is stored. The Glean SDK will always
+return a map, but it will be empty if no data is stored. 
 Has an optional argument to specify the name of the ping you wish to retrieve data from, except
 in Rust where it's required. `None` or no argument will default to the first value found for `send_in_pings`.
 
@@ -107,8 +109,9 @@ in Rust where it's required. `None` or no argument will default to the first val
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Login
 
+val values = Login.errorsByStage.testGetValue()
 // Does the metric have the expected value?
-assertTrue(Login.errorsByStage["server_auth"].testGetValue())
+assertTrue(values["category.errorsByStage/server_auth"])
 ```
 </div>
 
@@ -117,16 +120,18 @@ assertTrue(Login.errorsByStage["server_auth"].testGetValue())
 ```Java
 import org.mozilla.yourApplication.GleanMetrics.Login;
 
+Map<String, ?> values = Login.INSTANCE.errorsByStage().testGetValue();
 // Does the metric have the expected value?
-assertTrue(Login.INSTANCE.errorsByStage()["server_auth"].testGetValue());
+assertTrue(values["category.errorsByStage/server_auth"]);
 ```
 </div>
 
 <div data-lang="Swift" class="tab">
 
 ```Swift
+let values = Login.errorsByStage.testGetValue()
 // Does the metric have the expected value?
-XCTAssert(Login.errorsByStage["server_auth"].testGetValue())
+XCTAssert(values["category.errorsByStage/server_auth"])
 ```
 
 </div>
@@ -137,8 +142,9 @@ XCTAssert(Login.errorsByStage["server_auth"].testGetValue())
 from glean import load_metrics
 metrics = load_metrics("metrics.yaml")
 
+values = metrics.login.errors_by_stage.testGetValue()
 # Does the metric have the expected value?
-assert "Invalid password" == metrics.login.errors_by_stage["server_auth"].testGetValue())
+assert "Invalid password" == values["category.errorsByStage/server_auth"])
 ```
 </div>
 
@@ -147,8 +153,9 @@ assert "Invalid password" == metrics.login.errors_by_stage["server_auth"].testGe
 ```Rust
 use glean_metrics::login;
 
+let values = login::errors_by_stage.test_get_value(None).unwrap();
 // Does the metric have the expected value?
-assert!(login::errors_by_stage.get("server_auth").test_get_value());
+assert!(values["category.errorsByStage/server_auth"]);
 ```
 </div>
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -162,13 +162,13 @@ class LabeledMetricType<T>(
      * @return The values for each label in the labeled metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetLabeledValues(pingName: String? = null): Map<String, Any> {
+    fun testGetValue(pingName: String? = null): Map<String, Any> {
         return when (this.inner) {
-            is LabeledBoolean -> this.inner.metric.testGetLabeledValues(pingName)
-            is LabeledCounter -> this.inner.metric.testGetLabeledValues(pingName)
-            is LabeledString -> this.inner.metric.testGetLabeledValues(pingName)
-            is LabeledQuantity -> this.inner.metric.testGetLabeledValues(pingName)
+            is LabeledBoolean -> this.inner.metric.testGetValue(pingName)
+            is LabeledCounter -> this.inner.metric.testGetValue(pingName)
+            is LabeledString -> this.inner.metric.testGetValue(pingName)
+            is LabeledQuantity -> this.inner.metric.testGetValue(pingName)
             else -> error("Can not create a labeled version of this metric type")
-        }
+        }!!
     }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/LabeledMetricType.kt
@@ -150,4 +150,25 @@ class LabeledMetricType<T>(
             else -> error("Can not create a labeled version of this metric type")
         }
     }
+
+    /**
+     * Returns the currently stored values for each label as the appropriate type for the given
+     * metric.
+     *
+     * This doesn't clear the stored value.
+     *
+     * @param pingName The optional name of the ping to retrieve the metrics for. Defaults to the
+     *   first value in `send_in_pings`.
+     * @return The values for each label in the labeled metric.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun testGetLabeledValues(pingName: String? = null): Map<String, Any> {
+        return when (this.inner) {
+            is LabeledBoolean -> this.inner.metric.testGetLabeledValues(pingName)
+            is LabeledCounter -> this.inner.metric.testGetLabeledValues(pingName)
+            is LabeledString -> this.inner.metric.testGetLabeledValues(pingName)
+            is LabeledQuantity -> this.inner.metric.testGetLabeledValues(pingName)
+            else -> error("Can not create a labeled version of this metric type")
+        }
+    }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -538,7 +538,7 @@ class LabeledMetricTypeTest {
 
         val values = labeledCounterMetric.testGetValue()
         assertEquals(2, values.size)
-        assertEquals(1, values["telemetry.labeled_counter_metric/label1"])
-        assertEquals(2, values["telemetry.labeled_counter_metric/label2"])
+        assertEquals(1, values["label1"])
+        assertEquals(2, values["label2"])
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -511,4 +511,34 @@ class LabeledMetricTypeTest {
         assertEquals(maxAttempts, labeledCounterMetric["foo"].testGetValue())
         assertEquals(0, labeledCounterMetric.testGetNumRecordedErrors(ErrorType.INVALID_LABEL))
     }
+
+    @Test
+    fun `test labeled metric testGetLabeledValues`() {
+        val counterMetric = CounterMetricType(
+            CommonMetricData(
+                disabled = false,
+                category = "telemetry",
+                lifetime = Lifetime.APPLICATION,
+                name = "labeled_counter_metric",
+                sendInPings = listOf("metrics"),
+            ),
+        )
+
+        val labeledCounterMetric = LabeledMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.APPLICATION,
+            name = "labeled_counter_metric",
+            sendInPings = listOf("metrics"),
+            subMetric = counterMetric,
+        )
+
+        labeledCounterMetric["label1"].add(1)
+        labeledCounterMetric["label2"].add(2)
+
+        val labeledValues = labeledCounterMetric.testGetLabeledValues()
+        assertEquals(2, labeledValues.size)
+        assertEquals(1, labeledValues["telemetry.labeled_counter_metric/label1"])
+        assertEquals(2, labeledValues["telemetry.labeled_counter_metric/label2"])
+    }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -513,7 +513,7 @@ class LabeledMetricTypeTest {
     }
 
     @Test
-    fun `test labeled metric testGetLabeledValues`() {
+    fun `test labeled metric testGetValue`() {
         val counterMetric = CounterMetricType(
             CommonMetricData(
                 disabled = false,
@@ -536,9 +536,9 @@ class LabeledMetricTypeTest {
         labeledCounterMetric["label1"].add(1)
         labeledCounterMetric["label2"].add(2)
 
-        val labeledValues = labeledCounterMetric.testGetValue()
-        assertEquals(2, labeledValues.size)
-        assertEquals(1, labeledValues["telemetry.labeled_counter_metric/label1"])
-        assertEquals(2, labeledValues["telemetry.labeled_counter_metric/label2"])
+        val values = labeledCounterMetric.testGetValue()
+        assertEquals(2, values.size)
+        assertEquals(1, values["telemetry.labeled_counter_metric/label1"])
+        assertEquals(2, values["telemetry.labeled_counter_metric/label2"])
     }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/LabeledMetricTypeTest.kt
@@ -536,7 +536,7 @@ class LabeledMetricTypeTest {
         labeledCounterMetric["label1"].add(1)
         labeledCounterMetric["label2"].add(2)
 
-        val labeledValues = labeledCounterMetric.testGetLabeledValues()
+        val labeledValues = labeledCounterMetric.testGetValue()
         assertEquals(2, labeledValues.size)
         assertEquals(1, labeledValues["telemetry.labeled_counter_metric/label1"])
         assertEquals(2, labeledValues["telemetry.labeled_counter_metric/label2"])

--- a/glean-core/ios/Glean/Metrics/LabeledMetric.swift
+++ b/glean-core/ios/Glean/Metrics/LabeledMetric.swift
@@ -22,6 +22,7 @@ public class LabeledMetricType<T> {
     /// * `BooleanMetricType`
     /// * `CounterMetricType`
     /// * `StringMetricType`
+    /// * `QuantityMetric`
     ///
     /// Throws an exception when used with unsupported sub-metrics.
     public init(
@@ -106,6 +107,30 @@ public class LabeledMetricType<T> {
             return (self.inner as! LabeledString).testGetNumRecordedErrors(errorType)
         case is LabeledQuantity:
             return (self.inner as! LabeledQuantity).testGetNumRecordedErrors(errorType)
+        default:
+            // The constructor will already throw an exception on an unhandled sub-metric type
+            assertUnreachable()
+        }
+    }
+
+    /// Returns the currently stored values for each label as the appropriate type for the given metric.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// - parameters:
+    ///     * pingName: The optional name of the ping to retrieve the metrics for. Defaults to the first value in
+    ///       `send_in_pings`.
+    /// - returns: The values for each label in the labeled metric.
+    public func testGetLabeledValues(_ pingName: String? = nil) -> [String: Any] {
+        switch self.inner {
+        case is LabeledCounter:
+            return (self.inner as! LabeledCounter).testGetLabeledValues(pingName)
+        case is LabeledBoolean:
+            return (self.inner as! LabeledBoolean).testGetLabeledValues(pingName)
+        case is LabeledString:
+            return (self.inner as! LabeledString).testGetLabeledValues(pingName)
+        case is LabeledQuantity:
+            return (self.inner as! LabeledQuantity).testGetLabeledValues(pingName)
         default:
             // The constructor will already throw an exception on an unhandled sub-metric type
             assertUnreachable()

--- a/glean-core/ios/Glean/Metrics/LabeledMetric.swift
+++ b/glean-core/ios/Glean/Metrics/LabeledMetric.swift
@@ -121,16 +121,16 @@ public class LabeledMetricType<T> {
     ///     * pingName: The optional name of the ping to retrieve the metrics for. Defaults to the first value in
     ///       `send_in_pings`.
     /// - returns: The values for each label in the labeled metric.
-    public func testGetLabeledValues(_ pingName: String? = nil) -> [String: Any] {
+    public func testGetValue(_ pingName: String? = nil) -> [String: Any] {
         switch self.inner {
-        case is LabeledCounter:
-            return (self.inner as! LabeledCounter).testGetLabeledValues(pingName)
-        case is LabeledBoolean:
-            return (self.inner as! LabeledBoolean).testGetLabeledValues(pingName)
-        case is LabeledString:
-            return (self.inner as! LabeledString).testGetLabeledValues(pingName)
-        case is LabeledQuantity:
-            return (self.inner as! LabeledQuantity).testGetLabeledValues(pingName)
+        case let labeled as LabeledCounter:
+            return labeled.testGetValue(pingName)!
+        case let labeled as LabeledBoolean:
+            return labeled.testGetValue(pingName)!
+        case let labeled as LabeledString:
+            return labeled.testGetValue(pingName)!
+        case let labeled as LabeledQuantity:
+            return labeled.testGetValue(pingName)!
         default:
             // The constructor will already throw an exception on an unhandled sub-metric type
             assertUnreachable()

--- a/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
@@ -247,4 +247,31 @@ class LabeledMetricTypeTests: XCTestCase {
             XCTAssertEqual(error as! String, "Can not create a labeled version of this metric type")
         }
     }
+
+    func testLabeledMetricTestGetLabeledValues() {
+        let counterMetric = CounterMetricType(CommonMetricData(
+            category: "telemetry",
+            name: "labeled_counter_metric",
+            sendInPings: ["metrics"],
+            lifetime: .application,
+            disabled: false
+        ))
+
+        let labeledCounterMetric = try! LabeledMetricType<CounterMetricType>(
+            category: "telemetry",
+            name: "labeled_counter_metric",
+            sendInPings: ["metrics"],
+            lifetime: .application,
+            disabled: false,
+            subMetric: counterMetric
+        )
+
+        labeledCounterMetric["label1"].add(1)
+        labeledCounterMetric["label2"].add(2)
+
+        let labeledValues = labeledCounterMetric.testGetLabeledValues()
+        XCTAssertEqual(2, labeledValues.count)
+        XCTAssertEqual(1, labeledValues["telemetry.labeled_counter_metric/label1"] as! Int32)
+        XCTAssertEqual(2, labeledValues["telemetry.labeled_counter_metric/label2"] as! Int32)
+    }
 }

--- a/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
@@ -269,7 +269,7 @@ class LabeledMetricTypeTests: XCTestCase {
         labeledCounterMetric["label1"].add(1)
         labeledCounterMetric["label2"].add(2)
 
-        let labeledValues = labeledCounterMetric.testGetLabeledValues()
+        let labeledValues = labeledCounterMetric.testGetValue()
         XCTAssertEqual(2, labeledValues.count)
         XCTAssertEqual(1, labeledValues["telemetry.labeled_counter_metric/label1"] as! Int32)
         XCTAssertEqual(2, labeledValues["telemetry.labeled_counter_metric/label2"] as! Int32)

--- a/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/LabeledMetricTests.swift
@@ -271,7 +271,7 @@ class LabeledMetricTypeTests: XCTestCase {
 
         let labeledValues = labeledCounterMetric.testGetValue()
         XCTAssertEqual(2, labeledValues.count)
-        XCTAssertEqual(1, labeledValues["telemetry.labeled_counter_metric/label1"] as! Int32)
-        XCTAssertEqual(2, labeledValues["telemetry.labeled_counter_metric/label2"] as! Int32)
+        XCTAssertEqual(1, labeledValues["label1"] as! Int32)
+        XCTAssertEqual(2, labeledValues["label2"] as! Int32)
     }
 }

--- a/glean-core/python/glean/metrics/labeled.py
+++ b/glean-core/python/glean/metrics/labeled.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from typing import Any, Optional, Set, Type, Dict
+from typing import Any, Dict, Optional, Set, Type
 
 
 from .._uniffi import LabeledBoolean

--- a/glean-core/python/glean/metrics/labeled.py
+++ b/glean-core/python/glean/metrics/labeled.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from typing import Any, Optional, Set, Type
+from typing import Any, Optional, Set, Type, Dict
 
 
 from .._uniffi import LabeledBoolean
@@ -68,14 +68,27 @@ class LabeledMetricBase:
 
         Args:
             error_type (ErrorType): The type of error recorded.
-            ping_name (str): (default: first value in send_in_pings) The name
-                of the ping to retrieve the metric for.
 
         Returns:
             num_errors (int): The number of errors recorded for the metric for
                 the given error type.
         """
         return self._inner.test_get_num_recorded_errors(error_type)
+
+    def test_get_value(self, ping_name: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Returns the currently stored value of the appropriate type for the given metric.
+
+        This doesn't clear the stored value.
+
+        Args:
+            ping_name (str): (default: first value in send_in_pings) The name
+                of the ping to retrieve the metric for.
+
+        Returns:
+            value (Dict[str: Any]): A map of the set labels to their values.
+        """
+        return self._inner.test_get_value(ping_name)
 
 
 class LabeledBooleanMetricType(LabeledMetricBase):

--- a/glean-core/python/tests/metrics/test_labeled.py
+++ b/glean-core/python/tests/metrics/test_labeled.py
@@ -31,6 +31,30 @@ def test_labeled_counter_type():
     assert 2 == labeled_counter_metric["label2"].test_get_value()
 
 
+def test_labeled_counter_type_test_get_metrics():
+    labeled_counter_metric = metrics.LabeledCounterMetricType(
+        LabeledMetricData.COMMON(
+            CommonMetricData(
+                disabled=False,
+                category="telemetry",
+                lifetime=Lifetime.APPLICATION,
+                name="labeled_counter_metric",
+                send_in_pings=["metrics"],
+                dynamic_label=None,
+            )
+        )
+    )
+
+    labeled_counter_metric["label1"].add(1)
+    labeled_counter_metric["label2"].add(2)
+
+    values = labeled_counter_metric.test_get_value()
+
+    assert 1 == values["telemetry.labeled_counter_metric/label1"]
+
+    assert 2 == values["telemetry.labeled_counter_metric/label2"]
+
+
 def test_labeled_boolean_type():
     labeled_boolean_metric = metrics.LabeledBooleanMetricType(
         LabeledMetricData.COMMON(

--- a/glean-core/python/tests/metrics/test_labeled.py
+++ b/glean-core/python/tests/metrics/test_labeled.py
@@ -50,9 +50,9 @@ def test_labeled_counter_type_test_get_metrics():
 
     values = labeled_counter_metric.test_get_value()
 
-    assert 1 == values["telemetry.labeled_counter_metric/label1"]
+    assert 1 == values["label1"]
 
-    assert 2 == values["telemetry.labeled_counter_metric/label2"]
+    assert 2 == values["label2"]
 
 
 def test_labeled_boolean_type():

--- a/glean-core/rlb/examples/delayed-ping-data.rs
+++ b/glean-core/rlb/examples/delayed-ping-data.rs
@@ -10,8 +10,7 @@ use std::{env, process};
 use once_cell::sync::Lazy;
 
 use flate2::read::GzDecoder;
-use glean::net;
-use glean::{private::PingType, ClientInfoMetrics, ConfigurationBuilder};
+use glean::{net, private::PingType, ClientInfoMetrics, ConfigurationBuilder, TestGetValue};
 
 pub mod glean_metrics {
     use glean::{private::CounterMetric, CommonMetricData, Lifetime};

--- a/glean-core/rlb/examples/enabled-pings.rs
+++ b/glean-core/rlb/examples/enabled-pings.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use flate2::read::GzDecoder;
 use glean::net;
-use glean::{ClientInfoMetrics, ConfigurationBuilder};
+use glean::{ClientInfoMetrics, ConfigurationBuilder, TestGetValue};
 
 /// A timing_distribution
 mod metrics {

--- a/glean-core/rlb/examples/long-running.rs
+++ b/glean-core/rlb/examples/long-running.rs
@@ -9,7 +9,7 @@ use std::{thread, time};
 use once_cell::sync::Lazy;
 
 use glean::net;
-use glean::{private::PingType, ClientInfoMetrics, ConfigurationBuilder};
+use glean::{private::PingType, ClientInfoMetrics, ConfigurationBuilder, TestGetValue};
 
 pub mod glean_metrics {
     use glean::{private::BooleanMetric, CommonMetricData, Lifetime};

--- a/glean-core/rlb/examples/pending-gets-removed.rs
+++ b/glean-core/rlb/examples/pending-gets-removed.rs
@@ -9,8 +9,7 @@ use std::fs::{read_dir, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-use glean::{net, Configuration};
-use glean::{ClientInfoMetrics, ConfigurationBuilder};
+use glean::{net, ClientInfoMetrics, Configuration, ConfigurationBuilder, TestGetValue};
 use serde_json::Value as JsonValue;
 
 /// A timing_distribution

--- a/glean-core/rlb/examples/ping-lifetime-flush.rs
+++ b/glean-core/rlb/examples/ping-lifetime-flush.rs
@@ -11,8 +11,7 @@ use std::{env, process, thread};
 use once_cell::sync::Lazy;
 
 use flate2::read::GzDecoder;
-use glean::net;
-use glean::{private::PingType, ClientInfoMetrics, ConfigurationBuilder};
+use glean::{net, private::PingType, ClientInfoMetrics, ConfigurationBuilder, TestGetValue};
 
 pub mod glean_metrics {
     use glean::{private::CounterMetric, CommonMetricData, Lifetime};

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -36,8 +36,8 @@ pub use configuration::{Builder as ConfigurationBuilder, Configuration};
 pub use core_metrics::ClientInfoMetrics;
 pub use glean_core::{
     metrics::{
-        Datetime, DistributionData, MemoryUnit, MetricIdentifier, Rate, RecordedEvent, TimeUnit,
-        TimerId,
+        Datetime, DistributionData, MemoryUnit, MetricIdentifier, Rate, RecordedEvent,
+        TestGetLabeledValues, TestGetValue, TimeUnit, TimerId,
     },
     traits, AttributionMetrics, CommonMetricData, DistributionMetrics, Error, ErrorType, Glean,
     HistogramType, LabeledMetricData, Lifetime, PingRateLimit, RecordedExperiment, Result,

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -37,7 +37,7 @@ pub use core_metrics::ClientInfoMetrics;
 pub use glean_core::{
     metrics::{
         Datetime, DistributionData, MemoryUnit, MetricIdentifier, Rate, RecordedEvent,
-        TestGetLabeledValues, TestGetValue, TimeUnit, TimerId,
+        TestGetValue, TimeUnit, TimerId,
     },
     traits, AttributionMetrics, CommonMetricData, DistributionMetrics, Error, ErrorType, Glean,
     HistogramType, LabeledMetricData, Lifetime, PingRateLimit, RecordedExperiment, Result,

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -1291,23 +1291,26 @@ fn test_labeled_counter_metric() {
     let _t = new_glean(None, false);
 
     let metric = LabeledCounter::new(
-        LabeledMetricData::Common { cmd: CommonMetricData {
-            name: "labeled_counter".into(),
-            category: "telemetry".into(),
-            send_in_pings: vec!["store1".into()],
-            disabled: false,
-            lifetime: Lifetime::Ping,
-            ..Default::default()
-        } },
+        LabeledMetricData::Common {
+            cmd: CommonMetricData {
+                name: "labeled_counter".into(),
+                category: "telemetry".into(),
+                send_in_pings: vec!["store1".into()],
+                disabled: false,
+                lifetime: Lifetime::Ping,
+                ..Default::default()
+            },
+        },
         Some(vec!["key1".into()]),
     );
 
     metric.get("key1").add(1);
+    metric.get("key2").add(2);
 
     // Check that the value was recorded
-    let value = metric
-        .test_get_value(Some("store1".into()));
-    assert_eq!(value.unwrap()["telemetry.labeled_counter/key1"], 1);
+    let value = metric.test_get_value(Some("store1".into())).unwrap();
+    assert_eq!(value["telemetry.labeled_counter/key1"], 1);
+    assert_eq!(value["telemetry.labeled_counter/key2"], 2);
 
     // Check for an invalid label
     let result = metric.test_get_num_recorded_errors(ErrorType::InvalidLabel);

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use crossbeam_channel::RecvTimeoutError;
 use flate2::read::GzDecoder;
-use glean_core::{glean_test_get_experimentation_id, DynamicLabelType};
+use glean_core::{glean_test_get_experimentation_id, DynamicLabelType, LabeledCounter};
 use serde_json::Value as JsonValue;
 
 use crate::private::PingType;
@@ -1281,6 +1281,36 @@ fn test_boolean_get_num_errors() {
     // Check specifically for an invalid label
     let result = metric.test_get_num_recorded_errors(ErrorType::InvalidLabel);
 
+    assert_eq!(result, 0);
+}
+
+#[test]
+fn test_labeled_counter_metric() {
+    let _lock = lock_test();
+
+    let _t = new_glean(None, false);
+
+    let metric = LabeledCounter::new(
+        LabeledMetricData::Common { cmd: CommonMetricData {
+            name: "labeled_counter".into(),
+            category: "telemetry".into(),
+            send_in_pings: vec!["store1".into()],
+            disabled: false,
+            lifetime: Lifetime::Ping,
+            ..Default::default()
+        } },
+        Some(vec!["key1".into()]),
+    );
+
+    metric.get("key1").add(1);
+
+    // Check that the value was recorded
+    let value = metric
+        .test_get_value(Some("store1".into()));
+    assert_eq!(value.unwrap()["telemetry.labeled_counter/key1"], 1);
+
+    // Check for an invalid label
+    let result = metric.test_get_num_recorded_errors(ErrorType::InvalidLabel);
     assert_eq!(result, 0);
 }
 

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -1309,8 +1309,8 @@ fn test_labeled_counter_metric() {
 
     // Check that the value was recorded
     let value = metric.test_get_value(Some("store1".into())).unwrap();
-    assert_eq!(value["telemetry.labeled_counter/key1"], 1);
-    assert_eq!(value["telemetry.labeled_counter/key2"], 2);
+    assert_eq!(value["key1"], 1);
+    assert_eq!(value["key2"], 2);
 
     // Check for an invalid label
     let result = metric.test_get_num_recorded_errors(ErrorType::InvalidLabel);

--- a/glean-core/rlb/tests/interruptible_shutdown.rs
+++ b/glean-core/rlb/tests/interruptible_shutdown.rs
@@ -18,8 +18,7 @@ use crossbeam_channel::{bounded, Sender};
 use flate2::read::GzDecoder;
 use serde_json::Value as JsonValue;
 
-use glean::net;
-use glean::{ConfigurationBuilder, PingRateLimit};
+use glean::{net, ConfigurationBuilder, PingRateLimit, TestGetValue};
 
 mod metrics {
     #![allow(non_upper_case_globals)]

--- a/glean-core/rlb/tests/labeled_metrics.rs
+++ b/glean-core/rlb/tests/labeled_metrics.rs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+mod common;
+
+use glean::ConfigurationBuilder;
+use glean_core::TestGetValue;
+
+/// Some user metrics.
+mod metrics {
+    use glean::Lifetime;
+    use glean_core::{CommonMetricData, LabeledBoolean, LabeledMetricData};
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static labeled_boolean: Lazy<LabeledBoolean> = Lazy::new(|| {
+        LabeledBoolean::new(
+            LabeledMetricData::Common {
+                cmd: CommonMetricData {
+                    name: "labeled_boolean".into(),
+                    category: "sample".into(),
+                    send_in_pings: vec!["validation".into()],
+                    lifetime: Lifetime::Ping,
+                    disabled: false,
+                    ..Default::default()
+                },
+            },
+            None,
+        )
+    });
+}
+
+mod pings {
+    use super::*;
+    use glean::private::PingType;
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static validation: Lazy<PingType> = Lazy::new(|| {
+        common::PingBuilder::new("validation")
+            .with_send_if_empty(true)
+            .build()
+    });
+}
+
+#[test]
+fn test_labeled_metrics_test_get_value_functions_appropriately() {
+    common::enable_test_logging();
+
+    metrics::labeled_boolean.get("label1").set(true);
+
+    // Create a custom configuration to use a validating uploader.
+    let dir = tempfile::tempdir().unwrap();
+    let tmpname = dir.path().to_path_buf();
+
+    _ = &*pings::validation;
+    let cfg = ConfigurationBuilder::new(true, tmpname, "firefox-desktop")
+        .with_server_endpoint("invalid-test-host")
+        .build();
+    common::initialize(cfg);
+
+    let map = metrics::labeled_boolean.test_get_value(None).unwrap();
+    assert_eq!(map.len(), 1);
+    assert_eq!(map.get("sample.labeled_boolean/label1").unwrap(), &true);
+
+    pings::validation.submit(None);
+    let map = metrics::labeled_boolean.test_get_value(None).unwrap();
+    assert_eq!(map.len(), 0);
+    assert!(map.get("sample.labeled_boolean/label1").is_none());
+
+    glean::shutdown();
+}

--- a/glean-core/rlb/tests/labeled_metrics.rs
+++ b/glean-core/rlb/tests/labeled_metrics.rs
@@ -62,12 +62,12 @@ fn test_labeled_metrics_test_get_value_functions_appropriately() {
 
     let map = metrics::labeled_boolean.test_get_value(None).unwrap();
     assert_eq!(map.len(), 1);
-    assert_eq!(map.get("sample.labeled_boolean/label1").unwrap(), &true);
+    assert_eq!(map.get("label1").unwrap(), &true);
 
     pings::validation.submit(None);
     let map = metrics::labeled_boolean.test_get_value(None).unwrap();
     assert_eq!(map.len(), 0);
-    assert!(!map.contains_key("sample.labeled_boolean/label1"));
+    assert!(!map.contains_key("label1"));
 
     glean::shutdown();
 }

--- a/glean-core/rlb/tests/labeled_metrics.rs
+++ b/glean-core/rlb/tests/labeled_metrics.rs
@@ -67,7 +67,7 @@ fn test_labeled_metrics_test_get_value_functions_appropriately() {
     pings::validation.submit(None);
     let map = metrics::labeled_boolean.test_get_value(None).unwrap();
     assert_eq!(map.len(), 0);
-    assert!(map.get("sample.labeled_boolean/label1").is_none());
+    assert!(!map.contains_key("sample.labeled_boolean/label1"));
 
     glean::shutdown();
 }

--- a/glean-core/rlb/tests/overflowing_preinit.rs
+++ b/glean-core/rlb/tests/overflowing_preinit.rs
@@ -10,7 +10,7 @@
 
 mod common;
 
-use glean::ConfigurationBuilder;
+use glean::{ConfigurationBuilder, TestGetValue};
 
 /// Some user metrics.
 mod metrics {

--- a/glean-core/rlb/tests/upload_timing.rs
+++ b/glean-core/rlb/tests/upload_timing.rs
@@ -21,6 +21,7 @@ use serde_json::Value as JsonValue;
 
 use glean::net;
 use glean::ConfigurationBuilder;
+use glean_core::TestGetValue;
 
 pub mod metrics {
     #![allow(non_upper_case_globals)]

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -460,6 +460,8 @@ interface LabeledCounter {
     CounterMetric get(string label);
 
     i32 test_get_num_recorded_errors(ErrorType error);
+
+    record<string, i32> test_get_labeled_values(optional string? ping_name = null);
 };
 
 interface LabeledBoolean {
@@ -468,6 +470,8 @@ interface LabeledBoolean {
     BooleanMetric get(string label);
 
     i32 test_get_num_recorded_errors(ErrorType error);
+
+    record<string, boolean> test_get_labeled_values(optional string? ping_name = null);
 };
 
 interface LabeledString {
@@ -476,6 +480,8 @@ interface LabeledString {
     StringMetric get(string label);
 
     i32 test_get_num_recorded_errors(ErrorType error);
+
+    record<string, string> test_get_labeled_values(optional string? ping_name = null);
 };
 
 interface LabeledQuantity {
@@ -484,6 +490,8 @@ interface LabeledQuantity {
     QuantityMetric get(string label);
 
     i32 test_get_num_recorded_errors(ErrorType error);
+
+    record<string, i64> test_get_labeled_values(optional string? ping_name = null);
 };
 
 interface StringListMetric {

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -461,7 +461,7 @@ interface LabeledCounter {
 
     i32 test_get_num_recorded_errors(ErrorType error);
 
-    record<string, i32> test_get_labeled_values(optional string? ping_name = null);
+    record<string, i32>? test_get_value(optional string? ping_name = null);
 };
 
 interface LabeledBoolean {
@@ -471,7 +471,7 @@ interface LabeledBoolean {
 
     i32 test_get_num_recorded_errors(ErrorType error);
 
-    record<string, boolean> test_get_labeled_values(optional string? ping_name = null);
+    record<string, boolean>? test_get_value(optional string? ping_name = null);
 };
 
 interface LabeledString {
@@ -481,7 +481,7 @@ interface LabeledString {
 
     i32 test_get_num_recorded_errors(ErrorType error);
 
-    record<string, string> test_get_labeled_values(optional string? ping_name = null);
+    record<string, string>? test_get_value(optional string? ping_name = null);
 };
 
 interface LabeledQuantity {
@@ -491,7 +491,7 @@ interface LabeledQuantity {
 
     i32 test_get_num_recorded_errors(ErrorType error);
 
-    record<string, i64> test_get_labeled_values(optional string? ping_name = null);
+    record<string, i64>? test_get_value(optional string? ping_name = null);
 };
 
 interface StringListMetric {

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -75,7 +75,8 @@ pub use crate::metrics::{
     LocalCustomDistribution, LocalMemoryDistribution, LocalTimingDistribution,
     MemoryDistributionMetric, MemoryUnit, NumeratorMetric, ObjectMetric, PingType, QuantityMetric,
     Rate, RateMetric, RecordedEvent, RecordedExperiment, StringListMetric, StringMetric,
-    TextMetric, TimeUnit, TimerId, TimespanMetric, TimingDistributionMetric, UrlMetric, UuidMetric,
+    TestGetLabeledValues, TestGetValue, TextMetric, TimeUnit, TimerId, TimespanMetric,
+    TimingDistributionMetric, UrlMetric, UuidMetric,
 };
 pub use crate::upload::{PingRequest, PingUploadTask, UploadResult, UploadTaskAction};
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -75,8 +75,8 @@ pub use crate::metrics::{
     LocalCustomDistribution, LocalMemoryDistribution, LocalTimingDistribution,
     MemoryDistributionMetric, MemoryUnit, NumeratorMetric, ObjectMetric, PingType, QuantityMetric,
     Rate, RateMetric, RecordedEvent, RecordedExperiment, StringListMetric, StringMetric,
-    TestGetLabeledValues, TestGetValue, TextMetric, TimeUnit, TimerId, TimespanMetric,
-    TimingDistributionMetric, UrlMetric, UuidMetric,
+    TextMetric, TimeUnit, TimerId, TimespanMetric, TimingDistributionMetric, UrlMetric, UuidMetric,
+    TestGetValue,
 };
 pub use crate::upload::{PingRequest, PingUploadTask, UploadResult, UploadTaskAction};
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -75,8 +75,8 @@ pub use crate::metrics::{
     LocalCustomDistribution, LocalMemoryDistribution, LocalTimingDistribution,
     MemoryDistributionMetric, MemoryUnit, NumeratorMetric, ObjectMetric, PingType, QuantityMetric,
     Rate, RateMetric, RecordedEvent, RecordedExperiment, StringListMetric, StringMetric,
-    TextMetric, TimeUnit, TimerId, TimespanMetric, TimingDistributionMetric, UrlMetric, UuidMetric,
-    TestGetValue,
+    TestGetValue, TextMetric, TimeUnit, TimerId, TimespanMetric, TimingDistributionMetric,
+    UrlMetric, UuidMetric,
 };
 pub use crate::upload::{PingRequest, PingUploadTask, UploadResult, UploadTaskAction};
 

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use crate::common_metric_data::{CommonMetricDataInternal, DynamicLabelType};
 use crate::error_recording::{test_get_num_recorded_errors, ErrorType};
-use crate::metrics::Metric;
 use crate::metrics::MetricType;
+use crate::metrics::{Metric, TestGetValue};
 use crate::storage::StorageManager;
 use crate::CommonMetricData;
 use crate::Glean;
@@ -100,25 +100,6 @@ impl BooleanMetric {
         }
     }
 
-    /// **Test-only API (exported for FFI purposes).**
-    ///
-    /// Gets the currently stored value as an integer.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - the optional name of the ping to retrieve the metric
-    ///                 for. Defaults to the first value in `send_in_pings`.
-    ///
-    /// # Returns
-    ///
-    /// The stored value or `None` if nothing stored.
-    pub fn test_get_value(&self, ping_name: Option<String>) -> Option<bool> {
-        crate::block_on_dispatcher();
-        crate::core::with_glean(|glean| self.get_value(glean, ping_name.as_deref()))
-    }
-
     /// **Exported for test purposes.**
     ///
     /// Gets the number of recorded errors for the given metric and error type.
@@ -136,5 +117,26 @@ impl BooleanMetric {
         crate::core::with_glean(|glean| {
             test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
+    }
+}
+
+impl TestGetValue<bool> for BooleanMetric {
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Gets the currently stored value as a boolean.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - the optional name of the ping to retrieve the metric
+    ///                 for. Defaults to the first value in `send_in_pings`.
+    ///
+    /// # Returns
+    ///
+    /// The stored value or `None` if nothing stored.
+    fn test_get_value(&self, ping_name: Option<String>) -> Option<bool> {
+        crate::block_on_dispatcher();
+        crate::core::with_glean(|glean| self.get_value(glean, ping_name.as_deref()))
     }
 }

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -10,8 +10,8 @@ use crate::error_recording::{record_error, test_get_num_recorded_errors, ErrorTy
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
-use crate::CommonMetricData;
 use crate::Glean;
+use crate::{CommonMetricData, TestGetValue};
 
 /// A counter metric.
 ///
@@ -137,25 +137,6 @@ impl CounterMetric {
         }
     }
 
-    /// **Test-only API (exported for FFI purposes).**
-    ///
-    /// Gets the currently stored value as an integer.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - the optional name of the ping to retrieve the metric
-    ///                 for. Defaults to the first value in `send_in_pings`.
-    ///
-    /// # Returns
-    ///
-    /// The stored value or `None` if nothing stored.
-    pub fn test_get_value(&self, ping_name: Option<String>) -> Option<i32> {
-        crate::block_on_dispatcher();
-        crate::core::with_glean(|glean| self.get_value(glean, ping_name.as_deref()))
-    }
-
     /// **Exported for test purposes.**
     ///
     /// Gets the number of recorded errors for the given metric and error type.
@@ -173,5 +154,26 @@ impl CounterMetric {
         crate::core::with_glean(|glean| {
             test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
+    }
+}
+
+impl TestGetValue<i32> for CounterMetric {
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Gets the currently stored value as an integer.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - the optional name of the ping to retrieve the metric
+    ///                 for. Defaults to the first value in `send_in_pings`.
+    ///
+    /// # Returns
+    ///
+    /// The stored value or `None` if nothing stored.
+    fn test_get_value(&self, ping_name: Option<String>) -> Option<i32> {
+        crate::block_on_dispatcher();
+        crate::core::with_glean(|glean| self.get_value(glean, ping_name.as_deref()))
     }
 }

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -363,7 +363,10 @@ where
         let map = self.label_map.lock().unwrap();
         map.iter().for_each(|(label, submetric)| {
             if let Some(v) = submetric.test_get_value(ping_name.clone()) {
-                out.insert(label.clone(), v);
+                out.insert(
+                    label.replace(&format!("{}/", self.submetric.meta().base_identifier()), ""),
+                    v,
+                );
             }
         });
         Some(out)

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -14,11 +14,7 @@ use malloc_size_of::MallocSizeOf;
 use crate::common_metric_data::{CommonMetricData, CommonMetricDataInternal, DynamicLabelType};
 use crate::error_recording::{record_error, test_get_num_recorded_errors, ErrorType};
 use crate::histogram::HistogramType;
-use crate::metrics::{
-    BooleanMetric, CounterMetric, CustomDistributionMetric, MemoryDistributionMetric, MemoryUnit,
-    Metric, MetricType, QuantityMetric, StringMetric, TestGetLabeledValues, TestGetValue, TimeUnit,
-    TimingDistributionMetric,
-};
+use crate::metrics::{BooleanMetric, CounterMetric, CustomDistributionMetric, MemoryDistributionMetric, MemoryUnit, Metric, MetricType, QuantityMetric, StringMetric, TestGetValue, TimeUnit, TimingDistributionMetric};
 use crate::Glean;
 
 const MAX_LABELS: usize = 16;
@@ -353,12 +349,12 @@ where
     }
 }
 
-impl<T, S> TestGetLabeledValues<S> for LabeledMetric<T>
+impl <T, S> TestGetValue<HashMap<String, S>> for LabeledMetric<T>
 where
     T: AllowLabeled + TestGetValue<S>,
     S: Any,
 {
-    fn test_get_labeled_values(&self, ping_name: Option<String>) -> HashMap<String, S> {
+    fn test_get_value(&self, ping_name: Option<String>) -> Option<HashMap<String, S>> {
         let mut out = HashMap::new();
         let map = self.label_map.lock().unwrap();
         map.iter().for_each(|(label, submetric)| {
@@ -366,7 +362,7 @@ where
                 out.insert(label.clone(), v);
             }
         });
-        out
+        Some(out)
     }
 }
 

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::any::Any;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::collections::{hash_map::Entry, HashMap};
@@ -15,7 +16,8 @@ use crate::error_recording::{record_error, test_get_num_recorded_errors, ErrorTy
 use crate::histogram::HistogramType;
 use crate::metrics::{
     BooleanMetric, CounterMetric, CustomDistributionMetric, MemoryDistributionMetric, MemoryUnit,
-    Metric, MetricType, QuantityMetric, StringMetric, TimeUnit, TimingDistributionMetric,
+    Metric, MetricType, QuantityMetric, StringMetric, TestGetLabeledValues, TestGetValue, TimeUnit,
+    TimingDistributionMetric,
 };
 use crate::Glean;
 
@@ -348,6 +350,23 @@ where
         crate::core::with_glean(|glean| {
             test_get_num_recorded_errors(glean, self.submetric.meta(), error).unwrap_or(0)
         })
+    }
+}
+
+impl<T, S> TestGetLabeledValues<S> for LabeledMetric<T>
+where
+    T: AllowLabeled + TestGetValue<S>,
+    S: Any,
+{
+    fn test_get_labeled_values(&self, ping_name: Option<String>) -> HashMap<String, S> {
+        let mut out = HashMap::new();
+        let map = self.label_map.lock().unwrap();
+        map.iter().for_each(|(label, submetric)| {
+            if let Some(v) = submetric.test_get_value(ping_name.clone()) {
+                out.insert(label.clone(), v);
+            }
+        });
+        out
     }
 }
 

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -14,7 +14,11 @@ use malloc_size_of::MallocSizeOf;
 use crate::common_metric_data::{CommonMetricData, CommonMetricDataInternal, DynamicLabelType};
 use crate::error_recording::{record_error, test_get_num_recorded_errors, ErrorType};
 use crate::histogram::HistogramType;
-use crate::metrics::{BooleanMetric, CounterMetric, CustomDistributionMetric, MemoryDistributionMetric, MemoryUnit, Metric, MetricType, QuantityMetric, StringMetric, TestGetValue, TimeUnit, TimingDistributionMetric};
+use crate::metrics::{
+    BooleanMetric, CounterMetric, CustomDistributionMetric, MemoryDistributionMetric, MemoryUnit,
+    Metric, MetricType, QuantityMetric, StringMetric, TestGetValue, TimeUnit,
+    TimingDistributionMetric,
+};
 use crate::Glean;
 
 const MAX_LABELS: usize = 16;
@@ -349,7 +353,7 @@ where
     }
 }
 
-impl <T, S> TestGetValue<HashMap<String, S>> for LabeledMetric<T>
+impl<T, S> TestGetValue<HashMap<String, S>> for LabeledMetric<T>
 where
     T: AllowLabeled + TestGetValue<S>,
     S: Any,

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -269,6 +269,47 @@ pub trait MetricIdentifier<'a> {
     fn get_identifiers(&'a self) -> (&'a str, &'a str, Option<&'a str>);
 }
 
+/// [`TestGetValue`] describes an interface for retrieving the value for a given metric
+pub trait TestGetValue<T> {
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Returns the currently stored value of the appropriate type for the given metric.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - the optional name of the ping to retrieve the metric
+    ///                 for. Defaults to the first value in `send_in_pings`.
+    ///
+    /// # Returns
+    ///
+    /// The stored value or `None` if nothing stored.
+    fn test_get_value(&self, ping_name: Option<String>) -> Option<T>;
+}
+
+/// [`TestGetLabeledValues`] describes an interface for retrieving all labels and values
+/// for a given labeled metric
+pub trait TestGetLabeledValues<T> {
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Returns the currently stored values for each label as the appropriate type for the given
+    /// metric.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - the optional name of the ping to retrieve the metric
+    ///                 for. Defaults to the first value in `send_in_pings`.
+    ///
+    /// # Returns
+    ///
+    /// A HashMap mapping each label to its metric's stored value. If the label exists but there is
+    /// nothing stored for it, it will not be returned on the HashMap.
+    fn test_get_labeled_values(&self, ping_name: Option<String>) -> HashMap<String, T>;
+}
+
 // Provide a blanket implementation for MetricIdentifier for all the types
 // that implement MetricType.
 impl<'a, T> MetricIdentifier<'a> for T

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -288,28 +288,6 @@ pub trait TestGetValue<T> {
     fn test_get_value(&self, ping_name: Option<String>) -> Option<T>;
 }
 
-/// [`TestGetLabeledValues`] describes an interface for retrieving all labels and values
-/// for a given labeled metric
-pub trait TestGetLabeledValues<T> {
-    /// **Test-only API (exported for FFI purposes).**
-    ///
-    /// Returns the currently stored values for each label as the appropriate type for the given
-    /// metric.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - the optional name of the ping to retrieve the metric
-    ///                 for. Defaults to the first value in `send_in_pings`.
-    ///
-    /// # Returns
-    ///
-    /// A HashMap mapping each label to its metric's stored value. If the label exists but there is
-    /// nothing stored for it, it will not be returned on the HashMap.
-    fn test_get_labeled_values(&self, ping_name: Option<String>) -> HashMap<String, T>;
-}
-
 // Provide a blanket implementation for MetricIdentifier for all the types
 // that implement MetricType.
 impl<'a, T> MetricIdentifier<'a> for T

--- a/glean-core/src/metrics/quantity.rs
+++ b/glean-core/src/metrics/quantity.rs
@@ -9,8 +9,8 @@ use crate::error_recording::{record_error, test_get_num_recorded_errors, ErrorTy
 use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
-use crate::CommonMetricData;
 use crate::Glean;
+use crate::{CommonMetricData, TestGetValue};
 
 /// A quantity metric.
 ///
@@ -149,5 +149,26 @@ impl QuantityMetric {
         crate::core::with_glean(|glean| {
             test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
+    }
+}
+
+impl TestGetValue<i64> for QuantityMetric {
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Gets the currently stored value as an integer.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - the optional name of the ping to retrieve the metric
+    ///                 for. Defaults to the first value in `send_in_pings`.
+    ///
+    /// # Returns
+    ///
+    /// The stored value or `None` if nothing stored.
+    fn test_get_value(&self, ping_name: Option<String>) -> Option<i64> {
+        crate::block_on_dispatcher();
+        crate::core::with_glean(|glean| self.get_value(glean, ping_name.as_deref()))
     }
 }

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -10,8 +10,8 @@ use crate::metrics::Metric;
 use crate::metrics::MetricType;
 use crate::storage::StorageManager;
 use crate::util::truncate_string_at_boundary_with_error;
-use crate::CommonMetricData;
 use crate::Glean;
+use crate::{CommonMetricData, TestGetValue};
 
 const MAX_LENGTH_VALUE: usize = 255;
 
@@ -107,25 +107,6 @@ impl StringMetric {
         }
     }
 
-    /// **Test-only API (exported for FFI purposes).**
-    ///
-    /// Gets the currently stored value as a string.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - the optional name of the ping to retrieve the metric
-    ///                 for. Defaults to the first value in `send_in_pings`.
-    ///
-    /// # Returns
-    ///
-    /// The stored value or `None` if nothing stored.
-    pub fn test_get_value(&self, ping_name: Option<String>) -> Option<String> {
-        crate::block_on_dispatcher();
-        crate::core::with_glean(|glean| self.get_value(glean, ping_name.as_deref()))
-    }
-
     /// **Exported for test purposes.**
     ///
     /// Gets the number of recorded errors for the given metric and error type.
@@ -143,6 +124,27 @@ impl StringMetric {
         crate::core::with_glean(|glean| {
             test_get_num_recorded_errors(glean, self.meta(), error).unwrap_or(0)
         })
+    }
+}
+
+impl TestGetValue<String> for StringMetric {
+    /// **Test-only API (exported for FFI purposes).**
+    ///
+    /// Gets the currently stored value as a string.
+    ///
+    /// This doesn't clear the stored value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ping_name` - the optional name of the ping to retrieve the metric
+    ///                 for. Defaults to the first value in `send_in_pings`.
+    ///
+    /// # Returns
+    ///
+    /// The stored value or `None` if nothing stored.
+    fn test_get_value(&self, ping_name: Option<String>) -> Option<String> {
+        crate::block_on_dispatcher();
+        crate::core::with_glean(|glean| self.get_value(glean, ping_name.as_deref()))
     }
 }
 

--- a/glean-core/src/traits/boolean.rs
+++ b/glean-core/src/traits/boolean.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Boolean : TestGetValue<bool> {
+pub trait Boolean: TestGetValue<bool> {
     /// Sets to the specified boolean value.
     ///
     /// # Arguments

--- a/glean-core/src/traits/boolean.rs
+++ b/glean-core/src/traits/boolean.rs
@@ -2,31 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ErrorType;
+use crate::{ErrorType, TestGetValue};
 
 /// A description for the [`BooleanMetric`](crate::metrics::BooleanMetric) type.
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Boolean {
+pub trait Boolean : TestGetValue<bool> {
     /// Sets to the specified boolean value.
     ///
     /// # Arguments
     ///
     /// * `value` - the value to set.
     fn set(&self, value: bool);
-
-    /// **Exported for test purposes.**
-    ///
-    /// Gets the currently stored value as a boolean.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
-    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<bool>;
 
     /// **Exported for test purposes.**
     ///

--- a/glean-core/src/traits/counter.rs
+++ b/glean-core/src/traits/counter.rs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ErrorType;
+use crate::{ErrorType, TestGetValue};
 
 /// A description for the [`CounterMetric`](crate::metrics::CounterMetric) type.
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Counter {
+pub trait Counter : TestGetValue<i32> {
     /// Increases the counter by `amount`.
     ///
     /// # Arguments
@@ -19,18 +19,6 @@ pub trait Counter {
     ///
     /// Logs an error if the `amount` is 0 or negative.
     fn add(&self, amount: i32);
-
-    /// **Exported for test purposes.**
-    ///
-    /// Gets the currently stored value as an integer.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
-    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i32>;
 
     /// **Exported for test purposes.**
     ///

--- a/glean-core/src/traits/counter.rs
+++ b/glean-core/src/traits/counter.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Counter : TestGetValue<i32> {
+pub trait Counter: TestGetValue<i32> {
     /// Increases the counter by `amount`.
     ///
     /// # Arguments

--- a/glean-core/src/traits/labeled.rs
+++ b/glean-core/src/traits/labeled.rs
@@ -2,15 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ErrorType;
+use std::any::Any;
+use std::collections::HashMap;
+use crate::{ErrorType, TestGetValue};
 
 /// A description for the [`LabeledMetric`](crate::metrics::LabeledMetric) type.
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Labeled<T>
+pub trait Labeled<T, S> : TestGetValue<HashMap<String, S>>
 where
-    T: Clone,
+    T: Clone + TestGetValue<S>,
+    S: Any
 {
     /// Gets a specific metric for a given label.
     ///

--- a/glean-core/src/traits/labeled.rs
+++ b/glean-core/src/traits/labeled.rs
@@ -2,18 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::{ErrorType, TestGetValue};
 use std::any::Any;
 use std::collections::HashMap;
-use crate::{ErrorType, TestGetValue};
 
 /// A description for the [`LabeledMetric`](crate::metrics::LabeledMetric) type.
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Labeled<T, S> : TestGetValue<HashMap<String, S>>
+pub trait Labeled<T, S>: TestGetValue<HashMap<String, S>>
 where
     T: Clone + TestGetValue<S>,
-    S: Any
+    S: Any,
 {
     /// Gets a specific metric for a given label.
     ///

--- a/glean-core/src/traits/quantity.rs
+++ b/glean-core/src/traits/quantity.rs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ErrorType;
+use crate::{ErrorType, TestGetValue};
 
 /// A description for the [`QuantityMetric`](crate::metrics::QuantityMetric) type.
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Quantity {
+pub trait Quantity : TestGetValue<i64> {
     /// Sets the value. Must be non-negative.
     ///
     /// # Arguments
@@ -19,18 +19,6 @@ pub trait Quantity {
     ///
     /// Logs an error if the `value` is negative.
     fn set(&self, value: i64);
-
-    /// **Exported for test purposes.**
-    ///
-    /// Gets the currently stored value as an integer.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
-    fn test_get_value<'a, S: Into<Option<&'a str>>>(&self, ping_name: S) -> Option<i64>;
 
     /// **Exported for test purposes.**
     ///

--- a/glean-core/src/traits/quantity.rs
+++ b/glean-core/src/traits/quantity.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Quantity : TestGetValue<i64> {
+pub trait Quantity: TestGetValue<i64> {
     /// Sets the value. Must be non-negative.
     ///
     /// # Arguments

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ErrorType;
+use crate::{ErrorType, TestGetValue};
 
 /// A description for the [`StringMetric`](crate::metrics::StringMetric) type.
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait String {
+pub trait String : TestGetValue<std::string::String> {
     /// Sets to the specified value.
     ///
     /// # Arguments
@@ -19,21 +19,6 @@ pub trait String {
     ///
     /// Truncates the value if it is longer than `MAX_LENGTH_VALUE` bytes and logs an error.
     fn set<S: Into<std::string::String>>(&self, value: S);
-
-    /// **Exported for test purposes.**
-    ///
-    /// Gets the currently stored value as a string.
-    ///
-    /// This doesn't clear the stored value.
-    ///
-    /// # Arguments
-    ///
-    /// * `ping_name` - represents the optional name of the ping to retrieve the
-    ///   metric for. Defaults to the first value in `send_in_pings`.
-    fn test_get_value<'a, S: Into<Option<&'a str>>>(
-        &self,
-        ping_name: S,
-    ) -> Option<std::string::String>;
 
     /// **Exported for test purposes.**
     ///

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait String : TestGetValue<std::string::String> {
+pub trait String: TestGetValue<std::string::String> {
     /// Sets to the specified value.
     ///
     /// # Arguments

--- a/samples/rust/src/main.rs
+++ b/samples/rust/src/main.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use tempfile::Builder;
 
 use flate2::read::GzDecoder;
-use glean::{net, ClientInfoMetrics, ConfigurationBuilder, ErrorType};
+use glean::{net, ClientInfoMetrics, ConfigurationBuilder, ErrorType, TestGetValue};
 
 #[allow(clippy::all)] // Don't lint generated code.
 pub mod glean_metrics {


### PR DESCRIPTION
This PR updates the `testGetValue` function to be a trait that can be exported across the FFI boundary. 

It also defines a new `testGetLabeledValues` function on `LabeledMetrics` that is exported across the FFI boundary for metrics on which it is implemented.