### PR TITLE
Rust test: Avoid a deadlock in the signaling test

### DIFF
--- a/glean-core/rlb/src/net/mod.rs
+++ b/glean-core/rlb/src/net/mod.rs
@@ -110,7 +110,7 @@ impl UploadManager {
 
     /// Signals Glean to upload pings at the next best opportunity.
     pub(crate) fn trigger_upload(&self) {
-        // If no other upload proces is running, we're the one starting it.
+        // If no other upload process is running, we're the one starting it.
         // Need atomic compare/exchange to avoid any further races
         // or we can end up with 2+ uploader threads.
         if self

--- a/glean-core/rlb/tests/signaling_done.rs
+++ b/glean-core/rlb/tests/signaling_done.rs
@@ -85,6 +85,12 @@ fn signaling_done() {
     // Sync up with the upload thread.
     barrier.wait();
 
+    // The uploader thread needs some CPU time to actually shut down.
+    // We yield and still wait to make the scheduler give it that time.
+    // Using just one of the ways wasn't reliable enough.
+    std::thread::yield_now();
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
     // Submit another ping and wait for it to do work.
     pings::custom_ping.submit(None);
 


### PR DESCRIPTION
The uploader thread needs some CPU time to actually shut down. We yield and still wait to make the scheduler give it that time. Using just one of the ways wasn't reliable enough.

---

On my mac with the latest `main` I've been able to reproduce this in like 1 out of every 100 runs.
We have seen that deadlock on CI before as well (#3278, #3274)

```bash
for i in $(seq 1 1000); do 
  echo "===== Run $i ====="
  cargo test -p glean --test signaling_done -- || break
done
```

With this patch I can run the above loop (1000 runs) with no blockers.

(fixed a typo while I was around)