### PR TITLE
bug 2060890 - Early Event Acceleration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     * Keep state about migration in the database ([#3545](https://github.com/mozilla/glean/pull/3545))
     * The database connection is closed on shutdown ([#3584](https://github.com/mozilla/glean/pull/3584))
   * BREAKING CHANGE: Updated to UniFFI 0.32.0 ([#3538](https://github.com/mozilla/glean/pull/3538))
+  * New optional configuration option and Server Knob: `events_ping_acceleration_factor: N`. Accelerate the first `N-1` "events" pings in each session ([bug 2060890](https://bugzilla.mozilla.org/show_bug.cgi?id=2060890))
 * Rust
   * glean-sym
     * Implement glean-noop as a feature of glean-sym ([#3541](https://github.com/mozilla/glean/pull/3541))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * General
   * Updated to `glean_parser` v20.1.0 ([#3539](https://github.com/mozilla/glean/issues/3539))
   * BUGFIX: Ensure errors are not put into the client_info or any other internal section ([#3564](https://github.com/mozilla/glean/pull/3564))
+  * New optional configuration option and Server Knob: `events_ping_acceleration_factor: N`. Accelerate the first `N-1` "events" pings in each session ([bug 2060890](https://bugzilla.mozilla.org/show_bug.cgi?id=2060890))
 
 # v69.0.0 (2026-06-22)
 

--- a/docs/user/SUMMARY.md
+++ b/docs/user/SUMMARY.md
@@ -38,6 +38,7 @@
     - [Experimenter Configuration](user/server-knobs/pings/experimenter-configuration.md)
   - [Other Server Knobs](user/server-knobs/other/index.md)
     - [Max Events per Ping](user/server-knobs/other/max-events.md)
+    - [Events Ping Acceleration Factor](user/server-knobs/other/events-accel.md)
 - [Debugging products using Glean](user/debugging/index.md)
     - [Android](user/debugging/android.md)
     - [iOS](user/debugging/ios.md)

--- a/docs/user/reference/general/initializing.md
+++ b/docs/user/reference/general/initializing.md
@@ -75,6 +75,7 @@ Check the respective SDK documentation for details.
 | `experimentationId` | - | Optional. An identifier derived by the application to be sent in all pings for the purpose of experimentation. See the experiments API documentation for more information. |
 | `enableInternalPings` | `true` | Whether to enable the internal "baseline", "events", and "metrics" pings. |
 | `delayPingLifetimeIo` | `false` | Whether Glean should delay persistence of data from metrics with `ping` lifetime. On Android data is automatically persisted every 1000 writes and on backgrounding when enabled. |
+| `eventsPingAccelerationFactor` | - | Optional. Determines how many "events" pings to accelerate after init by decreasing the max events needed to be recorded before submission. |
 
 To learn about SDK specific configuration options available, refer to the [Reference](#reference) section.
 

--- a/docs/user/user/server-knobs/other/events-accel.md
+++ b/docs/user/user/server-knobs/other/events-accel.md
@@ -1,0 +1,23 @@
+# Events Ping Acceleration Factor
+
+By default, Glean batches events together to submit on a single ["events" ping](../../pings/events.md).
+The number of events Glean will collect before submitting an "events" ping is determined at
+[Glean initialization](../../../reference/general/initializing.md) via the `maxEvents`
+configuration option and can be changed remotely via the
+[`event_threshold` Server Knob](./max-events.md).
+
+This Server Knob overrides the `eventsPingAccelerationFactor` configuration option from Glean initialization.
+It takes effect immediately, but if the number of "events" pings already submitted this session exceeds the factor,
+it might have no practical effect.
+
+## Example Configuration:
+
+```json
+{
+  "gleanMetricConfiguration": {
+    "events_ping_acceleration_factor": 5
+  }
+}
+```
+
+{{#include ../../../_includes/server-knobs-config-in-pings.md}}

--- a/docs/user/user/server-knobs/other/index.md
+++ b/docs/user/user/server-knobs/other/index.md
@@ -4,6 +4,7 @@ Below are additional Glean parameters and settings that are exposed via Server K
 
 ## Contents
 - [Max Events per Event Ping]
+- [Events Ping Acceleration Factor]
 
 Additional Glean settings will be added to Server Knobs as needed or by request.
 
@@ -13,3 +14,4 @@ Additional Glean settings will be added to Server Knobs as needed or by request.
 [Controlling Metrics with Server Knobs]: ../metrics/index.md
 [Controlling Pings with Server Knobs]: ../pings/index.md
 [Max Events per Event Ping]: ./max-events.md
+[Events Ping Acceleration Factor]: ./events-accel.md

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/Glean.kt
@@ -275,6 +275,7 @@ open class GleanInternalAPI internal constructor() {
                 sessionMode = configuration.sessionMode,
                 sessionSampleRate = configuration.sessionSampleRate,
                 sessionInactivityTimeoutMs = configuration.sessionInactivityTimeoutMs.toULong(),
+                eventsPingAccelerationFactor = null,
             )
             val clientInfo = getClientInfo(configuration, buildInfo)
             val callbacks = OnGleanEventsImpl(this@GleanInternalAPI)

--- a/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
+++ b/glean-core/android/src/main/java/mozilla/telemetry/glean/config/Configuration.kt
@@ -39,6 +39,7 @@ import mozilla.telemetry.glean.net.PingUploader
  * @property sessionSampleRate Session sampling rate (0.0–1.0). Default: `1.0`.
  * @property sessionInactivityTimeoutMs Inactivity timeout (milliseconds) before AUTO-mode
  *           sessions expire. Default: 30 minutes.
+ * @property eventsPingAccelerationFactor The number of "events" pings to accelerate each session, plus one.
  */
 data class Configuration
     @JvmOverloads
@@ -64,6 +65,7 @@ data class Configuration
         val sessionMode: SessionMode = SessionMode.AUTO,
         val sessionSampleRate: Double = 1.0,
         val sessionInactivityTimeoutMs: Long = DEFAULT_SESSION_INACTIVITY_TIMEOUT_MS,
+        val eventsPingAccelerationFactor: Int? = null,
     ) {
         companion object {
             /**

--- a/glean-core/benchmark/benches/dispatcher.rs
+++ b/glean-core/benchmark/benches/dispatcher.rs
@@ -88,6 +88,7 @@ pub fn metric_dispatcher_benchmark(c: &mut Criterion) {
         session_mode: glean_core::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     };
     let client_info = ClientInfoMetrics::unknown();
 

--- a/glean-core/benchmark/benches/lifetime_buffering.rs
+++ b/glean-core/benchmark/benches/lifetime_buffering.rs
@@ -36,6 +36,7 @@ pub fn delay_io_benchmark(c: &mut Criterion) {
             session_mode: glean_core::SessionMode::Auto,
             session_sample_rate: 1.0,
             session_inactivity_timeout_ms: 1_800_000,
+            events_ping_acceleration_factor: None,
         };
         let glean = Glean::new(cfg).unwrap();
 
@@ -83,6 +84,7 @@ pub fn delay_io_benchmark(c: &mut Criterion) {
             session_mode: glean_core::SessionMode::Auto,
             session_sample_rate: 1.0,
             session_inactivity_timeout_ms: 1_800_000,
+            events_ping_acceleration_factor: None,
         };
         let glean = Glean::new(cfg).unwrap();
 
@@ -130,6 +132,7 @@ pub fn delay_io_benchmark(c: &mut Criterion) {
             session_mode: glean_core::SessionMode::Auto,
             session_sample_rate: 1.0,
             session_inactivity_timeout_ms: 1_800_000,
+            events_ping_acceleration_factor: None,
         };
         let glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/examples/rkv-open.rs
+++ b/glean-core/examples/rkv-open.rs
@@ -56,6 +56,7 @@ fn main() {
         session_mode: glean_core::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     };
 
     let client_info = ClientInfoMetrics::unknown();

--- a/glean-core/ios/Glean/Config/Configuration.swift
+++ b/glean-core/ios/Glean/Config/Configuration.swift
@@ -22,6 +22,7 @@ public struct Configuration {
     let httpClient: PingUploader
     let maxPendingPingsCount: UInt64?
     let maxPendingPingsDirectorySize: UInt64?
+    let eventsPingAccelerationFactor: UInt32?
 
     struct Constants {
         static let defaultTelemetryEndpoint =
@@ -56,6 +57,8 @@ public struct Configuration {
     ///   * sessionInactivityTimeoutMs Inactivity timeout (ms) before AUTO-mode
     ///   sessions expire. Default: 30 minutes (1,800,000 ms).
     ///   * httpClient An http uploader that supports the `PingUploader` protocol
+    ///   * eventsPingAccelerationFactor The number of "events" pings to accelerate each session,
+    ///     plus one.
     public init(
         maxEvents: Int32? = nil,
         channel: String? = nil,
@@ -74,6 +77,7 @@ public struct Configuration {
         sessionSampleRate: Double = 1.0,
         sessionInactivityTimeoutMs: UInt64 = 1_800_000,
         httpClient: PingUploader = HttpPingUploader()
+        eventsPingAccelerationFactor: UInt32? = nil,
     ) {
         self.serverEndpoint =
             serverEndpoint ?? Constants.defaultTelemetryEndpoint
@@ -93,5 +97,6 @@ public struct Configuration {
         self.sessionSampleRate = sessionSampleRate
         self.sessionInactivityTimeoutMs = sessionInactivityTimeoutMs
         self.httpClient = httpClient
+        self.eventsPingAccelerationFactor = eventsPingAccelerationFactor
     }
 }

--- a/glean-core/ios/Glean/Glean.swift
+++ b/glean-core/ios/Glean/Glean.swift
@@ -217,7 +217,8 @@ public final class Glean: @unchecked Sendable {
             maxPendingPingsDirectorySize: configuration.maxPendingPingsDirectorySize,
             sessionMode: configuration.sessionMode,
             sessionSampleRate: configuration.sessionSampleRate,
-            sessionInactivityTimeoutMs: configuration.sessionInactivityTimeoutMs
+            sessionInactivityTimeoutMs: configuration.sessionInactivityTimeoutMs,
+            eventsPingAccelerationFactor: configuration.eventsPingAccelerationFactor
         )
         let clientInfo = getClientInfo(configuration, buildInfo: buildInfo)
         let callbacks = OnGleanEventsImpl(glean: self)

--- a/glean-core/metrics.yaml
+++ b/glean-core/metrics.yaml
@@ -449,6 +449,11 @@ glean.internal.metrics:
           type: number
           description: |
             Optional sample rate for session pings. Can be null if not set.
+        events_ping_acceleration_factor:
+          type: number
+          description: |
+            Optional acceleration factor for events pings.
+            Can be null if not set.
 
 
 glean.internal.metrics.attribution:

--- a/glean-core/python/glean/config.py
+++ b/glean-core/python/glean/config.py
@@ -45,6 +45,7 @@ class Configuration:
         session_mode: SessionMode = SessionMode.AUTO,
         session_sample_rate: float = 1.0,
         session_inactivity_timeout_ms: int = DEFAULT_SESSION_INACTIVITY_TIMEOUT_MS,
+        events_ping_acceleration_factor: Optional[int] = None,
     ):
         """
         Args:
@@ -75,6 +76,8 @@ class Configuration:
                 Default: `1.0`.
             session_inactivity_timeout_ms (int): Inactivity timeout (milliseconds)
                 before AUTO-mode sessions expire. Default: 30 minutes.
+            events_ping_acceleration_factor (int): Optional.
+                The number of "events" pings to accelerate each session, plus one.
         """
         if server_endpoint is None:
             server_endpoint = DEFAULT_TELEMETRY_ENDPOINT
@@ -93,6 +96,7 @@ class Configuration:
         self._session_mode = session_mode
         self._session_sample_rate = session_sample_rate
         self._session_inactivity_timeout_ms = session_inactivity_timeout_ms
+        self._events_ping_acceleration_factor = events_ping_acceleration_factor
 
     @property
     def server_endpoint(self) -> str:
@@ -171,6 +175,11 @@ class Configuration:
     def session_inactivity_timeout_ms(self) -> int:
         """Inactivity timeout (milliseconds) before AUTO-mode sessions expire."""
         return self._session_inactivity_timeout_ms
+
+    @property
+    def events_ping_acceleration_factor(self) -> Optional[int]:
+        """The number of "events" pings to accelerate each session, plus one."""
+        return self._events_ping_acceleration_factor
 
 
 __all__ = ["Configuration"]

--- a/glean-core/python/glean/glean.py
+++ b/glean-core/python/glean/glean.py
@@ -243,6 +243,7 @@ class Glean:
             session_mode=configuration.session_mode,
             session_sample_rate=configuration.session_sample_rate,
             session_inactivity_timeout_ms=configuration.session_inactivity_timeout_ms,
+            events_ping_acceleration_factor=configuration.events_ping_acceleration_factor,
         )
 
         _uniffi.glean_initialize(cfg, client_info, callbacks)

--- a/glean-core/python/glean/net/ping_upload_worker.py
+++ b/glean-core/python/glean/net/ping_upload_worker.py
@@ -133,6 +133,7 @@ def _process(data_dir: Path, application_id: str, configuration) -> bool:
             session_mode=SessionMode.AUTO,
             session_sample_rate=1.0,
             session_inactivity_timeout_ms=1_800_000,
+            events_ping_acceleration_factor=configuration.events_ping_acceleration_factor,
         )
         if not glean_initialize_for_subprocess(cfg):
             log.error("Couldn't initialize Glean in subprocess")

--- a/glean-core/rlb/src/configuration.rs
+++ b/glean-core/rlb/src/configuration.rs
@@ -65,6 +65,8 @@ pub struct Configuration {
     pub session_sample_rate: f64,
     /// Inactivity timeout for AUTO mode sessions. Default: 30 minutes.
     pub session_inactivity_timeout: Duration,
+    /// The number of "events" pings to accelerate each session, plus one.
+    pub events_ping_acceleration_factor: Option<usize>,
 }
 
 /// Configuration builder.
@@ -127,6 +129,8 @@ pub struct Builder {
     pub session_sample_rate: f64,
     /// Inactivity timeout for AUTO mode sessions. Default: 30 minutes.
     pub session_inactivity_timeout: Duration,
+    /// The number of "events" pings to accelerate each session, plus one.
+    pub events_ping_acceleration_factor: Option<usize>,
 }
 
 impl Builder {
@@ -157,6 +161,7 @@ impl Builder {
             session_mode: SessionMode::Auto,
             session_sample_rate: 1.0,
             session_inactivity_timeout: Duration::from_secs(30 * 60),
+            events_ping_acceleration_factor: None,
         }
     }
 
@@ -183,6 +188,7 @@ impl Builder {
             session_mode: self.session_mode,
             session_sample_rate: self.session_sample_rate,
             session_inactivity_timeout: self.session_inactivity_timeout,
+            events_ping_acceleration_factor: self.events_ping_acceleration_factor,
         }
     }
 
@@ -279,6 +285,12 @@ impl Builder {
     /// After what time to auto-flush. 0 disables it.
     pub fn with_ping_lifetime_max_time(mut self, value: Duration) -> Self {
         self.ping_lifetime_max_time = value;
+        self
+    }
+
+    /// Set the number of "events" pings to accelerate each session, plus one.
+    pub fn with_events_ping_acceleration_factor(mut self, factor: usize) -> Self {
+        self.events_ping_acceleration_factor = Some(factor);
         self
     }
 }

--- a/glean-core/rlb/src/lib.rs
+++ b/glean-core/rlb/src/lib.rs
@@ -135,6 +135,7 @@ fn initialize_internal(cfg: Configuration, client_info: ClientInfoMetrics) -> Op
         session_mode: cfg.session_mode,
         session_sample_rate: cfg.session_sample_rate,
         session_inactivity_timeout_ms: cfg.session_inactivity_timeout.as_millis() as u64,
+        events_ping_acceleration_factor: cfg.events_ping_acceleration_factor.map(|x| x as u32),
     };
 
     glean_core::glean_initialize(core_cfg, client_info.into(), callbacks);

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -145,6 +145,7 @@ where
 ///     session_mode: glean_core::SessionMode::Auto,
 ///     session_sample_rate: 1.0,
 ///     session_inactivity_timeout_ms: 1_800_000,
+///     events_ping_acceleration_factor: None,
 /// };
 /// let mut glean = Glean::new(cfg).unwrap();
 /// let ping = PingType::new("sample", true, false, true, true, true, vec![], vec![], true, vec![]);
@@ -194,6 +195,7 @@ pub struct Glean {
     pub(crate) ping_schedule: HashMap<String, Vec<String>>,
     #[ignore_malloc_size_of = "TODO: Expose session memory allocations (bug 2043355)"]
     pub(crate) session_manager: SessionManager,
+    events_ping_acceleration_factor: Option<usize>,
 }
 
 impl Glean {
@@ -274,6 +276,9 @@ impl Glean {
                 cfg.session_sample_rate,
                 std::time::Duration::from_millis(cfg.session_inactivity_timeout_ms),
             ),
+            events_ping_acceleration_factor: cfg
+                .events_ping_acceleration_factor
+                .map(|x| x as usize),
         };
 
         // Ensuring these pings are registered.
@@ -598,6 +603,7 @@ impl Glean {
             session_mode: SessionMode::Auto,
             session_sample_rate: 1.0,
             session_inactivity_timeout_ms: 1_800_000,
+            events_ping_acceleration_factor: None,
         };
 
         let mut glean = Self::new(cfg).unwrap();
@@ -1023,6 +1029,17 @@ impl Glean {
         }
     }
 
+    /// Gets the number of "events" pings to accelerate each session, plus one.
+    pub fn get_events_ping_acceleration_factor(&self) -> usize {
+        let remote_settings_config = self.remote_settings_config.lock().unwrap();
+
+        if let Some(factor) = remote_settings_config.events_ping_acceleration_factor {
+            factor
+        } else {
+            self.events_ping_acceleration_factor.unwrap_or(1)
+        }
+    }
+
     /// Gets the next task for an uploader.
     ///
     /// This can be one of:
@@ -1248,6 +1265,9 @@ impl Glean {
                 }
                 clamped
             });
+
+            remote_settings_config.events_ping_acceleration_factor =
+                cfg.events_ping_acceleration_factor;
 
             // Store the Server Knobs configuration as an ObjectMetric
             // Since RemoteSettingsConfig only contains maps with string keys and primitives,

--- a/glean-core/src/event_database/mod.rs
+++ b/glean-core/src/event_database/mod.rs
@@ -10,7 +10,7 @@ use std::io::BufReader;
 use std::io::Write;
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{atomic, Arc, Mutex, RwLock};
 use std::{fs, mem};
 
 use chrono::{DateTime, FixedOffset, Utc};
@@ -111,6 +111,9 @@ pub struct EventDatabase {
     event_store_files: RwLock<HashMap<String, Arc<File>>>,
     /// A lock to be held when doing operations on the filesystem
     file_lock: Mutex<()>,
+    /// How many "events" pings have been submitted,
+    /// as estimated from how often the "events" store is snapshotted and cleared.
+    events_pings_submitted: atomic::AtomicUsize,
 }
 
 impl MallocSizeOf for EventDatabase {
@@ -144,6 +147,7 @@ impl EventDatabase {
             event_stores: RwLock::new(HashMap::new()),
             event_store_files: RwLock::new(HashMap::new()),
             file_lock: Mutex::new(()),
+            events_pings_submitted: atomic::AtomicUsize::new(0),
         })
     }
 
@@ -232,7 +236,13 @@ impl EventDatabase {
                         EventSessionContext::OutOfSession,
                     );
                 }
-                has_events_events && glean.submit_ping_by_name("events", Some("startup"))
+                if has_events_events && glean.submit_ping_by_name("events", Some("startup")) {
+                    self.events_pings_submitted
+                        .fetch_sub(1, atomic::Ordering::Relaxed);
+                    true
+                } else {
+                    false
+                }
             }
             Err(err) => {
                 log::warn!("Error loading events from disk: {}", err);
@@ -351,8 +361,24 @@ impl EventDatabase {
                 let event_json = serde_json::to_string(&event).unwrap(); // safe unwrap, event can always be serialized
                 store.push(event);
                 self.write_event_to_disk(store_name, &event_json);
-                if store_name == "events" && store.len() == glean.get_max_events() {
-                    submit_max_capacity_event_ping = true;
+                if store_name == "events" {
+                    if store.len() == glean.get_max_events() {
+                        submit_max_capacity_event_ping = true;
+                    }
+                    let factor = glean.get_events_ping_acceleration_factor();
+                    let events_pings_submitted =
+                        self.events_pings_submitted.load(atomic::Ordering::Relaxed);
+                    if factor > events_pings_submitted {
+                        // The early "events" ping acceleration formula is y = ax^2.
+                        let a = glean.get_max_events() / factor.saturating_mul(factor);
+                        let x = events_pings_submitted + 1; // We want the y for the next ping.
+                        let y = a.saturating_mul(x.saturating_mul(x));
+                        // It is possible to apply an acceleration factor at runtime that would
+                        // decrease y below store.len(). Submit a ping on the next event in that case.
+                        if store.len() >= y {
+                            submit_max_capacity_event_ping = true;
+                        }
+                    }
                 }
             }
         }
@@ -673,6 +699,11 @@ impl EventDatabase {
                     _ => log::warn!("Error removing events queue file '{}': {}", store_name, err),
                 }
             }
+        }
+
+        if clear_store && store_name == "events" {
+            self.events_pings_submitted
+                .fetch_add(1, atomic::Ordering::Relaxed);
         }
 
         result

--- a/glean-core/src/glean.udl
+++ b/glean-core/src/glean.udl
@@ -126,6 +126,7 @@ dictionary InternalConfiguration {
     SessionMode session_mode;
     f64 session_sample_rate; // Must be in [0.0, 1.0]; values outside are clamped.
     u64 session_inactivity_timeout_ms; // Milliseconds; 0 means sessions never time out.
+    u32? events_ping_acceleration_factor;
 };
 
 // Session management mode.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -181,6 +181,8 @@ pub struct InternalConfiguration {
     /// Inactivity timeout in milliseconds for AUTO mode before a new session starts.
     /// Default: 1 800 000 ms (30 minutes).
     pub session_inactivity_timeout_ms: u64,
+    /// The number of "events" pings to accelerate each session, plus one.
+    pub events_ping_acceleration_factor: Option<u32>,
 }
 
 /// How to specify the rate at which pings may be uploaded before they are throttled.

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -182,6 +182,8 @@ pub struct InternalConfiguration {
     /// Inactivity timeout in milliseconds for AUTO mode before a new session starts.
     /// Default: 1 800 000 ms (30 minutes).
     pub session_inactivity_timeout_ms: u64,
+    /// The number of "events" pings to accelerate each session, plus one.
+    pub events_ping_acceleration_factor: Option<u32>,
 }
 
 /// How to specify the rate at which pings may be uploaded before they are throttled.

--- a/glean-core/src/lib_unit_tests.rs
+++ b/glean-core/src/lib_unit_tests.rs
@@ -237,6 +237,7 @@ fn experimentation_id_is_set_correctly() {
         session_mode: crate::session::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     })
     .unwrap();
 

--- a/glean-core/src/metrics/remote_settings_config.rs
+++ b/glean-core/src/metrics/remote_settings_config.rs
@@ -46,6 +46,11 @@ pub struct RemoteSettingsConfig {
     /// Changes take effect at the next session start.
     #[serde(default)]
     pub session_sample_rate: Option<f64>,
+
+    /// The number of "events" pings to accelerate each session, plus one.
+    /// It overrides the value configured at initialization time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub events_ping_acceleration_factor: Option<usize>,
 }
 
 impl RemoteSettingsConfig {

--- a/glean-core/src/ping/mod.rs
+++ b/glean-core/src/ping/mod.rs
@@ -552,6 +552,7 @@ mod test {
             pings_enabled,
             event_threshold: Some(41),
             session_sample_rate: None,
+            events_ping_acceleration_factor: Some(5),
         };
         glean.apply_server_knobs_config(config);
 
@@ -563,6 +564,7 @@ mod test {
         assert_eq!(server_knobs["metrics_enabled"]["test.counter"], true);
         assert_eq!(server_knobs["pings_enabled"]["custom"], false);
         assert_eq!(server_knobs["event_threshold"], 41);
+        assert_eq!(server_knobs["events_ping_acceleration_factor"], 5);
     }
 
     #[test]
@@ -632,5 +634,8 @@ mod test {
         // pings_enabled and event_threshold should be absent (not empty object / null)
         assert!(server_knobs.get("pings_enabled").is_none());
         assert!(server_knobs.get("event_threshold").is_none());
+        assert!(server_knobs
+            .get("events_ping_acceleration_factor")
+            .is_none());
     }
 }

--- a/glean-core/tests/common/mod.rs
+++ b/glean-core/tests/common/mod.rs
@@ -74,6 +74,7 @@ pub fn new_glean_with_upload(
         session_mode: glean_core::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     };
     let mut glean = Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/event.rs
+++ b/glean-core/tests/event.rs
@@ -558,6 +558,7 @@ fn with_event_timestamps() {
         session_mode: glean_core::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     };
     let mut glean = Glean::new(cfg).unwrap();
     let ping = PingBuilder::new("store1").build();
@@ -624,5 +625,251 @@ fn doesnt_crash_on_inaccessible_event_store_file() {
         assert_eq!("telemetry", events[0].category);
         assert_eq!("test_event_no_optional", events[0].name);
         assert!(events[0].extra.is_none());
+    }
+}
+
+#[test]
+fn test_server_knobs_config_events_factor() {
+    let (mut glean, _t) = new_glean(None);
+
+    let store_names: Vec<String> = vec!["events".into()];
+
+    glean.register_ping_type(
+        &PingBuilder::new(&store_names[0])
+            .with_reasons(vec!["max_capacity".to_string()])
+            .build(),
+    );
+
+    // 1. Set up an event to record
+    let click = EventMetric::new(
+        CommonMetricData {
+            name: "click".into(),
+            category: "ui".into(),
+            send_in_pings: store_names,
+            disabled: false,
+            lifetime: Lifetime::Ping,
+            ..Default::default()
+        },
+        vec!["test_event_number".into()],
+    );
+
+    // 2. Set a Server Knobs configuration to accelerate the ping
+    let remote_settings_config = json!(
+        {
+            "events_ping_acceleration_factor": 5
+        }
+    )
+    .to_string();
+    glean
+        .apply_server_knobs_config(RemoteSettingsConfig::try_from(remote_settings_config).unwrap());
+
+    // 3. Record 21 events. We expect to get the first 20 in the first ping and 1
+    // remaining afterward
+    for i in 0..21 {
+        let mut extra = HashMap::new();
+        extra.insert("test_event_number".to_string(), i.to_string());
+        click.record_sync(&glean, i, extra, 0);
+    }
+
+    assert_eq!(1, click.get_value(&glean, "events").unwrap().len());
+
+    let (url, json, _) = &get_queued_pings(glean.get_data_path()).unwrap()[0];
+    assert!(url.starts_with(format!("/submit/{}/events/", glean.get_application_id()).as_str()));
+    assert_eq!(20, json["events"].as_array().unwrap().len());
+    assert_eq!(
+        "max_capacity",
+        json["ping_info"].as_object().unwrap()["reason"]
+            .as_str()
+            .unwrap()
+    );
+
+    for i in 0..20 {
+        let event = &json["events"].as_array().unwrap()[i];
+        assert_eq!(i.to_string(), event["extra"]["test_event_number"]);
+    }
+
+    let snapshot = glean
+        .event_storage()
+        .snapshot_as_json(&glean, "events", false)
+        .unwrap();
+    assert_eq!(1, snapshot.as_array().unwrap().len());
+    let event = &snapshot.as_array().unwrap()[0];
+    assert_eq!(20.to_string(), event["extra"]["test_event_number"]);
+}
+
+#[test]
+fn test_server_knobs_config_events_factor_decrease() {
+    let (mut glean, _t) = new_glean(None);
+
+    let store_names: Vec<String> = vec!["events".into()];
+
+    glean.register_ping_type(
+        &PingBuilder::new(&store_names[0])
+            .with_reasons(vec!["max_capacity".to_string()])
+            .build(),
+    );
+
+    // 1. Set up an event to record
+    let click = EventMetric::new(
+        CommonMetricData {
+            name: "click".into(),
+            category: "ui".into(),
+            send_in_pings: store_names,
+            disabled: false,
+            lifetime: Lifetime::Ping,
+            ..Default::default()
+        },
+        vec!["test_event_number".into()],
+    );
+
+    // 2. Record 21 events. We expect no "events" ping to yet be submitted (threshold's 500).
+    for i in 0..21 {
+        let mut extra = HashMap::new();
+        extra.insert("test_event_number".to_string(), i.to_string());
+        click.record_sync(&glean, i, extra, 0);
+    }
+
+    assert_eq!(21, click.get_value(&glean, "events").unwrap().len());
+
+    // 3. Set a Server Knobs configuration to accelerate the ping
+    let remote_settings_config = json!(
+        {
+            "events_ping_acceleration_factor": 5
+        }
+    )
+    .to_string();
+    glean
+        .apply_server_knobs_config(RemoteSettingsConfig::try_from(remote_settings_config).unwrap());
+
+    // 4. We expect the ping to still not have been sent, even though the threshold's now 20.
+    // (Maybe in the future this will change.)
+    assert_eq!(21, click.get_value(&glean, "events").unwrap().len());
+
+    // 5. We record one more event (total: 22). A ping is submitted. All events are on it.
+    let mut extra = HashMap::new();
+    extra.insert("test_event_number".to_string(), 21.to_string());
+    click.record_sync(&glean, 21, extra, 0);
+    assert_eq!(None, click.get_value(&glean, "events"));
+
+    let (url, json, _) = &get_queued_pings(glean.get_data_path()).unwrap()[0];
+    assert!(url.starts_with(format!("/submit/{}/events/", glean.get_application_id()).as_str()));
+    assert_eq!(22, json["events"].as_array().unwrap().len());
+    assert_eq!(
+        "max_capacity",
+        json["ping_info"].as_object().unwrap()["reason"]
+            .as_str()
+            .unwrap()
+    );
+
+    for i in 0..22 {
+        let event = &json["events"].as_array().unwrap()[i];
+        assert_eq!(i.to_string(), event["extra"]["test_event_number"]);
+    }
+}
+
+#[test]
+fn events_factor_discounts_startup_ping() {
+    let (mut tempdir, _) = tempdir();
+
+    let store_name = "events";
+    let event = EventMetric::new(
+        CommonMetricData {
+            name: "name".into(),
+            category: "category".into(),
+            send_in_pings: vec![store_name.into()],
+            lifetime: Lifetime::Ping,
+            ..Default::default()
+        },
+        vec!["test_event_number".into()],
+    );
+
+    {
+        let (glean, dir) = new_glean(Some(tempdir));
+        // We don't need a full init. Just to deal with on-disk events:
+        assert!(!glean
+            .event_storage()
+            .flush_pending_events_on_startup(&glean, false));
+        tempdir = dir;
+
+        event.record_sync(&glean, 10, HashMap::new(), 0);
+    }
+
+    {
+        let (glean, _dir) = new_glean(Some(tempdir));
+        // Set a Server Knobs configuration to accelerate pings
+        let remote_settings_config = json!(
+            {
+                "events_ping_acceleration_factor": 5
+            }
+        )
+        .to_string();
+        glean.apply_server_knobs_config(
+            RemoteSettingsConfig::try_from(remote_settings_config).unwrap(),
+        );
+
+        // Ensure we flush the last session's event.
+        assert!(glean
+            .event_storage()
+            .flush_pending_events_on_startup(&glean, false));
+
+        // Record 21 events. We expect an "events" ping to be submitted at 20, with 1 left over.
+        for i in 0..21 {
+            let mut extra = HashMap::new();
+            extra.insert("test_event_number".to_string(), i.to_string());
+            event.record_sync(&glean, i, extra, 0);
+        }
+        assert_eq!(1, event.get_value(&glean, "events").unwrap().len());
+
+        let pings = get_queued_pings(glean.get_data_path()).unwrap();
+        assert!(
+            pings.len() >= 2,
+            "We expect at least the two 'events' pings"
+        );
+        let pattern = format!("/submit/{}/events/", glean.get_application_id());
+        let events_pings: Vec<(String, JsonValue, _)> = pings
+            .into_iter()
+            .filter(|p| p.0.starts_with(&pattern))
+            .collect();
+        assert_eq!(events_pings.len(), 2);
+
+        let startup_events_ping = events_pings
+            .iter()
+            .filter(|p| {
+                p.1["ping_info"].as_object().unwrap()["reason"]
+                    .as_str()
+                    .unwrap()
+                    == "startup"
+            })
+            .collect::<Vec<_>>()[0];
+        assert_eq!(1, startup_events_ping.1["events"].as_array().unwrap().len());
+
+        let accelerated_events_ping = events_pings
+            .iter()
+            .filter(|p| {
+                p.1["ping_info"].as_object().unwrap()["reason"]
+                    .as_str()
+                    .unwrap()
+                    == "max_capacity"
+            })
+            .collect::<Vec<_>>()[0];
+        assert_eq!(
+            20,
+            accelerated_events_ping.1["events"]
+                .as_array()
+                .unwrap()
+                .len()
+        );
+        for i in 0..20 {
+            let event = &accelerated_events_ping.1["events"].as_array().unwrap()[i];
+            assert_eq!(i.to_string(), event["extra"]["test_event_number"]);
+        }
+
+        let snapshot = glean
+            .event_storage()
+            .snapshot_as_json(&glean, "events", false)
+            .unwrap();
+        assert_eq!(1, snapshot.as_array().unwrap().len());
+        let event = &snapshot.as_array().unwrap()[0];
+        assert_eq!(20.to_string(), event["extra"]["test_event_number"]);
     }
 }

--- a/glean-core/tests/ping.rs
+++ b/glean-core/tests/ping.rs
@@ -388,6 +388,7 @@ fn clearing_storage_by_prefix_doesnt_clear_unrelated_delayed_ping_io() {
         session_mode: glean_core::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     };
     let mut glean = glean_core::Glean::new(cfg).unwrap();
 

--- a/glean-core/tests/ping_maker.rs
+++ b/glean-core/tests/ping_maker.rs
@@ -101,6 +101,7 @@ fn test_metrics_must_report_experimentation_id() {
         session_mode: glean_core::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     })
     .unwrap();
     let ping_maker = PingMaker::new();
@@ -161,6 +162,7 @@ fn experimentation_id_is_removed_if_send_if_empty_is_false() {
         session_mode: glean_core::SessionMode::Auto,
         session_sample_rate: 1.0,
         session_inactivity_timeout_ms: 1_800_000,
+        events_ping_acceleration_factor: None,
     })
     .unwrap();
     let ping_maker = PingMaker::new();

--- a/glean-core/tests/session.rs
+++ b/glean-core/tests/session.rs
@@ -46,6 +46,7 @@ fn session_cfg(
         session_mode: mode,
         session_sample_rate: sample_rate,
         session_inactivity_timeout_ms: timeout_ms,
+        events_ping_acceleration_factor: None,
     }
 }
 

--- a/glean-core/tests/sqlite.rs
+++ b/glean-core/tests/sqlite.rs
@@ -204,6 +204,7 @@ mod unix {
             session_mode: glean_core::SessionMode::Auto,
             session_sample_rate: 1.0,
             session_inactivity_timeout_ms: 1_800_000,
+            events_ping_acceleration_factor: None,
         };
         let glean = Glean::new(cfg);
         assert!(glean.is_err());
@@ -251,6 +252,7 @@ fn database_externally_locked() {
         session_inactivity_timeout_ms: 0,
         session_mode: SessionMode::Auto,
         session_sample_rate: 1.0,
+        events_ping_acceleration_factor: None,
     };
     let glean = Glean::new(cfg);
     assert!(glean.is_err());


### PR DESCRIPTION
Add a new configuration property and Server Knob to accelerate the first few "events" pings each session by decreasing the number of `event` records needed to trigger a `max_capacity`-reason "events" ping submission.