### PR TITLE
Since `UIApplication.shared` is not available in app extensions, anno…

### DIFF
--- a/glean-core/ios/Glean/Net/PingUploadScheduler.swift
+++ b/glean-core/ios/Glean/Net/PingUploadScheduler.swift
@@ -26,6 +26,10 @@ func startUploader() {
 /// uploader specified in the Glean `Configuration`.
 ///
 /// This will typically be invoked by the appropriate scheduling mechanism to trigger uploading a ping to the server.
+///
+/// Note: The use of `UIApplication.shared` is not permitted in app extensions because app extensions run in a
+/// restricted environment and cannot access the `UIApplication`.
+@available(iOSApplicationExtension, unavailable)
 public class PingUploadScheduler {
     let httpUploader: PingUploader
     let httpEndpoint: String


### PR DESCRIPTION
Followup to #3347.

Unfortunately, we realized after trying to pull in the latest 66.2.0 Glean SDK release that `UIApplication.shared` can't be exposed in the init API for app extensions. I haven't worked a lot with Swift packages so I apologize not catching this sooner!

<img width="1501" height="530" alt="Screenshot 2025-12-10 at 11 10 42 AM" src="https://github.com/user-attachments/assets/cfa1c6c7-8c48-467b-a20d-d1f0ed657e28" />

The fix is to hide it, or annotate the `PingUploadScheduler` class as unavailable for iOS app extensions. I opted to hide it so we didn't need to add any restrictions to the package. That said, Firefox for iOS never uses the Glean SDK directly from our app extensions (which are separate processes from the Firefox for iOS client). Instead, we use other ways to pass telemetry back to our main Client.

I was able to set up the Glean SDK framework for local testing with my Firefox for iOS client and this change appears to fix the problem. I will be able to better test future work better this way! 🙏 