### PR TITLE
Keep `rkv_load_error` active while Rkv-powered Glean is still in use

### DIFF
--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -955,6 +955,23 @@ glean.database:
       - glean-team@mozilla.com
     expires: never
 
+  rkv_load_error:
+    type: string
+    description: |
+      If there was an error loading the RKV database, record it.
+    send_in_pings:
+      - metrics
+      - health
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1815253
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1815253
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+
   load_error:
     type: string
     description: |

--- a/glean-core/tests/metrics_sync.rs
+++ b/glean-core/tests/metrics_sync.rs
@@ -29,6 +29,8 @@ static DEFINITION_ONLY: &[&str] = &[
     "glean.session_start",
     /* in foreign language wrapper */
     "glean.validation.foreground_count",
+    /* kept active while Rkv-powered Glean is in use */
+    "glean.database.rkv_load_error",
 ];
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This just restores what was previously there.