### PR TITLE
sqlite: Ignore ExecuteReturnedResults on PRAGMA calls

### DIFF
--- a/glean-core/src/database/conn_ext.rs
+++ b/glean-core/src/database/conn_ext.rs
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use rusqlite::Connection;
+
+/// This trait exists so that we can use these helpers on `rusqlite::{Transaction, Connection}`.
+/// Note that you must import ConnExt in order to call these methods on anything.
+pub trait ConnExt {
+    /// The method you need to implement to opt in to all of this.
+    fn conn(&self) -> &Connection;
+
+    /// Execute a single statement.
+    fn execute_one(&self, stmt: &str) -> Result<(), rusqlite::Error> {
+        match self.conn().execute(stmt, []) {
+            Ok(_) => Ok(()),
+            // Ignore ExecuteReturnedResults error because they're pointless
+            // and annoying.
+            Err(rusqlite::Error::ExecuteReturnedResults) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl ConnExt for Connection {
+    #[inline]
+    fn conn(&self) -> &Connection {
+        self
+    }
+}

--- a/glean-core/src/database/mod.rs
+++ b/glean-core/src/database/mod.rs
@@ -2,5 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod conn_ext;
 pub mod migration;
 pub mod sqlite;
+
+pub use conn_ext::ConnExt;

--- a/glean-core/src/database/sqlite.rs
+++ b/glean-core/src/database/sqlite.rs
@@ -28,6 +28,8 @@ use crate::Glean;
 use crate::Lifetime;
 use crate::Result;
 
+use super::ConnExt;
+
 mod connection;
 mod schema;
 
@@ -280,14 +282,14 @@ impl Database {
             conn.query_row_and_then("PRAGMA auto_vacuum", [], |row| row.get(0))?;
         if !force_full && auto_vacuum_setting == 2 {
             // Ideally, we run an incremental vacuum to delete 2 pages
-            conn.execute("PRAGMA incremental_vacuum(2)", [])?;
+            conn.execute_one("PRAGMA incremental_vacuum(2)")?;
         } else {
             // If auto_vacuum=incremental isn't set, configure it and run a full vacuum.
             log::warn!(
                 "run_maintenance_vacuum: Need to run a full vacuum to set auto_vacuum=incremental"
             );
-            conn.execute("PRAGMA auto_vacuum=incremental", [])?;
-            conn.execute("VACUUM", [])?;
+            conn.execute_one("PRAGMA auto_vacuum=incremental")?;
+            conn.execute_one("VACUUM")?;
         }
         Ok(())
     }


### PR DESCRIPTION
There's rare occasions where that error is returned for ... I don't know why. I couldn't get `query_row_and_then` to work on that same pragma either.

This code is copied from appservices:
https://github.com/mozilla/application-services/blob/407a2421c6f731b921894927cdf9a6bacaa3813d/components/support/sql/src/conn_ext.rs#L45-L63

---

fwiw hitting this error seems to be what's causing the iOS errors on #3538 