### PR TITLE
Swift 6 migration - PingUploader callback should be Sendable

### DIFF
--- a/glean-core/ios/Glean/Net/PingUploader.swift
+++ b/glean-core/ios/Glean/Net/PingUploader.swift
@@ -15,7 +15,7 @@ public protocol PingUploader {
      */
     func upload(
         request: CapablePingUploadRequest,
-        callback: @escaping (UploadResult) -> Void
+        callback: @escaping @Sendable (UploadResult) -> Void
     )
 }
 


### PR DESCRIPTION
## Context
We're fixing some warnings as part of the Swift 6 migration. We're slowly chipping away at strict concurrency warnings under the Firefox iOS project. 

## Description
We're using the custom ping uploader protocol, which callback should be made `@Sendable`. `UploadResult` is an enum, which means it can be Sendable (or sent across isolation boundaries) as it's a value type.