### PR TITLE
CI: Use Rust 1.97 to build other Python Linux targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -871,7 +871,13 @@ jobs:
       - image: cimg/python:3.13
     steps:
       - install-rustup
-      - setup-rust-toolchain
+      - setup-rust-toolchain:
+          # We're using an older maturin,
+          # which pulls in an older Zig build,
+          # which doesn't filter a certain parameter (https://github.com/rust-cross/cargo-zigbuild/pull/452),
+          # which breaks the build.
+          # Rust 1.97 however is fine, for now.
+          rust-version: "1.97"
       - checkout
       - run:
           name: Setup Python env


### PR DESCRIPTION
We're using an older maturin,
which pulls in an older Zig build,
which doesn't filter a certain parameter (https://github.com/rust-cross/cargo-zigbuild/pull/452), which breaks the build.
Rust 1.97 however is fine, for now.

---

Causing a failure like this: https://app.circleci.com/pipelines/github/mozilla/glean/15126/details?workflowId=58b6a90f-225b-4316-8a26-04f110ea9796&job=4afbcaf4-cdd5-4096-9fc2-2ea138b74ef1&buildNumber=302551&jobType=build#step-107-

```
error: linking with `/home/circleci/.cache/cargo-zigbuild/0.22.1/zigcc-aarch64-unknown-linux-gnu.2.17-aa8f.sh` failed: exit status: 1
[...]
  = note: error: unsupported linker arg: --fix-cortex-a53-843419
```

[Rust 1.98 was released yesterday](https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/), which is why this breaks today.