### PR TITLE
Merge back version bump to 66.1.2

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-libraryVersion: 66.1.1
+libraryVersion: 66.1.2
 groupId: org.mozilla.telemetry
 projects:
   glean:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla/glean/compare/v66.1.1...main)
+[Full changelog](https://github.com/mozilla/glean/compare/v66.1.2...main)
 
 * General
   * Stop reporting db file sizes during init phase ([#3331](https://github.com/mozilla/glean/pull/3331))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "glean"
-version = "66.1.1"
+version = "66.1.2"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "glean-core"
-version = "66.1.1"
+version = "66.1.2"
 dependencies = [
  "android_logger",
  "bincode",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4451,7 +4451,7 @@ THE SOFTWARE.
 
 The following text applies to code linked from these dependencies:
 
-* [whatsys 0.3.1]( https://github.com/badboy/whatsys )
+* [whatsys 0.3.2]( https://github.com/badboy/whatsys )
 
 ```
 The MIT License (MIT)
@@ -4606,9 +4606,9 @@ SOFTWARE.
 
 The following text applies to code linked from these dependencies:
 
-* [glean-core 66.1.1]( https://github.com/mozilla/glean )
+* [glean-core 66.1.2]( https://github.com/mozilla/glean )
 * [glean-build 18.0.6]( https://github.com/mozilla/glean )
-* [glean 66.1.1]( https://github.com/mozilla/glean )
+* [glean 66.1.2]( https://github.com/mozilla/glean )
 * [zeitstempel 0.2.0]( https://github.com/badboy/zeitstempel )
 
 ```

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean-core"
-version = "66.1.1"
+version = "66.1.2"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A modern Telemetry library"
 repository = "https://github.com/mozilla/glean"

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glean"
-version = "66.1.1"
+version = "66.1.2"
 authors = ["Jan-Erik Rediger <jrediger@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "Glean SDK Rust language bindings"
 repository = "https://github.com/mozilla/glean"
@@ -23,7 +23,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies.glean-core]
 path = ".."
-version = "66.1.1"
+version = "66.1.2"
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy
@@ -535,7 +535,7 @@ except:
     void apply(Project project) {
         isOffline = project.gradle.startParameter.offline
 
-        project.ext.glean_version = "66.1.1"
+        project.ext.glean_version = "66.1.2"
         def parserVersion = gleanParserVersion(project)
 
         // Print the required glean_parser version to the console. This is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "glean-sdk"
-version = "66.1.1"
+version = "66.1.2"
 requires-python = ">=3.9"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
f408493f9b merged back the changelog for the 66.1.2 release, but not the actual version bump.
Correcting this now.

The next release will be a regular one on top of `main`.