### PR TITLE
Bug 2005557 - CI: Deploy pages using GhA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ definitions:
   - ci_filters: &ci-filters
       branches:
         ignore: release
+  - ci_only: &ci-only
+      branches:
+        ignore:
+          - main
+          - release
 
 ##########################################################################
 # COMMANDS
@@ -600,24 +605,12 @@ jobs:
             else
                 make test-swift
             fi
-      - run:
-          name: Generate Swift documentation
-          command: |
-            # Skip doc generation for pull requests.
-            if [ "$CIRCLE_BRANCH" = "main" ]; then
-              make docs-swift
-            else
-              mkdir -p build/docs/swift
-            fi
       - store_artifacts:
           path: raw_xcodebuild.log
           destination: raw_xcodebuild.log
       - store_artifacts:
           path: raw_xcodetest.log
           destination: raw_xcodetest.log
-      - persist_to_workspace:
-          root: build/
-          paths: docs/swift
       - run:
           name: Build XCFramework archive
           no_output_timeout: 20m
@@ -1030,35 +1023,6 @@ jobs:
           name: Check documentation spelling
           command: bin/spellcheck.sh list
 
-  # via https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
-  docs-deploy:
-    docker:
-      - image: cimg/node:22.6
-    steps:
-      - checkout
-      - attach_workspace:
-          at: build/
-      - run:
-          name: Disable jekyll builds
-          command: touch build/docs/.nojekyll
-      - run:
-          name: Show contents
-          command: ls -R
-      # Needed for write access to the GitHub repository;
-      # see https://circleci.com/docs/2.0/gh-bb-integration/#deployment-keys-and-user-keys
-      - add_ssh_keys:
-          fingerprints:
-            - "52:a9:c6:64:9e:df:60:70:73:da:81:02:71:9e:00:1b"
-      # The gh-pages npm package can be used to push a directory to a git branch;
-      # see https://www.npmjs.com/package/gh-pages
-      - run:
-          name: Deploy docs to gh-pages branch
-          command: |
-            git config user.email "jrediger@mozilla.com"
-            git config user.name "CircleCI docs-deploy job"
-            npm install gh-pages@6.1.1
-            npx gh-pages --dotfiles --message "[skip ci] Updates" --dist build/docs
-
 ###########################################################################
 # Workflows
 
@@ -1116,27 +1080,18 @@ workflows:
           filters: *ci-filters
 
       - Generate Rust documentation:
-          requires:
-            - docs-spellcheck
-          filters: *ci-filters
+          filters: *ci-only
       - Generate Python documentation:
           requires:
             - Python 3_10 tests
-          filters: *ci-filters
+          filters: *ci-only
       - docs-linkcheck:
           requires:
             - Generate Rust documentation
             - Generate Python documentation
-          filters: *ci-filters
+          filters: *ci-only
       - docs-spellcheck:
-          filters: *ci-filters
-      - docs-deploy:
-          requires:
-            - docs-linkcheck
-            - iOS build and test
-          filters:
-            branches:
-              only: main
+          filters: *ci-only
 
   # iOS jobs require manual approval on PRs
   iOS:

