### PR TITLE
Swift: Test to verify accumulateSamples & accumulateSingleSample work for timing distributions

### DIFF
--- a/docs/user/reference/metrics/timing_distribution.md
+++ b/docs/user/reference/metrics/timing_distribution.md
@@ -276,7 +276,17 @@ void onPageLoaded(Event e) {
 ```
 
 </div>
-<div data-lang="Swift" class="tab"></div>
+<div data-lang="Swift" class="tab">
+
+```Swift
+import Glean
+
+func onPageLoaded() {
+    Pages.pageLoad.accumulateSamples(samples);
+}
+```
+
+</div>
 <div data-lang="Python" class="tab">
 
 ```Python
@@ -384,7 +394,17 @@ void onPageLoaded(Event e) {
 ```
 
 </div>
-<div data-lang="Swift" class="tab"></div>
+<div data-lang="Swift" class="tab">
+
+```Swift
+import Glean
+
+func onPageLoaded() {
+    Pages.pageLoad.accumulateSingleSample(sample);
+}
+```
+
+</div>
 <div data-lang="Python" class="tab">
 
 ```Python

--- a/docs/user/reference/metrics/timing_distribution.md
+++ b/docs/user/reference/metrics/timing_distribution.md
@@ -239,6 +239,100 @@ Glean.pages.pageLoad.stopAndAccumulate(timerId);
 
 {{#include ../../../shared/tab_footer.md}}
 
+### `cancel`
+
+Aborts a previous `start` call.
+No error is recorded if `start` was not called.
+
+{{#include ../../../shared/tab_header.md}}
+
+<div data-lang="Kotlin" class="tab">
+
+```Kotlin
+import org.mozilla.yourApplication.GleanMetrics.Pages
+
+fun onPageError(e: Event) {
+    Pages.pageLoad.cancel(timerId)
+}
+```
+
+</div>
+<div data-lang="Java" class="tab">
+
+```Java
+import org.mozilla.yourApplication.GleanMetrics.Pages;
+
+fun onPageError(e: Event) {
+    Pages.INSTANCE.pageLoad().cancel(timerId);
+}
+```
+
+</div>
+<div data-lang="Swift" class="tab">
+
+```Swift
+import Glean
+
+func onPageError() {
+    Pages.pageLoad.cancel(timerId)
+}
+```
+
+</div>
+<div data-lang="Python" class="tab">
+
+```Python
+from glean import load_metrics
+metrics = load_metrics("metrics.yaml")
+
+class PageHandler:
+    def on_page_error(self, event):
+        metrics.pages.page_load.cancel(self.timer_id)
+```
+
+</div>
+<div data-lang="Rust" class="tab">
+
+```Rust
+use glean_metrics::pages;
+
+fn on_page_error() {
+    pages::page_load.cancel(self.timer_id);
+}
+```
+
+</div>
+<div data-lang="JavaScript" class="tab">
+
+```Javascript
+import * as pages from "./path/to/generated/files/pages.js";
+
+function onPageError() {
+    pages.pageLoad.cancel(timerId);
+}
+```
+
+</div>
+<div data-lang="Firefox Desktop" class="tab">
+
+**C++**
+
+```c++
+#include "mozilla/glean/DomMetrics.h"
+
+mozilla::glean::pages::page_load.Cancel(std::move(timerId));
+```
+
+**JavaScript**
+
+```js
+Glean.pages.pageLoad.cancel(timerId);
+```
+
+</div>
+
+{{#include ../../../shared/tab_footer.md}}
+
 ### `accumulateSamples`
 
 Accumulates the provided signed samples in the metric.
@@ -530,100 +624,6 @@ with metrics.pages.page_load.measure():
 **JavaScript**
 
 *Not currently implemented.*
-
-</div>
-
-{{#include ../../../shared/tab_footer.md}}
-
-### `cancel`
-
-Aborts a previous `start` call.
-No error is recorded if `start` was not called.
-
-{{#include ../../../shared/tab_header.md}}
-
-<div data-lang="Kotlin" class="tab">
-
-```Kotlin
-import org.mozilla.yourApplication.GleanMetrics.Pages
-
-fun onPageError(e: Event) {
-    Pages.pageLoad.cancel(timerId)
-}
-```
-
-</div>
-<div data-lang="Java" class="tab">
-
-```Java
-import org.mozilla.yourApplication.GleanMetrics.Pages;
-
-fun onPageError(e: Event) {
-    Pages.INSTANCE.pageLoad().cancel(timerId);
-}
-```
-
-</div>
-<div data-lang="Swift" class="tab">
-
-```Swift
-import Glean
-
-func onPageError() {
-    Pages.pageLoad.cancel(timerId)
-}
-```
-
-</div>
-<div data-lang="Python" class="tab">
-
-```Python
-from glean import load_metrics
-metrics = load_metrics("metrics.yaml")
-
-class PageHandler:
-    def on_page_error(self, event):
-        metrics.pages.page_load.cancel(self.timer_id)
-```
-
-</div>
-<div data-lang="Rust" class="tab">
-
-```Rust
-use glean_metrics::pages;
-
-fn on_page_error() {
-    pages::page_load.cancel(self.timer_id);
-}
-```
-
-</div>
-<div data-lang="JavaScript" class="tab">
-
-```Javascript
-import * as pages from "./path/to/generated/files/pages.js";
-
-function onPageError() {
-    pages.pageLoad.cancel(timerId);
-}
-```
-
-</div>
-<div data-lang="Firefox Desktop" class="tab">
-
-**C++**
-
-```c++
-#include "mozilla/glean/DomMetrics.h"
-
-mozilla::glean::pages::page_load.Cancel(std::move(timerId));
-```
-
-**JavaScript**
-
-```js
-Glean.pages.pageLoad.cancel(timerId);
-```
 
 </div>
 

--- a/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
@@ -202,4 +202,27 @@ class TimingDistributionTypeTests: XCTestCase {
 
         XCTAssertNil(metric.testGetValue())
     }
+
+    func testTiminingDistributionAccumulatesSamples() {
+        let metric = TimingDistributionMetricType(CommonMetricData(
+            category: "telemetry",
+            name: "timing_distribution",
+            sendInPings: ["store1"],
+            lifetime: .ping,
+            disabled: false
+        ), .nanosecond)
+
+        XCTAssertNil(metric.testGetValue())
+
+        // Accumulate a few values
+        metric.accumulateSamples([1, 2])
+        metric.accumulateSingleSample(3)
+
+        // Check that data was properly recorded.
+        // We can only check the count, as we don't control the time.
+        let snapshot = metric.testGetValue()!
+        let sum = snapshot.values.values.reduce(0, +)
+        XCTAssertEqual(3, sum)
+        XCTAssertEqual(3, snapshot.count)
+    }
 }

--- a/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
+++ b/glean-core/ios/GleanTests/Metrics/TimingDistributionMetricTests.swift
@@ -202,4 +202,25 @@ class TimingDistributionTypeTests: XCTestCase {
 
         XCTAssertNil(metric.testGetValue())
     }
+
+    func testTiminingDistributionAccumulatesSamples() {
+        let metric = TimingDistributionMetricType(CommonMetricData(
+            category: "telemetry",
+            name: "timing_distribution",
+            sendInPings: ["store1"],
+            lifetime: .ping,
+            disabled: false
+        ), .nanosecond)
+
+        XCTAssertNil(metric.testGetValue())
+
+        // Accumulate a few values
+        metric.accumulateSamples([1, 2])
+        metric.accumulateSingleSample(3)
+
+        // Check that data was properly recorded.
+        let snapshot = metric.testGetValue()!
+        XCTAssertEqual(6, snapshot.sum)
+        XCTAssertEqual(3, snapshot.count)
+    }
 }


### PR DESCRIPTION
The docs said accumulateSamples and accumulateSingleSample didn't exist on Swift, but that's not true.
Now verified by a test and updated docs.

While I'm there I also reordered `cancel` above everything else, which seemed much more logical and is also how it's ordered for labeled timing distributions.