### PR TITLE
Refactor FXIOS-13276 - Missing public typealias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v65.0.2...main)
 
+* Swift
+  * "Swift: BUGFIX: Refactor uploader interfaces to permit customization ([#3235](https://github.com/mozilla/glean/pull/3235), [#3239](https://github.com/mozilla/glean/pull/3239))
+
 # v65.0.2 (2025-08-25)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v65.0.1...v65.0.2)

--- a/glean-core/ios/Glean.xcodeproj/project.pbxproj
+++ b/glean-core/ios/Glean.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		60006D2B2E0DB174000C14E3 /* PingUploadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60006D2A2E0DB174000C14E3 /* PingUploadScheduler.swift */; };
 		6003AE252E0C6E9400BC8E07 /* PingUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6003AE242E0C6E9400BC8E07 /* PingUploader.swift */; };
 		60691AEB28DD0BF200BDF31A /* BaselinePingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60691AEA28DD0BF200BDF31A /* BaselinePingTests.swift */; };
+		8AF3BEA12E60EC670007A9ED /* PingUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3BEA02E60EC620007A9ED /* PingUploaderTests.swift */; };
+		8AF3BEA32E60EEDD0007A9ED /* makeCapablePingUploadRequestForTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3BEA22E60EED50007A9ED /* makeCapablePingUploadRequestForTests.swift */; };
 		AC06529C26E032E300D92D5E /* QuantityMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC06529B26E032E300D92D5E /* QuantityMetric.swift */; };
 		AC06529E26E034BF00D92D5E /* QuantityMetricTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC06529D26E034BF00D92D5E /* QuantityMetricTypeTest.swift */; };
 		AC1DB401237EF0ED005A0F8A /* Glean.h in Headers */ = {isa = PBXBuildFile; fileRef = BF3DE3942243A2F20018E23F /* Glean.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -105,6 +107,8 @@
 		60006D2A2E0DB174000C14E3 /* PingUploadScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingUploadScheduler.swift; sourceTree = "<group>"; };
 		6003AE242E0C6E9400BC8E07 /* PingUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingUploader.swift; sourceTree = "<group>"; };
 		60691AEA28DD0BF200BDF31A /* BaselinePingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BaselinePingTests.swift; path = Net/BaselinePingTests.swift; sourceTree = "<group>"; };
+		8AF3BEA02E60EC620007A9ED /* PingUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingUploaderTests.swift; sourceTree = "<group>"; };
+		8AF3BEA22E60EED50007A9ED /* makeCapablePingUploadRequestForTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = makeCapablePingUploadRequestForTests.swift; sourceTree = "<group>"; };
 		AC06529B26E032E300D92D5E /* QuantityMetric.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuantityMetric.swift; sourceTree = "<group>"; };
 		AC06529D26E034BF00D92D5E /* QuantityMetricTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuantityMetricTypeTest.swift; sourceTree = "<group>"; };
 		BF10007F23548B0500064051 /* MemoryDistributionMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDistributionMetric.swift; sourceTree = "<group>"; };
@@ -379,6 +383,8 @@
 		BF80AA5923992FFB00A8B172 /* Net */ = {
 			isa = PBXGroup;
 			children = (
+				8AF3BEA22E60EED50007A9ED /* makeCapablePingUploadRequestForTests.swift */,
+				8AF3BEA02E60EC620007A9ED /* PingUploaderTests.swift */,
 				60691AEA28DD0BF200BDF31A /* BaselinePingTests.swift */,
 				CD3682F22CAC10FE00B02F04 /* RidealongPingTests.swift */,
 				BF80AA5E2399305200A8B172 /* DeletionRequestPingTests.swift */,
@@ -642,6 +648,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F39E7B3239F0777009B13B3 /* GleanDebugUtilityTests.swift in Sources */,
+				8AF3BEA32E60EEDD0007A9ED /* makeCapablePingUploadRequestForTests.swift in Sources */,
+				8AF3BEA12E60EC670007A9ED /* PingUploaderTests.swift in Sources */,
 				BFAED50A2369752400DF293D /* StringListMetricTests.swift in Sources */,
 				60691AEB28DD0BF200BDF31A /* BaselinePingTests.swift in Sources */,
 				BF890561232BC227003CA2BA /* StringMetricTests.swift in Sources */,

--- a/glean-core/ios/Glean/Net/PingUploader.swift
+++ b/glean-core/ios/Glean/Net/PingUploader.swift
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-typealias HeadersList = [String: String]
+public typealias HeadersList = [String: String]
 
 /// The interface defining how to send pings.
 public protocol PingUploader {

--- a/glean-core/ios/GleanTests/PingUploaderTests.swift
+++ b/glean-core/ios/GleanTests/PingUploaderTests.swift
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Glean
+import XCTest
+
+/// Making sure the right `PingUploader` APIs are public
+final class PingUploaderTests: XCTestCase {
+    let capabilities = ["ohttp"]
+    let url = "http://example.com"
+    let path = "/hello"
+    let data = [UInt8]("{ \"ping\": \"test\" }".utf8)
+    let headers: HeadersList = [:]
+
+    func testPingRequestAccess_withCapableAccess() throws {
+        let subject = createSubject()
+        let request = try XCTUnwrap(subject.capable(capabilities))
+
+        // This data is accessible so customs `PingUploader` can build requests
+        XCTAssertEqual(url + path, request.url)
+        XCTAssertEqual(data, request.data)
+        XCTAssertEqual(headers, request.headers)
+    }
+
+    func testPingRequestAccess_withoutCapableAccess() throws {
+        let subject = createSubject()
+        XCTAssertNil(subject.capable(["dummy"]))
+    }
+
+    func createSubject() -> CapablePingUploadRequest {
+        let builder = CapablePingUploadRequestBuilder()
+        let subject = builder.makeCapablePingUploadRequestForTests(
+            url: url,
+            path: path,
+            data: data,
+            headers: headers,
+            capabilities: capabilities
+        )
+        return subject
+    }
+}

--- a/glean-core/ios/GleanTests/makeCapablePingUploadRequestForTests.swift
+++ b/glean-core/ios/GleanTests/makeCapablePingUploadRequestForTests.swift
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Glean
+
+/// Builds a `CapablePingUploadRequest` through the internal APIs so we can test public APIs
+struct CapablePingUploadRequestBuilder {
+    func makeCapablePingUploadRequestForTests(
+        url: String,
+        path: String,
+        data: [UInt8],
+        headers: HeadersList,
+        capabilities: [String]
+    ) -> CapablePingUploadRequest {
+        let testOhttpRequest = PingRequest(
+            documentId: "12345",
+            path: path,
+            body: data,
+            headers: headers,
+            bodyHasInfoSections: true,
+            pingName: "testPing",
+            uploaderCapabilities: capabilities
+        )
+        let request = PingUploadRequest(
+            request: testOhttpRequest,
+            endpoint: url
+        )
+        return CapablePingUploadRequest(request)
+    }
+}


### PR DESCRIPTION
Follow up on https://github.com/mozilla/glean/pull/3235

The headers are now public under the `PingUploadRequest`, but the typealias should be public too
```
public let headers: HeadersList
```