### PR TITLE
Bug 2048978 - docs: Specify that a record separator cannot be used in labels

### DIFF
--- a/docs/user/_includes/label-limits.md
+++ b/docs/user/_includes/label-limits.md
@@ -3,7 +3,7 @@
 * The list of labels is limited to:
   * 16 different dynamic labels if no static labels are defined.
     Additional labels will all record to the special label `__other__`.
-    These labels may contain any UTF-8 characters.
+    These labels may contain any UTF-8 characters except a record separator (`0x1E`).
   * 4096 labels if specified as static labels in `metrics.yaml`, see [Labels](#labels).
     Unknown labels will be recorded under the special label `__other__`.
     These labels may only be made of printable ASCII characters.

--- a/docs/user/reference/metrics/dual_labeled_counters.md
+++ b/docs/user/reference/metrics/dual_labeled_counters.md
@@ -68,7 +68,7 @@ Glean.gleanUpload.failures.get("baseline", "4xx").add(3);
 * The lists of key and category labels are limited to:
   * 16 different dynamic key labels and 16 category labels, if no static labels are defined.
     Additional key and category labels will all record to the special label `__other__`.
-    These labels may contain any UTF-8 characters.
+    These labels may contain any UTF-8 characters except a record separator (`0x1E`).
   * 4096 key labels and 4096 category labels if specified as static labels in `metrics.yaml`, see [key](#key) and [category](#category).
     Unknown key and category labels will be recorded under the special label `__other__`.
     These labels may only be made of printable ASCII characters.

--- a/docs/user/reference/metrics/index.md
+++ b/docs/user/reference/metrics/index.md
@@ -77,7 +77,8 @@ Labeled metrics come in two forms:
 
 ### Label format
 
-Labels must have a maximum of 111 characters, and may comprise any printable ASCII characters.
+Labels must have a maximum of 111 characters, and may may contain any UTF-8 characters except a record separator (`0x1E`).
+Static labels may only be made of printable ASCII characters.
 
 ## Adding or changing metric types
 Glean has a [well-defined process](https://wiki.mozilla.org/Glean/Adding_or_changing_Glean_metric_types) for requesting changes to existing metric types or suggesting the implementation of new metric types:


### PR DESCRIPTION
[doc only]