### PR TITLE
Bug 1989902 - Rust: Use an associated type for TestGetValue to make it clear it's an output parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v65.1.1...v65.2.0)
 
+* Rust
+  *  Rust: Use an associated type for `TestGetValue` ([#3259](https://github.com/mozilla/glean/pull/3259))
 * Swift
   * Glean for iOS is now being built with Xcode 16.2 ([#3189](https://github.com/mozilla/glean/pull/3189))
 * General

--- a/glean-core/rlb/src/private/event.rs
+++ b/glean-core/rlb/src/private/event.rs
@@ -72,7 +72,9 @@ impl<K: traits::ExtraKeys> EventMetric<K> {
 }
 
 #[inherent]
-impl<K> TestGetValue<Vec<RecordedEvent>> for EventMetric<K> {
+impl<K> TestGetValue for EventMetric<K> {
+    type Output = Vec<RecordedEvent>;
+
     pub fn test_get_value(&self, ping_name: Option<String>) -> Option<Vec<RecordedEvent>> {
         self.inner.test_get_value(ping_name)
     }

--- a/glean-core/rlb/src/private/object.rs
+++ b/glean-core/rlb/src/private/object.rs
@@ -39,7 +39,9 @@ impl<'a, K> MetricIdentifier<'a> for ObjectMetric<K> {
     }
 }
 
-impl<K> TestGetValue<JsonValue> for ObjectMetric<K> {
+impl<K> TestGetValue for ObjectMetric<K> {
+    type Output = JsonValue;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as JSON-encoded string.

--- a/glean-core/src/metrics/boolean.rs
+++ b/glean-core/src/metrics/boolean.rs
@@ -120,7 +120,8 @@ impl BooleanMetric {
     }
 }
 
-impl TestGetValue<bool> for BooleanMetric {
+impl TestGetValue for BooleanMetric {
+    type Output = bool;
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as a boolean.

--- a/glean-core/src/metrics/counter.rs
+++ b/glean-core/src/metrics/counter.rs
@@ -157,7 +157,9 @@ impl CounterMetric {
     }
 }
 
-impl TestGetValue<i32> for CounterMetric {
+impl TestGetValue for CounterMetric {
+    type Output = i32;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as an integer.

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -303,7 +303,9 @@ impl CustomDistributionMetric {
     }
 }
 
-impl TestGetValue<DistributionData> for CustomDistributionMetric {
+impl TestGetValue for CustomDistributionMetric {
+    type Output = DistributionData;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as an integer.

--- a/glean-core/src/metrics/datetime.rs
+++ b/glean-core/src/metrics/datetime.rs
@@ -277,7 +277,9 @@ impl DatetimeMetric {
     }
 }
 
-impl TestGetValue<Datetime> for DatetimeMetric {
+impl TestGetValue for DatetimeMetric {
+    type Output = Datetime;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the stored datetime value.

--- a/glean-core/src/metrics/denominator.rs
+++ b/glean-core/src/metrics/denominator.rs
@@ -127,7 +127,9 @@ impl DenominatorMetric {
     }
 }
 
-impl TestGetValue<i32> for DenominatorMetric {
+impl TestGetValue for DenominatorMetric {
+    type Output = i32;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as an integer.

--- a/glean-core/src/metrics/dual_labeled_counter.rs
+++ b/glean-core/src/metrics/dual_labeled_counter.rs
@@ -231,7 +231,9 @@ impl DualLabeledCounterMetric {
     }
 }
 
-impl TestGetValue<HashMap<String, HashMap<String, i32>>> for DualLabeledCounterMetric {
+impl TestGetValue for DualLabeledCounterMetric {
+    type Output = HashMap<String, HashMap<String, i32>>;
+
     fn test_get_value(
         &self,
         ping_name: Option<String>,

--- a/glean-core/src/metrics/event.rs
+++ b/glean-core/src/metrics/event.rs
@@ -212,7 +212,9 @@ impl EventMetric {
     }
 }
 
-impl TestGetValue<Vec<RecordedEvent>> for EventMetric {
+impl TestGetValue for EventMetric {
+    type Output = Vec<RecordedEvent>;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Get the vector of currently stored events for this event metric.

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -353,11 +353,13 @@ where
     }
 }
 
-impl<T, S> TestGetValue<HashMap<String, S>> for LabeledMetric<T>
+impl<T, S> TestGetValue for LabeledMetric<T>
 where
-    T: AllowLabeled + TestGetValue<S>,
+    T: AllowLabeled + TestGetValue<Output = S>,
     S: Any,
 {
+    type Output = HashMap<String, S>;
+
     fn test_get_value(&self, ping_name: Option<String>) -> Option<HashMap<String, S>> {
         let mut out = HashMap::new();
         let map = self.label_map.lock().unwrap();

--- a/glean-core/src/metrics/memory_distribution.rs
+++ b/glean-core/src/metrics/memory_distribution.rs
@@ -324,7 +324,9 @@ impl MemoryDistributionMetric {
     }
 }
 
-impl TestGetValue<DistributionData> for MemoryDistributionMetric {
+impl TestGetValue for MemoryDistributionMetric {
+    type Output = DistributionData;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value.

--- a/glean-core/src/metrics/mod.rs
+++ b/glean-core/src/metrics/mod.rs
@@ -270,7 +270,10 @@ pub trait MetricIdentifier<'a> {
 }
 
 /// [`TestGetValue`] describes an interface for retrieving the value for a given metric
-pub trait TestGetValue<T> {
+pub trait TestGetValue {
+    /// The output type of `test_get_value`
+    type Output;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Returns the currently stored value of the appropriate type for the given metric.
@@ -285,7 +288,7 @@ pub trait TestGetValue<T> {
     /// # Returns
     ///
     /// The stored value or `None` if nothing stored.
-    fn test_get_value(&self, ping_name: Option<String>) -> Option<T>;
+    fn test_get_value(&self, ping_name: Option<String>) -> Option<Self::Output>;
 }
 
 // Provide a blanket implementation for MetricIdentifier for all the types

--- a/glean-core/src/metrics/numerator.rs
+++ b/glean-core/src/metrics/numerator.rs
@@ -76,7 +76,9 @@ impl NumeratorMetric {
     }
 }
 
-impl TestGetValue<Rate> for NumeratorMetric {
+impl TestGetValue for NumeratorMetric {
+    type Output = Rate;
+
     /// **Exported for test purposes.**
     ///
     /// Gets the currently stored value as a pair of integers.

--- a/glean-core/src/metrics/object.rs
+++ b/glean-core/src/metrics/object.rs
@@ -151,7 +151,9 @@ impl ObjectMetric {
     }
 }
 
-impl TestGetValue<JsonValue> for ObjectMetric {
+impl TestGetValue for ObjectMetric {
+    type Output = JsonValue;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as JSON.

--- a/glean-core/src/metrics/quantity.rs
+++ b/glean-core/src/metrics/quantity.rs
@@ -152,7 +152,9 @@ impl QuantityMetric {
     }
 }
 
-impl TestGetValue<i64> for QuantityMetric {
+impl TestGetValue for QuantityMetric {
+    type Output = i64;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as an integer.

--- a/glean-core/src/metrics/rate.rs
+++ b/glean-core/src/metrics/rate.rs
@@ -178,7 +178,9 @@ impl RateMetric {
     }
 }
 
-impl TestGetValue<Rate> for RateMetric {
+impl TestGetValue for RateMetric {
+    type Output = Rate;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as a pair of integers.

--- a/glean-core/src/metrics/string.rs
+++ b/glean-core/src/metrics/string.rs
@@ -127,7 +127,9 @@ impl StringMetric {
     }
 }
 
-impl TestGetValue<String> for StringMetric {
+impl TestGetValue for StringMetric {
+    type Output = String;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as a string.

--- a/glean-core/src/metrics/string_list.rs
+++ b/glean-core/src/metrics/string_list.rs
@@ -186,7 +186,9 @@ impl StringListMetric {
     }
 }
 
-impl TestGetValue<Vec<String>> for StringListMetric {
+impl TestGetValue for StringListMetric {
+    type Output = Vec<String>;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently-stored values.

--- a/glean-core/src/metrics/text.rs
+++ b/glean-core/src/metrics/text.rs
@@ -131,7 +131,9 @@ impl TextMetric {
     }
 }
 
-impl TestGetValue<String> for TextMetric {
+impl TestGetValue for TextMetric {
+    type Output = String;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as a string.

--- a/glean-core/src/metrics/timespan.rs
+++ b/glean-core/src/metrics/timespan.rs
@@ -285,7 +285,8 @@ impl TimespanMetric {
     }
 }
 
-impl TestGetValue<i64> for TimespanMetric {
+impl TestGetValue for TimespanMetric {
+    type Output = i64;
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as an integer.

--- a/glean-core/src/metrics/timing_distribution.rs
+++ b/glean-core/src/metrics/timing_distribution.rs
@@ -613,7 +613,9 @@ impl TimingDistributionMetric {
     }
 }
 
-impl TestGetValue<DistributionData> for TimingDistributionMetric {
+impl TestGetValue for TimingDistributionMetric {
+    type Output = DistributionData;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as an integer.

--- a/glean-core/src/metrics/url.rs
+++ b/glean-core/src/metrics/url.rs
@@ -146,7 +146,9 @@ impl UrlMetric {
     }
 }
 
-impl TestGetValue<String> for UrlMetric {
+impl TestGetValue for UrlMetric {
+    type Output = String;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as a string.

--- a/glean-core/src/metrics/uuid.rs
+++ b/glean-core/src/metrics/uuid.rs
@@ -145,7 +145,9 @@ impl UuidMetric {
     }
 }
 
-impl TestGetValue<String> for UuidMetric {
+impl TestGetValue for UuidMetric {
+    type Output = String;
+
     /// **Test-only API (exported for FFI purposes).**
     ///
     /// Gets the currently stored value as a string.

--- a/glean-core/src/traits/boolean.rs
+++ b/glean-core/src/traits/boolean.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Boolean: TestGetValue<bool> {
+pub trait Boolean: TestGetValue<Output = bool> {
     /// Sets to the specified boolean value.
     ///
     /// # Arguments

--- a/glean-core/src/traits/counter.rs
+++ b/glean-core/src/traits/counter.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Counter: TestGetValue<i32> {
+pub trait Counter: TestGetValue<Output = i32> {
     /// Increases the counter by `amount`.
     ///
     /// # Arguments

--- a/glean-core/src/traits/custom_distribution.rs
+++ b/glean-core/src/traits/custom_distribution.rs
@@ -9,7 +9,7 @@ use crate::{DistributionData, ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait CustomDistribution: TestGetValue<DistributionData> {
+pub trait CustomDistribution: TestGetValue<Output = DistributionData> {
     /// Accumulates the provided signed samples in the metric.
     ///
     /// This is required so that the platform-specific code can provide us with

--- a/glean-core/src/traits/datetime.rs
+++ b/glean-core/src/traits/datetime.rs
@@ -10,7 +10,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Datetime: TestGetValue<crate::metrics::Datetime> {
+pub trait Datetime: TestGetValue<Output = crate::metrics::Datetime> {
     /// Sets the metric to a date/time which including the timezone offset.
     ///
     /// # Arguments

--- a/glean-core/src/traits/dual_labeled_counter.rs
+++ b/glean-core/src/traits/dual_labeled_counter.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait DualLabeledCounter: TestGetValue<HashMap<String, HashMap<String, i32>>> {
+pub trait DualLabeledCounter: TestGetValue<Output = HashMap<String, HashMap<String, i32>>> {
     /// Gets a specific counter for a given key/category pair.
     ///
     /// If a set of acceptable keys or categorires were specified in the `metrics.yaml` file,

--- a/glean-core/src/traits/event.rs
+++ b/glean-core/src/traits/event.rs
@@ -76,7 +76,7 @@ impl TryFrom<&str> for NoExtraKeys {
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Event: TestGetValue<Vec<RecordedEvent>> {
+pub trait Event: TestGetValue<Output = Vec<RecordedEvent>> {
     /// The type of the allowed extra keys for this event.
     type Extra: ExtraKeys;
 

--- a/glean-core/src/traits/memory_distribution.rs
+++ b/glean-core/src/traits/memory_distribution.rs
@@ -10,7 +10,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait MemoryDistribution: TestGetValue<DistributionData> {
+pub trait MemoryDistribution: TestGetValue<Output = DistributionData> {
     /// Accumulates the provided sample in the metric.
     ///
     /// # Arguments

--- a/glean-core/src/traits/numerator.rs
+++ b/glean-core/src/traits/numerator.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 // When changing this trait, ensure all operations are implemented in the
 // related type in `../metrics`. (Except test_get_num_errors)
 /// A description for the `NumeratorMetric` subtype of the [`RateMetric`](crate::metrics::RateMetric) type.
-pub trait Numerator: TestGetValue<Rate> {
+pub trait Numerator: TestGetValue<Output = Rate> {
     /// Increases the numerator by `amount`.
     ///
     /// # Arguments

--- a/glean-core/src/traits/quantity.rs
+++ b/glean-core/src/traits/quantity.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Quantity: TestGetValue<i64> {
+pub trait Quantity: TestGetValue<Output = i64> {
     /// Sets the value. Must be non-negative.
     ///
     /// # Arguments

--- a/glean-core/src/traits/rate.rs
+++ b/glean-core/src/traits/rate.rs
@@ -7,7 +7,7 @@ use crate::{ErrorType, TestGetValue};
 // When changing this trait, ensure all operations are implemented in the
 // related type in `../metrics`. (Except test_get_num_errors)
 /// A description for the [`RateMetric`](crate::metrics::RateMetric) type.
-pub trait Rate: TestGetValue<crate::Rate> {
+pub trait Rate: TestGetValue<Output = crate::Rate> {
     /// Increases the numerator by `amount`.
     ///
     /// # Arguments

--- a/glean-core/src/traits/string.rs
+++ b/glean-core/src/traits/string.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait String: TestGetValue<std::string::String> {
+pub trait String: TestGetValue<Output = std::string::String> {
     /// Sets to the specified value.
     ///
     /// # Arguments

--- a/glean-core/src/traits/string_list.rs
+++ b/glean-core/src/traits/string_list.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait StringList: TestGetValue<Vec<String>> {
+pub trait StringList: TestGetValue<Output = Vec<String>> {
     /// Adds a new string to the list.
     ///
     /// # Arguments

--- a/glean-core/src/traits/text.rs
+++ b/glean-core/src/traits/text.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Text: TestGetValue<String> {
+pub trait Text: TestGetValue<Output = String> {
     /// Sets to the specified value.
     ///
     /// # Arguments

--- a/glean-core/src/traits/timespan.rs
+++ b/glean-core/src/traits/timespan.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Timespan: TestGetValue<u64> {
+pub trait Timespan: TestGetValue<Output = u64> {
     /// Starts tracking time for the provided metric.
     ///
     /// This uses an internal monotonic timer.

--- a/glean-core/src/traits/timing_distribution.rs
+++ b/glean-core/src/traits/timing_distribution.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait TimingDistribution: TestGetValue<DistributionData> {
+pub trait TimingDistribution: TestGetValue<Output = DistributionData> {
     /// Start tracking time for the provided metric.
     /// Multiple timers can run simultaneously.
     ///

--- a/glean-core/src/traits/url.rs
+++ b/glean-core/src/traits/url.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Url: TestGetValue<String> {
+pub trait Url: TestGetValue<Output = String> {
     /// Sets to the specified stringified URL.
     ///
     /// # Arguments

--- a/glean-core/src/traits/uuid.rs
+++ b/glean-core/src/traits/uuid.rs
@@ -8,7 +8,7 @@ use crate::{ErrorType, TestGetValue};
 ///
 /// When changing this trait, make sure all the operations are
 /// implemented in the related type in `../metrics/`.
-pub trait Uuid: TestGetValue<uuid::Uuid> {
+pub trait Uuid: TestGetValue<Output = uuid::Uuid> {
     /// Sets to the specified value.
     ///
     /// # Arguments


### PR DESCRIPTION
Generic parameters are an "input".
A trait `TestGetValue<T>` can be implemented for the same type multiple times with different concrete types `T`.
That's never needed for `TestGetValue`, we only have a single type that should be returned from `test_get_value`.
An associated parameter is the way to do that.