### PR TITLE
Bug 2042327 - glean-sym: Enable it on iOS by using `this` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Disable the `glean.error.event_timestamp_clamped` metric ([#3500](https://github.com/mozilla/glean/pull/3500)).
 * Rust
   * Make `rate_limit` configurable in the configuration builder ([#3495](https://github.com/mozilla/glean/pull/3495))
+  * **Experimental**: Enable `glean-sym` on iOS ([#3471](https://github.com/mozilla/glean/pull/3471))
 
 # v67.5.0 (2026-06-09)
 

--- a/glean-core/glean-sym/src/lib.rs
+++ b/glean-core/glean-sym/src/lib.rs
@@ -57,14 +57,13 @@ macro_rules! library_binding {
         }
 
         impl GleanSym {
-            #[cfg(unix)]
+            #[cfg(all(unix, not(target_os = "ios")))]
             pub fn load() -> std::io::Result<Self> {
                 let name = libloading::library_filename("xul");
                 let library = match unsafe { libloading::Library::new(name) } {
                         Ok(lib) => Some(lib),
                         Err(_e) => None,
                 };
-                // Try each of the libraries, debug-logging load failures.
                 let $localname = library.ok_or_else(|| {
                     std::io::Error::new(std::io::ErrorKind::NotFound, "failed to find glean library")
                 })?;
@@ -72,6 +71,13 @@ macro_rules! library_binding {
                 let handle = GleanSym { $($load)* _library: $localname };
                 handle.check()?;
                 Ok(handle)
+            }
+
+            #[cfg(target_os = "ios")]
+            pub fn load() -> std::io::Result<Self> {
+                // On iOS we compile it all together and can look up symbols without loading a library
+                let $localname: libloading::Library = libloading::os::unix::Library::this().into();
+                Ok(GleanSym { $($load)* _library: $localname })
             }
 
             #[cfg(not(unix))]


### PR DESCRIPTION
This is the equivalent of using `dlsym(RTLD_DEFAULT, name)`, that is:

> looking for the desired symbols using the default shared object search order.
> The search will include global symbols in the executable and its

(from the dlsym(3) man page)