### PR TITLE
Update to MSRV 1.90

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,12 @@ definitions:
           - main
           - release
   - msrv_image: &msrv-image
-      cimg/rust:1.87
+      cimg/rust:1.90
   - msrv: &msrv
-      "1.87"
+      "1.90"
   # Used when running against latest stable Rust
   - rust_image: &rust-image
-      cimg/rust:1.92
+      cimg/rust:1.94.1
 
 ##########################################################################
 # COMMANDS

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The code in this repository is organized as follows:
 * [./glean-core/ios](glean-core/ios) contains the Swift bindings for use by iOS applications.
 * [./glean-core/python](glean-core/python) contains Python bindings.
 
-**Note: The Glean SDK requires at least [Rust 1.87.0](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/). Older versions are untested.**
+**Note: The Glean SDK requires at least [Rust 1.90.0](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/). Older versions are untested.**
 
 ## Contact
 

--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -18,7 +18,7 @@ include = [
   "/uniffi.toml",
   "/build.rs",
 ]
-rust-version = "1.87"
+rust-version = "1.90"
 
 [package.metadata.glean]
 glean-parser = "19.0.0"

--- a/glean-core/benchmark/Cargo.toml
+++ b/glean-core/benchmark/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 license = "MPL-2.0"
 # MSRV. Independent from what glean-core needs.
 # Note: We only test against latest stable on CI.
-rust-version = "1.87"
+rust-version = "1.90"
 
 [dependencies]
 glean-core = { path = "../", features = ["benchmark"] }

--- a/glean-core/build/Cargo.toml
+++ b/glean-core/build/Cargo.toml
@@ -13,7 +13,7 @@ include = [
   "/src",
   "/Cargo.toml",
 ]
-rust-version = "1.87"
+rust-version = "1.90"
 
 [dependencies]
 xshell-venv = "1.1.0"

--- a/glean-core/rlb/Cargo.toml
+++ b/glean-core/rlb/Cargo.toml
@@ -15,7 +15,7 @@ include = [
   "/tests",
   "/Cargo.toml",
 ]
-rust-version = "1.87"
+rust-version = "1.90"
 
 [badges]
 circle-ci = { repository = "mozilla/glean", branch = "main" }


### PR DESCRIPTION
Firefox 149 runs with MSRV 1.90 since January.
Work like #3426 uses new crates with MSRV above our current one (1.87).

So this is just good a time as any to update ours (if CI agrees)