### PR TITLE
CI: Use correct path to the glean schema in the CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ jobs:
           name: Check vendored schema for upstream updates
           command: |
             bin/update-schema.sh HEAD
-            if ! git diff --exit-code HEAD -- glean-core/preview/tests/glean.1.schema.json; then
+            if ! git diff --exit-code HEAD -- glean.1.schema.json; then
               echo "===================================="
               echo "Latest schema from upstream changed."
               echo "Please regenerate the file using:"

--- a/glean.1.schema.json
+++ b/glean.1.schema.json
@@ -923,6 +923,15 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "session_sample_rate": {
+              "description": "Remote override for the session sampling rate (0.0–1.0).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": [
+                "number",
+                "null"
+              ]
             }
           },
           "type": "object"


### PR DESCRIPTION
This check was added in 7d2589a7ca9 in February 2020. The schema was removed to the top-level in March 2020. That made the CI test ineffective. Noone ever noticed. This is not good.