### PR TITLE
Bug 2005554 - Kotlin: Rewrite Dispatcher to offload metrics to not cause main blocks

### DIFF
--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/BooleanMetricType.kt
@@ -53,7 +53,8 @@ class BooleanMetricType {
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -62,5 +63,6 @@ class BooleanMetricType {
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CounterMetricType.kt
@@ -54,14 +54,16 @@ class CounterMetricType {
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
      *
-     * @param errorType The type of error to get the error count of
+     * @param errorType The type of the error recorded.
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/CustomDistributionMetricType.kt
@@ -69,7 +69,8 @@ class CustomDistributionMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -78,5 +79,6 @@ class CustomDistributionMetricType(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DenominatorMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/DenominatorMetricType.kt
@@ -47,7 +47,8 @@ class DenominatorMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -56,5 +57,6 @@ class DenominatorMetricType(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/EventMetricType.kt
@@ -74,7 +74,8 @@ class EventMetricType<ExtraObject> constructor(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null): List<RecordedEvent>? = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -83,5 +84,6 @@ class EventMetricType<ExtraObject> constructor(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/MemoryDistributionMetricType.kt
@@ -54,7 +54,8 @@ class MemoryDistributionMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -63,5 +64,6 @@ class MemoryDistributionMetricType(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/NumeratorMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/NumeratorMetricType.kt
@@ -45,7 +45,8 @@ class NumeratorMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -54,5 +55,6 @@ class NumeratorMetricType(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/ObjectMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/ObjectMetricType.kt
@@ -61,11 +61,12 @@ class ObjectMetricType<K> constructor(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null): JsonElement? {
-        return inner.testGetValue(pingName)?.let {
-            return Json.decodeFromString(it)
+    fun testGetValue(pingName: String? = null): JsonElement? =
+        Dispatchers.Delayed.launchBlocking {
+            inner.testGetValue(pingName)?.let {
+                Json.decodeFromString(it)
+            }
         }
-    }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -74,5 +75,6 @@ class ObjectMetricType<K> constructor(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/PingType.kt
@@ -159,12 +159,14 @@ class PingType<ReasonCodesEnum>(
      */
     @JvmOverloads
     fun submit(reason: ReasonCodesEnum? = null) {
-        Dispatchers.Delayed.launch {
-            this.testCallback?.let {
-                it(reason)
-            }
-            this.testCallback = null
+        this.testCallback?.let {
+            // If there's a callback, we're in tests and can block to wait for other recordings.
+            // The callback needs to be called on _this_ thread, as it may put things on the dispatcher.
+            it(reason)
+        }
+        this.testCallback = null
 
+        Dispatchers.Delayed.launch {
             val reasonString = reason?.let { this.reasonCodes[it.code()] }
             this.innerPing.submit(reasonString)
         }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/QuantityMetricType.kt
@@ -53,7 +53,8 @@ class QuantityMetricType {
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -62,5 +63,6 @@ class QuantityMetricType {
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/RateMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/RateMetricType.kt
@@ -55,7 +55,8 @@ class RateMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -64,5 +65,6 @@ class RateMetricType(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringListMetricType.kt
@@ -55,7 +55,8 @@ class StringListMetricType constructor(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -64,5 +65,6 @@ class StringListMetricType constructor(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/StringMetricType.kt
@@ -5,6 +5,8 @@
 package mozilla.telemetry.glean.private
 
 import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
 import mozilla.telemetry.glean.Dispatchers
 import mozilla.telemetry.glean.internal.StringMetric
 import mozilla.telemetry.glean.testing.ErrorType
@@ -23,7 +25,7 @@ class StringMetricType {
 
     constructor(meta: CommonMetricData) {
         Dispatchers.Delayed.launch {
-            inner = StringMetric(meta)
+            this.inner = StringMetric(meta)
         }
     }
 
@@ -54,7 +56,8 @@ class StringMetricType {
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -63,5 +66,6 @@ class StringMetricType {
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TextMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TextMetricType.kt
@@ -44,7 +44,8 @@ class TextMetricType constructor(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -53,5 +54,6 @@ class TextMetricType constructor(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimespanMetricType.kt
@@ -87,7 +87,8 @@ class TimespanMetricType constructor(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -96,5 +97,6 @@ class TimespanMetricType constructor(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/TimingDistributionMetricType.kt
@@ -95,7 +95,8 @@ class TimingDistributionMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -104,5 +105,6 @@ class TimingDistributionMetricType(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(error: ErrorType) = inner.testGetNumRecordedErrors(error)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UrlMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UrlMetricType.kt
@@ -44,7 +44,8 @@ class UrlMetricType constructor(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @JvmOverloads
-    fun testGetValue(pingName: String? = null) = inner.testGetValue(pingName)
+    fun testGetValue(pingName: String? = null) =
+        Dispatchers.Delayed.launchBlocking { this.inner.testGetValue(pingName) }
 
     /**
      * Returns the number of errors recorded for the given metric.
@@ -53,5 +54,6 @@ class UrlMetricType constructor(
      * @return the number of errors recorded for the metric.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetNumRecordedErrors(errorType: ErrorType) = inner.testGetNumRecordedErrors(errorType)
+    fun testGetNumRecordedErrors(errorType: ErrorType) =
+        Dispatchers.Delayed.launchBlocking { inner.testGetNumRecordedErrors(errorType) }
 }

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/private/UuidMetricType.kt
@@ -55,5 +55,9 @@ class UuidMetricType(
      * @return value of the stored UUID
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String? = null): UUID? = inner.testGetValue(pingName)?.let { UUID.fromString(it) }
+    fun testGetValue(pingName: String? = null): UUID? =
+        Dispatchers.Delayed
+            .launchBlocking {
+                inner.testGetValue(pingName)
+            }?.let { UUID.fromString(it) }
 }

--- a/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
+++ b/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanTest.kt
@@ -935,6 +935,7 @@ class GleanTest {
         val buildDate = Calendar
             .getInstance(TimeZone.getTimeZone("GMT+0"))
             .also { cal -> cal.set(2020, 10, 6, 11, 30, 50) }
+        Glean.setTestingMode(true)
         Glean.initialize(
             context,
             true,


### PR DESCRIPTION
This has a new problem now though:
Not all metrics go through that and could be recorded in a different order.

Is that fine?
I think that's fine because:
1. Same metric types are recorded on the dispatcher, so e.g. counting is always in correct order.
2. Recording of a not-dispatched metric is always unrelated to any other metric, so the precise order doesn't matter either
3. Ping methods _are_ dispatched, so a call to a non-dispatched metric, followed by a dispatched ping submit keeps the correct order.


Note: things _still_ go through the Glean Rust dispatcher, so things are ordered there in the way they come in.