### PR TITLE
Include benches directory in crate distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * General
   * Updated to `glean_parser` v18.2.0 ([#3356](https://github.com/mozilla/glean/issues/3356))
+* Python
+  * Source wheel builds now build the SDK upon install correctly ([#3359](https://github.com/mozilla/glean/pull/3359))
 
 # v66.2.0 (2025-12-09)
 

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -13,6 +13,7 @@ include = [
   "/LICENSE",
   "/src",
   "/examples",
+  "/benches",
   "/tests",
   "/Cargo.toml",
   "/uniffi.toml",


### PR DESCRIPTION
Otherwise the package is incomplete. And the Python source tarballs won't have this file and thus won't build.