### PR TITLE
event database: Force an fsync after write

### DIFF
--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -376,6 +376,7 @@ impl EventDatabase {
             file.write_all(event_json.as_bytes())?;
             file.write_all(b"\n")?;
             file.flush()?;
+            file.sync_all()?;
             Ok::<(), std::io::Error>(())
         })();
 


### PR DESCRIPTION
Otherwise the file might be empty looking to outsiders. At least on Windows this caused test failures in m-c when we were implement a prototype-health ping and checking files on disk.

Only by syncing it all do we actually get the right file size on disk.

Before we used to open/close the event database files all the time, which internally does a sync.
Now `sync_all` is potentially _more_ expensive than a close (through drop), as the latter is not required to block until the data is written (according to the docs: https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_all)