### PR TITLE
[no-bug] - Remove setting test-mode from test_reset_glean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased changes
 
 [Full changelog](https://github.com/mozilla/glean/compare/v65.1.0...main)
+* General
+  * Remove newly added call to set test-mode in `test_reset_glean`, instead setting test-mode only in necessary tests.
 
 # v65.1.0 (2025-09-09)
 

--- a/glean-core/python/tests/metrics/test_uuid.py
+++ b/glean-core/python/tests/metrics/test_uuid.py
@@ -11,6 +11,7 @@ from glean import metrics
 from glean import testing
 from glean.metrics import Lifetime, CommonMetricData
 from glean.testing import _RecordingUploader
+from glean._uniffi import glean_set_test_mode
 
 
 def test_the_api_saves_to_its_storage_engine():
@@ -135,6 +136,8 @@ def test_what_looks_like_it_might_be_uuid(tmpdir, helpers):
     import hashlib
 
     Glean._reset()
+
+    glean_set_test_mode(True)
 
     info_path = Path(str(tmpdir)) / "info.txt"
 

--- a/glean-core/python/tests/test_glean.py
+++ b/glean-core/python/tests/test_glean.py
@@ -446,6 +446,8 @@ def test_set_application_id_and_version(safe_httpserver):
     safe_httpserver.serve_content(b"", code=200)
     Glean._reset()
 
+    glean_set_test_mode(True)
+
     Glean._initialize_with_tempdir_for_testing(
         application_id="my-id",
         application_version="my-version",
@@ -459,20 +461,17 @@ def test_set_application_id_and_version(safe_httpserver):
     )
 
     _builtins.pings.baseline.submit()
-    wait_for_requests(safe_httpserver, 3)
+    wait_for_requests(safe_httpserver, 1)
 
-    # Expect 3 total requests: 1 baseline + 2 health
-    assert 3 == len(safe_httpserver.requests)
+    assert 1 == len(safe_httpserver.requests)
 
     # Extract all ping URLs
     ping_urls = [req.url for req in safe_httpserver.requests]
 
     # Verify ping counts
     baseline_pings = [url for url in ping_urls if "baseline" in url]
-    health_pings = [url for url in ping_urls if "health" in url]
 
     assert len(baseline_pings) == 1
-    assert len(health_pings) == 2
 
     # All requests should include the application id
     for url in ping_urls:
@@ -523,6 +522,8 @@ def test_sending_deletion_ping_if_disabled_outside_of_run(tmpdir, ping_schema_ur
 
     Glean._reset()
 
+    glean_set_test_mode(True)
+
     Glean.initialize(
         application_id=GLEAN_APP_ID,
         application_version=glean_version,
@@ -532,6 +533,8 @@ def test_sending_deletion_ping_if_disabled_outside_of_run(tmpdir, ping_schema_ur
     )
 
     Glean._reset()
+
+    glean_set_test_mode(True)
 
     Glean.initialize(
         application_id=GLEAN_APP_ID,
@@ -739,6 +742,8 @@ def test_presubmit_makes_a_valid_ping(tmpdir, ping_schema_url, monkeypatch, help
         sys.stdout,
         schema_url=ping_schema_url,
     )
+
+    Glean._reset()
 
 
 def test_app_display_version_unknown():

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -251,7 +251,6 @@ pub(crate) fn destroy_glean(clear_stores: bool, data_path: &Path) {
 /// Resets the Glean state and triggers init again.
 pub fn test_reset_glean(cfg: Configuration, client_info: ClientInfoMetrics, clear_stores: bool) {
     destroy_glean(clear_stores, &cfg.data_path);
-    glean_core::glean_set_test_mode(true);
     initialize_internal(cfg, client_info);
     glean_core::join_init();
 }

--- a/glean-core/rlb/src/test.rs
+++ b/glean-core/rlb/src/test.rs
@@ -358,6 +358,8 @@ fn sending_of_startup_baseline_ping() {
 fn no_dirty_baseline_on_clean_shutdowns() {
     let _lock = lock_test();
 
+    glean_core::glean_set_test_mode(true);
+
     // Create an instance of Glean, wait for init and then flip the dirty
     // bit to true.
     let data_dir = new_glean(None, true);
@@ -593,6 +595,8 @@ fn ping_collection_must_happen_after_concurrently_scheduled_metrics_recordings()
 
     let (s, r) = crossbeam_channel::bounded(1);
 
+    glean_core::glean_set_test_mode(true);
+
     // Define a fake uploader that reports back the submission URL
     // using a crossbeam channel.
     #[derive(Debug)]
@@ -773,6 +777,8 @@ fn no_sending_of_deletion_ping_if_unchanged_outside_of_run() {
     let _lock = lock_test();
 
     let (s, r) = crossbeam_channel::bounded::<String>(1);
+
+    glean_core::glean_set_test_mode(true);
 
     // Define a fake uploader that reports back the submission URL
     // using a crossbeam channel.
@@ -1119,6 +1125,8 @@ fn flipping_upload_enabled_respects_order_of_events() {
 
     let (s, r) = crossbeam_channel::bounded::<String>(1);
 
+    glean_core::glean_set_test_mode(true);
+
     // Define a fake uploader that reports back the submission URL
     // using a crossbeam channel.
     #[derive(Debug)]
@@ -1455,6 +1463,8 @@ fn configure_ping_throttling() {
     let _lock = lock_test();
 
     let (s, r) = crossbeam_channel::bounded::<String>(1);
+
+    glean_core::glean_set_test_mode(true);
 
     // Define a fake uploader that reports back the submission URL
     // using a crossbeam channel.


### PR DESCRIPTION
In order to cut down on issues vendoring the current release into mozilla-central, I'm removing setting of test-mode when calling `test_reset_glean` and instead only setting test-mode for tests that need it.