### PR TITLE
Bump pytest from 8.4.1 to 8.4.2 in /glean-core/python

### DIFF
--- a/glean-core/python/requirements_dev.txt
+++ b/glean-core/python/requirements_dev.txt
@@ -6,7 +6,7 @@ pip
 pytest-localserver==0.10.0
 MarkupSafe==2.0.1
 pytest-runner==5.3.2
-pytest==8.4.1
+pytest==8.4.2
 ruff==0.7.2
 semver==2.13.0
 setuptools-git==1.2


### PR DESCRIPTION
Just bumping to the latest version of 8.x (9.x dropped Python 3.9 support, which we still build for)