### PR TITLE
Bug 1979598 - MPS: Properly calculate rescheduled duration using local time and avoid re-scheduling anything immediately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,11 @@ commands:
           name: Run Rust RLB pending-gets-removed test
           command: |
             glean-core/rlb/tests/test-pending-gets-removed.sh
+      - run:
+          name: Run Rust RLB mps-delay test
+          command: |
+            sudo apt install -y faketime
+            glean-core/rlb/tests/test-mps-delay.sh
 
   install-rustup:
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Performance improvement: Reduce file system operations when recording events ([#3179](https://github.com/mozilla/glean/pull/3179))
   * `LabeledMetric` improvement: Added `testGetValue` as a test method on all labeled metric types ([#3190](https://github.com/mozilla/glean/pull/3190))
   * New metric: `glean.ping.uploader_capabilities` reporting the requested uploader capabilities for a ping ([#3188](https://github.com/mozilla/glean/pull/3188))
+  * BUGFIX: Avoid accidental rapid rescheduling of the `metrics` ping on startup ([#3201](https://github.com/mozilla/glean/pull/3201))
 * Android
   * Updated Android Gradle Plugin to 8.11.0 ([#3180](https://github.com/mozilla/glean/pull/3180))
   * Updated Android SDK target to version 36 ([#3180](https://github.com/mozilla/glean/pull/3180))

--- a/glean-core/rlb/examples/mps-delay.rs
+++ b/glean-core/rlb/examples/mps-delay.rs
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Test that the metrics ping is correctly scheduled and not repeated.
+//! Driven by `test-mps-delay.sh` which sets a timezone and fakes the system time.
+//!
+//! Note: `libfaketime` behavior on macOS seems to be incorrect for the condvar wakeups.
+
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{env, thread};
+
+use flate2::read::GzDecoder;
+use glean::net;
+use glean::{ClientInfoMetrics, ConfigurationBuilder, TestGetValue};
+
+/// A timing_distribution
+mod metrics {
+    use glean::private::*;
+    use glean::Lifetime;
+    use glean_core::CommonMetricData;
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static boo: Lazy<CounterMetric> = Lazy::new(|| {
+        CounterMetric::new(CommonMetricData {
+            name: "boo".into(),
+            category: "sample".into(),
+            send_in_pings: vec!["metrics".into()],
+            lifetime: Lifetime::Ping,
+            disabled: false,
+            ..Default::default()
+        })
+    });
+}
+
+#[derive(Debug)]
+struct MovingUploader(PathBuf);
+
+impl MovingUploader {
+    fn new(mut path: PathBuf) -> Self {
+        path.push("sent_pings");
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl net::PingUploader for MovingUploader {
+    fn upload(&self, upload_request: net::CapablePingUploadRequest) -> net::UploadResult {
+        let upload_request = upload_request.capable(|_| true).unwrap();
+        let net::PingUploadRequest {
+            body, url, headers, ..
+        } = upload_request;
+        let mut gzip_decoder = GzDecoder::new(&body[..]);
+        let mut s = String::with_capacity(body.len());
+
+        let data = gzip_decoder
+            .read_to_string(&mut s)
+            .ok()
+            .map(|_| &s[..])
+            .or_else(|| std::str::from_utf8(&body).ok())
+            .unwrap();
+
+        let docid = url.rsplit('/').next().unwrap();
+        let out_path = self.0.join(format!("{docid}.json"));
+        let mut fp = File::create(out_path).unwrap();
+
+        // pseudo-JSON, let's hope this works.
+        writeln!(fp, "{{").unwrap();
+        writeln!(fp, "  \"url\": {url},").unwrap();
+        for (key, val) in headers {
+            writeln!(fp, "  \"{key}\": \"{val}\",").unwrap();
+        }
+        writeln!(fp, "}}").unwrap();
+        writeln!(fp, "{data}").unwrap();
+
+        net::UploadResult::http_status(200)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum State {
+    Init,
+    Second,
+    Third,
+}
+
+impl From<&str> for State {
+    fn from(state: &str) -> Self {
+        match state {
+            "init" => State::Init,
+            "second" => State::Second,
+            "third" => State::Third,
+            _ => {
+                panic!("unknown argument: {state}");
+            }
+        }
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let mut args = env::args().skip(1);
+
+    let data_path = PathBuf::from(args.next().expect("need data path"));
+    let state = args.next().unwrap_or_default();
+    let state = State::from(&*state);
+    log::info!("Runing state {state:?}");
+
+    let uploader = MovingUploader::new(data_path.clone());
+    let cfg = ConfigurationBuilder::new(true, data_path, "glean.mps-delay")
+        .with_server_endpoint("invalid-test-host")
+        .with_use_core_mps(true)
+        .with_uploader(uploader)
+        .build();
+
+    let client_info = ClientInfoMetrics {
+        app_build: env!("CARGO_PKG_VERSION").to_string(),
+        app_display_version: env!("CARGO_PKG_VERSION").to_string(),
+        channel: None,
+        locale: None,
+    };
+
+    glean::initialize(cfg, client_info);
+
+    // Wait for init to finish,
+    // otherwise we might be to quick with calling `shutdown`.
+    let _ = metrics::boo.test_get_value(None);
+    metrics::boo.add(1);
+
+    thread::sleep(Duration::from_millis(100));
+
+    glean::shutdown(); // Cleanly shut down at the end of the test.
+}

--- a/glean-core/rlb/tests/test-mps-delay.sh
+++ b/glean-core/rlb/tests/test-mps-delay.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Test harness for testing the RLB processes from the outside.
+#
+# Some behavior can only be observed when properly exiting the process running Glean,
+# e.g. when an uploader runs in another thread.
+# On exit the threads will be killed, regardless of their state.
+
+# Remove the temporary data path on all exit conditions
+cleanup() {
+  if [ -n "$datapath" ]; then
+    rm -r "$datapath"
+  fi
+}
+trap cleanup INT ABRT TERM EXIT
+
+WORKSPACE_ROOT="$( cd "$(dirname "$0")/../../.." ; pwd -P )"
+cd "$WORKSPACE_ROOT"
+
+tmp="${TMPDIR:-/tmp}"
+datapath=$(mktemp -d "${tmp}/glean_mps_delay.XXXX")
+
+# Build it once
+cargo build -p glean --example mps-delay || exit 1
+
+cmd="target/debug/examples/mps-delay $datapath"
+
+# Set a timezone (Los Angeles = -07:00)
+export TZ=America/Los_Angeles
+export RUST_LOG=debug
+
+timeout 5s faketime --exclude-monotonic -f "2025-07-27 04:05:00" $cmd init
+count=$(ls -1q "$datapath/sent_pings" | wc -l)
+if [[ "$count" -ne 0 ]]; then
+  echo "1/3 test result: FAILED. Expected 0, got $count pings"
+  exit 101
+fi
+
+timeout 5s faketime --exclude-monotonic -f "2025-07-28 22:27:00" $cmd second
+count=$(ls -1q "$datapath/sent_pings" | wc -l)
+if [[ "$count" -ne 1 ]]; then
+  echo "2/3 test result: FAILED. Expected 1, got $count pings"
+  exit 101
+fi
+
+timeout 5s faketime --exclude-monotonic -f "2025-07-28 22:30:00" $cmd third
+count=$(ls -1q "$datapath/sent_pings" | wc -l)
+if [[ "$count" -ne 1 ]]; then
+  echo "3/3 test result: FAILED. Expected 1, got $count pings"
+  exit 101
+fi
+
+echo "test result: PASSED."
+exit 0


### PR DESCRIPTION
This code changed with the recent chrono update and can cause rapid rescheduling of metric pings due to wrong date and time math, that mixes local, naive and UTC times.

We now do the time math _always_ in the local timezone, ensuring to aim for a 4am submission of the metrics ping (in case it gets rescheduled). We also avoid any 0-duration reschedule (immediate). If somehow our math doesn't work out we schedule the metrics ping 24 hours into the future.

I used the following code to dig into what's happening:

```rust
#![allow(dead_code)]

use chrono::{DateTime, Days, Duration, FixedOffset, Local, NaiveDate, TimeZone, Utc};

fn local_now_with_offset() -> DateTime<FixedOffset> {
    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1611770.
    //
    // It's not clear if this bug on Windows still exist with the latest versions of
    // the `time` crate. Removed the workaround.
    let now: DateTime<Local> = Local::now();
    now.with_timezone(now.offset())
}

#[derive(Debug, PartialEq)]
enum When {
    Today,
    Tomorrow,
    Reschedule,
}

impl When {
    /// Returns the duration from now until our deadline.
    /// Note that std::time::Duration doesn't do negative time spans, so if
    /// our deadline has passed, this will return zero.
    fn until(&self, now: DateTime<FixedOffset>) -> std::time::Duration {
        let now_local = now.naive_local();

        let fire_date = match self {
            Self::Today => now_local.date().and_hms_opt(SCHEDULED_HOUR, 0, 0).unwrap(),
            // Doesn't actually save us from being an hour off on DST because
            // chrono doesn't know when DST changes. : (
            Self::Tomorrow | Self::Reschedule => {
                let next_day = now_local.checked_add_days(Days::new(1)).unwrap();
                let next_day_date = next_day.date();
                next_day_date.and_hms_opt(SCHEDULED_HOUR, 0, 0).unwrap()
            }
        };
        // After rust-lang/rust#73544 can use std::time::Duration::ZERO
        (fire_date - now_local)
            .to_std()
            .unwrap_or_else(|_| std::time::Duration::from_millis(0))
    }
}

fn schedule(now: DateTime<FixedOffset>) -> When {
    let last_sent_time = Some(
            FixedOffset::west_opt(3600 * 7)
            .unwrap()
            .with_ymd_and_hms(2025, 7, 27, 4, 27, 59)
            .unwrap()
    );
    let already_sent_today = last_sent_time.is_some_and(|d| d.date_naive() == now.date_naive());
    // Today's 04:00 in local time
    let cutoff_time = now
        .naive_local()
        .date()
        .and_hms_opt(SCHEDULED_HOUR, 0, 0)
        .unwrap()
        .and_local_timezone(now.timezone())
        .unwrap();

    if already_sent_today {
        // Case #1
        eprintln!("The 'metrics' ping was already sent today, {}", now);
        When::Tomorrow
    } else if now > cutoff_time {
        // Case #2
        eprintln!("Sending the 'metrics' ping immediately, {}", now);
        When::Reschedule
    } else {
        // Case #3
        eprintln!("The 'metrics' collection is scheduled for today, {}", now);
        When::Today
    }
}

const SCHEDULED_HOUR: u32 = 4;

fn main() {
    let datetime = NaiveDate::from_ymd_opt(2025, 7, 28)
        .unwrap()
        .and_hms_opt(5, 27, 59)
        .unwrap();
    let offset = FixedOffset::west_opt(3600 * 7).unwrap();
    let now = DateTime::from_naive_utc_and_offset(datetime, offset);

    let target =
        Utc.from_utc_datetime(&now.date_naive().and_hms_opt(SCHEDULED_HOUR, 0, 0).unwrap());

    let when = When::Reschedule;
    let dur = when.until(now);

    dbg!(&now);
    dbg!(&target);
    dbg!(now > target);
    dbg!(dur);

    let datetime = NaiveDate::from_ymd_opt(2025, 7, 28)
        .unwrap()
        .and_hms_opt(10, 27, 59)
        .unwrap();
    let offset = FixedOffset::west_opt(3600 * 7).unwrap();
    let now = DateTime::from_naive_utc_and_offset(datetime, offset);
    let dur = When::Today.until(now);
    dbg!(now);
    dbg!(dur);

    let cutoff_time = now
        .naive_local()
        .date()
        .and_hms_opt(SCHEDULED_HOUR, 0, 0).unwrap()
        .and_local_timezone(now.timezone())
        .unwrap();
    dbg!(cutoff_time);
    dbg!(now > cutoff_time);

    println!();
    println!();

    let now = FixedOffset::west_opt(3600 * 7)
        .unwrap()
        .with_ymd_and_hms(2025, 7, 27, 22, 27, 59)
        .unwrap();

    dbg!(now);
    let when = schedule(now);
    dbg!(&when, when.until(now), "---");

    let now = FixedOffset::west_opt(3600 * 7)
        .unwrap()
        .with_ymd_and_hms(2025, 7, 27, 3, 27, 59)
        .unwrap();

    dbg!(now);
    let when = schedule(now);
    dbg!(&when, when.until(now), "---");

    let now = FixedOffset::west_opt(3600 * 7)
        .unwrap()
        .with_ymd_and_hms(2025, 7, 28, 3, 27, 59)
        .unwrap();

    dbg!(now);
    let when = schedule(now);
    dbg!(&when, when.until(now), "---");

    let now = FixedOffset::west_opt(3600 * 7)
        .unwrap()
        .with_ymd_and_hms(2025, 7, 28, 4, 27, 59)
        .unwrap();

    dbg!(now);
    let when = schedule(now);
    dbg!(&when, when.until(now), "---");
}
```