### PR TITLE
Bug 2017277 - [RLB] Expose client_info.os_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Add first-class Sessions support: configurable session management (`Auto`, `Lifecycle`, `Manual` modes), session-level sampling, `glean.session_start`/`glean.session_end` boundary events in the `events` ping, and per-event session metadata for downstream analysis ([bug 2020962](https://bugzilla.mozilla.org/show_bug.cgi?id=2020962))
 * Rust
   * **Experimental**: Introduce `glean-sym`, a Rust API built on top of the Glean UniFFI C FFI ([#3426](https://github.com/mozilla/glean/issues/3426))
+  * `client_info.os_version` can now be set by the application. If unset Glean still uses the auto-detection ([#3419](https://github.com/mozilla/glean/pull/3419))
 * Android
   * Updated Kotlin to 2.3.21 ([#3456](https://github.com/mozilla/glean/pull/3456))
   * The Gradle plugin now uses the modern AGP variant API, making it compatible with AGP 9 (maintaining AGP 8 compatibility) ([#3472](https://github.com/mozilla/glean/pull/3472)).

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -251,6 +251,7 @@ let client_info = ClientInfoMetrics {
     app_display_version: env!("CARGO_PKG_VERSION").to_string(),
     channel: None,
     locale: None,
+    os_version: None, // auto-detected
 };
 
 glean::initialize(cfg, client_info);

--- a/glean-core/rlb-tests/src/bin/crashing-threads.rs
+++ b/glean-core/rlb-tests/src/bin/crashing-threads.rs
@@ -123,6 +123,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb-tests/src/bin/delayed-ping-data.rs
+++ b/glean-core/rlb-tests/src/bin/delayed-ping-data.rs
@@ -115,6 +115,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb-tests/src/bin/enabled-pings.rs
+++ b/glean-core/rlb-tests/src/bin/enabled-pings.rs
@@ -160,6 +160,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb-tests/src/bin/long-running.rs
+++ b/glean-core/rlb-tests/src/bin/long-running.rs
@@ -74,6 +74,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb-tests/src/bin/mps-delay.rs
+++ b/glean-core/rlb-tests/src/bin/mps-delay.rs
@@ -126,6 +126,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb-tests/src/bin/pending-gets-removed.rs
+++ b/glean-core/rlb-tests/src/bin/pending-gets-removed.rs
@@ -141,6 +141,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     // Ensure this ping is always registered early.

--- a/glean-core/rlb-tests/src/bin/ping-lifetime-flush.rs
+++ b/glean-core/rlb-tests/src/bin/ping-lifetime-flush.rs
@@ -118,6 +118,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb/examples/frequent-events.rs
+++ b/glean-core/rlb/examples/frequent-events.rs
@@ -96,6 +96,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb/examples/prototype.rs
+++ b/glean-core/rlb/examples/prototype.rs
@@ -66,6 +66,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/glean-core/rlb/src/core_metrics.rs
+++ b/glean-core/rlb/src/core_metrics.rs
@@ -15,6 +15,8 @@ pub struct ClientInfoMetrics {
     pub channel: Option<String>,
     /// The locale of the application during initialization (e.g. "es-ES").
     pub locale: Option<String>,
+    /// The user-visible version of the operating system (e.g. "1.2.3").
+    pub os_version: Option<String>,
 }
 
 impl ClientInfoMetrics {
@@ -25,6 +27,7 @@ impl ClientInfoMetrics {
             app_display_version: "Unknown".to_string(),
             channel: None,
             locale: None,
+            os_version: None,
         }
     }
 }
@@ -36,7 +39,7 @@ impl From<ClientInfoMetrics> for glean_core::ClientInfoMetrics {
             app_display_version: metrics.app_display_version,
             channel: metrics.channel,
             locale: metrics.locale,
-            os_version: system::get_os_version(),
+            os_version: metrics.os_version.unwrap_or_else(system::get_os_version),
             windows_build_number: system::get_windows_build_number(),
             architecture: system::ARCH.to_string(),
             ..Default::default()

--- a/glean-core/rlb/tests/collection_enabled.rs
+++ b/glean-core/rlb/tests/collection_enabled.rs
@@ -114,6 +114,7 @@ fn nofollows_contains_client_info_when_collection_disabled() {
         app_display_version: "1.0.0".to_string(),
         channel: Some("testing".to_string()),
         locale: Some("xx-XX".to_string()),
+        os_version: None,
     };
     glean::test_reset_glean(cfg, client_info, false);
 

--- a/glean-core/rlb/tests/collection_enabled_bin.rs
+++ b/glean-core/rlb/tests/collection_enabled_bin.rs
@@ -112,6 +112,7 @@ fn nofollows_contains_client_info_when_collection_disabled() {
         app_display_version: "1.0.0".to_string(),
         channel: Some("testing".to_string()),
         locale: Some("xx-XX".to_string()),
+        os_version: None,
     };
     glean::test_reset_glean(cfg, client_info, false);
 

--- a/glean-core/rlb/tests/common/mod.rs
+++ b/glean-core/rlb/tests/common/mod.rs
@@ -46,6 +46,7 @@ pub fn initialize(cfg: Configuration) {
         app_display_version: "1.0.0".to_string(),
         channel: Some("testing".to_string()),
         locale: Some("xx-XX".to_string()),
+        os_version: None,
     };
 
     _ = PingBuilder::new("store1").with_send_if_empty(true).build();

--- a/glean-core/rlb/tests/schema.rs
+++ b/glean-core/rlb/tests/schema.rs
@@ -83,6 +83,7 @@ fn validate_against_schema() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: Some("testing".to_string()),
         locale: Some("xx-XX".to_string()),
+        os_version: None,
     };
 
     glean::initialize(cfg, client_info);

--- a/samples/glean-sym-test/xul/lib.rs
+++ b/samples/glean-sym-test/xul/lib.rs
@@ -99,6 +99,7 @@ unsafe extern "C" fn startup(path: *const c_char) {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     _ = &*glean_metrics::prototype;

--- a/samples/rapid-metrics/src/main.rs
+++ b/samples/rapid-metrics/src/main.rs
@@ -78,6 +78,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     _ = &*glean_metrics::prototype;

--- a/samples/rust/src/main.rs
+++ b/samples/rust/src/main.rs
@@ -111,6 +111,7 @@ fn main() {
         app_display_version: env!("CARGO_PKG_VERSION").to_string(),
         channel: None,
         locale: None,
+        os_version: None,
     };
 
     _ = &*glean_metrics::prototype;


### PR DESCRIPTION
Note this by itself doesn't even change the value! We still fall back to what `whatsys` gives us.