### PR TITLE
Bug 2053772 - CI: Enable SSDLC actions

### DIFF
--- a/.github/workflows/ssdlc.yml
+++ b/.github/workflows/ssdlc.yml
@@ -1,0 +1,17 @@
+name: SSDLC Actions
+
+on:
+  push:
+    branches:
+    - "main"
+  pull_request:
+    branches:
+    - "main"
+
+permissions: {}
+
+jobs:
+  code-security-analysis:
+    permissions:
+      security-events: write # required for uploading code scanning alerts
+    uses: mozilla/ssdlc-actions/.github/workflows/code-security-analysis-public-repo.yml@ca8be48f3c06204fb16a3bd5ffa6d916782bbc76 # 2026-06-29


### PR DESCRIPTION
Guess that's an easy start for now. It's necessary as per the new and updated security guidelines.