### PR TITLE
Use correct parameter and properly warn when clearing fails instead of silently dropping errors

### DIFF
--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -878,13 +878,34 @@ impl Glean {
         // Note that this also includes the ping sequence numbers, so it has
         // the effect of resetting those to their initial values.
         if let Some(data) = self.data_store.as_ref() {
-            _ = data.clear_lifetime_storage(Lifetime::User, "glean_internal_info");
-            _ = data.remove_single_metric(Lifetime::User, "glean_client_info", "client_id");
+            let warn_on_error = |result, msg| {
+                if let Err(e) = result {
+                    log::warn!("{msg}: {e}");
+                }
+            };
+
+            warn_on_error(
+                data.clear_lifetime_storage(Lifetime::User, "glean_internal_info"),
+                "failed to clear interanl storage",
+            );
+            warn_on_error(
+                data.remove_single_metric(Lifetime::User, "glean_client_info", "client_id"),
+                "failed to clear internal client info storage",
+            );
             for (ping_name, ping) in &self.ping_registry {
                 if ping.follows_collection_enabled() {
-                    _ = data.clear_ping_lifetime_storage(ping_name);
-                    _ = data.clear_lifetime_storage(Lifetime::User, ping_name);
-                    _ = data.clear_lifetime_storage(Lifetime::Application, ping_name);
+                    warn_on_error(
+                        data.clear_ping_lifetime_storage(ping_name),
+                        "failed to clear ping lifetime storage",
+                    );
+                    warn_on_error(
+                        data.clear_lifetime_storage(Lifetime::User, ping_name),
+                        "failed to clear user lifetime storage",
+                    );
+                    warn_on_error(
+                        data.clear_lifetime_storage(Lifetime::Application, ping_name),
+                        "failed to clear application lifetime storage",
+                    );
                 }
             }
         }

--- a/glean-core/src/database/sqlite.rs
+++ b/glean-core/src/database/sqlite.rs
@@ -358,7 +358,7 @@ impl Database {
     ///
     /// This function will **not** panic on database errors.
     pub fn clear_ping_lifetime_storage(&self, storage_name: &str) -> Result<()> {
-        let clear_sql = "DELETE FROM telemetry WHERE lifetime = 'ping' AND ping = ?2";
+        let clear_sql = "DELETE FROM telemetry WHERE lifetime = 'ping' AND ping = ?1";
         self.conn.write(|tx| {
             let mut stmt = tx.prepare_cached(clear_sql)?;
             stmt.execute([storage_name])?;


### PR DESCRIPTION
My change in the earlier PR was not entirely correct and made several tests fail (in the full change).
Hard to track down as we dropped the error on the floor. Now we're getting a warning for it.