### PR TITLE
[backport/v65.2] Kotlin: For lateinit metrics, check that the metric was instantiated before recording on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v65.2.2...main)
 
+* Kotlin
+  * BUGFIX: For `lateinit` metrics, check that the metric was instantiated before recording on it ([#3309](https://github.com/mozilla/glean/pull/3309))
+
 # v65.2.2 (2025-10-02)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v65.2.1...v65.2.2)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -37,7 +37,9 @@ class BooleanMetricType {
      */
     fun set(value: Boolean) {
         Dispatchers.Delayed.launch {
-            inner.set(value)
+            if (this::inner.isInitialized) {
+                inner.set(value)
+            }
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -38,7 +38,9 @@ class CounterMetricType {
      */
     fun add(amount: Int = 1) {
         Dispatchers.Delayed.launch {
-            inner.add(amount)
+            if (this::inner.isInitialized) {
+                inner.add(amount)
+            }
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -37,7 +37,9 @@ class QuantityMetricType {
      */
     fun set(value: Long) {
         Dispatchers.Delayed.launch {
-            inner.set(value)
+            if (this::inner.isInitialized) {
+                inner.set(value)
+            }
         }
     }
 

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -38,7 +38,9 @@ class StringMetricType {
      */
     fun set(value: String) {
         Dispatchers.Delayed.launch {
-            inner.set(value)
+            if (this::inner.isInitialized) {
+                inner.set(value)
+            }
         }
     }
 


### PR DESCRIPTION
This _should not_ happen, but apparently it does in Fenix. I have no idea why or how to prevent it.
But we can mitigate it.
Downside: If the instance is not instantiated by the time `set` actually runs we don't record any data. But then again before we just crashed, which also didn't record data.

---

Same as #3309, backported to v65.2