### PR TITLE
glean-sym sample: Brief wait in test to give it time to process pings

### DIFF
--- a/samples/glean-sym-test/Makefile
+++ b/samples/glean-sym-test/Makefile
@@ -15,4 +15,4 @@ help:
 .PHONY: run
 run:  ## Run the sample app
 	cargo build --locked
-	env $(LIB_PATH_NAME)=target/debug uv run pytest app.py
+	env $(LIB_PATH_NAME)=target/debug RUST_LOG=uv=error,debug uv run pytest --capture=no app.py

--- a/samples/glean-sym-test/app.py
+++ b/samples/glean-sym-test/app.py
@@ -55,9 +55,8 @@ def test_run():
         xul.shutdown()
 
         # Check that
-        # * We submitted one ping only
-        # * It's the `prototype` ping
-        # * It contains several metrics with the expected values
+        # * We submitted two pings: `prototype` from xul and `services-info` from services
+        # * Both pings contain some data
         path = os.path.join(data_path, "sent_pings")
         for root, dirs, files in os.walk(path):
             assert len(files) == 2

--- a/samples/glean-sym-test/xul/lib.rs
+++ b/samples/glean-sym-test/xul/lib.rs
@@ -6,6 +6,8 @@ use std::ffi::{CStr, c_char};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 use flate2::read::GzDecoder;
 use glean::{ClientInfoMetrics, ConfigurationBuilder, net};
@@ -14,7 +16,7 @@ use glean::{ClientInfoMetrics, ConfigurationBuilder, net};
 /// Chosen empirically.
 /// If this crashes with `oom` increase it.
 #[global_allocator]
-static ALLOCATOR: local_allocator::Allocator::<2048> = local_allocator::Allocator::new("xul");
+static ALLOCATOR: local_allocator::Allocator<2048> = local_allocator::Allocator::new("xul");
 
 #[allow(clippy::all)] // Don't lint generated code.
 pub mod glean_metrics {
@@ -118,5 +120,6 @@ unsafe extern "C" fn submit() {
 #[unsafe(no_mangle)]
 unsafe extern "C" fn shutdown() {
     log::info!("Shutdown invoked");
+    thread::sleep(Duration::from_millis(200));
     glean::shutdown();
 }


### PR DESCRIPTION
It seems to frequently fail with the second ping not correctly sent.