### PR TITLE
Refactor FXIOS-13276 - Adapt PingUploadRequest and CapablePingUploadRequest so they can be used to create custom uploaders

### DIFF
--- a/glean-core/ios/Glean/Net/PingUploader.swift
+++ b/glean-core/ios/Glean/Net/PingUploader.swift
@@ -36,7 +36,7 @@ public struct PingUploadRequest {
 }
 
 public struct CapablePingUploadRequest {
-    public let request: PingUploadRequest
+    private let request: PingUploadRequest
 
     init(_ request: PingUploadRequest) {
         self.request = request


### PR DESCRIPTION
[Task](https://mozilla-hub.atlassian.net/browse/FXIOS-13276)

### Context💡   
TLDR; I am looking to start using the interface added in https://github.com/mozilla/glean/pull/3175 so we can provide a custom uploader so Glean can send [OHTTP pings](https://github.com/mozilla-mobile/firefox-ios/pull/26949).

The new uploader we'll be providing to `Glean` is the [OHttpManager](https://github.com/mozilla/application-services/blob/release-v125/components/as-ohttp-client/ios/ASOhttpClient/OhttpManager.swift). I am implementing the integration between the `Glean` uploader interface and this `OHttpManager` to enable them to interoperate, as they expose different interfaces.

### Description ✏️
`Glean` creates the `PingUploadRequest` and we need the `OHttpManager` to access this `URLRequest` information so it can properly send it through the `OhttpSession`. But the request is currently private, so I am proposing here to make it and its related information public.

I also noted the `HttpPingUploader` is the one [making the check](https://github.com/mozilla/glean/blob/72a785653c6935d398796005342c0be177c3c62e/glean-core/ios/Glean/Net/HttpPingUploader.swift#L45) to ensure the ping is actually following the required capability. This is why I am proposing to make the `func capable(:)` function public. 

Let me know if I am missing something obvious 🙏 