### PR TITLE
Bug 2036761 - CI: Specifically use get-pip targeting Python 3.9, our current lowest-Python target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ commands:
           name: Set up dependencies for Python for Windows
           command: |
             echo "export WINEDEBUG=-all" >> $BASH_ENV
-            wget https://bootstrap.pypa.io/get-pip.py
+            wget https://bootstrap.pypa.io/pip/3.9/get-pip.py
             $WINPYTHON get-pip.py
             echo "import site" >> winpython/python39._pth
             echo "import sys; sys.path.insert(0, '')" >> winpython/sitecustomize.py


### PR DESCRIPTION
Looks like the no-version-specified script got updated and doesn't support (EoL) Python 3.9 anymore (see [latest runs](https://app.circleci.com/pipelines/github/mozilla/glean/14509/workflows/52f99154-875d-48af-bae6-39066d3fcca8/jobs/287122)). Hopefully using the old script will work for a while longer.