### PR TITLE
sqlite: Simplify read "transactions"

### DIFF
--- a/glean-core/src/common_metric_data.rs
+++ b/glean-core/src/common_metric_data.rs
@@ -243,7 +243,7 @@ impl CommonMetricDataInternal {
     /// No error is recorded in the database if the check fails.
     /// Extract the validated label, if any, using [`LabelCheck::label`].
     /// Record an error, if any, using [`LabelCheck::record_error`].
-    pub(crate) fn check_labels(&self, tx: &Transaction<'_>) -> LabelCheck {
+    pub(crate) fn check_labels(&self, tx: &rusqlite::Connection) -> LabelCheck {
         let base_identifier = self.base_identifier();
 
         if let Some(label) = &self.inner.label {

--- a/glean-core/src/database/sqlite/connection.rs
+++ b/glean-core/src/database/sqlite/connection.rs
@@ -97,12 +97,12 @@ impl Connection {
     }
 
     /// Accesses the database for reading.
-    pub fn read<T, E>(&self, f: impl FnOnce(&Transaction<'_>) -> Result<T, E>) -> Result<T, E> {
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn
-            .transaction_with_behavior(TransactionBehavior::Immediate)
-            .unwrap();
-        f(&tx)
+    pub fn read<T, E>(
+        &self,
+        f: impl FnOnce(&rusqlite::Connection) -> Result<T, E>,
+    ) -> Result<T, E> {
+        let conn = self.conn.lock().unwrap();
+        f(&conn)
     }
 
     /// Accesses the database in a transaction for reading and writing.

--- a/glean-core/src/metrics/dual_labeled_counter.rs
+++ b/glean-core/src/metrics/dual_labeled_counter.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::sync::{Arc, Mutex};
 
-use rusqlite::{params, Transaction};
+use rusqlite::params;
 
 use crate::common_metric_data::{
     CommonMetricData, CommonMetricDataInternal, LabelCheck, MetricLabel,
@@ -249,7 +249,7 @@ impl TestGetValue for DualLabeledCounterMetric {
 }
 
 pub fn validate_dual_label_sqlite(
-    tx: &Transaction,
+    tx: &rusqlite::Connection,
     base_identifier: &str,
     key: &str,
     category: &str,

--- a/glean-core/src/metrics/labeled.rs
+++ b/glean-core/src/metrics/labeled.rs
@@ -9,7 +9,7 @@ use std::mem;
 use std::sync::{Arc, Mutex};
 
 use malloc_size_of::MallocSizeOf;
-use rusqlite::{params, Transaction};
+use rusqlite::params;
 
 use crate::common_metric_data::{CommonMetricData, LabelCheck, MetricLabel};
 use crate::error_recording::{test_get_num_recorded_errors, ErrorType};
@@ -384,7 +384,7 @@ where
 }
 
 pub fn validate_dynamic_label_sqlite(
-    tx: &Transaction,
+    tx: &rusqlite::Connection,
     base_identifier: &str,
     label: &str,
 ) -> LabelCheck {


### PR DESCRIPTION
See https://sqlite.org/lang_transaction.html for details on transactions in SQLite.

Any single SQL statement is automatically a transaction. It gets upgraded if it's a write, otherwise it's a read transaction.

Now rusqlite, on top of it, automatically rolls back `Transactions` unless `commit()` is called. It's doing that by executing `ROLLBACK`. Even if this transaction only ever did reads it does that. And even if that then doesn't really have to do much it does more than necessary.

We can skip all that.
The connection is already behind a lock, so we already don't run into concurrency issues on that access.