### PR TITLE
(backported) MPS: Properly calculate rescheduled duration using local…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,11 @@ commands:
           name: Run Rust RLB pending-gets-removed test
           command: |
             glean-core/rlb/tests/test-pending-gets-removed.sh
+      - run:
+          name: Run Rust RLB mps-delay test
+          command: |
+            sudo apt install -y faketime
+            glean-core/rlb/tests/test-mps-delay.sh
 
   install-rustup:
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v64.5.2...main)
 
+* General
+  * BUGFIX: Avoid accidental rapid rescheduling of the `metrics` ping on startup ([#3201](https://github.com/mozilla/glean/pull/3201))
+
 # v64.5.2 (2025-07-01)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v64.5.1...v64.5.2)

--- a/glean-core/rlb/examples/mps-delay.rs
+++ b/glean-core/rlb/examples/mps-delay.rs
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Test that the metrics ping is correctly scheduled and not repeated.
+//! Driven by `test-mps-delay.sh` which sets a timezone and fakes the system time.
+//!
+//! Note: `libfaketime` behavior on macOS seems to be incorrect for the condvar wakeups.
+
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{env, thread};
+
+use flate2::read::GzDecoder;
+use glean::net;
+use glean::{ClientInfoMetrics, ConfigurationBuilder};
+
+/// A timing_distribution
+mod metrics {
+    use glean::private::*;
+    use glean::Lifetime;
+    use glean_core::CommonMetricData;
+    use once_cell::sync::Lazy;
+
+    #[allow(non_upper_case_globals)]
+    pub static boo: Lazy<CounterMetric> = Lazy::new(|| {
+        CounterMetric::new(CommonMetricData {
+            name: "boo".into(),
+            category: "sample".into(),
+            send_in_pings: vec!["metrics".into()],
+            lifetime: Lifetime::Ping,
+            disabled: false,
+            ..Default::default()
+        })
+    });
+}
+
+#[derive(Debug)]
+struct MovingUploader(PathBuf);
+
+impl MovingUploader {
+    fn new(mut path: PathBuf) -> Self {
+        path.push("sent_pings");
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl net::PingUploader for MovingUploader {
+    fn upload(&self, upload_request: net::CapablePingUploadRequest) -> net::UploadResult {
+        let upload_request = upload_request.capable(|_| true).unwrap();
+        let net::PingUploadRequest {
+            body, url, headers, ..
+        } = upload_request;
+        let mut gzip_decoder = GzDecoder::new(&body[..]);
+        let mut s = String::with_capacity(body.len());
+
+        let data = gzip_decoder
+            .read_to_string(&mut s)
+            .ok()
+            .map(|_| &s[..])
+            .or_else(|| std::str::from_utf8(&body).ok())
+            .unwrap();
+
+        let docid = url.rsplit('/').next().unwrap();
+        let out_path = self.0.join(format!("{docid}.json"));
+        let mut fp = File::create(out_path).unwrap();
+
+        // pseudo-JSON, let's hope this works.
+        writeln!(fp, "{{").unwrap();
+        writeln!(fp, "  \"url\": {url},").unwrap();
+        for (key, val) in headers {
+            writeln!(fp, "  \"{key}\": \"{val}\",").unwrap();
+        }
+        writeln!(fp, "}}").unwrap();
+        writeln!(fp, "{data}").unwrap();
+
+        net::UploadResult::http_status(200)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum State {
+    Init,
+    Second,
+    Third,
+}
+
+impl From<&str> for State {
+    fn from(state: &str) -> Self {
+        match state {
+            "init" => State::Init,
+            "second" => State::Second,
+            "third" => State::Third,
+            _ => {
+                panic!("unknown argument: {state}");
+            }
+        }
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let mut args = env::args().skip(1);
+
+    let data_path = PathBuf::from(args.next().expect("need data path"));
+    let state = args.next().unwrap_or_default();
+    let state = State::from(&*state);
+    log::info!("Runing state {state:?}");
+
+    let uploader = MovingUploader::new(data_path.clone());
+    let cfg = ConfigurationBuilder::new(true, data_path, "glean.mps-delay")
+        .with_server_endpoint("invalid-test-host")
+        .with_use_core_mps(true)
+        .with_uploader(uploader)
+        .build();
+
+    let client_info = ClientInfoMetrics {
+        app_build: env!("CARGO_PKG_VERSION").to_string(),
+        app_display_version: env!("CARGO_PKG_VERSION").to_string(),
+        channel: None,
+        locale: None,
+    };
+
+    glean::initialize(cfg, client_info);
+
+    // Wait for init to finish,
+    // otherwise we might be to quick with calling `shutdown`.
+    let _ = metrics::boo.test_get_value(None);
+    metrics::boo.add(1);
+
+    thread::sleep(Duration::from_millis(100));
+
+    glean::shutdown(); // Cleanly shut down at the end of the test.
+}

--- a/glean-core/rlb/tests/test-mps-delay.sh
+++ b/glean-core/rlb/tests/test-mps-delay.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Test harness for testing the RLB processes from the outside.
+#
+# Some behavior can only be observed when properly exiting the process running Glean,
+# e.g. when an uploader runs in another thread.
+# On exit the threads will be killed, regardless of their state.
+
+# Remove the temporary data path on all exit conditions
+cleanup() {
+  if [ -n "$datapath" ]; then
+    rm -r "$datapath"
+  fi
+}
+trap cleanup INT ABRT TERM EXIT
+
+WORKSPACE_ROOT="$( cd "$(dirname "$0")/../../.." ; pwd -P )"
+cd "$WORKSPACE_ROOT"
+
+tmp="${TMPDIR:-/tmp}"
+datapath=$(mktemp -d "${tmp}/glean_mps_delay.XXXX")
+
+# Build it once
+cargo build -p glean --example mps-delay || exit 1
+
+cmd="target/debug/examples/mps-delay $datapath"
+
+# Set a timezone (Los Angeles = -07:00)
+export TZ=America/Los_Angeles
+export RUST_LOG=debug
+
+timeout 5s faketime --exclude-monotonic -f "2025-07-27 04:05:00" $cmd init
+count=$(ls -1q "$datapath/sent_pings" | wc -l)
+if [[ "$count" -ne 0 ]]; then
+  echo "1/3 test result: FAILED. Expected 0, got $count pings"
+  exit 101
+fi
+
+timeout 5s faketime --exclude-monotonic -f "2025-07-28 22:27:00" $cmd second
+count=$(ls -1q "$datapath/sent_pings" | wc -l)
+if [[ "$count" -ne 1 ]]; then
+  echo "2/3 test result: FAILED. Expected 1, got $count pings"
+  exit 101
+fi
+
+timeout 5s faketime --exclude-monotonic -f "2025-07-28 22:30:00" $cmd third
+count=$(ls -1q "$datapath/sent_pings" | wc -l)
+if [[ "$count" -ne 1 ]]; then
+  echo "3/3 test result: FAILED. Expected 1, got $count pings"
+  exit 101
+fi
+
+echo "test result: PASSED."
+exit 0


### PR DESCRIPTION
… time and avoid re-scheduling anything immediately

This code changed with the recent chrono update and can cause rapid rescheduling of metric pings due to wrong date and time math, that mixes local, naive and UTC times.

We now do the time math _always_ in the local timezone, ensuring to aim for a 4am submission of the metrics ping (in case it gets rescheduled). We also avoid any 0-duration reschedule (immediate). If somehow our math doesn't work out we schedule the metrics ping 24 hours into the future.

---

backports #3201 for patch release