### PR TITLE
Bug 1983023 - Kotlin: `testBeforeNextSubmit` now returns a job to await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   * Updated Kotlin to 2.2.0 ([#3182](https://github.com/mozilla/glean/pull/3182))
   * BREAKING CHANGE: Dispatch most metric recordings on a Kotlin dispatcher to avoid calling into glean-core early.
     This does not change any behavior: The dispatch queue is worked on right after initialization ([#3183](https://github.com/mozilla/glean/pull/3183))
+  * The `testBeforeNextSubmit` now returns a job to be awaited. This allows to wait for the callback
+    and properly handles exceptions ([#3218](https://github.com/mozilla/glean/pull/3218))
 * Python
   * Bump minimum required Python version to 3.9 ([#3164](https://github.com/mozilla/glean/issues/3164))
   * Report `client_info.architecture` as reported from Python again ([#3185](https://github.com/mozilla/glean/issues/3185))

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -6,6 +6,8 @@ package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
 import mozilla.telemetry.glean.Dispatchers
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import mozilla.telemetry.glean.internal.PingType as GleanPingType
 
 /**
@@ -34,6 +36,42 @@ enum class NoReasonCodes(
     val value: Int,
 ) : ReasonCode {
     // deliberately empty
+}
+
+class JobTimeoutException : Exception("Job timed out")
+
+/**
+ * A job awaiting an async `testBeforeNextSubmit` callback run.
+ *
+ * The callback is set using `PingType.testBeforeNextSubmit` and called upoon `PingType.submit`.
+ *
+ * A job **MUST* be `join()`ed in order to wait for the callback and rethrow any exceptions.
+ */
+class TestJob {
+    var lastException: Throwable? = null
+    val waitQueue: LinkedBlockingQueue<Boolean> = LinkedBlockingQueue()
+
+    /**
+     * Join the task.
+     *
+     * Blocks for the callback to finish once or time out.
+     * If it times out a `JobTimeoutException` is thrown.
+     * If the callback throws any `Throwable` it is rethrown.
+     *
+     * @param timeout how long to wait before giving up, in units of unit
+     * @param unit a `TimeUnit` determining how to interpret the `timeout` parameter
+     */
+    fun join(
+        timeout: Long = 3,
+        unit: TimeUnit = TimeUnit.SECONDS,
+    ) {
+        val wait = this.waitQueue.poll(timeout, unit)
+        if (wait == null) {
+            throw JobTimeoutException()
+        }
+        this.lastException?.let { throw it }
+        this.lastException = null
+    }
 }
 
 /**
@@ -87,11 +125,25 @@ class PingType<ReasonCodesEnum>(
      * Note: The callback will be called on any call to submit.
      * A ping might not be sent afterwards, e.g. if the ping is otherwise empty (and
      * `send_if_empty` is `false`).
+     *
+     * @returns a `TestJob` to `join` on the callback. `TestJob.join` resolves after the callback runs.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @Suppress("TooGenericExceptionCaught")
     @Synchronized
-    fun testBeforeNextSubmit(cb: (ReasonCodesEnum?) -> Unit) {
-        this.testCallback = cb
+    fun testBeforeNextSubmit(cb: (ReasonCodesEnum?) -> Unit): TestJob {
+        val testJob = TestJob()
+        this.testCallback = { reason ->
+            try {
+                cb(reason)
+            } catch (e: Throwable) {
+                testJob.lastException = e
+            } finally {
+                testJob.waitQueue.put(true)
+            }
+        }
+
+        return testJob
     }
 
     /**
@@ -107,12 +159,12 @@ class PingType<ReasonCodesEnum>(
      */
     @JvmOverloads
     fun submit(reason: ReasonCodesEnum? = null) {
-        this.testCallback?.let {
-            it(reason)
-        }
-        this.testCallback = null
-
         Dispatchers.Delayed.launch {
+            this.testCallback?.let {
+                it(reason)
+            }
+            this.testCallback = null
+
             val reasonString = reason?.let { this.reasonCodes[it.code()] }
             this.innerPing.submit(reasonString)
         }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/private/PingTypeTest.kt
@@ -24,6 +24,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -104,6 +105,62 @@ class PingTypeTest {
         assertNotNull(pingJson.getJSONObject("client_info")["locale"])
 
         checkPingSchema(pingJson)
+    }
+
+    @Test
+    fun `test testBeforeNextSubmit handles exceptions`() {
+        val server = getMockWebServer()
+
+        val context = getContext()
+        delayMetricsPing(context)
+        resetGlean(
+            context,
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            ),
+        )
+
+        val customPing = PingType<NoReasonCodes>(
+            name = "custom",
+            includeClientId = true,
+            sendIfEmpty = false,
+            preciseTimestamps = true,
+            includeInfoSections = true,
+            enabled = true,
+            schedulesPings = emptyList(),
+            reasonCodes = listOf(),
+            followsCollectionEnabled = true,
+            uploaderCapabilities = emptyList(),
+        )
+
+        val counter = CounterMetricType(
+            CommonMetricData(
+                disabled = false,
+                category = "test",
+                lifetime = Lifetime.APPLICATION,
+                name = "counter",
+                sendInPings = listOf("custom"),
+            ),
+        )
+
+        counter.add()
+        assertEquals(1, counter.testGetValue())
+
+        var job = customPing.testBeforeNextSubmit { _ ->
+            assertTrue(true)
+        }
+
+        customPing.submit()
+        // This works as expected
+        job.join()
+
+        // This throws an AssertionError, that `join` rethrows
+        job = customPing.testBeforeNextSubmit { _ ->
+            assertNotNull(null)
+        }
+
+        customPing.submit()
+        assertThrows(AssertionError::class.java) { job.join() }
     }
 
     @Test


### PR DESCRIPTION
This is necessary because `submit` runs asynchronously and in tests we need to wait for the callback to actually run.
Additionally we need to rethrow any exceptions and assertion errors, because the `submit` call might happen on a different coroutine, which might NOT bubble up those exceptions.