### PR TITLE
Downgrade to libloading 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,12 +852,12 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.9.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-targets",
 ]
 
 [[package]]

--- a/glean-core/glean-sym/Cargo.toml
+++ b/glean-core/glean-sym/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 edition = "2024"
 
 [dependencies]
-libloading = "0.9.0"
+libloading = "0.8.0"
 once_cell = "1.21.3"
 serde = { version = "1.0.228", features = ["derive"] }
 uniffi = "0.31.0"

--- a/samples/glean-sym-test/Cargo.lock
+++ b/samples/glean-sym-test/Cargo.lock
@@ -749,12 +749,12 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
-version = "0.9.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-targets",
 ]
 
 [[package]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -108,6 +108,10 @@ criteria = "safe-to-run"
 version = "0.2.139"
 criteria = "safe-to-deploy"
 
+[[exemptions.libloading]]
+version = "0.8.6"
+criteria = "safe-to-deploy"
+
 [[exemptions.memchr]]
 version = "2.5.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
0.8.6 is already bundled in m-c

Adds `libloading 0.8.6` to the exemption list, because otherwise it makes me vet the _downgrade_:

    cargo vet diff libloading 0.9.0 0.8.6

But the libloading 0.8.6 _update_ is already reviewed in m-c.