### PR TITLE
Rust: Fix up all doc warnings

### DIFF
--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -938,7 +938,7 @@ impl Glean {
     /// Return the value for the debug view tag or [`None`] if it hasn't been set.
     ///
     /// The `debug_view_tag` may be set from an environment variable
-    /// (`GLEAN_DEBUG_VIEW_TAG`) or through the `set_debug_view_tag` function.
+    /// (`GLEAN_DEBUG_VIEW_TAG`) or through the [`set_debug_view_tag`](Glean::set_debug_view_tag) function.
     pub fn debug_view_tag(&self) -> Option<&String> {
         self.debug.debug_view_tag.get()
     }
@@ -961,7 +961,7 @@ impl Glean {
     /// Return the value for the source tags or [`None`] if it hasn't been set.
     ///
     /// The `source_tags` may be set from an environment variable (`GLEAN_SOURCE_TAGS`)
-    /// or through the [`set_source_tags`] function.
+    /// or through the [`set_source_tags`](Glean::set_source_tags) function.
     pub(crate) fn source_tags(&self) -> Option<&Vec<String>> {
         self.debug.source_tags.get()
     }

--- a/glean-core/src/fd_logger.rs
+++ b/glean-core/src/fd_logger.rs
@@ -23,7 +23,7 @@ use serde::Serialize;
 /// side) to filter the log messages based on their level.
 /// The JSON payload of each message in an object with the following keys:
 ///    - `level` (string): One of the logging levels defined here:
-///      https://docs.rs/log/0.4.11/log/enum.Level.html
+///      <https://docs.rs/log/0.4.11/log/enum.Level.html>
 ///    - `message` (string): The logging message.
 pub struct FdLogger {
     pub file: RwLock<File>,

--- a/glean-core/src/histogram/exponential.rs
+++ b/glean-core/src/histogram/exponential.rs
@@ -80,7 +80,7 @@ impl Bucketing for PrecomputedExponential {
     /// Get the bucket for the sample.
     ///
     /// This uses a binary search to locate the index `i` of the bucket such that:
-    /// bucket[i] <= sample < bucket[i+1]
+    /// `bucket[i] <= sample < bucket[i+1]`
     fn sample_to_bucket_minimum(&self, sample: u64) -> u64 {
         let limit = match self.ranges().binary_search(&sample) {
             // Found an exact match to fit it in

--- a/glean-core/src/histogram/linear.rs
+++ b/glean-core/src/histogram/linear.rs
@@ -58,7 +58,7 @@ impl Bucketing for PrecomputedLinear {
     /// Get the bucket for the sample.
     ///
     /// This uses a binary search to locate the index `i` of the bucket such that:
-    /// bucket[i] <= sample < bucket[i+1]
+    /// `bucket[i] <= sample < bucket[i+1]`
     fn sample_to_bucket_minimum(&self, sample: u64) -> u64 {
         let limit = match self.ranges().binary_search(&sample) {
             // Found an exact match to fit it in

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -802,7 +802,7 @@ fn initialize_core_metrics(glean: &Glean, client_info: &ClientInfoMetrics) {
     }
 }
 
-/// Checks if [`initialize`] was ever called.
+/// Checks if [`glean_initialize`] was ever called.
 ///
 /// # Returns
 ///
@@ -935,7 +935,7 @@ pub fn set_ping_enabled(ping: &PingType, enabled: bool) {
     }
 }
 
-/// Register a new [`PingType`](PingType).
+/// Register a new [`PingType`].
 pub(crate) fn register_ping_type(ping: &PingType) {
     // If this happens after Glean.initialize is called (and returns),
     // we dispatch ping registration on the thread pool.

--- a/glean-core/src/metrics/custom_distribution.rs
+++ b/glean-core/src/metrics/custom_distribution.rs
@@ -123,7 +123,7 @@ impl CustomDistributionMetric {
     /// ## Notes
     ///
     /// Discards any negative value of `sample` and reports an
-    /// [`ErrorType::InvalidValue`](crate::ErrorType::InvalidValue).
+    /// [`ErrorType::InvalidValue`].
     pub fn accumulate_single_sample(&self, sample: i64) {
         let metric = self.clone();
         crate::launch_with_glean(move |glean| metric.accumulate_samples_sync(glean, &[sample]))

--- a/glean-core/src/metrics/dual_labeled_counter.rs
+++ b/glean-core/src/metrics/dual_labeled_counter.rs
@@ -275,7 +275,7 @@ pub fn separate_label_into_key_and_category(label: &str) -> Option<(&str, &str)>
 }
 
 /// Construct and return a label from a given key and category with the RECORD_SEPARATOR
-/// characters in the format: <RS><key><RS><category>
+/// characters in the format: `<RS><key><RS><category>`
 pub fn make_label_from_key_and_category(key: &str, category: &str) -> String {
     format!(
         "{}{}{}{}",

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -231,7 +231,6 @@ impl PingMaker {
     ///
     /// A map of header names to header values.
     /// Might be empty if there are no extra headers to send.
-    /// ```
     fn get_headers(&self, glean: &Glean) -> HeaderMap {
         let mut headers_map = HeaderMap::new();
 

--- a/glean-core/src/traits/custom_distribution.rs
+++ b/glean-core/src/traits/custom_distribution.rs
@@ -24,8 +24,7 @@ pub trait CustomDistribution: TestGetValue<Output = DistributionData> {
     /// ## Notes
     ///
     /// Discards any negative value in `samples` and report an
-    /// [`ErrorType::InvalidValue`](crate::ErrorType::InvalidValue) for each of
-    /// them.
+    /// [`ErrorType::InvalidValue`] for each of them.
     fn accumulate_samples_signed(&self, samples: Vec<i64>);
 
     /// Accumulates precisely one signed sample in the metric.
@@ -41,7 +40,7 @@ pub trait CustomDistribution: TestGetValue<Output = DistributionData> {
     /// ## Notes
     ///
     /// Discards any negative value of `sample` and reports an
-    /// [`ErrorType::InvalidValue`](crate::ErrorType::InvalidValue).
+    /// [`ErrorType::InvalidValue`].
     fn accumulate_single_sample_signed(&self, sample: i64);
 
     /// **Exported for test purposes.**

--- a/glean-core/src/upload/policy.rs
+++ b/glean-core/src/upload/policy.rs
@@ -26,8 +26,8 @@ pub struct Policy {
     ///
     /// Limiting this is necessary to avoid infinite loops on requesting upload tasks.
     max_recoverable_failures: Option<u32>,
-    /// The maximum of [`PingUploadTask::Wait`] responses a user may get in a row
-    /// when calling [`get_upload_task`].
+    /// The maximum of [`PingUploadTask::Wait`](crate::PingUploadTask::Wait) responses a user may get in a row
+    /// when calling [`get_upload_task`](crate::Glean::get_upload_task).
     ///
     /// Limiting this is necessary to avoid infinite loops on requesting upload tasks.
     max_wait_attempts: Option<u32>,


### PR DESCRIPTION
Most of these only showed with:

    cargo doc --document-private-items

[doc only]