### PR TITLE
glean-core: fix 'occured' -> 'occurred' in error display strings

### DIFF
--- a/glean-core/src/error.rs
+++ b/glean-core/src/error.rs
@@ -201,8 +201,8 @@ impl Display for ClientIdFileError {
                 f,
                 "The operation lacked the necessary privileges to complete."
             ),
-            IoError(e) => write!(f, "IO error occured: {e}"),
-            ParseError(e) => write!(f, "Parse error occured: {e}"),
+            IoError(e) => write!(f, "IO error occurred: {e}"),
+            ParseError(e) => write!(f, "Parse error occurred: {e}"),
         }
     }
 }


### PR DESCRIPTION
Two `fmt::Display` implementations in `glean-core/src/error.rs` (lines 204-205) read `IO error occured` and `Parse error occured`. Fixed to `occurred`. Error-display-only change; no API or behavior change.