### PR TITLE
Remove experimental note on the buffer API

### DIFF
--- a/docs/user/reference/metrics/custom_distribution.md
+++ b/docs/user/reference/metrics/custom_distribution.md
@@ -161,7 +161,6 @@ Glean.graphics.checkerboardPeak.accumulateSingleSample(23);
 
 ### `startBuffer`
 
-**Experimental:**
 Start a new histogram buffer associated with this custom distribution metric.
 
 A histogram buffer accumulates in-memory.

--- a/docs/user/reference/metrics/memory_distribution.md
+++ b/docs/user/reference/metrics/memory_distribution.md
@@ -118,7 +118,6 @@ Glean.memory.heapAllocated.accumulate(bytes / 1024);
 
 ### `startBuffer`
 
-**Experimental:**
 Start a new histogram buffer associated with this custom distribution metric.
 
 A histogram buffer accumulates in-memory.

--- a/docs/user/reference/metrics/timing_distribution.md
+++ b/docs/user/reference/metrics/timing_distribution.md
@@ -611,7 +611,6 @@ Glean.pages.pageLoad.cancel(timerId);
 
 ### `startBuffer`
 
-**Experimental:**
 Start a new histogram buffer associated with this custom distribution metric.
 
 A histogram buffer accumulates in-memory.


### PR DESCRIPTION
This API has been around since early 2025. We should just consider it stable.

[doc only]