### PR TITLE
Bug 2054457 - Run database maintenance at shutdown & after collecting ping data

### DIFF
--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -790,6 +790,12 @@ pub fn shutdown() {
         if let Err(e) = glean.persist_ping_lifetime_data() {
             log::info!("Can't persist ping lifetime data: {:?}", e);
         }
+
+        if let Some(database) = &glean.data_store {
+            if let Err(e) = database.run_maintenance(false) {
+                log::info!("Can't run database maintenance on shutdown: {:?}", e);
+            }
+        }
     });
 }
 

--- a/glean-core/src/storage/mod.rs
+++ b/glean-core/src/storage/mod.rs
@@ -160,6 +160,13 @@ impl StorageManager {
             if let Err(e) = storage.clear_ping_lifetime_storage(store_name) {
                 log::warn!("Failed to clear lifetime storage: {:?}", e);
             }
+
+            if let Err(e) = storage.run_maintenance(false) {
+                log::warn!(
+                    "Failed to run database maintenance after ping submission: {:?}",
+                    e
+                );
+            }
         }
 
         if snapshot.is_empty() {


### PR DESCRIPTION
The first one seems a no-brainer, the other one I'm a bit less sure about. But I don't think it's really harmful