### PR TITLE
Dependabot: Apply a 8 day cooldown period (and only run weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,18 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 8
     versioning-strategy: lockfile-only
 
   # glean-python
   - package-ecosystem: "pip"
     directory: "/glean-core/python"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 8
     ignore:
       # Updated in lockstep across all implementations
       - dependency-name: "glean_parser"


### PR DESCRIPTION
We don't upgrade that often and crate updates need an explicit vetting anyway. We can reduce the frequency of these updates AND apply a cooldown period just in case.

[doc only]