### PR TITLE
CI: Switch to m4pro.medium instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,7 @@ jobs:
   Check Swift formatting:
     macos:
       xcode: "16.4"
-    resource_class: "macos.m1.medium.gen1"
+    resource_class: "m4pro.medium"
     steps:
       - checkout
       - run:
@@ -517,7 +517,7 @@ jobs:
   iOS build and test:
     macos:
       xcode: "16.4"
-    resource_class: "macos.m1.medium.gen1"
+    resource_class: "m4pro.medium"
     steps:
       - checkout
       - run:
@@ -618,7 +618,7 @@ jobs:
   iOS integration test:
     macos:
       xcode: "16.4"
-    resource_class: "macos.m1.medium.gen1"
+    resource_class: "m4pro.medium"
     steps:
       - checkout
       - skip-if-doc-only
@@ -663,7 +663,7 @@ jobs:
   iOS Framework release:
     macos:
       xcode: "16.4"
-    resource_class: "macos.m1.medium.gen1"
+    resource_class: "m4pro.medium"
     steps:
       - checkout
       - attach_workspace:
@@ -902,7 +902,7 @@ jobs:
   pypi-macos-release:
     macos:
       xcode: "16.4"
-    resource_class: "macos.m1.medium.gen1"
+    resource_class: "m4pro.medium"
     steps:
       - install-rustup
       - setup-rust-toolchain


### PR DESCRIPTION
m1.medium.gen1 will be deprecated next year: https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/

m4pro.medium is the smallest macOS VM now.
Prices according to https://circleci.com/pricing/price-list/

Current: 150 credits/min
New: 200 credits/min

So slightly more expensive, but maybe they make that up by being faster and thus running less!