### PR TITLE
Dispatcher: Reduce operations by moving things into a single Arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * General
   * Stop reporting db file sizes during init phase ([#3331](https://github.com/mozilla/glean/pull/3331))
+  * Tiny performance improvement for putting tasks on the dispatcher ([#3318](https://github.com/mozilla/glean/pull/3318))
 
 # v66.1.1 (2025-11-06)
 


### PR DESCRIPTION
Before dropping a `DispatchGuard` required invoking drop on 2 `Arc`s (reducing their reference count) and 3 `Sender`.

That happens for every single `launch` on the global dispatcher (because that clones a new guard).
That's a bit overkill.
`Sender` is already `Sync` (when its `T` is `Send`), that means it's enough if we keep one of them around (behind the outer `Arc`, our `T` is the launched function with an explicit `Send` bound). Before this the drop of `DispatchGuard` shows up in profiles for a synthetic benchmark (7.5% for that drop, with 3.4% attributed to dropping `Sender`).
With this patch that overhead seems to be gone.

---

I'm working on reliable numbers to back this up, but I wanted to already push it up and get CI going.