### PR TITLE
Reduce log level for potentially-frequent log message

### DIFF
--- a/glean-core/src/dispatcher/global.rs
+++ b/glean-core/src/dispatcher/global.rs
@@ -58,7 +58,7 @@ pub fn launch(task: impl FnOnce() + Send + 'static) {
             // TODO: Record this as an error.
         }
         Err(_) => {
-            log::info!("Failed to launch a task on the queue. Discarding task.");
+            log::debug!("Failed to launch a task on the queue. Discarding task.");
         }
     }
 


### PR DESCRIPTION
This log message gets triggered many times in tests, due to the process shutting down, but the test still triggering things. It's not an actionable log and thus better to reduce it to debug.