### PR TITLE
Avoid unsafety and count the allocation for the underlying atomic bool directly

### DIFF
--- a/glean-core/src/upload/mod.rs
+++ b/glean-core/src/upload/mod.rs
@@ -241,8 +241,7 @@ impl MallocSizeOf for PingUploadManager {
 
         let mut n = shallow_size
             + self.directory_manager.size_of(ops)
-            // SAFETY: We own this arc and can pass a pointer to it to an external function.
-            + unsafe { ops.malloc_size_of(self.processed_pending_pings.as_ptr()) }
+            + mem::size_of::<AtomicBool>() // Allocated inside the `self.processed_pending_pings` `Arc`.
             + self.cached_pings.read().unwrap().size_of(ops)
             + self.rate_limiter.as_ref().map(|rl| {
                 let lock = rl.read().unwrap();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=2037809#c4