### PR TITLE
Correctly mark sample code as MPL-2.0 licensed

### DIFF
--- a/samples/rapid-metrics/Cargo.toml
+++ b/samples/rapid-metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "rapid-metrics"
 version = "0.1.0"
 edition = "2021"
 publish = false
-license = "MIT"
+license = "MPL-2.0"
 
 [dependencies]
 env_logger = { version = "0.10.0", default-features = false, features = ["humantime"] }

--- a/samples/rust/Cargo.toml
+++ b/samples/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "sample"
 version = "0.1.0"
 edition = "2021"
 publish = false
-license = "MIT"
+license = "MPL-2.0"
 
 [dependencies]
 env_logger = { version = "0.10.0", default-features = false, features = ["humantime"] }


### PR DESCRIPTION
[doc only]

These were mistakenly tagged as MIT in the Cargo.toml. They do contain the usual MPL header in source code.
