### PR TITLE
Close the database on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     * Run database maintenance at shutdown & after collecting ping data ([#3559](https://github.com/mozilla/glean/pull/3559))
     * Validate that the database connection on open is usable for reads and writes ([#3513](https://github.com/mozilla/glean/pull/3513))
     * Keep state about migration in the database ([#3545](https://github.com/mozilla/glean/pull/3545))
+    * The database connection is closed on shutdown ([#3584](https://github.com/mozilla/glean/pull/3584))
   * BREAKING CHANGE: Updated to UniFFI 0.32.0 ([#3538](https://github.com/mozilla/glean/pull/3538))
 * Rust
   * glean-sym

--- a/glean-core/src/core/mod.rs
+++ b/glean-core/src/core/mod.rs
@@ -608,10 +608,10 @@ impl Glean {
         glean
     }
 
-    /// Destroys the database.
+    /// Close the database connection.
     ///
     /// After this Glean needs to be reinitialized.
-    pub fn destroy_db(&mut self) {
+    pub fn close_db(&mut self) {
         self.data_store = None;
     }
 

--- a/glean-core/src/lib.rs
+++ b/glean-core/src/lib.rs
@@ -787,7 +787,7 @@ pub fn shutdown() {
     uploader_shutdown();
 
     // Be sure to call this _after_ draining the dispatcher
-    core::with_glean(|glean| {
+    core::with_glean_mut(|glean| {
         if let Err(e) = glean.persist_ping_lifetime_data() {
             log::info!("Can't persist ping lifetime data: {:?}", e);
         }
@@ -797,6 +797,8 @@ pub fn shutdown() {
                 log::info!("Can't run database maintenance on shutdown: {:?}", e);
             }
         }
+
+        glean.close_db();
     });
 }
 
@@ -1344,7 +1346,7 @@ pub fn glean_test_destroy_glean(clear_stores: bool, data_path: Option<String>) {
                 if clear_stores {
                     glean.test_clear_all_stores()
                 }
-                glean.destroy_db()
+                glean.close_db()
             });
         }
 


### PR DESCRIPTION
This ensure we actually close the database connection, which is a good idea to do when we can.
Renamed the function to reflect better what it is doing.