### PR TITLE
Swift: Longer timeout for BaselinePingTest

### DIFF
--- a/samples/ios/app/glean-sample-appUITests/BaselinePingTest.swift
+++ b/samples/ios/app/glean-sample-appUITests/BaselinePingTest.swift
@@ -53,7 +53,7 @@ class BaselinePingTest: XCTestCase {
         app.launchArguments = ["USE_MOCK_SERVER", "\(try! server.port())"]
         app.launch()
 
-        waitForExpectations(timeout: 5.0) { error in
+        waitForExpectations(timeout: 10.0) { error in
             XCTAssertNil(error, "Test timed out waiting for upload: \(error!)")
         }
         // Set as a glean_parser parameter in the build task


### PR DESCRIPTION
I've seen that test time out several times now, e.g. https://app.circleci.com/pipelines/github/mozilla/glean/13859/workflows/bd6ee56e-c65c-465e-aee5-0058c96af300/jobs/271623/steps

From the log:

```
Test Suite 'BaselinePingTest' started at 2025-10-06 10:26:44.031.
Test Case '-[glean_sample_appUITests.BaselinePingTest testValidateBaselinePing]' started.
    t =     0.00s Start Test at 2025-10-06 10:26:44.031
    t =     1.47s Set Up
    t =     1.48s Open org.mozilla.glean-sample-app
    t =     1.48s     Launch org.mozilla.glean-sample-app
    t =     8.12s         Setting up automation session
    t =     9.61s         Wait for org.mozilla.glean-sample-app to idle
<unknown>:0: error: -[glean_sample_appUITests.BaselinePingTest testValidateBaselinePing] : Asynchronous wait failed: Exceeded timeout of 5 seconds, with unfulfilled expectations: "Completed upload (initial active)".
    t =    16.13s Tear Down
Test Case '-[glean_sample_appUITests.BaselinePingTest testValidateBaselinePing]' failed (16.641 seconds).
```

Other tests work fine:

```
Test Suite 'DeletionRequestPingTest' started at 2025-10-06 10:27:00.673.
Test Case '-[glean_sample_appUITests.DeletionRequestPingTest testDeletionRequestPing]' started.
    t =     0.00s Start Test at 2025-10-06 10:27:00.673
    t =     0.97s Set Up
    t =     0.99s Open org.mozilla.glean-sample-app
    t =     0.99s     Launch org.mozilla.glean-sample-app
    t =     0.99s         Terminate org.mozilla.glean-sample-app:8499
    t =     3.15s         Setting up automation session
    t =     5.41s         Wait for org.mozilla.glean-sample-app to idle
    t =     6.65s Tap Switch (First Match)
    t =     6.65s     Wait for org.mozilla.glean-sample-app to idle
    t =     6.65s     Find the Switch (First Match)
Middleware: ::80e3:6600:60:0 -> POST -> /submit/org-mozilla-glean-sample-app/health/1/61920aa9-307f-427d-b6aa-c73ff3152a5f
    t =     6.69s     Check for interrupting elements affecting "1" Switch
```

I do wonder if that might be due to slow CI and maybe just giving the first test a little bit more time might help to run more reliably.