### PR TITLE
Bug 1899618 - Register Glean threads with the Gecko profiler (feature-gated)

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 301 utf-8
+personal_ws-1.1 en 302 utf-8
 AAR
 AARs
 ABI
@@ -236,6 +236,7 @@ polyfill
 pre
 prebuilt
 preinit
+profiler
 py
 pytest
 rethrow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   * Report `client_info.architecture` as reported from Python again ([#3185](https://github.com/mozilla/glean/issues/3185))
 * Swift
   * Expose an interface by which to supply an external uploader on iOS ([Bug 1950143](https://bugzilla.mozilla.org/show_bug.cgi?id=1950143))
+* Rust
+  * New feature `gecko`. If enabled spawned threads are registered with the Gecko profiler (non-Android only) ([#3212](https://github.com/mozilla/glean/pull/3212))
 
 # v64.5.4 (2025-07-29)
 

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -63,3 +63,5 @@ uniffi = { version = "0.29.3", default-features = false, features = ["build"] }
 [features]
 # Enable `env_logger`. Only works on non-Android non-iOS targets.
 enable_env_logger = ["env_logger"]
+# Enable gecko-specific APIs
+gecko = []

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -40,3 +40,6 @@ jsonschema-valid = "0.5.0"
 libc = "0.2"
 serde_json = "1.0.44"
 tempfile = "3.1.0"
+
+[features]
+gecko = ["glean-core/gecko"]

--- a/glean-core/src/dispatcher/mod.rs
+++ b/glean-core/src/dispatcher/mod.rs
@@ -28,7 +28,7 @@ use std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
-    thread::{self, JoinHandle},
+    thread::JoinHandle,
     time::Duration,
 };
 
@@ -265,66 +265,62 @@ impl Dispatcher {
         let queue_preinit = Arc::new(AtomicBool::new(true));
         let overflow_count = Arc::new(AtomicUsize::new(0));
 
-        let worker = thread::Builder::new()
-            .name("glean.dispatcher".into())
-            .spawn(move || {
-                match block_receiver.recv() {
+        let worker = crate::thread::spawn("glean.dispatcher", move || {
+            match block_receiver.recv() {
+                Err(_) => {
+                    // The other side was disconnected.
+                    // There's nothing the worker thread can do.
+                    log::error!("The task producer was disconnected. Worker thread will exit.");
+                    return;
+                }
+                Ok(Blocked::Shutdown) => {
+                    // The other side wants us to stop immediately
+                    return;
+                }
+                Ok(Blocked::Continue) => {
+                    // Queue is unblocked, processing continues as normal.
+                }
+            }
+
+            let mut receiver = preinit_receiver;
+            loop {
+                use Command::*;
+
+                match receiver.recv() {
+                    Ok(Shutdown) => {
+                        break;
+                    }
+
+                    Ok(Task(f)) => {
+                        (f)();
+                    }
+
+                    Ok(Swap(swap_done)) => {
+                        // A swap should only occur exactly once.
+                        // This is upheld by `flush_init`, which errors out if the preinit buffer
+                        // was already flushed.
+
+                        // We swap the channels we listen on for new tasks.
+                        // The next iteration will continue with the unbounded queue.
+                        mem::swap(&mut receiver, &mut unbounded_receiver);
+
+                        // The swap command MUST be the last one received on the preinit buffer,
+                        // so by the time we run this we know all preinit tasks were processed.
+                        // We can notify the other side.
+                        swap_done
+                            .send(())
+                            .expect("The caller of `flush_init` has gone missing");
+                    }
+
+                    // Other side was disconnected.
                     Err(_) => {
-                        // The other side was disconnected.
-                        // There's nothing the worker thread can do.
                         log::error!("The task producer was disconnected. Worker thread will exit.");
                         return;
                     }
-                    Ok(Blocked::Shutdown) => {
-                        // The other side wants us to stop immediately
-                        return;
-                    }
-                    Ok(Blocked::Continue) => {
-                        // Queue is unblocked, processing continues as normal.
-                    }
                 }
-
-                let mut receiver = preinit_receiver;
-                loop {
-                    use Command::*;
-
-                    match receiver.recv() {
-                        Ok(Shutdown) => {
-                            break;
-                        }
-
-                        Ok(Task(f)) => {
-                            (f)();
-                        }
-
-                        Ok(Swap(swap_done)) => {
-                            // A swap should only occur exactly once.
-                            // This is upheld by `flush_init`, which errors out if the preinit buffer
-                            // was already flushed.
-
-                            // We swap the channels we listen on for new tasks.
-                            // The next iteration will continue with the unbounded queue.
-                            mem::swap(&mut receiver, &mut unbounded_receiver);
-
-                            // The swap command MUST be the last one received on the preinit buffer,
-                            // so by the time we run this we know all preinit tasks were processed.
-                            // We can notify the other side.
-                            swap_done
-                                .send(())
-                                .expect("The caller of `flush_init` has gone missing");
-                        }
-
-                        // Other side was disconnected.
-                        Err(_) => {
-                            log::error!(
-                                "The task producer was disconnected. Worker thread will exit."
-                            );
-                            return;
-                        }
-                    }
-                }
-            })
-            .expect("Failed to spawn Glean's dispatcher thread");
+            }
+        })
+        .expect("Failed to spawn Glean's dispatcher thread");
 
         let guard = DispatchGuard {
             queue_preinit,
@@ -362,6 +358,7 @@ mod test {
     use super::*;
     use std::sync::atomic::AtomicU8;
     use std::sync::Mutex;
+    use std::thread;
 
     fn enable_test_logging() {
         // When testing we want all logs to go to stdout/stderr by default,

--- a/glean-core/src/thread.rs
+++ b/glean-core/src/thread.rs
@@ -1,0 +1,13 @@
+use std::io;
+use std::thread::{self, JoinHandle};
+
+/// Spawns a new thread, returning a [`JoinHandle`] for it.
+///
+/// Wrapper around [`std::thread::spawn`], but automatically naming the thread.
+pub fn spawn<F, T>(name: &'static str, f: F) -> Result<JoinHandle<T>, io::Error>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    thread::Builder::new().name(name.to_string()).spawn(f)
+}

--- a/glean-core/src/thread.rs
+++ b/glean-core/src/thread.rs
@@ -1,6 +1,37 @@
 use std::io;
 use std::thread::{self, JoinHandle};
 
+#[cfg(all(feature = "gecko", not(target_os = "android")))]
+mod bindings {
+    extern "C" {
+        pub fn gecko_profiler_register_thread(name: *const std::ffi::c_char);
+        pub fn gecko_profiler_unregister_thread();
+    }
+}
+
+/// Register a thread with the Gecko Profiler.
+#[cfg(all(feature = "gecko", not(target_os = "android")))]
+fn register_thread(thread_name: &str) {
+    let name = std::ffi::CString::new(thread_name).unwrap();
+    unsafe {
+        // gecko_profiler_register_thread copies the passed name here.
+        bindings::gecko_profiler_register_thread(name.as_ptr());
+    }
+}
+
+#[cfg(any(not(feature = "gecko"), target_os = "android"))]
+fn register_thread(_thread_name: &str) {}
+
+/// Unregister a thread with the Gecko Profiler.
+#[cfg(all(feature = "gecko", not(target_os = "android")))]
+fn unregister_thread() {
+    unsafe {
+        bindings::gecko_profiler_unregister_thread();
+    }
+}
+#[cfg(any(not(feature = "gecko"), target_os = "android"))]
+fn unregister_thread() {}
+
 /// Spawns a new thread, returning a [`JoinHandle`] for it.
 ///
 /// Wrapper around [`std::thread::spawn`], but automatically naming the thread.
@@ -9,5 +40,12 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    thread::Builder::new().name(name.to_string()).spawn(f)
+    thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            register_thread(name);
+            let res = f();
+            unregister_thread();
+            res
+        })
 }


### PR DESCRIPTION
As I was working on some profiling today I was getting annoyed by not seeing those threads.
So I'm bringing this back now.

As noted last time in the bug doing that on Android is not possible because of ... things (which we hopefully gonna fix at some point), but for Desktop we can register just fine.

I split it up into 2 commits:
1. Refactoring things so we spawn using a single function
2. Adding the Gecko thread registration in that one unique place

The diff looks bigger than it is due to the change in indentation, but `?w=1` in the URL should make that less noisy.