### PR TITLE
Apply a high watermark for pending pings to process from disk

### DIFF
--- a/glean-core/src/internal_metrics.rs
+++ b/glean-core/src/internal_metrics.rs
@@ -208,6 +208,7 @@ pub struct UploadMetrics {
     pub pending_pings_directory_size: MemoryDistributionMetric,
     pub deleted_pings_after_quota_hit: CounterMetric,
     pub pending_pings: CounterMetric,
+    pub discarded_pings: QuantityMetric,
     pub send_success: TimingDistributionMetric,
     pub send_failure: TimingDistributionMetric,
     pub in_flight_pings_dropped: CounterMetric,
@@ -273,6 +274,15 @@ impl UploadMetrics {
 
             pending_pings: CounterMetric::new(CommonMetricData {
                 name: "pending_pings".into(),
+                category: "glean.upload".into(),
+                send_in_pings: vec!["metrics".into()],
+                lifetime: Lifetime::Ping,
+                disabled: false,
+                dynamic_label: None,
+            }),
+
+            discarded_pings: QuantityMetric::new(CommonMetricData {
+                name: "discarded_pings".into(),
                 category: "glean.upload".into(),
                 send_in_pings: vec!["metrics".into()],
                 lifetime: Lifetime::Ping,

--- a/glean-core/src/upload/policy.rs
+++ b/glean-core/src/upload/policy.rs
@@ -17,7 +17,7 @@ const MAX_PENDING_PINGS_DIRECTORY_SIZE: u64 = 10 * 1024 * 1024; // 10MB
 // A baseline ping file averages about 600 bytes, so that's a total of just 144 kB we store.
 // With the default rate limit of 15 pings per 60s it would take roughly 16 minutes to send out all pending
 // pings.
-const MAX_PENDING_PINGS_COUNT: u64 = 250;
+pub(crate) const MAX_PENDING_PINGS_COUNT: u64 = 250;
 
 /// A struct holding the values for all the policies related to ping storage, uploading and requests.
 #[derive(Debug, MallocSizeOf)]


### PR DESCRIPTION
If we detect more files in the pending pings directory they are removed without processing. Usually we read all files into memory to sort them and then discard the oldest ones if necessary. However if a user has too many files that's very costly (in both processing time and memory usage), so we add a high watermark. This means there's now a case where we can drop arbitrary data. However if a user has _that many pending pings_ some things might have gone awry and the data is less important than keeping the user's application running smoothly.