### PR TITLE
Depend on the minimum version of mozbuild

### DIFF
--- a/glean-core/Cargo.toml
+++ b/glean-core/Cargo.toml
@@ -64,7 +64,7 @@ xshell = "0.2.7"
 yaml-rust2 = "0.10"
 
 [build-dependencies]
-mozbuild = "0.1.1"
+mozbuild = "0.1.0"
 uniffi = { version = "0.32.0", default-features = false, features = ["build"] }
 
 [features]


### PR DESCRIPTION
0.1.0 is the version of mozbuild in the Gecko tree, and we're fine using that.
0.1.1 is on crates.io, now with a lib.rs to avoid a build warning.