### PR TITLE
[ci full] Fix module-build-glean-native on TC

### DIFF
--- a/taskcluster/scripts/cross-compile-setup.sh
+++ b/taskcluster/scripts/cross-compile-setup.sh
@@ -45,18 +45,18 @@ export TARGET_CFLAGS="-DNDEBUG"
 #   (drop the "index." prefix, ensure the "public/build" path matches the artifacts of the TC task)
 pushd /builds/worker
 curl -sfSL --retry 5 --retry-delay 10 \
-    https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.linux64-cctools-port.pushdate.2024.07.23.20240723071212/artifacts/public%2Fbuild%2Fcctools.tar.zst > cctools.tar.zst
+    https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.linux64-cctools-port.pushdate.2025.07.22.20250722101257/artifacts/public%2Fbuild%2Fcctools.tar.zst > cctools.tar.zst
 tar -I zstd -xf cctools.tar.zst
 rm cctools.tar.zst
 curl -sfSL --retry 5 --retry-delay 10 \
-    https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.clang-dist-toolchain.pushdate.2024.07.30.20240730145721/artifacts/public%2Fbuild%2Fclang-dist-toolchain.tar.xz > clang-dist-toolchain.tar.xz
+    https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.clang-dist-toolchain.pushdate.2025.07.22.20250722101257/artifacts/public%2Fbuild%2Fclang-dist-toolchain.tar.xz > clang-dist-toolchain.tar.xz
 tar -xf clang-dist-toolchain.tar.xz
 mv builds/worker/toolchains/clang clang
 rm clang-dist-toolchain.tar.xz
 
 # Fixup symlink
 rm /builds/worker/clang/bin/clang
-ln -s /builds/worker/clang/bin/clang-18 /builds/worker/clang/bin/clang
+ln -s /builds/worker/clang/bin/clang-19 /builds/worker/clang/bin/clang
 
 popd
 
@@ -80,6 +80,6 @@ rustup target add x86_64-pc-windows-gnu
 echo "Verifying paths after extraction"
 ls -la /builds/worker/clang/bin
 file /builds/worker/clang/bin/clang
-file /builds/worker/clang/bin/clang-18
+file /builds/worker/clang/bin/clang-19
 
 set +eu

--- a/taskcluster/scripts/macos.manifest
+++ b/taskcluster/scripts/macos.manifest
@@ -1,13 +1,5 @@
 [
   {
-    "size":  31991917,
-    "visibility": "internal",
-    "digest": "c5c0be09972b56b5980dc9d06b61ff49cf58c4572913437256a79b202e19e936af3c0ab0924df72b9f648d518c257597f84800a84bb80e68af4eabdaf1df5f24",
-    "algorithm": "sha512",
-    "unpack": true,
-    "filename": "MacOSX10.12.sdk.tar.xz"
-  },
-  {
     "size": 68798037,
     "visibility": "internal",
     "digest": "5bdc3270d0b660889b66194aa8cbcdbdb9163188bf976f31cc87837e6b0b5590db8d76cc17e9ea863b50f6735779cfd4338a4121997888b13139f4af1fdbb504",


### PR DESCRIPTION
Currently failing: https://firefox-ci-tc.services.mozilla.com/tasks/GlOeui8_RZuohXu9XfipBw/runs/0/logs/public/logs/live.log


```
[task 2025-07-25T08:43:23.604Z] error: linking with `/builds/worker/clang/bin/clang` failed: exit status: 1
[task 2025-07-25T08:43:23.604Z]   |
[task 2025-07-25T08:43:23.604Z]   = note:  "/builds/worker/clang/bin/clang" "-Wl,-exported_symbols_list" "-Wl,/tmp/rustcQ8uBYG/list" "/tmp/rustcQ8uBYG/symbols.o" "<1 object files omitted>" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/{libcompiler_builtins-*}.rlib" "-framework" "CoreFoundation" "-liconv" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=11.0.0" "-o" "/builds/worker/checkouts/vcs/target/aarch64-apple-darwin/release/deps/libxul.dylib" "-Wl,-dead_strip" "-dynamiclib" "-nodefaultlibs" "-fuse-ld=/builds/worker/cctools/bin/aarch64-apple-darwin-ld" "-B" "/builds/worker/cctools/bin" "-target" "aarch64-apple-darwin" "-isysroot" "/tmp/MacOSX11.0.sdk" "-Wl,-syslibroot,/tmp/MacOSX11.0.sdk" "-Wl,-dead_strip" "-Wl,-no_encryption"
[task 2025-07-25T08:43:23.604Z]   = note: some arguments are omitted. use `--verbose` to show all linker arguments
[task 2025-07-25T08:43:23.604Z]   = note: clang: error: invalid linker name in argument '-fuse-ld=/builds/worker/cctools/bin/aarch64-apple-darwin-ld'
```