### PR TITLE
Bug 2031446 - Retrieve the OS version on Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v67.2.0...main)
 
+* Rust
+  * Add support for determining `client_info.os_version` for Android binaries ([#3434](https://github.com/mozilla/glean/pull/3434))
+
 # v67.2.0 (2026-04-06)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v67.1.0...v67.2.0)

--- a/glean-core/rlb/src/system.rs
+++ b/glean-core/rlb/src/system.rs
@@ -86,7 +86,44 @@ pub fn get_os_version() -> String {
     whatsys::kernel_version().unwrap_or_else(|| "Unknown".to_owned())
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "android")]
+mod android {
+    use std::ffi::{c_char, c_int, CStr, CString};
+
+    const PROP_VALUE_MAX: usize = 92;
+
+    extern "C" {
+        fn __system_property_get(name: *const c_char, value: *mut c_char) -> c_int;
+    }
+
+    pub fn get_os_version() -> String {
+        let mut value: [c_char; PROP_VALUE_MAX] = [0; PROP_VALUE_MAX];
+        let prop_key = CString::new("ro.build.version.release").unwrap();
+        let length =
+            unsafe { __system_property_get(prop_key.as_ptr(), value.as_mut_slice().as_mut_ptr()) };
+        if length > 0 {
+            // SAFETY: the value is guaranteed to be nul-terminated, and valid until this is converted to an owned
+            // String (within this scope).
+            unsafe { CStr::from_ptr(value.as_slice().as_ptr()) }
+                .to_str()
+                .ok()
+        } else {
+            None
+        }
+        .unwrap_or("Unknown")
+        .to_owned()
+    }
+}
+
+#[cfg(target_os = "android")]
+pub use android::get_os_version;
+
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 /// Returns "Unknown" for platforms other than Linux, MacOS or Windows
 pub fn get_os_version() -> String {
     "Unknown".to_owned()


### PR DESCRIPTION
It is surprising difficult to find the API you're supposed to use for this nowadays (aside from invoking the `getprop` program). I tested that this compiles, but I did not have an environment set up to run it to see if it works as expected.

I will do some shenanigans to check whether this works.