### PR TITLE
v64 backport: Handle ping schedules even for otherwise disabled pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v64.5.4...main)
 
+* General
+  * Pings on a ping schedule now get submitted even if the related ping might be disabled ([#3226](https://github.com/mozilla/glean/pull/3226))
+
 # v64.5.4 (2025-07-29)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v64.5.3...v64.5.4)


### PR DESCRIPTION
That is: if pings adhere to the baseline schedule but upload is disabled, any pings with `ping_schedule: [baseline]` still need to be checked and submitted if enabled.

Same as #3226