--- a/.github/workflows/crate-ci.sh
+++ b/.github/workflows/crate-ci.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+
+# Based on install.sh from https://github.com/japaric/trust
+# License: MIT/Apache.
+# See:
+# * https://github.com/japaric/trust/blob/master/LICENSE-MIT
+# * https://github.com/japaric/trust/blob/master/LICENSE-APACHE
+
+set -e
+
+help() {
+    cat <<'EOF'
+Install a binary release of a Rust crate hosted on github.com
+
+Usage:
+    crate-ci.sh [options]
+
+Options:
+    -h, --help      Display this message
+    --git SLUG      Get the crate from "https://github.com/$SLUG"
+    -f, --force     Force overwriting an existing binary
+    --crate NAME    Name of the crate to install (default <repository name>)
+    --tag TAG       Tag (version) of the crate to install (default <latest release>)
+    --target TARGET Install the release compiled for $TARGET (default <`rustc` host>)
+    --to LOCATION   Where to install the binary (default ~/.cargo/bin)
+EOF
+}
+
+say() {
+    echo "install.sh: $1"
+}
+
+say_err() {
+    say "$1" >&2
+}
+
+err() {
+    if [ -n "$td" ]; then
+        rm -rf "$td"
+    fi
+
+    say_err "ERROR $1"
+    exit 1
+}
+
+need() {
+    if ! command -v "$1" > /dev/null 2>&1; then
+        err "need $1 (command not found)"
+    fi
+}
+
+force=false
+while test $# -gt 0; do
+    case $1 in
+        --crate)
+            crate=$2
+            shift
+            ;;
+        --force | -f)
+            force=true
+            ;;
+        --git)
+            git=$2
+            shift
+            ;;
+        --help | -h)
+            help
+            exit 0
+            ;;
+        --tag)
+            tag=$2
+            shift
+            ;;
+        --target)
+            target=$2
+            shift
+            ;;
+        --to)
+            dest=$2
+            shift
+            ;;
+        *)
+            ;;
+    esac
+    shift
+done
+
+# Dependencies
+need basename
+need curl
+need install
+need mkdir
+need mktemp
+need tar
+
+# Optional dependencies
+if [ -z "$crate" ] || [ -z "$tag" ] || [ -z "$target" ]; then
+    need cut
+fi
+
+if [ -z "$tag" ]; then
+    need rev
+fi
+
+if [ -z "$target" ]; then
+    need grep
+    need rustc
+fi
+
+if [ -z "$git" ]; then
+    # Markdown-style backticks
+    # shellcheck disable=SC2016
+    err 'must specify a git repository using `--git`. Example: `install.sh --git japaric/cross`'
+fi
+
+url="https://github.com/$git"
+say_err "Git repository: $url"
+
+if [ -z "$crate" ]; then
+    crate=$(echo "$git" | cut -d'/' -f2)
+fi
+
+say_err "Crate: $crate"
+
+url="$url/releases"
+
+if [ -z "$tag" ]; then
+    latest_url=$url/latest
+    tag_url=$(curl -Ls -o /dev/null -w "%{url_effective}" "$latest_url")
+    tag=$(echo "$tag_url" | rev | cut -d'/' -f1 | rev)
+    if [ -z "$tag" ]; then
+        err "Failed to get tag from $latest_url"
+    fi
+    say_err "Tag: latest ($tag)"
+else
+    say_err "Tag: $tag"
+fi
+
+if [ -z "$target" ]; then
+    target=$(rustc -Vv | grep host | cut -d' ' -f2)
+fi
+
+say_err "Target: $target"
+
+if [ -z "$dest" ]; then
+    dest="$HOME/.cargo/bin"
+fi
+
+say_err "Installing to: $dest"
+
+url="$url/download/$tag/$crate-$tag-$target.tar.gz"
+
+td=$(mktemp -d || mktemp -d -t tmp)
+curl -sL "$url" | tar xz -f - -C "$td"
+
+for f in "$td"/*; do
+    test -x "$f" || continue
+    test -f "$f" || continue
+
+    if [ -e "$dest/$(basename "$f")" ] && [ "$force" = false ]; then
+        err "$f already exists in $dest"
+    else
+        mkdir -p "$dest"
+        install -m 755 "$f" "$dest"
+    fi
+done
+
+rm -rf "$td"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,56 @@
+name: Publish Docs on GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install mdbook-dtmo
+        run: |
+          .github/workflows/crate-ci.sh \
+            --git badboy/mdbook-dtmo \
+            --crate mdbook-dtmo \
+            --tag 0.15.2
+
+          ln -s $(which mdbook-dtmo) $(dirname $(which mdbook-dtmo))/mdbook
+          mdbook --version
+
+      - name: Build Rust Documentation
+        run: make docs-rust
+      - name: Build Python Documentation
+        run: make docs-python
+
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/docs/
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
It only runs on pushes to the `main` branch.
With this we can drop the `gh-pages` branch which bloats the entire repository.

This does the minimal thing:

It builds Rust docs, Python docs & the books.
It then deploys them.

On GitHub Actions this does NOT do:

1. Spellcheck
2. Linkcheck
3. Swift docs

(1) and (2) are still done on CI as part of the usual CI from branches/PR runs. We do not do them on merges to `main` though.

Swift docs (3) are a bit harder, as it requires Xcode and thus requires macOS. That's a bit more expensive in terms of resources. We could bring it back on GitHub Actions too if needed. But it's not fully clear how much value those rendered docs bring.

---

I have tested this over on my own fork: https://github.com/badboy/glean/actions/runs/20164355091