### PR TITLE
Bug 1987918 - Log failing to persist data as an info note

### DIFF
--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -502,7 +502,7 @@ impl Database {
                 if let Err(e) =
                     self.record_per_lifetime(data.inner.lifetime, ping_name, &name, value)
                 {
-                    log::error!(
+                    log::info!(
                         "Failed to record metric '{}' into {}: {:?}",
                         data.base_identifier(),
                         ping_name,
@@ -573,7 +573,7 @@ impl Database {
                     &name,
                     &mut transform,
                 ) {
-                    log::error!(
+                    log::info!(
                         "Failed to record metric '{}' into {}: {:?}",
                         data.base_identifier(),
                         ping_name,

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -748,7 +748,7 @@ pub fn shutdown() {
     // Be sure to call this _after_ draining the dispatcher
     core::with_glean(|glean| {
         if let Err(e) = glean.persist_ping_lifetime_data() {
-            log::error!("Can't persist ping lifetime data: {:?}", e);
+            log::info!("Can't persist ping lifetime data: {:?}", e);
         }
     });
 }


### PR DESCRIPTION
Logging them as errors suggest there's a way to fix those, when often they are due to error conditions we don't control but gracefully handle.