### PR TITLE
Bug 2050398 - Don't clear unrelated stores if they share a prefix with the one being cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean/compare/v68.0.0...main)
 
+* General
+  * BUGFIX: Don't clear unrelated stores if they share a prefix with the one being cleared ([#3516](https://github.com/mozilla/glean/pull/3516))
+
 # v68.0.0 (2026-06-19)
 
 [Full changelog](https://github.com/mozilla/glean/compare/v67.5.0...v68.0.0)

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -648,22 +648,24 @@ impl Database {
     ///
     /// This function will **not** panic on database errors.
     pub fn clear_ping_lifetime_storage(&self, storage_name: &str) -> Result<()> {
+        let storage_name = Self::get_storage_key(storage_name, None);
+
         // Lifetime::Ping data will be saved to `ping_lifetime_data`
         // in case `delay_ping_lifetime_io` is set to true
         if let Some(ping_lifetime_data) = &self.ping_lifetime_data {
             ping_lifetime_data
                 .write()
                 .expect("Can't access ping lifetime data as writable")
-                .retain(|metric_id, _| !metric_id.starts_with(storage_name));
+                .retain(|metric_id, _| !metric_id.starts_with(&storage_name));
         }
 
         self.write_with_store(Lifetime::Ping, |mut writer, store| {
             let mut metrics = Vec::new();
             {
-                let mut iter = store.iter_from(&writer, storage_name)?;
+                let mut iter = store.iter_from(&writer, &storage_name)?;
                 while let Some(Ok((metric_id, _))) = iter.next() {
                     if let Ok(metric_id) = std::str::from_utf8(metric_id) {
-                        if !metric_id.starts_with(storage_name) {
+                        if !metric_id.starts_with(&storage_name) {
                             break;
                         }
                         metrics.push(metric_id.to_owned());

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -323,3 +323,103 @@ fn database_write_timings_get_recorded() {
         "writing should take some time"
     );
 }
+
+#[test]
+fn clearing_storage_by_prefix_doesnt_clear_unrelated() {
+    let (mut glean, _t) = new_glean(None);
+
+    let prefix = String::from("prefix");
+    let other = format!("{prefix}-other");
+
+    let prefix_ping = new_test_ping(&mut glean, &prefix);
+    glean.register_ping_type(&prefix_ping);
+
+    let other_ping = new_test_ping(&mut glean, &other);
+    glean.register_ping_type(&other_ping);
+
+    // We need to store a metric to record something.
+    let counter = CounterMetric::new(CommonMetricData {
+        name: "counter".into(),
+        category: "local".into(),
+        send_in_pings: vec![prefix.clone(), other.clone()],
+        ..Default::default()
+    });
+    counter.add_sync(&glean, 1);
+
+    assert_eq!(1, counter.get_value(&glean, Some(&*prefix)).unwrap());
+    assert_eq!(1, counter.get_value(&glean, Some(&*other)).unwrap());
+
+    assert!(prefix_ping.submit_sync(&glean, None));
+
+    assert_eq!(None, counter.get_value(&glean, Some(&*prefix)));
+    assert_eq!(1, counter.get_value(&glean, Some(&*other)).unwrap());
+
+    counter.add_sync(&glean, 1);
+    assert!(other_ping.submit_sync(&glean, None));
+
+    assert_eq!(1, counter.get_value(&glean, Some(&*prefix)).unwrap());
+    assert_eq!(None, counter.get_value(&glean, Some(&*other)));
+}
+
+#[test]
+fn clearing_storage_by_prefix_doesnt_clear_unrelated_delayed_ping_io() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let cfg = glean_core::InternalConfiguration {
+        data_path: dir.path().display().to_string(),
+        application_id: GLOBAL_APPLICATION_ID.into(),
+        language_binding_name: "Rust".into(),
+        upload_enabled: true,
+        max_events: None,
+        delay_ping_lifetime_io: true, // Differs from `new_glean`
+        app_build: "Unknown".into(),
+        use_core_mps: false,
+        trim_data_to_registered_pings: false,
+        log_level: None,
+        rate_limit: None,
+        enable_event_timestamps: false,
+        experimentation_id: None,
+        enable_internal_pings: true,
+        ping_schedule: Default::default(),
+        ping_lifetime_threshold: 0,
+        ping_lifetime_max_time: 0,
+        max_pending_pings_count: None,
+        max_pending_pings_directory_size: None,
+        session_mode: glean_core::SessionMode::Auto,
+        session_sample_rate: 1.0,
+        session_inactivity_timeout_ms: 1_800_000,
+    };
+    let mut glean = glean_core::Glean::new(cfg).unwrap();
+
+    let prefix = String::from("prefix");
+    let other = format!("{prefix}-other");
+
+    let prefix_ping = new_test_ping(&mut glean, &prefix);
+    glean.register_ping_type(&prefix_ping);
+
+    let other_ping = new_test_ping(&mut glean, &other);
+    glean.register_ping_type(&other_ping);
+
+    // We need to store a metric to record something.
+    let counter = CounterMetric::new(CommonMetricData {
+        name: "counter".into(),
+        category: "local".into(),
+        send_in_pings: vec![prefix.clone(), other.clone()],
+        ..Default::default()
+    });
+    counter.add_sync(&glean, 1);
+
+    assert_eq!(1, counter.get_value(&glean, Some(&*prefix)).unwrap());
+    assert_eq!(1, counter.get_value(&glean, Some(&*other)).unwrap());
+
+    assert!(prefix_ping.submit_sync(&glean, None));
+
+    assert_eq!(None, counter.get_value(&glean, Some(&*prefix)));
+    assert_eq!(1, counter.get_value(&glean, Some(&*other)).unwrap());
+
+    counter.add_sync(&glean, 1);
+    assert!(other_ping.submit_sync(&glean, None));
+
+    assert_eq!(1, counter.get_value(&glean, Some(&*prefix)).unwrap());
+    assert_eq!(None, counter.get_value(&glean, Some(&*other)));
+}


### PR DESCRIPTION
Note: This is against the support/v68.0 branch so we can backport it and release v68.0.1