### PR TITLE
sqlite: Set synchronous=NORMAL to sync less often, but at the critical moments

### DIFF
--- a/glean-core/src/database/sqlite/schema.rs
+++ b/glean-core/src/database/sqlite/schema.rs
@@ -25,6 +25,8 @@ impl ConnectionOpener for Schema {
             "
              -- we unconditionally want write-ahead-logging mode
              PRAGMA journal_mode = WAL;
+             -- Sync at the most criticial moments, but not with every write
+             PRAGMA synchronous = NORMAL;
              -- limit size of the journal. value currently arbitrary. needs refinement.
              PRAGMA journal_size_limit = 512000; -- 512 KB.
              -- We don't care about temp tables being persisted to disk


### PR DESCRIPTION
See all details:
https://sqlite.org/pragma.html#pragma_synchronous

The default (FULL) syncs on every write.
That's slightly higher guarantees, but also costly. We're already using WAL (write-ahead log). It's safe from corruption in NORMAL mode and consistent.
It does lose durability, that means data might roll back following a power loss or system crash.

Note: `rkv` does NOT sync at all. It only writes to disk (and moves files around). That's strictly worse than WAL in `NORMAL` mode.